### PR TITLE
[8.9] Initialise ES logging in CLI (#97353)

### DIFF
--- a/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
+++ b/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
@@ -112,6 +112,8 @@ class CliToolLauncher {
         final String loggerLevel = sysprops.getOrDefault("es.logger.level", Level.INFO.name());
         final Settings settings = Settings.builder().put("logger.level", loggerLevel).build();
         LogConfigurator.configureWithoutConfig(settings);
+        // a temporary fix to allow a cli-launcher.jar replacement. That method should is called in configureWithoutConfig
+        LogConfigurator.configureESLogging();
     }
 
     /**

--- a/docs/changelog/97353.yaml
+++ b/docs/changelog/97353.yaml
@@ -1,0 +1,6 @@
+pr: 97353
+summary: Initialise ES logging in CLI
+area: Infra/CLI
+type: bug
+issues:
+ - 97350

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -100,6 +100,7 @@ public class LogConfigurator {
      */
     public static void configureWithoutConfig(final Settings settings) {
         Objects.requireNonNull(settings);
+        configureESLogging();
         // we initialize the status logger immediately otherwise Log4j will complain when we try to get the context
         configureStatusLogger();
         configureLoggerLevels(settings);


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Initialise ES logging in CLI (#97353)