### PR TITLE
[Profiling] Wait for ILM policies to be created

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -98,17 +98,17 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
             return;
         }
 
-        // ensure that index templates are present
-        if (isAllTemplatesCreated(event) == false) {
-            logger.trace("Skipping index creation; not all templates are present yet");
+        // ensure that all resources are present that we need to create indices
+        if (isAllResourcesCreated(event) == false) {
+            logger.trace("Skipping index creation; not all required resources are present yet");
             return;
         }
 
         addIndicesIfMissing(event.state());
     }
 
-    protected boolean isAllTemplatesCreated(ClusterChangedEvent event) {
-        return ProfilingIndexTemplateRegistry.areAllTemplatesCreated(event.state());
+    protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
+        return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state());
     }
 
     private void addIndicesIfMissing(ClusterState state) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
@@ -261,7 +262,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
         }
     }
 
-    public static boolean areAllTemplatesCreated(ClusterState state) {
+    public static boolean isAllResourcesCreated(ClusterState state) {
         for (String componentTemplate : COMPONENT_TEMPLATE_CONFIGS.keySet()) {
             if (state.metadata().componentTemplates().containsKey(componentTemplate) == false) {
                 return false;
@@ -269,6 +270,12 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
         }
         for (String composableTemplate : COMPOSABLE_INDEX_TEMPLATE_CONFIGS.keySet()) {
             if (state.metadata().templatesV2().containsKey(composableTemplate) == false) {
+                return false;
+            }
+        }
+        for (LifecyclePolicy lifecyclePolicy : LIFECYCLE_POLICIES) {
+            IndexLifecycleMetadata ilmMetadata = state.metadata().custom(IndexLifecycleMetadata.TYPE);
+            if (ilmMetadata == null || ilmMetadata.getPolicies().containsKey(lifecyclePolicy.getName()) == false) {
                 return false;
             }
         }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetStatusAction.java
@@ -53,7 +53,7 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
     ) {
         boolean pluginEnabled = XPackSettings.PROFILING_ENABLED.get(state.getMetadata().settings());
         boolean resourceManagementEnabled = ProfilingPlugin.PROFILING_TEMPLATES_ENABLED.get(state.getMetadata().settings());
-        boolean resourcesCreated = ProfilingIndexTemplateRegistry.areAllTemplatesCreated(state);
+        boolean resourcesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state);
         listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated));
     }
 

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
@@ -62,7 +62,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
         indexManager = new ProfilingIndexManager(threadPool, client, clusterService) {
             @Override
-            protected boolean isAllTemplatesCreated(ClusterChangedEvent event) {
+            protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
                 return templatesCreated.get();
             }
         };


### PR DESCRIPTION
In order to create profiling indices we rely on index templates, hence we defer index creation until all of them are present. Some of these index templates might also specify an ILM policy. However, we did not defer index creation until the ILM policy was present which can lead to races between index and ILM policy creation. In this commit we add an additional check to wait until all required ILM policies have been created. Only then we proceed to create indices.