### PR TITLE
[DOC] Consistently reference indices parameter in API key examples

### DIFF
--- a/x-pack/docs/en/rest-api/security/bulk-update-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/bulk-update-api-keys.asciidoc
@@ -82,7 +82,7 @@ POST /_security/api_key
   "role_descriptors": {
     "role-a": {
       "cluster": ["all"],
-      "index": [
+      "indices": [
         {
           "names": ["index-a*"],
           "privileges": ["read"]
@@ -156,7 +156,7 @@ Further, assume that the owner user's permissions are:
 --------------------------------------------------
 {
   "cluster": ["all"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["all"]
@@ -178,7 +178,7 @@ POST /_security/api_key/_bulk_update
   ],
   "role_descriptors": {
     "role-a": {
-      "index": [
+      "indices": [
         {
           "names": ["*"],
           "privileges": ["write"]
@@ -215,7 +215,7 @@ Both API keys' effective permissions after the update will be the intersection o
 [source,js]
 --------------------------------------------------
 {
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["write"]
@@ -259,7 +259,7 @@ The API keys' effective permissions after the update will be the same as the own
 --------------------------------------------------
 {
   "cluster": ["all"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["all"]
@@ -275,7 +275,7 @@ For the next example, assume that the owner user's permissions have changed from
 --------------------------------------------------
 {
   "cluster": ["manage_security"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["read"]
@@ -318,7 +318,7 @@ Resulting in the following effective permissions for both API keys:
 --------------------------------------------------
 {
   "cluster": ["manage_security"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["read"]

--- a/x-pack/docs/en/rest-api/security/grant-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/grant-api-keys.asciidoc
@@ -127,7 +127,7 @@ POST /_security/api_key/grant
     "role_descriptors": {
       "role-a": {
         "cluster": ["all"],
-        "index": [
+        "indices": [
           {
           "names": ["index-a*"],
           "privileges": ["read"]
@@ -136,7 +136,7 @@ POST /_security/api_key/grant
       },
       "role-b": {
         "cluster": ["all"],
-        "index": [
+        "indices": [
           {
           "names": ["index-b*"],
           "privileges": ["all"]

--- a/x-pack/docs/en/rest-api/security/update-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/update-api-key.asciidoc
@@ -87,7 +87,7 @@ POST /_security/api_key
   "role_descriptors": {
     "role-a": {
       "cluster": ["all"],
-      "index": [
+      "indices": [
         {
           "names": ["index-a*"],
           "privileges": ["read"]
@@ -129,7 +129,7 @@ For the examples below, assume that the owner user's permissions are:
 --------------------------------------------------
 {
   "cluster": ["all"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["all"]
@@ -147,7 +147,7 @@ PUT /_security/api_key/VuaCfGcBCdbkQm-e5aOx
 {
   "role_descriptors": {
     "role-a": {
-      "index": [
+      "indices": [
         {
           "names": ["*"],
           "privileges": ["write"]
@@ -181,7 +181,7 @@ The API key's effective permissions after the update will be the intersection of
 [source,js]
 --------------------------------------------------
 {
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["write"]
@@ -217,7 +217,7 @@ The API key's effective permissions after the update will be the same as the own
 --------------------------------------------------
 {
   "cluster": ["all"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["all"]
@@ -233,7 +233,7 @@ For the next example, assume that the owner user's permissions have changed from
 --------------------------------------------------
 {
   "cluster": ["manage_security"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["read"]
@@ -266,7 +266,7 @@ Resulting in the following effective permissions for the API key:
 --------------------------------------------------
 {
   "cluster": ["manage_security"],
-  "index": [
+  "indices": [
     {
       "names": ["*"],
       "privileges": ["read"]


### PR DESCRIPTION
This PR adjusts API key examples to consistently use `indices` instead of `index` parameter. Technically, both are supported [as request parameters](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java#L491C10-L492), but `indices` is more aligned with get API key response.

Relates to https://github.com/elastic/elasticsearch/pull/97027, where the change was already made for create API key examples.