### PR TITLE
Fix flaky test in SetProcessorTests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
@@ -69,7 +69,9 @@ public final class RandomDocumentPicks {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) randomEntry.getValue();
             // we have reached an empty map hence the max depth we can reach
-            if (map.isEmpty()) break;
+            if (map.isEmpty()) {
+                break;
+            }
             Map<String, Object> treeMap = new TreeMap<>(map);
             randomEntry = RandomPicks.randomFrom(random, treeMap.entrySet());
             key += "." + randomEntry.getKey();

--- a/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
@@ -68,6 +68,8 @@ public final class RandomDocumentPicks {
         while (randomEntry.getValue() instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) randomEntry.getValue();
+            // we have reached an empty map hence the max depth we can reach
+            if (map.isEmpty()) break;
             Map<String, Object> treeMap = new TreeMap<>(map);
             randomEntry = RandomPicks.randomFrom(random, treeMap.entrySet());
             key += "." + randomEntry.getKey();


### PR DESCRIPTION
the random documents can have entries with an empty map, so, while building the full key in `randomExistingFieldName`, in case we stumble upon this empty map, we won't be able to find a new element because the entry set is empty.

1. Test using the same seed is passing
2. 10000 iterations, all passing
3. 40000 iterations, all passing

```
➜  elasticsearch git:(fix-97164) ✗ ./gradlew ':modules:ingest-common:test' --tests "org.elasticsearch.ingest.common.SetProcessorTests.testSetExistingFields" -Dtests.seed=8970DEFD8FE56CF
[..]

BUILD SUCCESSFUL in 7s
76 actionable tasks: 3 executed, 73 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/hunb7calp7oaq

➜  elasticsearch git:(fix-97164) ✗ ./gradlew ':modules:ingest-common:test' --tests "org.elasticsearch.ingest.common.SetProcessorTests.testSetExistingFields" -Dtests.iters=10000
[..]

BUILD SUCCESSFUL in 12s
76 actionable tasks: 1 executed, 75 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/wqums5silsxkw

➜  elasticsearch git:(fix-97164) ✗ ./gradlew ':modules:ingest-common:test' --tests "org.elasticsearch.ingest.common.SetProcessorTests.testSetExistingFields" -Dtests.iters=40000
[..]

BUILD SUCCESSFUL in 33s
76 actionable tasks: 1 executed, 75 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/3dwuvm6im5jh6

```

Closes #97164