### PR TITLE
Fix reused/recovered bytes for files that are recovered from cache

### DIFF
--- a/docs/changelog/97278.yaml
+++ b/docs/changelog/97278.yaml
@@ -1,0 +1,6 @@
+pr: 97278
+summary: Fix reused/recovered bytes for files that are recovered from cache
+area: Snapshot/Restore
+type: bug
+issues:
+ - 95994


### PR DESCRIPTION
Fix in #95987 wasn't complete, I did not restore all the previous behavior :(

Closes #95994
