### PR TITLE
Fix comment on (Serverless) Scope.INTERNAL

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/Scope.java
+++ b/server/src/main/java/org/elasticsearch/rest/Scope.java
@@ -10,5 +10,5 @@ package org.elasticsearch.rest;
 
 public enum Scope {
     PUBLIC, // available to all requests
-    INTERNAL // available only to requests with a X-elastic-internal-origin header
+    INTERNAL // available only to requests from an operator user
 }


### PR DESCRIPTION
Updates the comment on Scope.INTERNAL to match the latest implementation