### PR TITLE
Add evictAll to blob cache

### DIFF
--- a/docs/changelog/97124.yaml
+++ b/docs/changelog/97124.yaml
@@ -1,0 +1,5 @@
+pr: 97124
+summary: Add `evictAll` to blob cache
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
+++ b/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
@@ -61,9 +61,8 @@ public class FailedNodeException extends ElasticsearchException {
             nodeId,
             getMessage(),
             getClass().getName(), // subclasses should not have the same hash as their parent.
-            getStackTrace().length  // Could check uniqueness via mapping to list of strings, but there are different module path prefixes when serialized.
+            getStackTrace().length  // Could check uniqueness via mapping to list of strings, but there are different module path prefixes
+                                    // when serialized.
         );
     }
-
-
 }

--- a/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
+++ b/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
@@ -52,7 +52,8 @@ public class FailedNodeException extends ElasticsearchException {
         FailedNodeException that = (FailedNodeException) o;
         return Objects.equals(nodeId, that.nodeId)
             && getMessage().equals(that.getMessage())
-            && getStackTrace().length == that.getStackTrace().length;
+            && getStackTrace().length == that.getStackTrace().length; // Could check elements individually, though there can be slight
+                                                                      // differences when serialized.
     }
 
     @Override
@@ -60,9 +61,8 @@ public class FailedNodeException extends ElasticsearchException {
         return Objects.hash(
             nodeId,
             getMessage(),
-            getClass().getName(), // subclasses should not have the same hash as their parent.
-            getStackTrace().length  // Could check uniqueness via mapping to list of strings, but there are different module path prefixes
-                                    // when serialized.
+            getClass().getName(),
+            getStackTrace().length // Could check elements individually, though there can be slight differences when serialized.
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
+++ b/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class FailedNodeException extends ElasticsearchException {
 
@@ -43,4 +44,26 @@ public class FailedNodeException extends ElasticsearchException {
     protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field("node_id", nodeId);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FailedNodeException that = (FailedNodeException) o;
+        return Objects.equals(nodeId, that.nodeId)
+            && getMessage().equals(that.getMessage())
+            && getStackTrace().length == that.getStackTrace().length;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            nodeId,
+            getMessage(),
+            getClass().getName(), // subclasses should not have the same hash as their parent.
+            getStackTrace().length  // Could check uniqueness via mapping to list of strings, but there are different module path prefixes when serialized.
+        );
+    }
+
+
 }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -111,19 +111,4 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
      * Write the {@link #nodes} to the stream.
      */
     protected abstract void writeNodesTo(StreamOutput out, List<TNodeResponse> nodes) throws IOException;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BaseNodesResponse<?> that = (BaseNodesResponse<?>) o;
-        return Objects.equals(clusterName, that.clusterName)
-            && Objects.equals(failures, that.failures)
-            && Objects.equals(nodes, that.nodes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(clusterName, failures, nodes);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -112,4 +112,18 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
      */
     protected abstract void writeNodesTo(StreamOutput out, List<TNodeResponse> nodes) throws IOException;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseNodesResponse<?> that = (BaseNodesResponse<?>) o;
+        return Objects.equals(clusterName, that.clusterName)
+            && Objects.equals(failures, that.failures)
+            && Objects.equals(nodes, that.nodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterName, failures, nodes);
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireSerializingTestCase.java
@@ -12,12 +12,15 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 
 /**
  * Standard test case for testing the wire serialization of subclasses of {@linkplain Writeable}.
  * See {@link AbstractNamedWriteableTestCase} for subclasses of {@link NamedWriteable}.
+ * See {@link AbstractSerializationTestCase} for subclasses of {@link ToXContent} or {@link ChunkedToXContent}
  */
 public abstract class AbstractWireSerializingTestCase<T extends Writeable> extends AbstractWireTestCase<T> {
     /**

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -618,6 +618,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                 matchingEntries.add(value);
             }
         });
+        var evictedCount = 0;
         if (matchingEntries.isEmpty() == false) {
             synchronized (this) {
                 for (Entry<CacheFileRegion> entry : matchingEntries) {
@@ -625,11 +626,12 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                     if (evicted && entry.chunk.sharedBytesPos != -1) {
                         unlink(entry);
                         keyMapping.remove(entry.chunk.regionKey, entry);
+                        evictedCount++;
                     }
                 }
             }
         }
-        return matchingEntries.size();
+        return evictedCount;
     }
 
     /**

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -632,6 +632,15 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         return matchingEntries.size();
     }
 
+    /**
+     * Evicts all entries from the cache.
+     *
+     * @return The number of entries evicted from the keyMapping.
+     */
+    public int forceEvictAll(){
+        return forceEvict(entry -> true);
+    }
+
     // used by tests
     int getFreq(CacheFileRegion cacheFileRegion) {
         return keyMapping.get(cacheFileRegion.regionKey).freq;

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -634,15 +634,6 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         return evictedCount;
     }
 
-    /**
-     * Evicts all entries from the cache.
-     *
-     * @return The number of entries evicted from the keyMapping.
-     */
-    public int forceEvictAll() {
-        return forceEvict(entry -> true);
-    }
-
     // used by tests
     int getFreq(CacheFileRegion cacheFileRegion) {
         return keyMapping.get(cacheFileRegion.regionKey).freq;

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -637,7 +637,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
      *
      * @return The number of entries evicted from the keyMapping.
      */
-    public int forceEvictAll(){
+    public int forceEvictAll() {
         return forceEvict(entry -> true);
     }
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -605,7 +605,13 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         forceEvict(cacheKey::equals);
     }
 
-    public void forceEvict(Predicate<KeyType> cacheKeyPredicate) {
+    /**
+     * Evicts entries from the cache that match the given predicate.
+     *
+     * @param cacheKeyPredicate
+     * @return The number of entries evicted from the keyMapping.
+     */
+    public int forceEvict(Predicate<KeyType> cacheKeyPredicate) {
         final List<Entry<CacheFileRegion>> matchingEntries = new ArrayList<>();
         keyMapping.forEach((key, value) -> {
             if (cacheKeyPredicate.test(key.file)) {
@@ -623,6 +629,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                 }
             }
         }
+        return matchingEntries.size();
     }
 
     // used by tests


### PR DESCRIPTION
This PR adds the changes needed for adding/testing a clear blob-cache API to serverless.

