### PR TITLE
[8.9] Move get lifecycle API to Management thread pool and make cancellable (#97248)

### DIFF
--- a/docs/changelog/97248.yaml
+++ b/docs/changelog/97248.yaml
@@ -1,0 +1,6 @@
+pr: 97248
+summary: Move get lifecycle API to Management thread pool and make cancellable
+area: ILM+SLM
+type: enhancement
+issues:
+ - 96568

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
@@ -16,6 +16,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
@@ -23,6 +26,7 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> {
@@ -111,6 +115,11 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
 
         public Request() {
             policyNames = Strings.EMPTY_ARRAY;
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, "get-lifecycle-task", parentTaskId, headers);
         }
 
         public String[] getPolicyNames() {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestGetLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestGetLifecycleAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 
@@ -37,6 +38,10 @@ public class RestGetLifecycleAction extends BaseRestHandler {
         getLifecycleRequest.timeout(restRequest.paramAsTime("timeout", getLifecycleRequest.timeout()));
         getLifecycleRequest.masterNodeTimeout(restRequest.paramAsTime("master_timeout", getLifecycleRequest.masterNodeTimeout()));
 
-        return channel -> client.execute(GetLifecycleAction.INSTANCE, getLifecycleRequest, new RestToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            GetLifecycleAction.INSTANCE,
+            getLifecycleRequest,
+            new RestToXContentListener<>(channel)
+        );
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportGetLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportGetLifecycleAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -55,12 +56,18 @@ public class TransportGetLifecycleAction extends TransportMasterNodeAction<Reque
             Request::new,
             indexNameExpressionResolver,
             Response::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT
         );
     }
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) {
+        assert task instanceof CancellableTask : "get lifecycle requests should be cancellable";
+        final CancellableTask cancellableTask = (CancellableTask) task;
+        if (cancellableTask.notifyIfCancelled(listener)) {
+            return;
+        }
+
         IndexLifecycleMetadata metadata = clusterService.state().metadata().custom(IndexLifecycleMetadata.TYPE);
         if (metadata == null) {
             if (request.getPolicyNames().length == 0) {
@@ -88,6 +95,9 @@ public class TransportGetLifecycleAction extends TransportMasterNodeAction<Reque
             for (String name : names) {
                 if (Regex.isSimpleMatchPattern(name)) {
                     for (Map.Entry<String, LifecyclePolicyMetadata> entry : metadata.getPolicyMetadatas().entrySet()) {
+                        if (cancellableTask.notifyIfCancelled(listener)) {
+                            return;
+                        }
                         LifecyclePolicyMetadata policyMetadata = entry.getValue();
                         if (Regex.simpleMatch(name, entry.getKey())) {
                             policyResponseItemMap.put(


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Move get lifecycle API to Management thread pool and make cancellable (#97248)