### PR TITLE
Capture max processors in static init

### DIFF
--- a/docs/changelog/97119.yaml
+++ b/docs/changelog/97119.yaml
@@ -1,0 +1,6 @@
+pr: 97119
+summary: Capture max processors in static init
+area: Infra/Core
+type: bug
+issues:
+ - 97088

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -35,6 +35,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class EsExecutors {
 
+    // although the available processors may technically change, for node sizing we use the number available at launch
+    private static final int MAX_NUM_PROCESSORS = Runtime.getRuntime().availableProcessors();
+
     /**
      * Setting to manually control the number of allocated processors. This setting is used to adjust thread pool sizes per node. The
      * default value is {@link Runtime#availableProcessors()} but should be manually controlled if not all processors on the machine are
@@ -56,9 +59,8 @@ public class EsExecutors {
                 throw new IllegalArgumentException(err);
             }
 
-            final int maxNumberOfProcessors = Runtime.getRuntime().availableProcessors();
-            if (numberOfProcessors > maxNumberOfProcessors) {
-                String err = "Failed to parse value [" + textValue + "] for setting [node.processors] must be <= " + maxNumberOfProcessors;
+            if (numberOfProcessors > MAX_NUM_PROCESSORS) {
+                String err = "Failed to parse value [" + textValue + "] for setting [node.processors] must be <= " + MAX_NUM_PROCESSORS;
                 throw new IllegalArgumentException(err);
             }
             return Processors.of(numberOfProcessors);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -46,7 +46,7 @@ public class EsExecutors {
      */
     public static final Setting<Processors> NODE_PROCESSORS_SETTING = new Setting<>(
         "node.processors",
-        Double.toString(Runtime.getRuntime().availableProcessors()),
+        Double.toString(MAX_NUM_PROCESSORS),
         textValue -> {
             double numberOfProcessors = Double.parseDouble(textValue);
             if (Double.isNaN(numberOfProcessors) || Double.isInfinite(numberOfProcessors)) {


### PR DESCRIPTION
The number of processors available to the jvm can change over time. However, most of Elasticsearch assumes this value is constant. Although we could rework all code relying on the number of processors to dynamically support updates and poll the jvm, doing so has little value since the processors changing is an edge case. Instead, this commit fixes validation of the node.processors setting (our internal number of processors) to validate based on the max processors available at launch.

closes #97088