### PR TITLE
Mark /_cat/repo as internal API

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestRepositoriesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestRepositoriesAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestResponseListener;
 
 import java.util.List;
@@ -24,6 +26,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 /**
  * Cat API class to display information about snapshot repositories
  */
+@ServerlessScope(Scope.INTERNAL)
 public class RestRepositoriesAction extends AbstractCatAction {
 
     @Override


### PR DESCRIPTION
Since snapshots are not going to be exposed to a user in Serverless, we don't need information about repositories.
