### PR TITLE
[8.9] Chunk the GET _ilm/policy response (#97251)

### DIFF
--- a/docs/changelog/97251.yaml
+++ b/docs/changelog/97251.yaml
@@ -1,0 +1,6 @@
+pr: 97251
+summary: Chunk the GET _ilm/policy response
+area: ILM+SLM
+type: enhancement
+issues:
+ - 96569

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleResponseTests.java
@@ -7,10 +7,14 @@
 package org.elasticsearch.xpack.core.ilm.action;
 
 import org.elasticsearch.cluster.metadata.ItemUsage;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
 import org.elasticsearch.xpack.core.ilm.LifecycleType;
 import org.elasticsearch.xpack.core.ilm.MockAction;
@@ -18,11 +22,17 @@ import org.elasticsearch.xpack.core.ilm.TestLifecycleType;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction.LifecyclePolicyResponseItem;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction.Response;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ilm.LifecyclePolicyTests.randomTestLifecyclePolicy;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class GetLifecycleResponseTests extends AbstractWireSerializingTestCase<Response> {
 
@@ -41,6 +51,36 @@ public class GetLifecycleResponseTests extends AbstractWireSerializingTestCase<R
             );
         }
         return new Response(responseItems);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToXContent() throws IOException {
+        Response response = createTestInstance();
+        XContentBuilder builder = jsonBuilder().prettyPrint();
+        response.toXContentChunked(EMPTY_PARAMS).forEachRemaining(xcontent -> {
+            try {
+                xcontent.toXContent(builder, EMPTY_PARAMS);
+            } catch (IOException e) {
+                logger.error(e.getMessage(), e);
+                fail(e.getMessage());
+            }
+        });
+        Map<String, Object> xContentMap = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+        assertThat(xContentMap.size(), is(response.getPolicies().size()));
+        for (LifecyclePolicyResponseItem policy : response.getPolicies()) {
+            Map<String, Object> policyAsXContent = (Map<String, Object>) xContentMap.get(policy.getLifecyclePolicy().getName());
+            assertThat(policyAsXContent, notNullValue());
+            assertThat(policyAsXContent.get("version"), is(policy.getVersion()));
+            assertThat(policyAsXContent.get("modified_date"), is(policy.getModifiedDate()));
+            assertThat(policyAsXContent.get("policy"), notNullValue());
+        }
+    }
+
+    public void testChunkCount() {
+        Response response = createTestInstance();
+        // we have 2 chunks surrounding the policies - one for { and } respectively
+        // we have one chunk / policy
+        AbstractChunkedSerializingTestCase.assertChunkCount(response, ignored -> 2 + response.getPolicies().size());
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestGetLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestGetLifecycleAction.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 
 import java.util.List;
@@ -41,7 +41,7 @@ public class RestGetLifecycleAction extends BaseRestHandler {
         return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
             GetLifecycleAction.INSTANCE,
             getLifecycleRequest,
-            new RestToXContentListener<>(channel)
+            new RestChunkedToXContentListener<>(channel)
         );
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Chunk the GET _ilm/policy response (#97251)