### PR TITLE
[8.9] Capture max processors in static init (#97119)

### DIFF
--- a/docs/changelog/97119.yaml
+++ b/docs/changelog/97119.yaml
@@ -1,0 +1,6 @@
+pr: 97119
+summary: Capture max processors in static init
+area: Infra/Core
+type: bug
+issues:
+ - 97088

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -35,6 +35,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class EsExecutors {
 
+    // although the available processors may technically change, for node sizing we use the number available at launch
+    private static final int MAX_NUM_PROCESSORS = Runtime.getRuntime().availableProcessors();
+
     /**
      * Setting to manually control the number of allocated processors. This setting is used to adjust thread pool sizes per node. The
      * default value is {@link Runtime#availableProcessors()} but should be manually controlled if not all processors on the machine are
@@ -43,7 +46,7 @@ public class EsExecutors {
      */
     public static final Setting<Processors> NODE_PROCESSORS_SETTING = new Setting<>(
         "node.processors",
-        Double.toString(Runtime.getRuntime().availableProcessors()),
+        Double.toString(MAX_NUM_PROCESSORS),
         textValue -> {
             double numberOfProcessors = Double.parseDouble(textValue);
             if (Double.isNaN(numberOfProcessors) || Double.isInfinite(numberOfProcessors)) {
@@ -56,9 +59,8 @@ public class EsExecutors {
                 throw new IllegalArgumentException(err);
             }
 
-            final int maxNumberOfProcessors = Runtime.getRuntime().availableProcessors();
-            if (numberOfProcessors > maxNumberOfProcessors) {
-                String err = "Failed to parse value [" + textValue + "] for setting [node.processors] must be <= " + maxNumberOfProcessors;
+            if (numberOfProcessors > MAX_NUM_PROCESSORS) {
+                String err = "Failed to parse value [" + textValue + "] for setting [node.processors] must be <= " + MAX_NUM_PROCESSORS;
                 throw new IllegalArgumentException(err);
             }
             return Processors.of(numberOfProcessors);


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Capture max processors in static init (#97119)