### PR TITLE
[8.7] Incorrect name for sort field (#97328)

### DIFF
--- a/docs/reference/aggregations/metrics/geoline-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/geoline-aggregation.asciidoc
@@ -115,7 +115,7 @@ Example usage configuring `@timestamp` as the sort key:
 
 [source,js]
 ----
-"point": {
+"sort": {
   "field": "@timestamp"
 }
 ----


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Incorrect name for sort field (#97328)