### PR TITLE
[7.17] Clarify index template settings precedence (#87374)

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -28,6 +28,8 @@ applied.
 template, the settings from the <<indices-create-index,create index>> request
 take precedence over settings specified in the index template and its component
 templates.
+* Settings specified in the index template itself take precedence over the settings
+in its component templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.
 


### PR DESCRIPTION
Backport of #87374 to 7.17

It looks to me like this was intended to be backported to 7.17, but that didn't actually happen yet. It seemed simple enough to put up a PR for it.