### PR TITLE
Update Search Application API docs to discuss warnings

### DIFF
--- a/docs/reference/search-application/apis/get-search-application.asciidoc
+++ b/docs/reference/search-application/apis/get-search-application.asciidoc
@@ -10,7 +10,7 @@ beta::[]
 
 Retrieves information about a search application.
 
-If the search engine has an inconsistent state between its alias and configured indices, a warning header will be returned with the response.
+If the search application has an inconsistent state between its alias and configured indices, a warning header will be returned with the response.
 To resolve this inconsistent state, issue an updated <<put-search-application>> command.
 
 [[get-search-application-request]]

--- a/docs/reference/search-application/apis/get-search-application.asciidoc
+++ b/docs/reference/search-application/apis/get-search-application.asciidoc
@@ -8,7 +8,10 @@ beta::[]
 <titleabbrev>Get Search Application</titleabbrev>
 ++++
 
-Retrieves information about a Search Application.
+Retrieves information about a search application.
+
+If the search engine has an inconsistent state between its alias and configured indices, a warning header will be returned with the response.
+To resolve this inconsistent state, issue an updated <<put-search-application>> command.
 
 [[get-search-application-request]]
 ==== {api-request-title}

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -11,6 +11,9 @@ beta::[]
 Given specified query parameters, creates an Elasticsearch query to run. Any unspecified template parameters will be
 assigned their default values if applicable.
 
+If the search engine has an inconsistent state between its alias and configured indices, a warning header will be returned with the response.
+To resolve this inconsistent state, issue an updated <<put-search-application>> command.
+
 [[search-application-search-request]]
 ==== {api-request-title}
 

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -11,7 +11,7 @@ beta::[]
 Given specified query parameters, creates an Elasticsearch query to run. Any unspecified template parameters will be
 assigned their default values if applicable.
 
-If the search engine has an inconsistent state between its alias and configured indices, a warning header will be returned with the response.
+If the search application has an inconsistent state between its alias and configured indices, a warning header will be returned with the response.
 To resolve this inconsistent state, issue an updated <<put-search-application>> command.
 
 [[search-application-search-request]]


### PR DESCRIPTION
Updates Search Application API documentation to call out warnings returned in response headers and how to mitigate them. 