### PR TITLE
Muting complex async-search cancel-via-search-timeout test that fails due to IT infra flakiness

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -346,6 +346,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97286")
     public void testCancellationViaTimeoutWithAllowPartialResultsSetToFalse() throws Exception {
         setupTwoClusters();
 


### PR DESCRIPTION
Created issue #97286 for later research and fix.
