### PR TITLE
Mute some knn yml tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -94,8 +94,9 @@ setup:
 ---
 "kNN search plus query":
   - skip:
-      version: ' - 8.3.99'
-      reason: 'kNN added to search endpoint in 8.4'
+      version: all #' - 8.3.99'
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97144"
+      # reason: 'kNN added to search endpoint in 8.4'
   - do:
       search:
         index: test
@@ -121,8 +122,9 @@ setup:
 ---
 "kNN multi-field search with query":
   - skip:
-      version: ' - 8.6.99'
-      reason: 'multi-field kNN search added to search endpoint in 8.7'
+      version: all #' - 8.6.99'
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97144"
+      # reason: 'multi-field kNN search added to search endpoint in 8.7'
   - do:
       search:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/45_knn_search_byte.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/45_knn_search_byte.yml
@@ -66,6 +66,9 @@ setup:
 
 ---
 "kNN search plus query":
+  - skip:
+      version: all
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97144"
   - do:
       search:
         index: test


### PR DESCRIPTION
These tests are failing too often in mixed cluster scenarios at the moment.
Muting until https://github.com/elastic/elasticsearch/issues/97144 is adressed.