### PR TITLE
Copy index.lifecycle.name for ILM managed indices

### DIFF
--- a/docs/changelog/97110.yaml
+++ b/docs/changelog/97110.yaml
@@ -1,0 +1,6 @@
+pr: 97110
+summary: Copy "index.lifecycle.name" for ILM managed indices
+area: Downsampling
+type: bug
+issues:
+ - 96732

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
@@ -111,6 +111,7 @@ public class DownsampleAction implements LifecycleAction {
         StepKey downsampleKey = new StepKey(phase, NAME, DownsampleStep.NAME);
         StepKey waitForDownsampleIndexKey = new StepKey(phase, NAME, WaitForIndexColorStep.NAME);
         StepKey copyMetadataKey = new StepKey(phase, NAME, CopyExecutionStateStep.NAME);
+        StepKey copyIndexLifecycleKey = new StepKey(phase, NAME, CopySettingsStep.NAME);
         StepKey dataStreamCheckBranchingKey = new StepKey(phase, NAME, CONDITIONAL_DATASTREAM_CHECK_KEY);
         StepKey replaceDataStreamIndexKey = new StepKey(phase, NAME, ReplaceDataStreamBackingIndexStep.NAME);
         StepKey deleteIndexKey = new StepKey(phase, NAME, DeleteStep.NAME);
@@ -181,9 +182,16 @@ public class DownsampleAction implements LifecycleAction {
 
         CopyExecutionStateStep copyExecutionStateStep = new CopyExecutionStateStep(
             copyMetadataKey,
-            dataStreamCheckBranchingKey,
+            copyIndexLifecycleKey,
             (indexName, lifecycleState) -> lifecycleState.downsampleIndexName(),
             nextStepKey
+        );
+
+        CopySettingsStep copyLifecycleSettingsStep = new CopySettingsStep(
+            copyIndexLifecycleKey,
+            dataStreamCheckBranchingKey,
+            (index, lifecycleState) -> lifecycleState.downsampleIndexName(),
+            LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()
         );
 
         // By the time we get to this step we have 2 indices, the source and the downsampled one. We now need to choose an index
@@ -226,6 +234,7 @@ public class DownsampleAction implements LifecycleAction {
             downsampleStep,
             downsampleAllocatedStep,
             copyExecutionStateStep,
+            copyLifecycleSettingsStep,
             isDataStreamBranchingStep,
             replaceDataStreamBackingIndex,
             deleteSourceIndexStep,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
@@ -62,7 +62,7 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
         );
         List<Step> steps = action.toSteps(null, phase, nextStepKey);
         assertNotNull(steps);
-        assertEquals(13, steps.size());
+        assertEquals(14, steps.size());
 
         assertTrue(steps.get(0) instanceof BranchingStep);
         assertThat(steps.get(0).getKey().name(), equalTo(CONDITIONAL_TIME_SERIES_CHECK_KEY));
@@ -100,25 +100,29 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
 
         assertTrue(steps.get(8) instanceof CopyExecutionStateStep);
         assertThat(steps.get(8).getKey().name(), equalTo(CopyExecutionStateStep.NAME));
-        assertThat(steps.get(8).getNextStepKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
+        assertThat(steps.get(8).getNextStepKey().name(), equalTo(CopySettingsStep.NAME));
 
-        assertTrue(steps.get(9) instanceof BranchingStep);
-        assertThat(steps.get(9).getKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
-        expectThrows(IllegalStateException.class, () -> steps.get(9).getNextStepKey());
-        assertThat(((BranchingStep) steps.get(9)).getNextStepKeyOnFalse().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
-        assertThat(((BranchingStep) steps.get(9)).getNextStepKeyOnTrue().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
+        assertTrue(steps.get(9) instanceof CopySettingsStep);
+        assertThat(steps.get(9).getKey().name(), equalTo(CopySettingsStep.NAME));
+        assertThat(steps.get(9).getNextStepKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
 
-        assertTrue(steps.get(10) instanceof ReplaceDataStreamBackingIndexStep);
-        assertThat(steps.get(10).getKey().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
-        assertThat(steps.get(10).getNextStepKey().name(), equalTo(DeleteStep.NAME));
+        assertTrue(steps.get(10) instanceof BranchingStep);
+        assertThat(steps.get(10).getKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
+        expectThrows(IllegalStateException.class, () -> steps.get(10).getNextStepKey());
+        assertThat(((BranchingStep) steps.get(10)).getNextStepKeyOnFalse().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertThat(((BranchingStep) steps.get(10)).getNextStepKeyOnTrue().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
 
-        assertTrue(steps.get(11) instanceof DeleteStep);
-        assertThat(steps.get(11).getKey().name(), equalTo(DeleteStep.NAME));
-        assertThat(steps.get(11).getNextStepKey(), equalTo(nextStepKey));
+        assertTrue(steps.get(11) instanceof ReplaceDataStreamBackingIndexStep);
+        assertThat(steps.get(11).getKey().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
+        assertThat(steps.get(11).getNextStepKey().name(), equalTo(DeleteStep.NAME));
 
-        assertTrue(steps.get(12) instanceof SwapAliasesAndDeleteSourceIndexStep);
-        assertThat(steps.get(12).getKey().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertTrue(steps.get(12) instanceof DeleteStep);
+        assertThat(steps.get(12).getKey().name(), equalTo(DeleteStep.NAME));
         assertThat(steps.get(12).getNextStepKey(), equalTo(nextStepKey));
+
+        assertTrue(steps.get(13) instanceof SwapAliasesAndDeleteSourceIndexStep);
+        assertThat(steps.get(13).getKey().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertThat(steps.get(13).getNextStepKey(), equalTo(nextStepKey));
     }
 
     public void testEqualsAndHashCode() {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -167,6 +167,7 @@ public class DownsampleActionIT extends ESRestTestCase {
         assertBusy(() -> {
             Map<String, Object> settings = getOnlyIndexSettings(client(), rollupIndex);
             assertEquals(index, settings.get(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_NAME.getKey()));
+            assertEquals(policy, settings.get(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
             assertEquals(DownsampleTaskStatus.SUCCESS.toString(), settings.get(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.getKey()));
         });
         assertBusy(
@@ -246,6 +247,7 @@ public class DownsampleActionIT extends ESRestTestCase {
         assertBusy(() -> {
             Map<String, Object> settings = getOnlyIndexSettings(client(), rollupIndex);
             assertEquals(originalIndex, settings.get(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_NAME.getKey()));
+            assertEquals(policy, settings.get(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
             assertEquals(DownsampleTaskStatus.SUCCESS.toString(), settings.get(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.getKey()));
         });
     }
@@ -283,6 +285,7 @@ public class DownsampleActionIT extends ESRestTestCase {
         assertBusy(() -> {
             Map<String, Object> settings = getOnlyIndexSettings(client(), rollupIndex);
             assertEquals(backingIndexName, settings.get(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_NAME.getKey()));
+            assertEquals(policy, settings.get(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
             assertEquals(DownsampleTaskStatus.SUCCESS.toString(), settings.get(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.getKey()));
         });
     }

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/60_settings.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/60_settings.yml
@@ -111,6 +111,8 @@
                   allocation:
                     include:
                       _tier_preference: "data_warm"
+                lifecycle:
+                  name: dummy-lifecycle
             mappings:
               properties:
                 "@timestamp":
@@ -145,6 +147,7 @@
       indices.get_settings:
         index: $datastream-backing-index
   - match: { .$datastream-backing-index.settings.index.routing.allocation.include._tier_preference: "data_warm" }
+  - match: { .$datastream-backing-index.settings.index.lifecycle.name: "dummy-lifecycle" }
 
   - do:
       indices.put_settings:
@@ -167,6 +170,8 @@
       indices.get_settings:
         index: rollup-index
   - match: { rollup-index.settings.index.routing.allocation.include._tier_preference: "data_warm" }
+    # NOTE: copied only if index is managed through ILM
+  - match: { rollup-index.settings.index.lifecycle.name: null }
 
 ---
 teardown:

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -70,6 +70,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.downsample.DownsampleAction;
 import org.elasticsearch.xpack.core.downsample.DownsampleConfig;
 import org.elasticsearch.xpack.core.downsample.DownsampleIndexerAction;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField;
 import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessControl;
 
@@ -102,7 +103,8 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
     private static final Set<String> FORBIDDEN_SETTINGS = Set.of(
         IndexSettings.DEFAULT_PIPELINE.getKey(),
         IndexSettings.FINAL_PIPELINE.getKey(),
-        IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()
+        IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(),
+        LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()
     );
 
     private static final Set<String> OVERRIDE_SETTINGS = Set.of(DataTier.TIER_PREFERENCE_SETTING.getKey());

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -378,7 +378,11 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         GetIndexResponse indexSettingsResp = indicesAdmin().prepareGetIndex().addIndices(sourceIndex, rollupIndex).get();
         assertRollupIndexSettings(sourceIndex, rollupIndex, indexSettingsResp);
         for (String key : settings.keySet()) {
-            assertEquals(settings.get(key), indexSettingsResp.getSetting(rollupIndex, key));
+            if (LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey().equals(key)) {
+                assertNull(indexSettingsResp.getSetting(rollupIndex, key));
+            } else {
+                assertEquals(settings.get(key), indexSettingsResp.getSetting(rollupIndex, key));
+            }
         }
     }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -998,6 +998,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             rollupSettings.get(IndexMetadata.SETTING_NUMBER_OF_REPLICAS)
         );
 
+        assertNull(rollupSettings.get(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
         assertEquals("true", rollupSettings.get(IndexMetadata.SETTING_BLOCKS_WRITE));
         assertEquals(sourceSettings.get(IndexMetadata.SETTING_INDEX_HIDDEN), rollupSettings.get(IndexMetadata.SETTING_INDEX_HIDDEN));
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
@@ -35,7 +35,6 @@ public class TransportDownsampleActionTests extends ESTestCase {
                 .put(DataTier.TIER_PREFERENCE_SETTING.getKey(), randomFrom(tiers))
                 .put(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, randomAlphaOfLength(20))
                 .put(IndexMetadata.SETTING_CREATION_DATE, System.currentTimeMillis())
-                .put(LifecycleSettings.LIFECYCLE_NAME, randomAlphaOfLength(9))
         ).build();
         final IndexMetadata target = new IndexMetadata.Builder(randomAlphaOfLength(10)).settings(
             Settings.builder()

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 
 import java.util.List;
 import java.util.UUID;
@@ -34,6 +35,7 @@ public class TransportDownsampleActionTests extends ESTestCase {
                 .put(DataTier.TIER_PREFERENCE_SETTING.getKey(), randomFrom(tiers))
                 .put(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, randomAlphaOfLength(20))
                 .put(IndexMetadata.SETTING_CREATION_DATE, System.currentTimeMillis())
+                .put(LifecycleSettings.LIFECYCLE_NAME, randomAlphaOfLength(9))
         ).build();
         final IndexMetadata target = new IndexMetadata.Builder(randomAlphaOfLength(10)).settings(
             Settings.builder()
@@ -61,6 +63,7 @@ public class TransportDownsampleActionTests extends ESTestCase {
         assertTargetSettings(target, indexMetadata);
         assertSourceSettings(source, indexMetadata);
         assertEquals(IndexMetadata.INDEX_UUID_NA_VALUE, indexMetadata.get(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_UUID_KEY));
+        assertFalse(LifecycleSettings.LIFECYCLE_NAME_SETTING.exists(indexMetadata));
     }
 
     private static void assertSourceSettings(final IndexMetadata indexMetadata, final Settings settings) {
@@ -98,6 +101,7 @@ public class TransportDownsampleActionTests extends ESTestCase {
             indexMetadata.getSettings().get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()),
             settings.get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey())
         );
+        assertEquals(indexMetadata.getSettings().get(LifecycleSettings.LIFECYCLE_NAME), settings.get(LifecycleSettings.LIFECYCLE_NAME));
         // NOTE: setting both in source and target (not forbidden, not to override): expect target setting is used
         assertEquals(
             indexMetadata.getSettings().get(IndexMetadata.SETTING_CREATION_DATE),


### PR DESCRIPTION
If an index is managed through ILM we copy the `index.lifecycle.name`
from the downsampling source index to the downsampling target index.
When creating the downsampling target index we make sure we do not
set the property so that the index is not picked by ILM soon after being
created. We set the lifecycle policy later, only when the index is ready for
ILM management. For this purpose we include a new step in the downsample
action whose purpose is just to copy the "index.lifecycle.policy" setting.

Note that the setting is not copied if the index is not managed. If a user
is running downsampling by means of the downsampling API it is up to the
user making sure that whatever ILM policy is applied later setting the
`index.lifecycle.name` once the target index is ready.

Resolves #96732 