### PR TITLE
Fix composable templates with `subobjects: false`

### DIFF
--- a/docs/changelog/97199.yaml
+++ b/docs/changelog/97199.yaml
@@ -1,0 +1,6 @@
+pr: 97199
+summary: "Fix composable templates with `subobjects: false`"
+area: Mapping
+type: bug
+issues:
+ - 96768

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -158,9 +158,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
         tmpIndexMetadata.settings(finalResolvedSettings);
         // Create MapperService just to extract keyword dimension fields:
         try (var mapperService = mapperServiceFactory.apply(tmpIndexMetadata.build())) {
-            for (var mapping : combinedTemplateMappings) {
-                mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
-            }
+            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, combinedTemplateMappings, MapperService.MergeReason.INDEX_TEMPLATE);
 
             List<String> routingPaths = new ArrayList<>();
             for (var fieldMapper : mapperService.documentMapper().mappers().fieldMappers()) {

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -349,3 +349,37 @@
           index_patterns: ["purple-index"]
           composed_of: ["red", "blue"]
           ignore_missing_component_templates: ["foo"]
+
+---
+"Composable index templates that include subobjects: false":
+  - skip:
+      version: ' - 8.9.1'
+      reason: 'https://github.com/elastic/elasticsearch/issues/96768 fixed after 8.9.0'
+
+  - do:
+      cluster.put_component_template:
+        name: test-subobjects
+        body:
+          template:
+            mappings:
+              subobjects: false
+
+  - do:
+      cluster.put_component_template:
+        name: test-field
+        body:
+          template:
+            mappings:
+              properties:
+                parent.subfield:
+                  type: keyword
+
+  - do:
+      indices.put_index_template:
+        name: logs-composable-template
+        body:
+          index_patterns:
+            - test-*
+          composed_of:
+            - test-subobjects
+            - test-field

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -294,9 +294,7 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
             indexMetadata,
             tempIndexService -> {
                 MapperService mapperService = tempIndexService.mapperService();
-                for (CompressedXContent mapping : mappings) {
-                    mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
-                }
+                mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mappings, MapperService.MergeReason.INDEX_TEMPLATE);
 
                 DocumentMapper documentMapper = mapperService.documentMapper();
                 return documentMapper != null ? documentMapper.mappingSource() : null;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1336,9 +1336,7 @@ public class MetadataCreateIndexService {
         if (defaultMapping != null) {
             mapperService.merge(MapperService.SINGLE_MAPPING_NAME, defaultMapping, MergeReason.INDEX_TEMPLATE);
         }
-        for (CompressedXContent mapping : mappings) {
-            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
-        }
+        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mappings, MergeReason.INDEX_TEMPLATE);
         indexMode.validateTimestampFieldMapping(request.dataStreamName() != null, mapperService.mappingLookup());
 
         if (sourceMetadata == null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1589,10 +1589,7 @@ public class MetadataIndexTemplateService {
             List<CompressedXContent> mappings = collectMappings(stateWithIndex, templateName, indexName);
             try {
                 MapperService mapperService = tempIndexService.mapperService();
-                for (CompressedXContent mapping : mappings) {
-                    mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
-                }
-
+                mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mappings, MapperService.MergeReason.INDEX_TEMPLATE);
                 if (template.getDataStreamTemplate() != null) {
                     validateTimestampFieldMapping(mapperService.mappingLookup());
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
@@ -72,8 +73,13 @@ public final class MappingParser {
         return remainingFields.toString();
     }
 
-    @SuppressWarnings("unchecked")
     Mapping parse(@Nullable String type, CompressedXContent source) throws MapperParsingException {
+        return parse(type, source, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    Mapping parse(@Nullable String type, CompressedXContent source, @Nullable Explicit<Boolean> explicitSubobjects)
+        throws MapperParsingException {
         Objects.requireNonNull(source, "source cannot be null");
         Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
         if (mapping.isEmpty()) {
@@ -93,13 +99,14 @@ public final class MappingParser {
         if (type.isEmpty()) {
             throw new MapperParsingException("type cannot be an empty string");
         }
-        return parse(type, mapping);
+        return parse(type, mapping, explicitSubobjects);
     }
 
-    private Mapping parse(String type, Map<String, Object> mapping) throws MapperParsingException {
+    private Mapping parse(String type, Map<String, Object> mapping, @Nullable Explicit<Boolean> explicitSubobjects)
+        throws MapperParsingException {
         final MappingParserContext mappingParserContext = mappingParserContextSupplier.get();
 
-        RootObjectMapper.Builder rootObjectMapper = RootObjectMapper.parse(type, mapping, mappingParserContext);
+        RootObjectMapper.Builder rootObjectMapper = RootObjectMapper.parse(type, mapping, mappingParserContext, explicitSubobjects);
 
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersSupplier.get();
         Map<String, Object> meta = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -449,6 +449,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
         return subobjects.value();
     }
 
+    public final boolean subobjectsExplicit() {
+        return subobjects.explicit();
+    }
+
     @Override
     public ObjectMapper merge(Mapper mergeWith, MapperBuilderContext mapperBuilderContext) {
         return merge(mergeWith, MergeReason.MAPPING_UPDATE, mapperBuilderContext);

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -405,8 +405,7 @@ public class RootObjectMapper extends ObjectMapper {
         Map<String, Object> node,
         MappingParserContext parserContext,
         @Nullable Explicit<Boolean> explicitSubobjects
-    )
-        throws MapperParsingException {
+    ) throws MapperParsingException {
         Explicit<Boolean> subobjects = parseSubobjects(node);
         if (subobjects.explicit() == false && explicitSubobjects != null) {
             subobjects = explicitSubobjects;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DynamicTemplate.XContentFieldType;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
@@ -399,9 +400,17 @@ public class RootObjectMapper extends ObjectMapper {
         b.startObject();
     }
 
-    public static RootObjectMapper.Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext)
+    public static RootObjectMapper.Builder parse(
+        String name,
+        Map<String, Object> node,
+        MappingParserContext parserContext,
+        @Nullable Explicit<Boolean> explicitSubobjects
+    )
         throws MapperParsingException {
         Explicit<Boolean> subobjects = parseSubobjects(node);
+        if (subobjects.explicit() == false && explicitSubobjects != null) {
+            subobjects = explicitSubobjects;
+        }
         RootObjectMapper.Builder builder = new Builder(name, subobjects);
         Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
         while (iterator.hasNext()) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -2474,6 +2474,61 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         assertThat(e.getMessage(), containsString("missing component templates [fail] that does not exist"));
     }
 
+    public void testComposableTemplateWithSubobjectsFalse() throws Exception {
+        final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
+        ClusterState state = ClusterState.EMPTY_STATE;
+
+        ComponentTemplate subobjects = new ComponentTemplate(new Template(null, new CompressedXContent("""
+            {
+              "subobjects": false
+            }
+            """), null), null, null);
+
+        ComponentTemplate fieldMapping = new ComponentTemplate(new Template(null, new CompressedXContent("""
+            {
+              "properties": {
+                "parent.subfield": {
+                  "type": "keyword"
+                }
+              }
+            }
+            """), null), null, null);
+
+        state = service.addComponentTemplate(state, true, "subobjects", subobjects);
+        state = service.addComponentTemplate(state, true, "field_mapping", fieldMapping);
+        ComposableIndexTemplate it = new ComposableIndexTemplate(
+            List.of("test-*"),
+            new Template(null, null, null),
+            List.of("subobjects", "field_mapping"),
+            0L,
+            1L,
+            null,
+            null,
+            null
+        );
+        state = service.addIndexTemplateV2(state, true, "composable-template", it);
+
+        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "composable-template", "test-index");
+
+        assertNotNull(mappings);
+        assertThat(mappings.size(), equalTo(2));
+        List<Map<String, Object>> parsedMappings = mappings.stream().map(m -> {
+            try {
+                return MapperService.parseMapping(NamedXContentRegistry.EMPTY, m);
+            } catch (Exception e) {
+                logger.error(e);
+                fail("failed to parse mappings: " + m.string());
+                return null;
+            }
+        }).toList();
+
+        assertThat(parsedMappings.get(0), equalTo(Map.of("_doc", Map.of("subobjects", false))));
+        assertThat(
+            parsedMappings.get(1),
+            equalTo(Map.of("_doc", Map.of("properties", Map.of("parent.subfield", Map.of("type", "keyword")))))
+        );
+    }
+
     private static List<Throwable> putTemplate(NamedXContentRegistry xContentRegistry, PutRequest request) {
         ThreadPool testThreadPool = mock(ThreadPool.class);
         ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);


### PR DESCRIPTION
Fixes #96768 

A fix proposal based on the [identified root cause](https://github.com/elastic/elasticsearch/issues/96768#issuecomment-1609907429).

The problem in general is that mapping properties parsing is affected by the `subobjects` setting, so if multiple mappings are merged, whenever explicit `subobjects` setting is encountered, formerly parsed mappings become invalid.
What I tried in this PR is to re-parse mappings when explicit `subobjects` setting is encountered while merging mapping components. There are potentially better approaches to this.

If this fix proposal is evaluated as a valid path, we still need to:
- [ ] add javadoc
- [ ] add unit tests (e.g. different order of components in composedOf list; test merge in chunks and not in a single list)
- [ ] polish the new `MapperService#merge()` method and see how we minimize re-parsing