### PR TITLE
Increase blob container max register content length

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/support/BlobContainerUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/support/BlobContainerUtils.java
@@ -21,7 +21,7 @@ public class BlobContainerUtils {
         // no instances
     }
 
-    public static final int MAX_REGISTER_CONTENT_LENGTH = Long.BYTES;
+    public static final int MAX_REGISTER_CONTENT_LENGTH = 2 * Long.BYTES;
 
     public static void ensureValidRegisterContent(BytesReference bytesReference) {
         if (bytesReference.length() > MAX_REGISTER_CONTENT_LENGTH) {

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -188,7 +188,7 @@ public class FsBlobContainerTests extends ESTestCase {
             expectedValue.set(newValue);
         }
 
-        container.writeBlob(key, new BytesArray(new byte[9]), false);
+        container.writeBlob(key, new BytesArray(new byte[17]), false);
         expectThrows(
             IllegalStateException.class,
             () -> getBytesAsync(l -> container.compareAndExchangeRegister(key, expectedValue.get(), BytesArray.EMPTY, l))


### PR DESCRIPTION
We want to store another long in these now, so bump this up to 16.
