### PR TITLE
Keywords for main ILM doc

### DIFF
--- a/docs/reference/ilm/index.asciidoc
+++ b/docs/reference/ilm/index.asciidoc
@@ -2,6 +2,8 @@
 [[index-lifecycle-management]]
 == {ilm-init}: Manage the index lifecycle
 
+:keywords: ILM, lifecycle, index lifecycle management
+
 // [partintro]
 --
 You can configure {ilm} ({ilm-init}) policies to automatically manage indices


### PR DESCRIPTION
👋 howdy, team! I'm hoping adding keywords for ILM helps surface this main ILM doc in the ES doc's search.

Currently, searching for "ilm" does not find the main ILM doc:

<img width="788" alt="image" src="https://github.com/elastic/elasticsearch/assets/26751266/e26b06f5-e0a1-48ba-b50f-a8a88698cac3">

searching "index lif" (but not "index life") gets you to a sub-section

<img width="784" alt="image" src="https://github.com/elastic/elasticsearch/assets/26751266/4c901fe4-a2af-4cc0-bff4-12c195d9e680">

but you have to enter at least "index lifecycle" to find this main ILM page:

<img width="786" alt="image" src="https://github.com/elastic/elasticsearch/assets/26751266/597cd1df-2b16-4b14-bd5f-4c3bac627b77">
