### PR TITLE
Fix format of DiscoveryNode xcontent index version fields

### DIFF
--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -172,8 +172,8 @@ The API returns the following response:
                             "attributes": {},
                             "roles": [...],
                             "version": "8.10.0",
-                            "min_index_version": "7000099",
-                            "max_index_version": "8100099"
+                            "min_index_version": 7000099,
+                            "max_index_version": 8100099
                         },
                         "allocation_id": "2iNySv_OQVePRX-yaRH_lQ", <4>
                         "allocation" : "primary|replica|unused" <5>

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -172,8 +172,8 @@ The API returns the following response:
                             "attributes": {},
                             "roles": [...],
                             "version": "8.10.0",
-                            "minIndexVersion": "7000099",
-                            "maxIndexVersion": "8100099"
+                            "min_index_version": "7000099",
+                            "max_index_version": "8100099"
                         },
                         "allocation_id": "2iNySv_OQVePRX-yaRH_lQ", <4>
                         "allocation" : "primary|replica|unused" <5>

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -605,8 +605,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         }
         builder.endArray();
         builder.field("version", versionInfo.nodeVersion());
-        builder.field("minIndexVersion", versionInfo.minIndexVersion());
-        builder.field("maxIndexVersion", versionInfo.maxIndexVersion());
+        builder.field("min_index_version", versionInfo.minIndexVersion());
+        builder.field("max_index_version", versionInfo.maxIndexVersion());
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -345,7 +345,7 @@ public record IndexVersion(int id, Version luceneVersion) implements Comparable<
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.value(toString());
+        return builder.value(id);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -122,8 +122,8 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                               "voting_only"
                             ],
                             "version": "%s",
-                            "minIndexVersion": "%s",
-                            "maxIndexVersion": "%s"
+                            "min_index_version": "%s",
+                            "max_index_version": "%s"
                           }
                         },
                         "transport_versions": [

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -122,8 +122,8 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                               "voting_only"
                             ],
                             "version": "%s",
-                            "min_index_version": "%s",
-                            "max_index_version": "%s"
+                            "min_index_version": %s,
+                            "max_index_version": %s
                           }
                         },
                         "transport_versions": [

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -202,8 +202,8 @@ public class ClusterStateTests extends ESTestCase {
                                 "voting_only"
                               ],
                               "version": "%s",
-                              "min_index_version":"%s",
-                              "max_index_version":"%s"
+                              "min_index_version":%s,
+                              "max_index_version":%s
                             }
                           },
                           "transport_versions" : [
@@ -457,8 +457,8 @@ public class ClusterStateTests extends ESTestCase {
                             "voting_only"
                           ],
                           "version" : "%s",
-                          "min_index_version" : "%s",
-                          "max_index_version" : "%s"
+                          "min_index_version" : %s,
+                          "max_index_version" : %s
                         }
                       },
                       "transport_versions" : [
@@ -708,8 +708,8 @@ public class ClusterStateTests extends ESTestCase {
                             "voting_only"
                           ],
                           "version" : "%s",
-                          "min_index_version" : "%s",
-                          "max_index_version" : "%s"
+                          "min_index_version" : %s,
+                          "max_index_version" : %s
                         }
                       },
                       "transport_versions" : [

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -202,8 +202,8 @@ public class ClusterStateTests extends ESTestCase {
                                 "voting_only"
                               ],
                               "version": "%s",
-                              "minIndexVersion":"%s",
-                              "maxIndexVersion":"%s"
+                              "min_index_version":"%s",
+                              "max_index_version":"%s"
                             }
                           },
                           "transport_versions" : [
@@ -457,8 +457,8 @@ public class ClusterStateTests extends ESTestCase {
                             "voting_only"
                           ],
                           "version" : "%s",
-                          "minIndexVersion" : "%s",
-                          "maxIndexVersion" : "%s"
+                          "min_index_version" : "%s",
+                          "max_index_version" : "%s"
                         }
                       },
                       "transport_versions" : [

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -708,8 +708,8 @@ public class ClusterStateTests extends ESTestCase {
                             "voting_only"
                           ],
                           "version" : "%s",
-                          "minIndexVersion" : "%s",
-                          "maxIndexVersion" : "%s"
+                          "min_index_version" : "%s",
+                          "max_index_version" : "%s"
                         }
                       },
                       "transport_versions" : [

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -214,8 +214,8 @@ public class DiscoveryNodeTests extends ESTestCase {
                               "voting_only"
                             ],
                             "version" : "%s",
-                            "min_index_version" : "%s",
-                            "max_index_version" : "%s"
+                            "min_index_version" : %s,
+                            "max_index_version" : %s
                           }
                         }""",
                     transportAddress,

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -214,8 +214,8 @@ public class DiscoveryNodeTests extends ESTestCase {
                               "voting_only"
                             ],
                             "version" : "%s",
-                            "minIndexVersion" : "%s",
-                            "maxIndexVersion" : "%s"
+                            "min_index_version" : "%s",
+                            "max_index_version" : "%s"
                           }
                         }""",
                     transportAddress,

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -760,8 +760,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                       "master"
                     ],
                     "version": "%s",
-                    "minIndexVersion":"%s",
-                    "maxIndexVersion":"%s"
+                    "min_index_version":"%s",
+                    "max_index_version":"%s"
                   }
                 },
                 "transport_versions": []

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -760,8 +760,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                       "master"
                     ],
                     "version": "%s",
-                    "min_index_version":"%s",
-                    "max_index_version":"%s"
+                    "min_index_version":%s,
+                    "max_index_version":%s
                   }
                 },
                 "transport_versions": []


### PR DESCRIPTION
The min/max index version fields don't have the correct name format