### PR TITLE
[ML] When estimating memory usage account for the number of allocations

### DIFF
--- a/docs/changelog/97275.yaml
+++ b/docs/changelog/97275.yaml
@@ -1,0 +1,5 @@
+pr: 97275
+summary: When estimating memory usage account for the number of allocations
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -650,8 +650,11 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         }
     }
 
+    /**
+     * Usage for a single allocation
+     */
     public static long estimateMemoryUsageBytes(String modelId, long totalDefinitionLength) {
-        return estimateMemoryUsageBytes(modelId, totalDefinitionLength);
+        return estimateMemoryUsageBytes(modelId, totalDefinitionLength, 1);
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentTaskParamsTests.java
@@ -130,5 +130,11 @@ public class StartTrainedModelDeploymentTaskParamsTests extends AbstractXContent
             long elserMemUsagePerAllocation = ByteSizeValue.ofMb(1002).getBytes();
             assertEquals(elserMemUsage + 4 * elserMemUsagePerAllocation, task.estimateMemoryUsageBytes());
         }
+        {
+            assertEquals(
+                executableMemoryOverhead + 2 * modelSizeBytes,
+                StartTrainedModelDeploymentAction.estimateMemoryUsageBytes("not-elser", modelSizeBytes)
+            );
+        }
     }
 }


### PR DESCRIPTION
When a model deployment has multiple allocations and those allocations use the same model in memory the extra memory used by those is not accounted for when the trained model allocation service is making decisions about where to locate the allocations. This has not been an issue as the CPU to memory ratio on the machines provided by the major CSP offers protected from the problem. Each allocation requires a certain number of threads, at 1 hardware thread : 2GB memory the extra memory requirements are covered implicitly by trying to satisfy the CPU requirements.  