### PR TITLE
Add synonyms feature for test clusters

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.Version
+
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.rest-resources'
@@ -35,6 +37,10 @@ dependencies {
   clusterModules project(":modules:mapper-extras")
   clusterModules project(":modules:rest-root")
   clusterModules project(":modules:reindex")
+}
+
+testClusters.configureEach {
+  requiresFeature 'es.synonyms_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->


### PR DESCRIPTION
For snapshots builds we automatically enable all feature flags, but for release builds they need to be explicitly added to test clusters for tests.
This PR does it for synonyms feature.

Closes #96641, #97177