### PR TITLE
[8.9] [Profiling] Don't force-merge indices (#97229)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/ilm-policy/profiling-60-days.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/ilm-policy/profiling-60-days.json
@@ -18,9 +18,6 @@
       "actions": {
         "set_priority": {
           "priority": 50
-        },
-        "forcemerge": {
-          "max_num_segments": 1
         }
       }
     },


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [Profiling] Don't force-merge indices (#97229)