### PR TITLE
[7.17][DOC] Consistently reference indices parameter in API key examples

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -93,7 +93,7 @@ POST /_security/api_key
   "role_descriptors": { <2>
     "role-a": {
       "cluster": ["all"],
-      "index": [
+      "indices": [
         {
           "names": ["index-a*"],
           "privileges": ["read"]
@@ -102,7 +102,7 @@ POST /_security/api_key
     },
     "role-b": {
       "cluster": ["all"],
-      "index": [
+      "indices": [
         {
           "names": ["index-b*"],
           "privileges": ["all"]

--- a/x-pack/docs/en/rest-api/security/grant-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/grant-api-keys.asciidoc
@@ -123,7 +123,7 @@ POST /_security/api_key/grant
     "role_descriptors": {
       "role-a": {
         "cluster": ["all"],
-        "index": [
+        "indices": [
           {
           "names": ["index-a*"],
           "privileges": ["read"]
@@ -132,7 +132,7 @@ POST /_security/api_key/grant
       },
       "role-b": {
         "cluster": ["all"],
-        "index": [
+        "indices": [
           {
           "names": ["index-b*"],
           "privileges": ["all"]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOC] Consistently reference indices parameter in API key examples (#97174)
