### PR TITLE
Expose SettingsUpdater

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsUpdater;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.reservedstate.action.ReservedClusterSettingsAction;
 import org.elasticsearch.tasks.Task;
@@ -238,12 +239,12 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
         });
     }
 
-    public static class ClusterUpdateSettingsTask extends AckedClusterStateUpdateTask {
+    private static class ClusterUpdateSettingsTask extends AckedClusterStateUpdateTask {
         protected volatile boolean reroute = false;
         protected final SettingsUpdater updater;
         protected final ClusterUpdateSettingsRequest request;
 
-        public ClusterUpdateSettingsTask(
+        ClusterUpdateSettingsTask(
             final ClusterSettings clusterSettings,
             Priority priority,
             ClusterUpdateSettingsRequest request,
@@ -252,13 +253,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
             super(priority, request, listener);
             this.updater = new SettingsUpdater(clusterSettings);
             this.request = request;
-        }
-
-        /**
-         * Used by the reserved state handler {@link ReservedClusterSettingsAction}
-         */
-        public ClusterUpdateSettingsTask(final ClusterSettings clusterSettings, ClusterUpdateSettingsRequest request) {
-            this(clusterSettings, Priority.IMMEDIATE, request, null);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingsUpdater.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingsUpdater.java
@@ -6,15 +6,13 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.action.admin.cluster.settings;
+package org.elasticsearch.common.settings;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 
 import java.util.Map;
@@ -26,24 +24,24 @@ import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_
  * Updates transient and persistent cluster state settings if there are any changes
  * due to the update.
  */
-final class SettingsUpdater {
+public final class SettingsUpdater {
     final Settings.Builder transientUpdates = Settings.builder();
     final Settings.Builder persistentUpdates = Settings.builder();
     private final ClusterSettings clusterSettings;
 
-    SettingsUpdater(ClusterSettings clusterSettings) {
+    public SettingsUpdater(ClusterSettings clusterSettings) {
         this.clusterSettings = clusterSettings;
     }
 
-    synchronized Settings getTransientUpdates() {
+    public synchronized Settings getTransientUpdates() {
         return transientUpdates.build();
     }
 
-    synchronized Settings getPersistentUpdate() {
+    public synchronized Settings getPersistentUpdate() {
         return persistentUpdates.build();
     }
 
-    synchronized ClusterState updateSettings(
+    public synchronized ClusterState updateSettings(
         final ClusterState currentState,
         final Settings transientToApply,
         final Settings persistentToApply,

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsUpdaterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsUpdaterTests.java
@@ -5,16 +5,13 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-package org.elasticsearch.action.admin.cluster.settings;
+package org.elasticsearch.common.settings;
 
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Today the `SettingsUpdater` is a package-private class, visible only to
the update-settings API action framework, but this functionality is more
generally useful. For instance the `ReservedClusterSettingsAction` needs
it, but can only access it by creating an update-settings task which it
then runs directly (outside of the master service). This is kind of
backwards: the update-settings task should be isolated to the API which
uses it, and the general-purpose `SettingsUpdater` should be more widely
accessible.

This commit moves `SettingsUpdater` to `o.e.common.settings`, adjusts
`ReservedClusterSettingsAction` to use it, and makes the update-settings
task private.