### PR TITLE
[8.9] [DOCS] Note license requirements for CCS (#97252)

### DIFF
--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -10,10 +10,12 @@ _leader_ index is replicated to one or more read-only _follower_ indices on your
 configure disaster recovery, bring data closer to your users, or establish a 
 centralized reporting cluster to process reports locally.
 
-<<modules-cross-cluster-search,{ccs-cap}>> enables you to run a search request 
-against one or more remote clusters. This capability provides each region
-with a global view of all clusters, allowing you to send a search request from
-a local cluster and return results from all connected remote clusters. 
+<<modules-cross-cluster-search,{ccs-cap}>> enables you to run a search request
+against one or more remote clusters. This capability provides each region with a
+global view of all clusters, allowing you to send a search request from a local
+cluster and return results from all connected remote clusters. For full {ccs}
+capabilities, the local and remote cluster must be on the same
+{subscriptions}[subscription level].
 
 Enabling and configuring security is important on both local and remote
 clusters. When connecting a local cluster to remote clusters, an {es} superuser

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -32,6 +32,9 @@ run {es} on your own hardware, see <<remote-clusters>>.
 To ensure your remote cluster configuration supports {ccs}, see
 <<ccs-supported-configurations>>.
 
+* For full {ccs} capabilities, the local and remote cluster must be on the same
+{subscriptions}[subscription level].
+
 * The local coordinating node must have the
 <<remote-node,`remote_cluster_client`>> node role.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] Note license requirements for CCS (#97252)](https://github.com/elastic/elasticsearch/pull/97252)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)