### PR TITLE
[8.9] [ML] Fix WordPiece tokenization where stripping accents results in an empty string (#97354)

### DIFF
--- a/docs/changelog/97354.yaml
+++ b/docs/changelog/97354.yaml
@@ -1,0 +1,6 @@
+pr: 97354
+summary: Fix `WordPiece` tokenization where stripping accents results in an empty
+  string
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [ML] Fix WordPiece tokenization where stripping accents results in an empty string (#97354)