### PR TITLE
Fix testScheduledRefresh

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3749,7 +3749,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
-     * Executes a scheduled refresh if necessary. Completes the listener with true if a refreshed was performed otherwise false.
+     * Executes a scheduled refresh if necessary. Completes the listener with true if a refresh was performed otherwise false.
      */
     public void scheduledRefresh(ActionListener<Boolean> listener) {
         ActionListener.run(listener, l -> {

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3817,12 +3817,12 @@ public class IndexShardTests extends IndexShardTestCase {
         assertBusy(() -> assertThat(primary.getThreadPool().relativeTimeInMillis(), greaterThan(lastSearchAccess)));
 
         // Make shard search active again and ensure previously index document is visible:
-        CountDownLatch latch = new CountDownLatch(1);
-        primary.ensureShardSearchActive(refreshed -> {
-            assertTrue(refreshed);
-            latch.countDown();
+        long refreshesBefore = primary.refreshStats().getTotal();
+        primary.ensureShardSearchActive(registered -> { assertTrue(registered); });
+        assertBusy(() -> {
+            assertFalse(primary.hasRefreshPending());
+            assertThat(primary.refreshStats().getTotal(), equalTo(refreshesBefore + 1));
         });
-        latch.await();
         assertNotEquals(
             "awaitShardSearchActive must access a searcher to remove search idle state",
             lastSearchAccess,
@@ -3833,19 +3833,19 @@ public class IndexShardTests extends IndexShardTestCase {
             assertEquals(2, searcher.getIndexReader().numDocs());
         }
 
-        // No documents were added and shard is search active so makeShardSearchActive(...) should behave like a noop:
+        // No documents were added and shard is search active so ensureShardSearchActive(...) should behave like a noop:
         assertFalse(primary.getEngine().refreshNeeded());
-        CountDownLatch latch1 = new CountDownLatch(1);
-        primary.ensureShardSearchActive(refreshed -> {
-            assertFalse(refreshed);
+        CountDownLatch latch = new CountDownLatch(1);
+        primary.ensureShardSearchActive(registered -> {
+            assertFalse(registered);
             try (Engine.Searcher searcher = primary.acquireSearcher("test")) {
                 assertEquals(2, searcher.getIndexReader().numDocs());
             } finally {
-                latch1.countDown();
+                latch.countDown();
             }
 
         });
-        latch1.await();
+        latch.await();
 
         // Index a document while shard is search active and ensure scheduleRefresh(...) makes documen visible:
         indexDoc(primary, "_doc", "2", "{\"foo\" : \"bar\"}");


### PR DESCRIPTION
Took several runs to reproduce the assertion error and finally understand that ensureShardSearchActive() does not necessarily wait for the async refresh to finish. More explanation in linked issue. This change ensures we also wait for the async refresh to finish. It did not have a failure in numerous iterations now.

Fixes #96920 
