### PR TITLE
Close file-handling resources in UberModuleClassLoaderTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/plugins/UberModuleClassLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/UberModuleClassLoaderTests.java
@@ -571,7 +571,7 @@ public class UberModuleClassLoaderTests extends ESTestCase {
      * conditions:
      *
      * 1. Service defined in package exported in parent layer.
-     * 2. Service defined in a compile-time dependency, optionally present at runtime
+     * 2. Service defined in a compile-time dependency, optionally present at runtime.
      * 3. Service defined in modular jar in uberjar
      * 4. Service defined in non-modular jar in uberjar
      *

--- a/test/framework/src/main/java/org/elasticsearch/test/compiler/InMemoryJavaCompiler.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/compiler/InMemoryJavaCompiler.java
@@ -141,7 +141,7 @@ public class InMemoryJavaCompiler {
                 throw new RuntimeException("Could not compile " + sources.entrySet().stream().toList());
             }
         } catch (IOException e) {
-            throw new RuntimeException("Could not compile " + sources.entrySet().stream().toList());
+            throw new RuntimeException("Could not close file manager for " + sources.entrySet().stream().toList());
         }
 
         return files.stream().collect(Collectors.toMap(InMemoryJavaFileObject::getClassName, InMemoryJavaFileObject::getByteCode));
@@ -166,7 +166,7 @@ public class InMemoryJavaCompiler {
                 throw new RuntimeException("Could not compile " + className + " with source code " + sourceCode);
             }
         } catch (IOException e) {
-            throw new RuntimeException("Could not compile " + className + " with source code " + sourceCode);
+            throw new RuntimeException("Could not close file handler for class " + className + " with source code " + sourceCode);
         }
         return file.getByteCode();
     }


### PR DESCRIPTION
There are a few places where we weren't cleaning up classloaders and file handlers, which becomes a problem on Windows. Here we're adjusting the tests to use explicitly closable classloaders and to close the file wrappers used in the in memory compiler.

Fixes #91609 