### PR TITLE
[Profiling] Don't force-merge indices

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/ilm-policy/profiling-60-days.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/ilm-policy/profiling-60-days.json
@@ -18,9 +18,6 @@
       "actions": {
         "set_priority": {
           "priority": 50
-        },
-        "forcemerge": {
-          "max_num_segments": 1
         }
       }
     },


### PR DESCRIPTION
With this commit we remove the `force-merge` action from the default ILM policy for Universal Profiling. We do this because our experiments have shown that `force-merge` only leads to a marginal reduction in storage space (around 2% in total) while having potentially negative side-effects:

* It is I/O and CPU intensive leading to potential stress on the warm tier.
* The required disk space temporarily increases up to double size of the index being force-merged.

Therefore we stop doing force merges by default.
