### PR TITLE
Rename origin text from lifecycle to data_stream_lifecycle

### DIFF
--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecyclePlugin.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecyclePlugin.java
@@ -59,7 +59,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.cluster.metadata.DataLifecycle.DLM_ORIGIN;
+import static org.elasticsearch.cluster.metadata.DataLifecycle.DATA_STREAM_LIFECYCLE_ORIGIN;
 
 /**
  * Plugin encapsulating Data Lifecycle Management Service.
@@ -109,7 +109,7 @@ public class DataLifecyclePlugin extends Plugin implements ActionPlugin {
         dataLifecycleInitialisationService.set(
             new DataLifecycleService(
                 settings,
-                new OriginSettingClient(client, DLM_ORIGIN),
+                new OriginSettingClient(client, DATA_STREAM_LIFECYCLE_ORIGIN),
                 clusterService,
                 getClock(),
                 threadPool,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
@@ -45,7 +45,7 @@ public class DataLifecycle implements SimpleDiffable<DataLifecycle>, ToXContentO
 
     private static final FeatureFlag DLM_FEATURE_FLAG = new FeatureFlag("dlm");
 
-    public static final String DLM_ORIGIN = "data_lifecycle";
+    public static final String DATA_STREAM_LIFECYCLE_ORIGIN = "data_stream_lifecycle";
 
     public static final ParseField DATA_RETENTION_FIELD = new ParseField("data_retention");
     private static final ParseField ROLLOVER_FIELD = new ParseField("rollover");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
 
 import static org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
 import static org.elasticsearch.action.support.replication.PostWriteRefresh.POST_WRITE_REFRESH_ORIGIN;
-import static org.elasticsearch.cluster.metadata.DataLifecycle.DLM_ORIGIN;
+import static org.elasticsearch.cluster.metadata.DataLifecycle.DATA_STREAM_LIFECYCLE_ORIGIN;
 import static org.elasticsearch.ingest.IngestService.INGEST_ORIGIN;
 import static org.elasticsearch.persistent.PersistentTasksService.PERSISTENT_TASK_ORIGIN;
 import static org.elasticsearch.synonyms.SynonymsManagementAPIService.SYNONYMS_ORIGIN;
@@ -128,7 +128,7 @@ public final class AuthorizationUtils {
             case POST_WRITE_REFRESH_ORIGIN:
                 securityContext.executeAsInternalUser(InternalUsers.STORAGE_USER, version, consumer);
                 break;
-            case DLM_ORIGIN:
+            case DATA_STREAM_LIFECYCLE_ORIGIN:
                 securityContext.executeAsInternalUser(InternalUsers.DATA_STREAM_LIFECYCLE_USER, version, consumer);
                 break;
             case WATCHER_ORIGIN:

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationUtilsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationUtilsTests.java
@@ -121,7 +121,11 @@ public class AuthorizationUtilsTests extends ESTestCase {
     }
 
     public void testSwitchWithDlmOrigin() throws Exception {
-        assertSwitchBasedOnOriginAndExecute(DataLifecycle.DLM_ORIGIN, InternalUsers.DATA_STREAM_LIFECYCLE_USER, randomTransportVersion());
+        assertSwitchBasedOnOriginAndExecute(
+            DataLifecycle.DATA_STREAM_LIFECYCLE_ORIGIN,
+            InternalUsers.DATA_STREAM_LIFECYCLE_USER,
+            randomTransportVersion()
+        );
     }
 
     public void testSwitchAndExecuteXpackUser() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
@@ -78,7 +78,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static org.elasticsearch.cluster.metadata.DataLifecycle.DLM_ORIGIN;
+import static org.elasticsearch.cluster.metadata.DataLifecycle.DATA_STREAM_LIFECYCLE_ORIGIN;
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
@@ -430,7 +430,7 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
             InternalUsers.XPACK_USER,
             ASYNC_SEARCH_ORIGIN,
             InternalUsers.ASYNC_SEARCH_USER,
-            DLM_ORIGIN,
+            DATA_STREAM_LIFECYCLE_ORIGIN,
             InternalUsers.DATA_STREAM_LIFECYCLE_USER
         );
 


### PR DESCRIPTION
Follow up of https://github.com/elastic/elasticsearch/issues/96875#:~:text=explain%20lifecycle%20API%20(-,Rebranding%20user%20facing%20DLM%20references%C2%A0%2396866,-).