### PR TITLE
Remove incorrect check for shard-in-recovery in IndicesClusterStateService

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -88,7 +88,9 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
             final UnassignedInfo unassignedInfo = allocationExplainResponse.getExplanation().getUnassignedInfo();
             assertThat(description, unassignedInfo, not(nullValue()));
             assertThat(description, unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
-            final Throwable cause = ExceptionsHelper.unwrap(unassignedInfo.getFailure(), TranslogCorruptedException.class);
+            var failure = unassignedInfo.getFailure();
+            assertNotNull(failure);
+            final Throwable cause = ExceptionsHelper.unwrap(failure, TranslogCorruptedException.class);
             if (cause != null) {
                 assertThat(description, cause.getMessage(), containsString(translogPath.toString()));
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -89,8 +89,9 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
             assertThat(description, unassignedInfo, not(nullValue()));
             assertThat(description, unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
             final Throwable cause = ExceptionsHelper.unwrap(unassignedInfo.getFailure(), TranslogCorruptedException.class);
-            assertThat(description, cause, not(nullValue()));
-            assertThat(description, cause.getMessage(), containsString(translogPath.toString()));
+            if (cause != null) {
+                assertThat(description, cause.getMessage(), containsString(translogPath.toString()));
+            }
         });
 
         assertThat(

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -931,10 +931,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         @Override
         public void accept(final IndexShard.ShardFailure shardFailure) {
             final ShardRouting shardRouting = shardFailure.routing();
-            if (shardRouting.initializing()) {
-                // no need to fail the shard here during recovery, the recovery code will take care of failing it
-                return;
-            }
             threadPool.generic().execute(() -> {
                 synchronized (IndicesClusterStateService.this) {
                     failAndRemoveShard(


### PR DESCRIPTION
This check was only there to fix the test that this PR adjust slightly. Very rarely, we would not get the translog corrupted exception in the test as a result of the engine failure happening before the recovery failure. I just made it so we don't assert anything for this rare case (not the greatest solution admittedly but some hacky assertion on the exception didn't really feel worth it here).
