### PR TITLE
[ML] Fix WordPiece tokenization where stripping accents results in an empty string

### DIFF
--- a/docs/changelog/97354.yaml
+++ b/docs/changelog/97354.yaml
@@ -1,0 +1,6 @@
+pr: 97354
+summary: Fix `WordPiece` tokenization where stripping accents results in an empty
+  string
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -75,9 +75,17 @@ public class BertTokenizerTests extends ESTestCase {
         List<String> vocab = List.of(
             "Arabic",
             ":",
-            "و, ##ق",
+            "##ق",
+            "و",
             "3",
-            "ا, ##ل, ##ا, ##ز, ##د, ##ه, ##ا, ##م",
+            "##م",
+            "##ا",
+            "##ه",
+            "##د",
+            "##ز",
+            "##ا",
+            "##ل",
+            "ا",
             ".",
             "4",
             "There",
@@ -112,52 +120,64 @@ public class BertTokenizerTests extends ESTestCase {
         String inputWithAccentsToStrip1 = "  Arabic: وَقْ 3 ُ الِازْدِهَام.4  ";
         String inputWithAccentsToStrip2 =
             "There are 2 main types of non melanoma skin cancer ̶̶ basal cell carcinoma (BCC) and squamous cell carcinoma (SCC).";
+        String inputWithAccentToStripAtEndOfString = "There are 2 main types of non melanoma skin cancer ̶̶";
+        String onlyAccents = " ̶̶";
         try (
             BertTokenizer tokenizer = BertTokenizer.builder(vocab, new BertTokenization(true, true, null, Tokenization.Truncate.NONE, -1))
                 .build()
         ) {
             TokenizationResult.Tokens tokenization = tokenizer.tokenize(inputWithAccentsToStrip1, Tokenization.Truncate.NONE, -1, 0).get(0);
-            assertThat(tokenization.tokenIds(), equalTo(new int[] { 29, 0, 1, 32, 3, 32, 5, 6, 30 }));
+            assertThat(tokenization.tokenIds(), equalTo(new int[] { 37, 0, 1, 3, 2, 4, 12, 11, 10, 9, 8, 7, 10, 5, 13, 14, 38 }));
 
             tokenization = tokenizer.tokenize(inputWithAccentsToStrip2, Tokenization.Truncate.NONE, -1, 0).get(0);
             assertThat(
                 tokenization.tokenIds(),
                 equalTo(
                     new int[] {
-                        29,
-                        7,
-                        8,
-                        9,
-                        10,
-                        11,
-                        12,
-                        13,
-                        14,
+                        37,
                         15,
                         16,
                         17,
                         18,
-                        32,
+                        19,
                         20,
                         21,
                         22,
-                        16,
                         23,
+                        24,
                         25,
-                        24,
-                        27,
-                        28,
-                        20,
-                        21,
-                        22,
-                        16,
-                        23,
                         26,
+                        40,
+                        28,
+                        29,
+                        30,
                         24,
-                        5,
-                        30 }
+                        31,
+                        33,
+                        32,
+                        35,
+                        36,
+                        28,
+                        29,
+                        30,
+                        24,
+                        31,
+                        34,
+                        32,
+                        13,
+                        38 }
                 )
             );
+
+            tokenization = tokenizer.tokenize(inputWithAccentToStripAtEndOfString, Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenization.tokenIds(), equalTo(new int[] { 37, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 38 }));
+            // the last token is the separator, the one before that should
+            // correspond to the last word in the input _not_ the accent
+            assertEquals("cancer", vocab.get(26));
+
+            tokenization = tokenizer.tokenize(onlyAccents, Tokenization.Truncate.NONE, -1, 0).get(0);
+            // empty tokenization only contains ClASS and SEP tokens
+            assertThat(tokenization.tokenIds(), equalTo(new int[] { 37, 38 }));
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Certain inputs strings can be tokenised in such a way that the token is an accent that is later removed if strip accents is enabled. This results and an empty string that the WordPiece algorithm skips over but the code expects at least one token to be produced.

The fix is to have the basic token filter proceed to the next token if the token is an empty string.