### PR TITLE
Initialise ES logging in CLI

### DIFF
--- a/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
+++ b/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
@@ -112,6 +112,8 @@ class CliToolLauncher {
         final String loggerLevel = sysprops.getOrDefault("es.logger.level", Level.INFO.name());
         final Settings settings = Settings.builder().put("logger.level", loggerLevel).build();
         LogConfigurator.configureWithoutConfig(settings);
+        // a temporary fix to allow a cli-launcher.jar replacement. That method should is called in configureWithoutConfig
+        LogConfigurator.configureESLogging();
     }
 
     /**

--- a/docs/changelog/97353.yaml
+++ b/docs/changelog/97353.yaml
@@ -1,6 +1,6 @@
 pr: 97353
 summary: Initialise ES logging in CLI
-area: "Infra/CLI, Infra/Logging"
+area: Infra/CLI
 type: bug
 issues:
  - 97350

--- a/docs/changelog/97353.yaml
+++ b/docs/changelog/97353.yaml
@@ -1,0 +1,6 @@
+pr: 97353
+summary: Initialise ES logging in CLI
+area: "Infra/CLI, Infra/Logging"
+type: bug
+issues:
+ - 97350

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -100,6 +100,7 @@ public class LogConfigurator {
      */
     public static void configureWithoutConfig(final Settings settings) {
         Objects.requireNonNull(settings);
+        configureESLogging();
         // we initialize the status logger immediately otherwise Log4j will complain when we try to get the context
         configureStatusLogger();
         configureLoggerLevels(settings);


### PR DESCRIPTION
ES logging has to be explicitly initialised with a call to LoggerFactory.setInstance This is normally done as LogConfigurator.configure(Environment,boolean) is calling this as part of initPhase1

However CLI tools were not using that method. Cli tools are using LogConfigurator.configureWithoutConfig and that method was not setting up ES logging

This commit modifies configureWithoutConfig to also configure esLogging It also adds a LogConfigurator.configureESLogging call explicitly in CliToolLauncher This allows to build a new cli-launcher.jar and replace it in previous 8.7-8.9 clusters

closes #97350