### PR TITLE
Remove the DiscoveryNode constructor that takes a Version

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -10,10 +10,10 @@ package org.elasticsearch.transport.netty4;
 
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -101,8 +101,8 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
     public void testDefaultKeepAliveSettings() throws IOException {
         assumeTrue("setting default keepalive options not supported on this platform", (IOUtils.LINUX || IOUtils.MAC_OS_X));
         try (
-            MockTransportService serviceC = buildService("TS_C", Version.CURRENT, TransportVersion.current(), Settings.EMPTY);
-            MockTransportService serviceD = buildService("TS_D", Version.CURRENT, TransportVersion.current(), Settings.EMPTY)
+            MockTransportService serviceC = buildService("TS_C", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY);
+            MockTransportService serviceD = buildService("TS_D", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY)
         ) {
 
             try (Transport.Connection connection = openConnection(serviceC, serviceD.getLocalDiscoNode(), TestProfiles.LIGHT_PROFILE)) {
@@ -145,8 +145,8 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
         );
 
         try (
-            MockTransportService serviceC = buildService("TS_C", Version.CURRENT, TransportVersion.current(), Settings.EMPTY);
-            MockTransportService serviceD = buildService("TS_D", Version.CURRENT, TransportVersion.current(), Settings.EMPTY)
+            MockTransportService serviceC = buildService("TS_C", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY);
+            MockTransportService serviceD = buildService("TS_D", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY)
         ) {
 
             try (Transport.Connection connection = openConnection(serviceC, serviceD.getLocalDiscoNode(), connectionProfile)) {
@@ -223,7 +223,7 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
             try (
                 TransportService service = buildService(
                     "TS_TPC",
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     null,
                     Settings.EMPTY,

--- a/plugins/discovery-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoveryTests.java
+++ b/plugins/discovery-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoveryTests.java
@@ -9,9 +9,9 @@
 package org.elasticsearch.discovery.gce;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.cloud.gce.GceInstancesServiceImpl;
 import org.elasticsearch.cloud.gce.GceMetadataService;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -88,7 +88,7 @@ public class GceDiscoveryTests extends ESTestCase {
     public void createTransportService() {
         transportService = MockTransportService.createNewService(
             Settings.EMPTY,
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportVersion.current(),
             threadPool,
             null

--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -14,7 +14,6 @@ import org.apache.http.nio.entity.NStringEntity;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -37,6 +36,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -92,7 +92,7 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
     private static MockTransportService startTransport(
         final String id,
         final List<DiscoveryNode> knownNodes,
-        final Version version,
+        final VersionInformation version,
         final TransportVersion transportVersion,
         final ThreadPool threadPool
     ) {
@@ -160,7 +160,7 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
             MockTransportService remoteTransport = startTransport(
                 "node0",
                 new CopyOnWriteArrayList<>(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             )
@@ -266,7 +266,7 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
             MockTransportService remoteTransport = startTransport(
                 "node0",
                 new CopyOnWriteArrayList<>(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             )

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -167,43 +167,6 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      * @param address          the nodes transport address
      * @param attributes       node attributes
      * @param roles            node roles
-     * @param version          the version of the node
-     */
-    public DiscoveryNode(
-        @Nullable String nodeName,
-        String nodeId,
-        TransportAddress address,
-        Map<String, String> attributes,
-        Set<DiscoveryNodeRole> roles,
-        @Nullable Version version
-    ) {
-        this(
-            nodeName,
-            nodeId,
-            UUIDs.randomBase64UUID(),
-            address.address().getHostString(),
-            address.getAddress(),
-            address,
-            attributes,
-            roles,
-            VersionInformation.inferVersions(version)
-        );
-    }
-
-    /**
-     * Creates a new {@link DiscoveryNode}
-     * <p>
-     * <b>Note:</b> if the version of the node is unknown {@link Version#minimumCompatibilityVersion()} should be used for the current
-     * version. it corresponds to the minimum version this elasticsearch version can communicate with. If a higher version is used
-     * the node might not be able to communicate with the remote node. After initial handshakes node versions will be discovered
-     * and updated.
-     * </p>
-     *
-     * @param nodeName         the nodes name
-     * @param nodeId           the nodes unique persistent id. An ephemeral id will be auto generated.
-     * @param address          the nodes transport address
-     * @param attributes       node attributes
-     * @param roles            node roles
      * @param versionInfo      node version info
      */
     public DiscoveryNode(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveIndexActionTests.java
@@ -9,10 +9,10 @@
 package org.elasticsearch.action.admin.indices.resolve;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -51,7 +51,7 @@ public class TransportResolveIndexActionTests extends ESTestCase {
         try {
             TransportService transportService = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -9,10 +9,10 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -53,7 +53,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
         try {
             TransportService transportService = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.GroupShardsIteratorTests;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -464,7 +465,7 @@ public class TransportSearchActionTests extends ESTestCase {
             MockTransportService remoteSeedTransport = RemoteClusterConnectionTests.startTransport(
                 "node_remote" + i,
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );
@@ -504,7 +505,7 @@ public class TransportSearchActionTests extends ESTestCase {
         try (
             MockTransportService service = MockTransportService.createNewService(
                 settings,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 null
@@ -569,7 +570,7 @@ public class TransportSearchActionTests extends ESTestCase {
         try (
             MockTransportService service = MockTransportService.createNewService(
                 settings,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 null
@@ -824,7 +825,7 @@ public class TransportSearchActionTests extends ESTestCase {
         try (
             MockTransportService service = MockTransportService.createNewService(
                 settings,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 null
@@ -1478,7 +1479,7 @@ public class TransportSearchActionTests extends ESTestCase {
         try {
             TransportService transportService = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );

--- a/server/src/test/java/org/elasticsearch/action/support/replication/PostWriteRefreshTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/PostWriteRefreshTests.java
@@ -9,13 +9,13 @@
 package org.elasticsearch.action.support.replication;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.refresh.TransportUnpromotableShardRefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.UnpromotableShardRefreshRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -57,7 +57,12 @@ public class PostWriteRefreshTests extends IndexShardTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        transportService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, TransportVersion.current(), threadPool);
+        transportService = MockTransportService.createNewService(
+            Settings.EMPTY,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
         transportService.start();
         transportService.acceptIncomingRequests();
         transportService.registerRequestHandler(

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
@@ -413,7 +414,7 @@ public class DiscoveryNodesTests extends ESTestCase {
                 buildNewFakeTransportAddress(),
                 Collections.emptyMap(),
                 new HashSet<>(randomSubsetOf(DiscoveryNodeRole.roles())),
-                Version.fromString("5.1.0")
+                VersionInformation.inferVersions(Version.fromString("5.1.0"))
             )
         );
         discoBuilder.add(
@@ -423,7 +424,7 @@ public class DiscoveryNodesTests extends ESTestCase {
                 buildNewFakeTransportAddress(),
                 Collections.emptyMap(),
                 new HashSet<>(randomSubsetOf(DiscoveryNodeRole.roles())),
-                Version.fromString("6.3.0")
+                VersionInformation.inferVersions(Version.fromString("6.3.0"))
             )
         );
         discoBuilder.localNodeId("node_" + between(1, 3));
@@ -437,7 +438,7 @@ public class DiscoveryNodesTests extends ESTestCase {
                 buildNewFakeTransportAddress(),
                 Collections.emptyMap(),
                 new HashSet<>(randomSubsetOf(DiscoveryNodeRole.roles())),
-                Version.fromString("1.1.0")
+                VersionInformation.inferVersions(Version.fromString("1.1.0"))
             )
         );
         DiscoveryNodes build = discoBuilder.build();
@@ -477,7 +478,7 @@ public class DiscoveryNodesTests extends ESTestCase {
             }
         };
 
-        final BiFunction<Integer, Version, DiscoveryNode> nodeVersionFactory = (i, v) -> new DiscoveryNode(
+        final BiFunction<Integer, VersionInformation, DiscoveryNode> nodeVersionFactory = (i, v) -> new DiscoveryNode(
             "name" + i,
             "id" + i,
             buildNewFakeTransportAddress(),
@@ -486,9 +487,12 @@ public class DiscoveryNodesTests extends ESTestCase {
             v
         );
 
-        final IntFunction<DiscoveryNode> nodeFactory = i -> nodeVersionFactory.apply(i, Version.CURRENT);
+        final IntFunction<DiscoveryNode> nodeFactory = i -> nodeVersionFactory.apply(i, VersionInformation.CURRENT);
 
-        final var node0 = nodeVersionFactory.apply(0, VersionUtils.randomVersion(random()));
+        final var node0 = nodeVersionFactory.apply(
+            0,
+            new VersionInformation(VersionUtils.randomVersion(random()), IndexVersion.MINIMUM_COMPATIBLE, IndexVersion.current())
+        );
         testHarness.accept(builder -> builder.add(node0), 0L);
 
         final var node1 = nodeFactory.apply(1);
@@ -511,7 +515,7 @@ public class DiscoveryNodesTests extends ESTestCase {
         testHarness.accept(builder -> builder.remove(node2), 2L);
 
         // if old nodes are present then the generation is forced to zero
-        final var node3 = nodeVersionFactory.apply(3, Version.V_8_8_0);
+        final var node3 = nodeVersionFactory.apply(3, VersionInformation.inferVersions(Version.V_8_8_0));
         testHarness.accept(builder -> builder.add(node3), 0L);
 
         // and it remains at zero while the old node is present

--- a/server/src/test/java/org/elasticsearch/discovery/DiscoveryModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/DiscoveryModuleTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.discovery;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.coordination.LeaderHeartbeatService;
@@ -16,6 +15,7 @@ import org.elasticsearch.cluster.coordination.PreVoteCollector;
 import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.coordination.StatefulPreVoteCollector;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.service.ClusterApplier;
 import org.elasticsearch.cluster.service.MasterService;
@@ -75,7 +75,7 @@ public class DiscoveryModuleTests extends ESTestCase {
     public void setupDummyServices() {
         transportService = MockTransportService.createNewService(
             Settings.EMPTY,
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportVersion.current(),
             mock(ThreadPool.class),
             null

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -11,10 +11,10 @@ package org.elasticsearch.tasks;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.tasks.TaskManagerTestCase;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -113,7 +113,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
 
             final MockTransportService parentTransportService = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );
@@ -124,7 +124,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
 
             final MockTransportService childTransportService = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchShardsAction;
 import org.elasticsearch.action.search.SearchShardsRequest;
@@ -17,6 +16,7 @@ import org.elasticsearch.action.search.SearchShardsResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
@@ -45,7 +45,13 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
     }
 
     private MockTransportService startTransport(String id, List<DiscoveryNode> knownNodes) {
-        return RemoteClusterConnectionTests.startTransport(id, knownNodes, Version.CURRENT, TransportVersion.current(), threadPool);
+        return RemoteClusterConnectionTests.startTransport(
+            id,
+            knownNodes,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
     }
 
     public void testSearchShards() throws Exception {
@@ -62,7 +68,7 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     builder.build(),
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -110,7 +116,7 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     builder.build(),
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -8,13 +8,13 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -53,7 +53,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             MockTransportService remoteTransport = startTransport(
                 "remote_node",
                 Collections.emptyList(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 remoteSettings
@@ -69,7 +69,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     localSettings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -106,7 +106,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             MockTransportService remoteTransport = startTransport(
                 "remote_node",
                 Collections.emptyList(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 remoteSettings
@@ -120,7 +120,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     localSettings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -157,7 +157,7 @@ public class RemoteClusterClientTests extends ESTestCase {
         try (
             MockTransportService service = MockTransportService.createNewService(
                 settings,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 null
@@ -180,7 +180,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             MockTransportService remoteTransport = startTransport(
                 "remote_node",
                 Collections.emptyList(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 remoteSettings
@@ -197,7 +197,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     localSettings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.transport;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
@@ -29,6 +28,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -94,7 +94,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
     private MockTransportService startTransport(
         String id,
         List<DiscoveryNode> knownNodes,
-        Version version,
+        VersionInformation version,
         TransportVersion transportVersion
     ) {
         return startTransport(id, knownNodes, version, transportVersion, threadPool);
@@ -103,7 +103,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
     public static MockTransportService startTransport(
         String id,
         List<DiscoveryNode> knownNodes,
-        Version version,
+        VersionInformation version,
         TransportVersion transportVersion,
         ThreadPool threadPool
     ) {
@@ -113,7 +113,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
     public static MockTransportService startTransport(
         final String id,
         final List<DiscoveryNode> knownNodes,
-        final Version version,
+        final VersionInformation version,
         final TransportVersion transportVersion,
         final ThreadPool threadPool,
         final Settings settings
@@ -230,7 +230,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -271,12 +271,22 @@ public class RemoteClusterConnectionTests extends ESTestCase {
     public void testCloseWhileConcurrentlyConnecting() throws IOException, InterruptedException, BrokenBarrierException {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
-            MockTransportService seedTransport1 = startTransport("seed_node_1", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
+            MockTransportService seedTransport1 = startTransport(
+                "seed_node_1",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -292,7 +302,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -387,7 +397,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             MockTransportService transport1 = startTransport(
                 "seed_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 seedTransportSettings
@@ -395,7 +405,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             MockTransportService transport2 = startTransport(
                 "seed_node_1",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 seedTransportSettings
@@ -403,7 +413,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             MockTransportService transport3 = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 seedTransportSettings
@@ -427,7 +437,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -596,7 +606,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             MockTransportService seedTransport = startTransport(
                 "seed_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 seedTransportSettings
@@ -610,7 +620,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -666,13 +676,20 @@ public class RemoteClusterConnectionTests extends ESTestCase {
 
     public void testNoChannelsExceptREG() throws Exception {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current())) {
+        try (
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            )
+        ) {
             DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
             knownNodes.add(seedTransport.getLocalDiscoNode());
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -720,7 +737,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                 MockTransportService transportService = startTransport(
                     "discoverable_node" + i,
                     knownNodes,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current()
                 );
                 discoverableNodes.add(transportService.getLocalNode());
@@ -738,7 +755,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -811,11 +828,16 @@ public class RemoteClusterConnectionTests extends ESTestCase {
     public void testGetConnection() throws Exception {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService disconnectedTransport = startTransport(
                 "disconnected_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -828,7 +850,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.ActionTestUtils;
@@ -16,6 +15,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.AbstractScopedSettings;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -65,7 +65,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     private MockTransportService startTransport(
         String id,
         List<DiscoveryNode> knownNodes,
-        Version version,
+        VersionInformation version,
         TransportVersion transportVersion
     ) {
         return startTransport(id, knownNodes, version, transportVersion, Settings.EMPTY);
@@ -74,7 +74,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     private MockTransportService startTransport(
         final String id,
         final List<DiscoveryNode> knownNodes,
-        final Version version,
+        final VersionInformation version,
         final TransportVersion transportVersion,
         final Settings settings
     ) {
@@ -128,13 +128,13 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService cluster1Transport = startTransport(
                 "cluster_1_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             );
             MockTransportService cluster2Transport = startTransport(
                 "cluster_2_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -147,7 +147,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -209,13 +209,13 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService cluster1Transport = startTransport(
                 "cluster_1_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             );
             MockTransportService cluster2Transport = startTransport(
                 "cluster_2_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -228,7 +228,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -319,13 +319,13 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService cluster1Transport = startTransport(
                 "cluster_1_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             );
             MockTransportService cluster2Transport = startTransport(
                 "cluster_2_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -338,7 +338,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -395,7 +395,12 @@ public class RemoteClusterServiceTests extends ESTestCase {
     public void testDefaultPingSchedule() throws IOException {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("cluster_1_node", knownNodes, Version.CURRENT, TransportVersion.current())
+            MockTransportService seedTransport = startTransport(
+                "cluster_1_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            )
         ) {
             DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
             knownNodes.add(seedTransport.getLocalDiscoNode());
@@ -412,7 +417,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     settings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -443,13 +448,13 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService cluster1Transport = startTransport(
                 "cluster_1_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             );
             MockTransportService cluster2Transport = startTransport(
                 "cluster_2_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -467,7 +472,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     transportSettings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -502,7 +507,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService cluster1Transport = startTransport(
                 "cluster_1_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -513,7 +518,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -560,16 +565,32 @@ public class RemoteClusterServiceTests extends ESTestCase {
         final List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         final Settings gateway = Settings.builder().put("node.attr.gateway", true).build();
         try (
-            MockTransportService c1N1 = startTransport("cluster_1_node_1", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService c1N1 = startTransport(
+                "cluster_1_node_1",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService c1N2 = startTransport(
                 "cluster_1_node_2",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 gateway
             );
-            MockTransportService c2N1 = startTransport("cluster_2_node_1", knownNodes, Version.CURRENT, TransportVersion.current());
-            MockTransportService c2N2 = startTransport("cluster_2_node_2", knownNodes, Version.CURRENT, TransportVersion.current(), gateway)
+            MockTransportService c2N1 = startTransport(
+                "cluster_2_node_1",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
+            MockTransportService c2N2 = startTransport(
+                "cluster_2_node_2",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                gateway
+            )
         ) {
             final DiscoveryNode c1N1Node = c1N1.getLocalDiscoNode();
             final DiscoveryNode c1N2Node = c1N2.getLocalDiscoNode();
@@ -584,7 +605,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     settings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -638,19 +659,31 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService c1N1 = startTransport(
                 "cluster_1_node_1",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 dedicatedMaster
             );
-            MockTransportService c1N2 = startTransport("cluster_1_node_2", knownNodes, Version.CURRENT, TransportVersion.current(), data);
+            MockTransportService c1N2 = startTransport(
+                "cluster_1_node_2",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                data
+            );
             MockTransportService c2N1 = startTransport(
                 "cluster_2_node_1",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 dedicatedMaster
             );
-            MockTransportService c2N2 = startTransport("cluster_2_node_2", knownNodes, Version.CURRENT, TransportVersion.current(), data)
+            MockTransportService c2N2 = startTransport(
+                "cluster_2_node_2",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                data
+            )
         ) {
             final DiscoveryNode c1N1Node = c1N1.getLocalDiscoNode();
             final DiscoveryNode c1N2Node = c1N2.getLocalDiscoNode();
@@ -665,7 +698,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     settings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -723,28 +756,28 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService c1N1 = startTransport(
                 "cluster_1_node_1",
                 knownNodes_c1,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 settings
             );
             MockTransportService c1N2 = startTransport(
                 "cluster_1_node_2",
                 knownNodes_c1,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 settings
             );
             MockTransportService c2N1 = startTransport(
                 "cluster_2_node_1",
                 knownNodes_c2,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 settings
             );
             MockTransportService c2N2 = startTransport(
                 "cluster_2_node_2",
                 knownNodes_c2,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 settings
             )
@@ -763,7 +796,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     settings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -999,8 +1032,18 @@ public class RemoteClusterServiceTests extends ESTestCase {
     public void testReconnectWhenStrategySettingsUpdated() throws Exception {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService cluster_node_0 = startTransport("cluster_node_0", knownNodes, Version.CURRENT, TransportVersion.current());
-            MockTransportService cluster_node_1 = startTransport("cluster_node_1", knownNodes, Version.CURRENT, TransportVersion.current())
+            MockTransportService cluster_node_0 = startTransport(
+                "cluster_node_0",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
+            MockTransportService cluster_node_1 = startTransport(
+                "cluster_node_1",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            )
         ) {
 
             final DiscoveryNode node0 = cluster_node_0.getLocalDiscoNode();
@@ -1012,7 +1055,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -1092,7 +1135,14 @@ public class RemoteClusterServiceTests extends ESTestCase {
 
     public void testSkipUnavailable() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current())) {
+        try (
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            )
+        ) {
             DiscoveryNode seedNode = seedTransport.getLocalDiscoNode();
             knownNodes.add(seedNode);
             Settings.Builder builder = Settings.builder();
@@ -1100,7 +1150,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService service = MockTransportService.createNewService(
                     builder.build(),
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null
@@ -1127,7 +1177,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
         try (
             MockTransportService service = MockTransportService.createNewService(
                 settings,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 null
@@ -1148,7 +1198,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
         try (
             MockTransportService service = MockTransportService.createNewService(
                 settings,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool,
                 null
@@ -1170,14 +1220,14 @@ public class RemoteClusterServiceTests extends ESTestCase {
             MockTransportService c1 = startTransport(
                 "cluster_1",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 Settings.builder()
                     .put(RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED.getKey(), "true")
                     .put(RemoteClusterPortSettings.PORT.getKey(), "0")
                     .build()
             );
-            MockTransportService c2 = startTransport("cluster_2", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService c2 = startTransport("cluster_2", knownNodes, VersionInformation.CURRENT, TransportVersion.current());
         ) {
             final DiscoveryNode c1Node = c1.getLocalDiscoNode().withTransportAddress(c1.boundRemoteAccessAddress().publishAddress());
             final DiscoveryNode c2Node = c2.getLocalDiscoNode();
@@ -1188,7 +1238,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             try (
                 MockTransportService transportService = MockTransportService.createNewService(
                     settings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool,
                     null

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.AbstractScopedSettings;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -30,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.VersionUtils;
@@ -91,7 +93,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     private MockTransportService startTransport(
         String id,
         List<DiscoveryNode> knownNodes,
-        Version version,
+        VersionInformation version,
         TransportVersion transportVersion
     ) {
         return startTransport(id, knownNodes, version, transportVersion, Settings.EMPTY);
@@ -100,7 +102,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public MockTransportService startTransport(
         final String id,
         final List<DiscoveryNode> knownNodes,
-        final Version version,
+        final VersionInformation version,
         final TransportVersion transportVersion,
         final Settings settings
     ) {
@@ -150,11 +152,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testSniffStrategyWillConnectToAndDiscoverNodes() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -167,7 +174,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     clientSettings,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -210,11 +217,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testSniffStrategyWillResolveDiscoveryNodesEachConnect() throws Exception {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -233,7 +245,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -277,17 +289,22 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testSniffStrategyWillConnectToMaxAllowedNodesAndOpenNewConnectionsOnDisconnect() throws Exception {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport1 = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             );
             MockTransportService discoverableTransport2 = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -302,7 +319,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -353,10 +370,19 @@ public class SniffConnectionStrategyTests extends ESTestCase {
 
     public void testDiscoverWithSingleIncompatibleSeedNode() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        Version incompatibleVersion = Version.CURRENT.minimumCompatibilityVersion().minimumCompatibilityVersion();
+        VersionInformation incompatibleVersion = new VersionInformation(
+            Version.CURRENT.minimumCompatibilityVersion().minimumCompatibilityVersion(),
+            IndexVersion.MINIMUM_COMPATIBLE,
+            IndexVersion.current()
+        );
         TransportVersion incompatibleTransportVersion = TransportVersionUtils.getPreviousVersion(TransportVersion.MINIMUM_COMPATIBLE);
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService incompatibleSeedTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
@@ -366,7 +392,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -381,7 +407,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -423,7 +449,11 @@ public class SniffConnectionStrategyTests extends ESTestCase {
 
     public void testConnectFailsWithIncompatibleNodes() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        Version incompatibleVersion = Version.CURRENT.minimumCompatibilityVersion().minimumCompatibilityVersion();
+        VersionInformation incompatibleVersion = new VersionInformation(
+            Version.CURRENT.minimumCompatibilityVersion().minimumCompatibilityVersion(),
+            IndexVersion.MINIMUM_COMPATIBLE,
+            IndexVersion.current()
+        );
         TransportVersion incompatibleTransportVersion = TransportVersionUtils.getPreviousVersion(TransportVersion.MINIMUM_COMPATIBLE);
         try (
             MockTransportService incompatibleSeedTransport = startTransport(
@@ -439,7 +469,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -479,11 +509,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testFilterNodesWithNodePredicate() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -497,7 +532,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -543,11 +578,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testConnectFailsIfNoConnectionsOpened() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService closedTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -559,7 +599,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -603,24 +643,24 @@ public class SniffConnectionStrategyTests extends ESTestCase {
         Settings otherSettings = Settings.builder().put("cluster.name", "otherCluster").build();
 
         try (
-            MockTransportService seed = startTransport("other_seed", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seed = startTransport("other_seed", knownNodes, VersionInformation.CURRENT, TransportVersion.current());
             MockTransportService discoverable = startTransport(
                 "other_discoverable",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             );
             MockTransportService otherSeed = startTransport(
                 "other_seed",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 otherSettings
             );
             MockTransportService otherDiscoverable = startTransport(
                 "other_discoverable",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 otherSettings
             )
@@ -637,7 +677,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -704,11 +744,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testMultipleCallsToConnectEnsuresConnection() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -721,7 +766,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -775,16 +820,21 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testConfiguredProxyAddressModeWillReplaceNodeAddress() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService accessible = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService accessible = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService unresponsive1 = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             );
             MockTransportService unresponsive2 = MockTransportService.createNewService(
                 Settings.EMPTY,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 threadPool
             )
@@ -816,7 +866,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )
@@ -878,11 +928,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
     public void testSniffStrategyWillNeedToBeRebuiltIfNumOfConnectionsOrSeedsOrProxyChange() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (
-            MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT, TransportVersion.current());
+            MockTransportService seedTransport = startTransport(
+                "seed_node",
+                knownNodes,
+                VersionInformation.CURRENT,
+                TransportVersion.current()
+            );
             MockTransportService discoverableTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current()
             )
         ) {
@@ -895,7 +950,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             try (
                 MockTransportService localService = MockTransportService.createNewService(
                     Settings.EMPTY,
-                    Version.CURRENT,
+                    VersionInformation.CURRENT,
                     TransportVersion.current(),
                     threadPool
                 )

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -12,12 +12,14 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.RefCounted;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancellationService;
@@ -46,13 +48,21 @@ public class TransportActionProxyTests extends ESTestCase {
     protected ThreadPool threadPool;
     // we use always a non-alpha or beta version here otherwise minimumCompatibilityVersion will be different for the two used versions
     private static final Version CURRENT_VERSION = Version.fromString(String.valueOf(Version.CURRENT.major) + ".0.0");
-    protected static final Version version0 = CURRENT_VERSION.minimumCompatibilityVersion();
+    protected static final VersionInformation version0 = new VersionInformation(
+        CURRENT_VERSION.minimumCompatibilityVersion(),
+        IndexVersion.MINIMUM_COMPATIBLE,
+        IndexVersion.current()
+    );
     protected static final TransportVersion transportVersion0 = TransportVersion.MINIMUM_COMPATIBLE;
 
     protected DiscoveryNode nodeA;
     protected MockTransportService serviceA;
 
-    protected static final Version version1 = Version.fromId(CURRENT_VERSION.id + 1);
+    protected static final VersionInformation version1 = new VersionInformation(
+        Version.fromId(CURRENT_VERSION.id + 1),
+        IndexVersion.MINIMUM_COMPATIBLE,
+        IndexVersion.current()
+    );
     protected static final TransportVersion transportVersion1 = TransportVersion.fromId(TransportVersion.current().id() + 1);
     protected DiscoveryNode nodeB;
     protected MockTransportService serviceB;
@@ -87,7 +97,7 @@ public class TransportActionProxyTests extends ESTestCase {
         IOUtils.close(serviceA, serviceB, serviceC, serviceD, () -> { terminate(threadPool); });
     }
 
-    private MockTransportService buildService(Version version, TransportVersion transportVersion) {
+    private MockTransportService buildService(VersionInformation version, TransportVersion transportVersion) {
         MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, version, transportVersion, threadPool, null);
         service.start();
         service.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -15,12 +15,14 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
@@ -62,7 +64,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         String nodeNameAndId,
         Settings settings,
         TransportVersion transportVersion,
-        Version nodeVersion,
+        VersionInformation nodeVersion,
         TransportInterceptor transportInterceptor
     ) {
         TcpTransport transport = new Netty4Transport(
@@ -119,14 +121,18 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         TransportService transportServiceB = startServices(
             "TS_B",
             settings,
             TransportVersionUtils.randomCompatibleVersion(random()),
-            VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.CURRENT),
+            new VersionInformation(
+                VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.CURRENT),
+                IndexVersion.MINIMUM_COMPATIBLE,
+                IndexVersion.current()
+            ),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
@@ -156,14 +162,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             Settings.builder().put("cluster.name", "a").build(),
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         TransportService transportServiceB = startServices(
             "TS_B",
             Settings.builder().put("cluster.name", "b").build(),
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
@@ -195,14 +201,18 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         TransportService transportServiceB = startServices(
             "TS_B",
             settings,
             TransportVersion.MINIMUM_COMPATIBLE,
-            VersionUtils.getPreviousVersion(Version.CURRENT.minimumCompatibilityVersion()),
+            new VersionInformation(
+                VersionUtils.getPreviousVersion(Version.CURRENT.minimumCompatibilityVersion()),
+                IndexVersion.MINIMUM_COMPATIBLE,
+                IndexVersion.current()
+            ),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
@@ -242,14 +252,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         TransportService transportServiceB = startServices(
             "TS_B",
             settings,
             TransportVersionUtils.getPreviousVersion(TransportVersion.MINIMUM_COMPATIBLE),
-            Version.CURRENT.minimumCompatibilityVersion(),
+            new VersionInformation(Version.CURRENT.minimumCompatibilityVersion(), IndexVersion.MINIMUM_COMPATIBLE, IndexVersion.current()),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
@@ -278,14 +288,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         TransportService transportServiceB = startServices(
             "TS_B",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder(randomAlphaOfLength(10))
@@ -314,14 +324,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             transportInterceptorA
         );
         final TransportService transportServiceB = startServices(
             "TS_B",
             settings,
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             transportInterceptorB
         );
         final DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
@@ -365,14 +375,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
                 "TS_A",
                 settings,
                 TransportVersion.current(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 transportInterceptorA
             );
             final TransportService transportServiceB = startServices(
                 "TS_B",
                 settings,
                 TransportVersion.current(),
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 transportInterceptorB
             );
             AbstractSimpleTransportTestCase.connectToNode(transportServiceA, transportServiceB.getLocalNode(), TestProfiles.LIGHT_PROFILE);
@@ -391,14 +401,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             "TS_A",
             Settings.builder().put("cluster.name", "a").build(),
             TransportVersion.current(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             transportInterceptorA
         );
         final TransportService transportServiceB = startServices(
             "TS_B",
             Settings.builder().put("cluster.name", "a").build(),
             TransportVersion.MINIMUM_COMPATIBLE,
-            Version.CURRENT.minimumCompatibilityVersion(),
+            new VersionInformation(Version.CURRENT.minimumCompatibilityVersion(), IndexVersion.MINIMUM_COMPATIBLE, IndexVersion.current()),
             transportInterceptorB
         );
         AbstractSimpleTransportTestCase.connectToNode(transportServiceA, transportServiceB.getLocalNode(), TestProfiles.LIGHT_PROFILE);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -99,7 +100,7 @@ public class MockTransportService extends TransportService {
 
     public static MockTransportService createNewService(
         Settings settings,
-        Version version,
+        VersionInformation version,
         TransportVersion transportVersion,
         ThreadPool threadPool
     ) {
@@ -108,7 +109,7 @@ public class MockTransportService extends TransportService {
 
     public static MockTransportService createNewService(
         Settings settings,
-        Version version,
+        VersionInformation version,
         TransportVersion transportVersion,
         ThreadPool threadPool,
         @Nullable ClusterSettings clusterSettings
@@ -143,7 +144,7 @@ public class MockTransportService extends TransportService {
     public static MockTransportService createNewService(
         Settings settings,
         Transport transport,
-        Version version,
+        VersionInformation version,
         ThreadPool threadPool,
         @Nullable ClusterSettings clusterSettings,
         Set<String> taskHeaders
@@ -154,7 +155,7 @@ public class MockTransportService extends TransportService {
     public static MockTransportService createNewService(
         Settings settings,
         Transport transport,
-        Version version,
+        VersionInformation version,
         ThreadPool threadPool,
         @Nullable ClusterSettings clusterSettings,
         Set<String> taskHeaders,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
@@ -103,7 +104,7 @@ public class SourceDestValidatorTests extends ESTestCase {
     private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
     private final TransportService transportService = MockTransportService.createNewService(
         Settings.EMPTY,
-        Version.CURRENT,
+        VersionInformation.CURRENT,
         TransportVersion.current(),
         threadPool
     );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -29,6 +30,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.VersionUtils;
@@ -417,7 +419,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
                     new TransportAddress(TransportAddress.META_ADDRESS, nodePort),
                     Node.NODE_ATTRIBUTES.getAsMap(nodeSettings),
                     DiscoveryNode.getRolesFromSettings(nodeSettings),
-                    oldVersion
+                    new VersionInformation(oldVersion, IndexVersion.MINIMUM_COMPATIBLE, IndexVersion.current())
                 )
             );
         }
@@ -489,7 +491,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
                     new TransportAddress(TransportAddress.META_ADDRESS, nodePort),
                     Node.NODE_ATTRIBUTES.getAsMap(nodeSettings),
                     DiscoveryNode.getRolesFromSettings(nodeSettings),
-                    oldVersion
+                    new VersionInformation(oldVersion, IndexVersion.MINIMUM_COMPATIBLE, IndexVersion.current())
                 )
             );
         }
@@ -559,7 +561,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
                     new TransportAddress(TransportAddress.META_ADDRESS, nodePort),
                     Node.NODE_ATTRIBUTES.getAsMap(nodeSettings),
                     DiscoveryNode.getRolesFromSettings(nodeSettings),
-                    oldVersion
+                    new VersionInformation(oldVersion, IndexVersion.MINIMUM_COMPATIBLE, IndexVersion.current())
                 )
             );
         }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/CancellationTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/CancellationTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.eql.analysis;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
@@ -18,6 +17,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
@@ -69,7 +69,12 @@ public class CancellationTests extends ESTestCase {
     public void mockTransportService() {
         threadPool = new TestThreadPool(getClass().getName());
         // The TransportService needs to be able to return a valid RemoteClusterServices object down the stream, required by the Verifier.
-        transportService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, TransportVersion.current(), threadPool);
+        transportService = MockTransportService.createNewService(
+            Settings.EMPTY,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
     }
 
     @After

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -102,7 +103,7 @@ public class MlAutoUpdateServiceIT extends MlSingleNodeTestCase {
                                 new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
                                 Collections.emptyMap(),
                                 Set.of(DiscoveryNodeRole.MASTER_ROLE),
-                                Version.V_8_0_0
+                                VersionInformation.inferVersions(Version.V_8_0_0)
                             )
                         )
                         .localNodeId("node_id")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -201,7 +202,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
             isMlNode
                 ? Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)
                 : Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE),
-            nodeVersion
+            VersionInformation.inferVersions(nodeVersion)
         );
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -1467,10 +1468,16 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
     }
 
     private static DiscoveryNode buildNode(String name, boolean isML, long nativeMemory, int allocatedProcessors) {
-        return buildNode(name, isML, nativeMemory, allocatedProcessors, Version.CURRENT);
+        return buildNode(name, isML, nativeMemory, allocatedProcessors, VersionInformation.CURRENT);
     }
 
-    private static DiscoveryNode buildNode(String name, boolean isML, long nativeMemory, int allocatedProcessors, Version version) {
+    private static DiscoveryNode buildNode(
+        String name,
+        boolean isML,
+        long nativeMemory,
+        int allocatedProcessors,
+        VersionInformation version
+    ) {
         return new DiscoveryNode(
             name,
             name,
@@ -1490,7 +1497,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
     }
 
     private static DiscoveryNode buildOldNode(String name, boolean isML, long nativeMemory, int allocatedProcessors) {
-        return buildNode(name, isML, nativeMemory, allocatedProcessors, Version.V_7_15_0);
+        return buildNode(name, isML, nativeMemory, allocatedProcessors, VersionInformation.inferVersions(Version.V_7_15_0));
     }
 
     private static StartTrainedModelDeploymentAction.TaskParams newParams(String modelId, long modelSize) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -873,7 +874,7 @@ public class JobNodeSelectorTests extends ESTestCase {
                     new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
                     nodeAttr,
                     ROLES_WITH_ML,
-                    Version.fromString("6.2.0")
+                    VersionInformation.inferVersions(Version.fromString("6.2.0"))
                 )
             )
             .add(
@@ -883,7 +884,7 @@ public class JobNodeSelectorTests extends ESTestCase {
                     new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
                     nodeAttr,
                     ROLES_WITH_ML,
-                    Version.fromString("6.1.0")
+                    VersionInformation.inferVersions(Version.fromString("6.1.0"))
                 )
             )
             .build();
@@ -931,7 +932,7 @@ public class JobNodeSelectorTests extends ESTestCase {
                     new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
                     nodeAttr,
                     ROLES_WITH_ML,
-                    Version.fromString("6.2.0")
+                    VersionInformation.inferVersions(Version.fromString("6.2.0"))
                 )
             )
             .add(
@@ -941,7 +942,7 @@ public class JobNodeSelectorTests extends ESTestCase {
                     new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
                     nodeAttr,
                     ROLES_WITH_ML,
-                    Version.fromString("6.4.0")
+                    VersionInformation.inferVersions(Version.fromString("6.4.0"))
                 )
             )
             .build();

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.remotecluster;
 
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
@@ -17,6 +16,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -437,7 +437,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
 
         final MockTransportService service = MockTransportService.createNewService(
             builder.build(),
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportVersion.current(),
             threadPool,
             null

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
@@ -12,7 +12,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
@@ -28,6 +27,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -1106,7 +1106,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
             .build();
         final MockTransportService service = MockTransportService.createNewService(
             settings,
-            Version.CURRENT,
+            VersionInformation.CURRENT,
             TransportVersion.current(),
             threadPool,
             null

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -14,12 +14,12 @@ import io.netty.handler.ssl.SslHandshakeTimeoutException;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.network.NetworkService;
@@ -186,7 +186,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         TcpTransport originalTransport = (TcpTransport) serviceA.getOriginalTransport();
 
         ConnectionProfile connectionProfile = ConnectionProfile.buildDefaultConnectionProfile(Settings.EMPTY);
-        try (TransportService service = buildService("TS_TPC", Version.CURRENT, TransportVersion.current(), Settings.EMPTY)) {
+        try (TransportService service = buildService("TS_TPC", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY)) {
             DiscoveryNode node = new DiscoveryNode(
                 "TS_TPC",
                 "TS_TPC",
@@ -385,7 +385,12 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         String value = randomCapitalization(SslClientAuthenticationMode.REQUIRED);
         Settings settings = Settings.builder().put("xpack.security.transport.ssl.client_authentication", value).build();
         try (
-            MockTransportService service = buildService("TS_REQUIRED_CLIENT_AUTH", Version.CURRENT, TransportVersion.current(), settings)
+            MockTransportService service = buildService(
+                "TS_REQUIRED_CLIENT_AUTH",
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                settings
+            )
         ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             try (Transport.Connection connection2 = openConnection(serviceA, service.getLocalNode(), TestProfiles.LIGHT_PROFILE)) {
@@ -398,7 +403,14 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         // test no client authentication
         value = randomCapitalization(SslClientAuthenticationMode.NONE);
         settings = Settings.builder().put("xpack.security.transport.ssl.client_authentication", value).build();
-        try (MockTransportService service = buildService("TS_NO_CLIENT_AUTH", Version.CURRENT, TransportVersion.current(), settings)) {
+        try (
+            MockTransportService service = buildService(
+                "TS_NO_CLIENT_AUTH",
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                settings
+            )
+        ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             try (Transport.Connection connection2 = openConnection(serviceA, service.getLocalNode(), TestProfiles.LIGHT_PROFILE)) {
                 sslEngine = getEngineFromAcceptedChannel(originalTransport, connection2);
@@ -411,7 +423,12 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         value = randomCapitalization(SslClientAuthenticationMode.OPTIONAL);
         settings = Settings.builder().put("xpack.security.transport.ssl.client_authentication", value).build();
         try (
-            MockTransportService service = buildService("TS_OPTIONAL_CLIENT_AUTH", Version.CURRENT, TransportVersion.current(), settings)
+            MockTransportService service = buildService(
+                "TS_OPTIONAL_CLIENT_AUTH",
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                settings
+            )
         ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             try (Transport.Connection connection2 = openConnection(serviceA, service.getLocalNode(), TestProfiles.LIGHT_PROFILE)) {
@@ -433,7 +450,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         try (
             MockTransportService service = buildService(
                 "TS_PROFILE_REQUIRE_CLIENT_AUTH",
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 settings
             )
@@ -463,7 +480,12 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             .put("transport.profiles.client.xpack.security.ssl.client_authentication", value)
             .build();
         try (
-            MockTransportService service = buildService("TS_PROFILE_NO_CLIENT_AUTH", Version.CURRENT, TransportVersion.current(), settings)
+            MockTransportService service = buildService(
+                "TS_PROFILE_NO_CLIENT_AUTH",
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                settings
+            )
         ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             TransportAddress clientAddress = originalTransport.profileBoundAddresses().get("client").publishAddress();
@@ -492,7 +514,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         try (
             MockTransportService service = buildService(
                 "TS_PROFILE_OPTIONAL_CLIENT_AUTH",
-                Version.CURRENT,
+                VersionInformation.CURRENT,
                 TransportVersion.current(),
                 settings
             )
@@ -540,7 +562,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             .put("xpack.security.remote_cluster_server.ssl.client_authentication", "none")
             .build();
 
-        try (MockTransportService fcService = buildService("FC", Version.CURRENT, TransportVersion.current(), fcSettings)) {
+        try (MockTransportService fcService = buildService("FC", VersionInformation.CURRENT, TransportVersion.current(), fcSettings)) {
             final TcpTransport originalTransport = (TcpTransport) fcService.getOriginalTransport();
             final TransportAddress remoteAccessAddress = originalTransport.profileBoundAddresses().get("_remote_cluster").publishAddress();
             final DiscoveryNode node = DiscoveryNodeUtils.create(
@@ -551,7 +573,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
             // 1. Connection will fail because FC server certificate is not trusted by default
             final Settings qcSettings1 = Settings.builder().build();
-            try (MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings1)) {
+            try (MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings1)) {
                 final ConnectTransportException e = expectThrows(
                     ConnectTransportException.class,
                     () -> openConnection(qcService, node, connectionProfile)
@@ -568,7 +590,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                 .put("remote_cluster.tcp.keep_alive", "false")
                 .build();
             try (
-                MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings2);
+                MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings2);
                 Transport.Connection connection = openConnection(qcService, node, connectionProfile)
             ) {
                 assertThat(connection, instanceOf(StubbableTransport.WrappedConnection.class));
@@ -604,7 +626,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                 .put("remote_cluster.tcp.keep_count", 102)
                 .build();
             try (
-                MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings3);
+                MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings3);
                 Transport.Connection connection = openConnection(qcService, node, connectionProfile)
             ) {
                 assertThat(connection, instanceOf(StubbableTransport.WrappedConnection.class));
@@ -660,7 +682,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             .put("xpack.security.remote_cluster_server.ssl.enabled", "false")
             .build();
 
-        try (MockTransportService fcService = buildService("FC", Version.CURRENT, TransportVersion.current(), fcSettings)) {
+        try (MockTransportService fcService = buildService("FC", VersionInformation.CURRENT, TransportVersion.current(), fcSettings)) {
             final TcpTransport originalTransport = (TcpTransport) fcService.getOriginalTransport();
             final TransportAddress remoteAccessAddress = originalTransport.profileBoundAddresses().get("_remote_cluster").publishAddress();
             final DiscoveryNode node = DiscoveryNodeUtils.create(
@@ -670,7 +692,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             );
             final Settings qcSettings = Settings.builder().put("xpack.security.remote_cluster_client.ssl.enabled", "false").build();
             try (
-                MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings);
+                MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings);
                 Transport.Connection connection = openConnection(qcService, node, connectionProfile)
             ) {
                 assertThat(connection, instanceOf(StubbableTransport.WrappedConnection.class));
@@ -717,7 +739,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                 .put(TransportSettings.TCP_REUSE_ADDRESS.getKey(), randomBoolean());
         }
         final Settings qcSettings1 = builder1.build();
-        try (MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings1)) {
+        try (MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings1)) {
             final var transport = (TestSecurityNetty4ServerTransport) qcService.getOriginalTransport();
             // RCS remote cluster client
             final Bootstrap rcsBootstrap = transport.getClientBootstrap(connectionProfile);
@@ -777,7 +799,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             .put(RemoteClusterPortSettings.TCP_REUSE_ADDRESS.getKey(), false)
             .build();
 
-        try (MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings2)) {
+        try (MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings2)) {
             final var transport = (TestSecurityNetty4ServerTransport) qcService.getOriginalTransport();
             // RCS remote cluster client
             final Map<ChannelOption<?>, Object> rcsOptions = transport.getClientBootstrap(connectionProfile).config().options();
@@ -814,7 +836,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
             .put(RemoteClusterPortSettings.TCP_KEEP_INTERVAL.getKey(), 101)
             .put(RemoteClusterPortSettings.TCP_KEEP_COUNT.getKey(), 102)
             .build();
-        try (MockTransportService qcService = buildService("QC", Version.CURRENT, TransportVersion.current(), qcSettings3)) {
+        try (MockTransportService qcService = buildService("QC", VersionInformation.CURRENT, TransportVersion.current(), qcSettings3)) {
             final var transport = (TestSecurityNetty4ServerTransport) qcService.getOriginalTransport();
             // RCS remote cluster client
             final Map<ChannelOption<?>, Object> rcsOptions = transport.getClientBootstrap(connectionProfile).config().options();


### PR DESCRIPTION
Remove the `Version` overload, so all `DiscoveryNode` constructors take `VersionInformation` only, and propagate