### PR TITLE
[Profiling] Remove fallback code for synthetic source

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
@@ -18,10 +18,6 @@ import java.util.Map;
 import java.util.Objects;
 
 final class StackFrame implements ToXContentObject {
-    private static final String[] PATH_FILE_NAME = new String[] { "Stackframe", "file", "name" };
-    private static final String[] PATH_FUNCTION_NAME = new String[] { "Stackframe", "function", "name" };
-    private static final String[] PATH_FUNCTION_OFFSET = new String[] { "Stackframe", "function", "offset" };
-    private static final String[] PATH_LINE_NUMBER = new String[] { "Stackframe", "line", "number" };
     List<String> fileName;
     List<String> functionName;
     List<Integer> functionOffset;
@@ -46,26 +42,12 @@ final class StackFrame implements ToXContentObject {
     }
 
     public static StackFrame fromSource(Map<String, Object> source) {
-        // stack frames may either be stored with synthetic source or regular one
-        // which results either in a nested or flat document structure.
-
-        if (source.containsKey("Stackframe")) {
-            // synthetic source
-            return new StackFrame(
-                ObjectPath.eval(PATH_FILE_NAME, source),
-                ObjectPath.eval(PATH_FUNCTION_NAME, source),
-                ObjectPath.eval(PATH_FUNCTION_OFFSET, source),
-                ObjectPath.eval(PATH_LINE_NUMBER, source)
-            );
-        } else {
-            // regular source
-            return new StackFrame(
-                source.get("Stackframe.file.name"),
-                source.get("Stackframe.function.name"),
-                source.get("Stackframe.function.offset"),
-                source.get("Stackframe.line.number")
-            );
-        }
+        return new StackFrame(
+            source.get("Stackframe.file.name"),
+            source.get("Stackframe.function.name"),
+            source.get("Stackframe.function.offset"),
+            source.get("Stackframe.line.number")
+        );
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.profiler;
 
-import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/StackFrameTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/StackFrameTests.java
@@ -23,25 +23,6 @@ import java.util.Map;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class StackFrameTests extends ESTestCase {
-    public void testCreateFromSyntheticSource() {
-        // tag::noformat
-        StackFrame frame = StackFrame.fromSource(
-            Map.of("Stackframe", Map.of(
-                "file", Map.of("name", "Main.java"),
-                "function", Map.of(
-                        "name", "helloWorld",
-                        "offset", 31733
-                    ),
-                "line", Map.of("number", 22))
-                )
-        );
-        // end::noformat
-        assertEquals(List.of("Main.java"), frame.fileName);
-        assertEquals(List.of("helloWorld"), frame.functionName);
-        assertEquals(List.of(31733), frame.functionOffset);
-        assertEquals(List.of(22), frame.lineNumber);
-    }
-
     public void testCreateFromRegularSource() {
         // tag::noformat
         StackFrame frame = StackFrame.fromSource(


### PR DESCRIPTION
Since release 8.7, the `profiling-stackframes` index does not use synthetic source any more.
This PR removes the special deserialization code needed to support synthetic source.

Related to https://github.com/elastic/prodfiler/issues/2993
