### PR TITLE
Fix possible NPE when transportversion is null in MainResponse

### DIFF
--- a/docs/changelog/97203.yaml
+++ b/docs/changelog/97203.yaml
@@ -1,0 +1,5 @@
+pr: 97203
+summary: Fix possible NPE when transportversion is null in `MainResponse`
+area: Infra/REST API
+type: bug
+issues: []

--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
@@ -113,7 +113,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("lucene_version", version.luceneVersion().toString())
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
-            .field("transport_version", transportVersion.toString())
+            .field("transport_version", transportVersion != null ? transportVersion.toString() : "unknown")
             .endObject();
         builder.field("tagline", "You Know, for Search");
         builder.endObject();


### PR DESCRIPTION
MainResponse deserialization conditionally reads TransportVersion based on the stream version, defaulting to `null`. But this will cause an NPE when outputting xcontent from such an object.