### PR TITLE
Test the SearchShards (transport-only) API can_match functionality against searchable snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsGroup.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsGroup.java
@@ -106,4 +106,18 @@ public class SearchShardsGroup implements Writeable {
     public int hashCode() {
         return Objects.hash(shardId, allocatedNodes, skipped, preFiltered);
     }
+
+    @Override
+    public String toString() {
+        return "SearchShardsGroup{"
+            + "shardId="
+            + shardId
+            + ", allocatedNodes="
+            + allocatedNodes
+            + ", skipped="
+            + skipped
+            + ", preFiltered="
+            + preFiltered
+            + '}';
+    }
 }


### PR DESCRIPTION
The existing SearchableSnapshotsCanMatchOnCoordinatorIntegTests were all enhanced to also search via the (transport-only) SearchShards API as well as the Search API. The SearchShards API allows doing only a can-match without the other search phases.