### PR TITLE
Test rate aggregation on partial buckets

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
@@ -442,3 +442,100 @@
   - close_to: { aggregations.ts.buckets.0.rate-month.value: { value: 63958020.00, error: 0.01 }}
   - close_to: { aggregations.ts.buckets.0.rate-quarter.value: { value: 191874060.00, error: 0.01 }}
   - close_to: { aggregations.ts.buckets.0.rate-year.value: { value: 767496240.00, error: 0.01 }}
+
+---
+"rate aggregation on counter field partial bucket":
+  - skip:
+      version: " - 8.6.99"
+      reason: "counter field support added in 8.7"
+      features: close_to
+
+  - do:
+      indices.create:
+        index: test-rate
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ host ]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              host:
+                type: keyword
+                time_series_dimension: true
+              bytes_counter:
+                type: long
+                time_series_metric: counter
+
+  - do:
+      bulk:
+        refresh: true
+        index: test-rate
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:04.000Z", "host": "one", "bytes_counter": 1000 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:14.000Z", "host": "one", "bytes_counter": 1100 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:24.000Z", "host": "one", "bytes_counter": 1200 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:34.000Z", "host": "one", "bytes_counter": 1250 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:44.000Z", "host": "one", "bytes_counter": 1310 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:54.000Z", "host": "one", "bytes_counter": 1350 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:01.000Z", "host": "two", "bytes_counter": 1000 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:11.000Z", "host": "two", "bytes_counter": 1100 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:21.000Z", "host": "two", "bytes_counter": 1200 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:31.000Z", "host": "two", "bytes_counter": 1250 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:41.000Z", "host": "two", "bytes_counter": 1310 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:01:51.000Z", "host": "two", "bytes_counter": 1350 }'
+
+  - do:
+      search:
+        index: test-rate
+        body:
+          size: 0
+          query:
+            bool:
+              filter:
+                range:
+                  "@timestamp":
+                    gte: "2021-04-28T18:01:03.000Z"
+                    lte: "2021-04-28T18:18:00.000Z"
+          aggs:
+            date_histogram:
+              date_histogram:
+                field: "@timestamp"
+                calendar_interval: 1h
+                time_zone: Europe/Ljubljana
+                min_doc_count: 1
+              aggs:
+                counter_rate:
+                  time_series:
+                    keyed: false
+                  aggs:
+                    bytes_counter_rate:
+                      rate:
+                        field: bytes_counter
+                        unit: second
+
+  - match: { hits.total.value: 11 }
+  - length: { aggregations.date_histogram.buckets: 1 }
+  - match: { aggregations.date_histogram.buckets.0.key_as_string: "2021-04-28T20:00:00.000+02:00" }
+  - match: { aggregations.date_histogram.buckets.0.doc_count: 11 }
+  # NOTE: (1350 - 1000) / (54 - 4) = 350 / 50 = 7.0
+  - close_to: { aggregations.date_histogram.buckets.0.counter_rate.buckets.0.bytes_counter_rate.value: { value: 7.00, error: 0.01 } }
+  # NOTE: (1350 - 1100) / (51 - 11) = 250 / 40 = 6.25 (we filter out the first sample due to the bool range filter)
+  - close_to: { aggregations.date_histogram.buckets.0.counter_rate.buckets.1.bytes_counter_rate.value: { value: 6.25, error: 0.01 } }


### PR DESCRIPTION
Here we test how the rate aggregation works when partial buckets are used.
When we speak about partial buckets we refer to buckets that are missing
some documents, typically the first bucket of a date histogram, due to a filter
clause that filters out some documents based on the timestamp.

The behaviour is as expected, per each bucket we always use the actual counter 
values and timestamp values to calculate the rate.

Resolves #94223 