### PR TITLE
[8.9] [Test] Use real instance of ReservedRolesStore to avoid NPE (#97185)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -2920,8 +2920,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             }).when(nativeRolesStore).getRoleDescriptors(isASet(), anyActionListener());
         }
         if (reservedRolesStore == null) {
-            reservedRolesStore = mock(ReservedRolesStore.class);
-            doCallRealMethod().when(reservedRolesStore).accept(anySet(), anyActionListener());
+            reservedRolesStore = new ReservedRolesStore();
         }
         if (licenseState == null) {
             licenseState = new XPackLicenseState(() -> 0);


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [Test] Use real instance of ReservedRolesStore to avoid NPE (#97185)