### PR TITLE
Fix DataStreamsClientYamlTestSuiteIT test {p0=data_stream/250_logs_no_subobjects/Test flattened document with subobjects-false}

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/250_logs_no_subobjects.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/250_logs_no_subobjects.yml
@@ -1,6 +1,9 @@
 ---
 Test flattened document with subobjects-false:
 # NOTE: this doesn't work. In order to run this test set "subobjects: false" through logs-mappings.json
+  - skip:
+      features: allowed_warnings
+
   - do:
       cluster.put_component_template:
         name: logs-test-subobjects-mappings
@@ -22,6 +25,8 @@ Test flattened document with subobjects-false:
                   type: constant_keyword
 
   - do:
+      allowed_warnings:
+          - "index template [logs-ecs-test-template] has index patterns [logs-*-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logs-ecs-test-template] will take precedence during new index creation"
       indices.put_index_template:
         name: logs-ecs-test-template
         body:


### PR DESCRIPTION
Both failing tests are passing now:

```
 ./gradlew ':modules:data-streams:yamlRestTest' --tests "org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT.test {p0=data_stream/250_logs_no_subobjects/Test flattened document with subobjects-false}" -Dtests.seed=41528256000D2860

> Configure project :x-pack:plugin:searchable-snapshots:qa:hdfs
hdfsFixture unsupported, please set HADOOP_HOME and put HADOOP_HOME\bin in PATH
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 8.1.1
  OS Info               : Mac OS X 13.4.1 (aarch64)
  JDK Version           : 19.0.1+11 (BellSoft Liberica)
  JAVA_HOME             : /Users/palcantar/.sdkman/candidates/java/19.0.1-librca
  Random Testing Seed   : 41528256000D2860
  In FIPS 140 mode      : false
=======================================

> Task :modules:data-streams:yamlRestTest
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.gradle.api.internal.tasks.testing.worker.TestWorker (file:/Users/palcantar/.gradle/wrapper/dists/gradle-8.1.1-all/bs1rrjki8hh9bujwbsqnxtuzr/gradle-8.1.1/lib/plugins/gradle-testing-base-8.1.1.jar)
WARNING: Please consider reporting this to the maintainers of org.gradle.api.internal.tasks.testing.worker.TestWorker
WARNING: System::setSecurityManager will be removed in a future release

BUILD SUCCESSFUL in 19s
506 actionable tasks: 5 executed, 501 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/7ocqcparkuvri

---

./gradlew ':modules:data-streams:yamlRestTest' --tests "org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT.test {p0=data_stream/250_logs_no_subobjects/Test flattened document with subobjects-false}" -Dtests.seed=6A8DB27272757BDF

> Configure project :x-pack:plugin:searchable-snapshots:qa:hdfs
hdfsFixture unsupported, please set HADOOP_HOME and put HADOOP_HOME\bin in PATH
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 8.1.1
  OS Info               : Mac OS X 13.4.1 (aarch64)
  JDK Version           : 19.0.1+11 (BellSoft Liberica)
  JAVA_HOME             : /Users/palcantar/.sdkman/candidates/java/19.0.1-librca
  Random Testing Seed   : 6A8DB27272757BDF
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 4s
506 actionable tasks: 5 executed, 1 from cache, 500 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/yfxgxywiedxjo
```

Closes #97155