### PR TITLE
[8.8] Fix reused/recovered bytes for files that are recovered from cache (#97278)

### DIFF
--- a/docs/changelog/97278.yaml
+++ b/docs/changelog/97278.yaml
@@ -1,0 +1,6 @@
+pr: 97278
+summary: Fix reused/recovered bytes for files that are recovered from cache
+area: Snapshot/Restore
+type: bug
+issues:
+ - 95994


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix reused/recovered bytes for files that are recovered from cache (#97278)