### PR TITLE
add match word on the explanation for allocation explain

### DIFF
--- a/docs/changelog/97308.yaml
+++ b/docs/changelog/97308.yaml
@@ -1,6 +1,0 @@
-pr: 97308
-summary: Add `match` word to the explanation return for the Cluster Include Filter Decider
-area: Allocation
-type: enhancement
-issues:
- - 97307

--- a/docs/changelog/97308.yaml
+++ b/docs/changelog/97308.yaml
@@ -1,0 +1,6 @@
+pr: 97308
+summary: Add `match` word to the explanation return for the Cluster Include Filter Decider
+area: Allocation
+type: enhancement
+issues:
+ - 97307

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -197,7 +197,7 @@ public class FilterAllocationDecider extends AllocationDecider {
                 return allocation.decision(
                     Decision.NO,
                     NAME,
-                    "node does not cluster setting [%s] filters [%s]",
+                    "node does not match cluster setting [%s] filters [%s]",
                     CLUSTER_ROUTING_INCLUDE_GROUP_PREFIX,
                     clusterIncludeFilters
                 );


### PR DESCRIPTION
Add the word _match_ on the field `explanation` for the Cluster Allocation Explain API.

Currently the message is:

> node does not cluster setting [cluster-setting] filters [filters]

But it should be

> node does not **match** cluster setting [cluster-setting] filters [filters]

This happens while checking the include decider at the Cluster level, the include decider at the Index level has the correct message already.

- Fix #97307 