### PR TITLE
Capture max processors in static init (#97119)

### DIFF
--- a/docs/changelog/97119.yaml
+++ b/docs/changelog/97119.yaml
@@ -1,0 +1,6 @@
+pr: 97119
+summary: Capture max processors in static init
+area: Infra/Core
+type: bug
+issues:
+ - 97088

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -40,12 +40,15 @@ public class EsExecutors {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(EsExecutors.class);
 
+    // although the available processors may technically change, for node sizing we use the number available at launch
+    private static final int MAX_NUM_PROCESSORS = Runtime.getRuntime().availableProcessors();
+
     /**
      * Setting to manually set the number of available processors. This setting is used to adjust thread pool sizes per node.
      */
     public static final Setting<Integer> PROCESSORS_SETTING = new Setting<>(
         "processors",
-        s -> Integer.toString(Runtime.getRuntime().availableProcessors()),
+        s -> Integer.toString(MAX_NUM_PROCESSORS),
         processorsParser("processors"),
         Property.Deprecated,
         Property.NodeScope
@@ -66,7 +69,7 @@ public class EsExecutors {
     private static Function<String, Integer> processorsParser(final String name) {
         return s -> {
             final int value = Setting.parseInt(s, 1, name);
-            final int availableProcessors = Runtime.getRuntime().availableProcessors();
+            final int availableProcessors = MAX_NUM_PROCESSORS;
             if (value > availableProcessors) {
                 deprecationLogger.critical(
                     DeprecationCategory.SETTINGS,


### PR DESCRIPTION
The number of processors available to the jvm can change over time. However, most of Elasticsearch assumes this value is constant. Although we could rework all code relying on the number of processors to dynamically support updates and poll the jvm, doing so has little value since the processors changing is an edge case. Instead, this commit fixes validation of the node.processors setting (our internal number of processors) to validate based on the max processors available at launch.

closes #97088