### PR TITLE
Incorrect name for sort field

### DIFF
--- a/docs/reference/aggregations/metrics/geoline-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geoline-aggregation.asciidoc
@@ -115,7 +115,7 @@ Example usage configuring `@timestamp` as the sort key:
 
 [source,js]
 ----
-"point": {
+"sort": {
   "field": "@timestamp"
 }
 ----


### PR DESCRIPTION
Trivial docs update. We're doing a much bigger change to this page for 8.9 (and main), so we only target 8.8 and earlier for this small fix.