### PR TITLE
[Test] Use real instance of ReservedRolesStore to avoid NPE

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -2920,8 +2920,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             }).when(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
         }
         if (reservedRolesStore == null) {
-            reservedRolesStore = mock(ReservedRolesStore.class);
-            doCallRealMethod().when(reservedRolesStore).accept(anySet(), anyActionListener());
+            reservedRolesStore = new ReservedRolesStore();
         }
         if (licenseState == null) {
             licenseState = new XPackLicenseState(() -> 0);


### PR DESCRIPTION
Since `ReservedRolesStore` must be properly initialized before calling real methods,
it is not possible to mock it and then still call real methods. Given that there is no real 
need for `CompositeRolesStoreTests` to use mocked `ReservedRolesStore`, this PR
changes the test setup to use real instance and thus avoid `NPE` when accessing 
`RESERVED_ROLES` property.


Fixes https://github.com/elastic/elasticsearch/issues/97172