### PR TITLE
Suppress more exception logging from retention lease syncs

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -660,7 +660,7 @@ public class ReplicationOperation<
     }
 
     public static class RetryOnPrimaryException extends ElasticsearchException {
-        RetryOnPrimaryException(ShardId shardId, String msg) {
+        public RetryOnPrimaryException(ShardId shardId, String msg) {
             this(shardId, msg, null);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -10,8 +10,6 @@ package org.elasticsearch.index.seqno;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.store.AlreadyClosedException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -26,12 +24,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -44,6 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.index.seqno.RetentionLeaseSyncAction.getExceptionLogLevel;
 
 /**
  * Replication action responsible for background syncing retention leases to replicas. This action is deliberately a replication action so
@@ -129,20 +125,7 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
                 public void handleException(TransportException e) {
                     task.setPhase("finished");
                     taskManager.unregister(task);
-                    if (ExceptionsHelper.unwrap(e, NodeClosedException.class) != null) {
-                        // node shutting down
-                        return;
-                    }
-                    if (ExceptionsHelper.unwrap(
-                        e,
-                        IndexNotFoundException.class,
-                        AlreadyClosedException.class,
-                        IndexShardClosedException.class
-                    ) != null) {
-                        // the index was deleted or the shard is closed
-                        return;
-                    }
-                    getLogger().warn(() -> format("%s retention lease background sync failed", shardId), e);
+                    LOGGER.log(getExceptionLogLevel(e), () -> format("%s retention lease background sync failed", shardId), e);
                 }
             }
         );

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.WriteResponse;
 import org.elasticsearch.action.support.replication.ReplicatedWriteRequest;
+import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
@@ -37,6 +38,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -146,10 +148,12 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
     static Level getExceptionLogLevel(Exception e) {
         return ExceptionsHelper.unwrap(
             e,
+            NodeClosedException.class,
             IndexNotFoundException.class,
             AlreadyClosedException.class,
             IndexShardClosedException.class,
-            ShardNotInPrimaryModeException.class
+            ShardNotInPrimaryModeException.class,
+            ReplicationOperation.RetryOnPrimaryException.class
         ) == null ? Level.WARN : Level.DEBUG;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
@@ -13,8 +13,10 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
@@ -30,6 +32,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -37,6 +40,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.index.seqno.RetentionLeaseSyncAction.getExceptionLogLevel;
@@ -192,21 +196,17 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
         assertEquals(Level.WARN, getExceptionLogLevel(new RuntimeException("simulated")));
         assertEquals(Level.WARN, getExceptionLogLevel(new RuntimeException("simulated", new RuntimeException("simulated"))));
 
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new IndexNotFoundException("index")));
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new RuntimeException("simulated", new IndexNotFoundException("index"))));
-
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new AlreadyClosedException("index")));
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new RuntimeException("simulated", new AlreadyClosedException("index"))));
-
         final var shardId = new ShardId("test", "_na_", 0);
-
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new IndexShardClosedException(shardId)));
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new RuntimeException("simulated", new IndexShardClosedException(shardId))));
-
-        assertEquals(Level.DEBUG, getExceptionLogLevel(new ShardNotInPrimaryModeException(shardId, IndexShardState.CLOSED)));
-        assertEquals(
-            Level.DEBUG,
-            getExceptionLogLevel(new RuntimeException("simulated", new ShardNotInPrimaryModeException(shardId, IndexShardState.CLOSED)))
-        );
+        for (final var exception : List.of(
+            new NodeClosedException(DiscoveryNodeUtils.create("node")),
+            new IndexNotFoundException(shardId.getIndexName()),
+            new AlreadyClosedException(shardId.getIndexName()),
+            new IndexShardClosedException(shardId),
+            new ShardNotInPrimaryModeException(shardId, IndexShardState.CLOSED),
+            new ReplicationOperation.RetryOnPrimaryException(shardId, "test")
+        )) {
+            assertEquals(Level.DEBUG, getExceptionLogLevel(exception));
+            assertEquals(Level.DEBUG, getExceptionLogLevel(new RuntimeException("wrapper", exception)));
+        }
     }
 }


### PR DESCRIPTION
In #97051 we reduced the log level for `ShardNotInPrimaryModeException`
reported by a retention lease sync. This commit adds the following to the list
of unimportant exceptions:

- `RetryOnPrimaryException`
- `NodeClosedException`

It also adopts the same logging logic in
`RetentionLeaseBackgroundSyncAction`.