### PR TITLE
Synonyms API - Delete synonym rule

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonym_rule.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonym_rule.delete.json
@@ -1,0 +1,39 @@
+{
+  "synonym_rule.delete": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonym-rule.html",
+      "description": "Deletes a synonym rule in a synonym set"
+    },
+    "stability": "experimental",
+    "visibility": "feature_flag",
+    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_synonyms/{synonyms_set}/{synonym_rule}",
+          "methods": [
+            "DELETE"
+          ],
+          "parts": {
+            "synonyms_set": {
+              "type": "string",
+              "description": "The id of the synonym set to be updated"
+            },
+            "synonym_rule": {
+              "type": "string",
+              "description": "The id of the synonym rule to be deleted"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -60,3 +60,32 @@ setup:
       synonym_rule.delete:
         synonyms_set: test-synonyms
         synonym_rule: test-non-existing-id
+
+---
+"Delete synonym rule - does not impact other synonym sets":
+  - do:
+      synonyms.put:
+        synonyms_set: test-other-synonyms
+        body:
+          synonyms_set:
+            - synonyms: "hola, hi"
+              id: "test-id-1"
+            - synonyms: "test => check"
+              id: "test-id-2"
+  - do:
+      synonym_rule.delete:
+        synonyms_set: test-synonyms
+        synonym_rule: test-id-1
+
+  - do:
+      synonyms.get:
+        synonyms_set: test-other-synonyms
+
+  - match:
+      count: 2
+  - match:
+      synonyms_set:
+        - synonyms: "hola, hi"
+          id: "test-id-1"
+        - synonyms: "test => check"
+          id: "test-id-2"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -1,0 +1,62 @@
+setup:
+  - skip:
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
+  - do:
+      synonyms.put:
+        synonyms_set: test-synonyms
+        body:
+          synonyms_set:
+            - synonyms: "hello, hi"
+              id: "test-id-1"
+            - synonyms: "bye => goodbye"
+              id: "test-id-2"
+            - synonyms: "test => check"
+              id: "test-id-3"
+
+---
+"Delete synonym rule":
+  - do:
+      synonym_rule.delete:
+        synonyms_set: test-synonyms
+        synonym_rule: test-id-2
+
+  - match:
+      acknowledged: true
+  - match: { reload_analyzers_details._shards.total: 0 }
+  - length: { reload_analyzers_details.reload_details: 0 }
+
+  - do:
+      catch: missing
+      synonym_rule.get:
+        synonyms_set: test-synonyms
+        synonym_rule: test-id-2
+
+  - do:
+      synonyms.get:
+        synonyms_set: test-synonyms
+
+  - match:
+      count: 2
+  - match:
+      synonyms_set:
+        - synonyms: "hello, hi"
+          id: "test-id-1"
+        - synonyms: "test => check"
+          id: "test-id-3"
+
+---
+"Delete synonym rule - missing synonym set":
+  - do:
+      catch: missing
+      synonym_rule.delete:
+        synonyms_set: test-non-existing-synonyms
+        synonym_rule: test-id-2
+
+---
+"Delete synonym rule - missing synonym rule":
+  - do:
+      catch: missing
+      synonym_rule.delete:
+        synonyms_set: test-synonyms
+        synonym_rule: test-non-existing-id

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -251,12 +251,14 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.synonyms.DeleteSynonymRuleAction;
 import org.elasticsearch.action.synonyms.DeleteSynonymsAction;
 import org.elasticsearch.action.synonyms.GetSynonymRuleAction;
 import org.elasticsearch.action.synonyms.GetSynonymsAction;
 import org.elasticsearch.action.synonyms.GetSynonymsSetsAction;
 import org.elasticsearch.action.synonyms.PutSynonymRuleAction;
 import org.elasticsearch.action.synonyms.PutSynonymsAction;
+import org.elasticsearch.action.synonyms.TransportDeleteSynonymRuleAction;
 import org.elasticsearch.action.synonyms.TransportDeleteSynonymsAction;
 import org.elasticsearch.action.synonyms.TransportGetSynonymRuleAction;
 import org.elasticsearch.action.synonyms.TransportGetSynonymsAction;
@@ -447,6 +449,7 @@ import org.elasticsearch.rest.action.search.RestKnnSearchAction;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchScrollAction;
+import org.elasticsearch.rest.action.synonyms.RestDeleteSynonymRuleAction;
 import org.elasticsearch.rest.action.synonyms.RestDeleteSynonymsAction;
 import org.elasticsearch.rest.action.synonyms.RestGetSynonymRuleAction;
 import org.elasticsearch.rest.action.synonyms.RestGetSynonymsAction;
@@ -803,6 +806,7 @@ public class ActionModule extends AbstractModule {
             actions.register(GetSynonymsSetsAction.INSTANCE, TransportGetSynonymsSetsAction.class);
             actions.register(PutSynonymRuleAction.INSTANCE, TransportPutSynonymRuleAction.class);
             actions.register(GetSynonymRuleAction.INSTANCE, TransportGetSynonymRuleAction.class);
+            actions.register(DeleteSynonymRuleAction.INSTANCE, TransportDeleteSynonymRuleAction.class);
         }
 
         return unmodifiableMap(actions.getRegistry());
@@ -1022,6 +1026,7 @@ public class ActionModule extends AbstractModule {
             registerHandler.accept(new RestGetSynonymsSetsAction());
             registerHandler.accept(new RestPutSynonymRuleAction());
             registerHandler.accept(new RestGetSynonymRuleAction());
+            registerHandler.accept(new RestDeleteSynonymRuleAction());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleAction.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.action.support.master.AcknowledgedResponse.ACKNOWLEDGED_KEY;
+
+public class DeleteSynonymRuleAction extends ActionType<DeleteSynonymRuleAction.Response> {
+
+    public static final DeleteSynonymRuleAction INSTANCE = new DeleteSynonymRuleAction();
+    public static final String NAME = "cluster:admin/synonym_rules/delete";
+
+    public DeleteSynonymRuleAction() {
+        super(NAME, DeleteSynonymRuleAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+        private final String synonymsSetId;
+
+        private final String synonymRuleId;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.synonymsSetId = in.readString();
+            this.synonymRuleId = in.readString();
+        }
+
+        public Request(String synonymsSetId, String synonymRuleId) {
+            this.synonymsSetId = synonymsSetId;
+            this.synonymRuleId = synonymRuleId;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+            if (Strings.isNullOrEmpty(synonymsSetId)) {
+                validationException = ValidateActions.addValidationError("synonyms set must be specified", validationException);
+            }
+            if (Strings.isNullOrEmpty(synonymRuleId)) {
+                validationException = ValidateActions.addValidationError("synonym rule id must be specified", validationException);
+            }
+
+            return validationException;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(synonymsSetId);
+            out.writeString(synonymRuleId);
+        }
+
+        public String synonymsSetId() {
+            return synonymsSetId;
+        }
+
+        public String synonymRuleId() {
+            return synonymRuleId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return Objects.equals(synonymsSetId, request.synonymsSetId) && Objects.equals(synonymRuleId, request.synonymRuleId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(synonymsSetId, synonymRuleId);
+        }
+    }
+
+    // TODO Remove duplicates
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private final AcknowledgedResponse acknowledgedResponse;
+        private final ReloadAnalyzersResponse reloadAnalyzersResponse;
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.acknowledgedResponse = AcknowledgedResponse.readFrom(in);
+            this.reloadAnalyzersResponse = new ReloadAnalyzersResponse(in);
+        }
+
+        public Response(AcknowledgedResponse acknowledgedResponse, ReloadAnalyzersResponse reloadAnalyzersResponse) {
+            super();
+            Objects.requireNonNull(acknowledgedResponse, "Acknowledge response must not be null");
+            Objects.requireNonNull(reloadAnalyzersResponse, "Reload analyzers response must not be null");
+            this.acknowledgedResponse = acknowledgedResponse;
+            this.reloadAnalyzersResponse = reloadAnalyzersResponse;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startObject();
+            {
+                builder.field(ACKNOWLEDGED_KEY, acknowledgedResponse.isAcknowledged());
+                builder.field("reload_analyzers_details");
+                reloadAnalyzersResponse.toXContent(builder, params);
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            acknowledgedResponse.writeTo(out);
+            reloadAnalyzersResponse.writeTo(out);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DeleteSynonymRuleAction.Response response = (DeleteSynonymRuleAction.Response) o;
+            return Objects.equals(acknowledgedResponse, response.acknowledgedResponse)
+                && Objects.equals(reloadAnalyzersResponse, response.reloadAnalyzersResponse);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(acknowledgedResponse, reloadAnalyzersResponse);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/synonyms/TransportDeleteSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/TransportDeleteSynonymRuleAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.synonyms.SynonymsManagementAPIService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportDeleteSynonymRuleAction extends HandledTransportAction<
+    DeleteSynonymRuleAction.Request,
+    DeleteSynonymRuleAction.Response> {
+
+    private final SynonymsManagementAPIService synonymsManagementAPIService;
+
+    @Inject
+    public TransportDeleteSynonymRuleAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+        super(DeleteSynonymRuleAction.NAME, transportService, actionFilters, DeleteSynonymRuleAction.Request::new);
+
+        this.synonymsManagementAPIService = new SynonymsManagementAPIService(client);
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        DeleteSynonymRuleAction.Request request,
+        ActionListener<DeleteSynonymRuleAction.Response> listener
+    ) {
+        synonymsManagementAPIService.deleteSynonymRule(
+            request.synonymsSetId(),
+            request.synonymRuleId(),
+            listener.map(dr -> new DeleteSynonymRuleAction.Response(dr.synonymsOperationResult(), dr.reloadAnalyzersResponse()))
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/synonyms/RestDeleteSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/synonyms/RestDeleteSynonymRuleAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action.synonyms;
+
+import org.elasticsearch.action.synonyms.DeleteSynonymRuleAction;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+@ServerlessScope(Scope.PUBLIC)
+public class RestDeleteSynonymRuleAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "synonyms_rules_delete_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, "/_synonyms/{synonymsSet}/{synonymRuleId}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        DeleteSynonymRuleAction.Request request = new DeleteSynonymRuleAction.Request(
+            restRequest.param("synonymsSet"),
+            restRequest.param("synonymRuleId")
+        );
+        return channel -> client.execute(DeleteSynonymRuleAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -291,7 +291,11 @@ public class SynonymsManagementAPIService {
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                     .execute(l1.delegateFailure((l2, deleteResponse) -> {
                         if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                            l2.onFailure(new ResourceNotFoundException("synonym rule [" + synonymRuleId + "] not found on synonym set [" + synonymSetId + "]"));
+                            l2.onFailure(
+                                new ResourceNotFoundException(
+                                    "synonym rule [" + synonymRuleId + "] not found on synonym set [" + synonymSetId + "]"
+                                )
+                            );
                             return;
                         }
 

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -288,6 +288,7 @@ public class SynonymsManagementAPIService {
             synonymSetId,
             listener.delegateFailure(
                 (l1, obj) -> client.prepareDelete(SYNONYMS_ALIAS_NAME, internalSynonymRuleId(synonymSetId, synonymRuleId))
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                     .execute(new DelegatingIndexNotFoundActionListener<>(synonymSetId, l1, (l2, deleteResponse) -> {
                         if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
                             l2.onFailure(new ResourceNotFoundException("synonym rule [" + synonymRuleId + "] not found"));

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -291,7 +291,7 @@ public class SynonymsManagementAPIService {
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                     .execute(l1.delegateFailure((l2, deleteResponse) -> {
                         if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                            l2.onFailure(new ResourceNotFoundException("synonym rule [" + synonymRuleId + "] not found"));
+                            l2.onFailure(new ResourceNotFoundException("synonym rule [" + synonymRuleId + "] not found on synonym set [" + synonymSetId + "]"));
                             return;
                         }
 

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -289,7 +289,7 @@ public class SynonymsManagementAPIService {
             listener.delegateFailure(
                 (l1, obj) -> client.prepareDelete(SYNONYMS_ALIAS_NAME, internalSynonymRuleId(synonymSetId, synonymRuleId))
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .execute(new DelegatingIndexNotFoundActionListener<>(synonymSetId, l1, (l2, deleteResponse) -> {
+                    .execute(l1.delegateFailure((l2, deleteResponse) -> {
                         if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
                             l2.onFailure(new ResourceNotFoundException("synonym rule [" + synonymRuleId + "] not found"));
                             return;

--- a/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleActionRequestSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleActionRequestSerializingTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class DeleteSynonymRuleActionRequestSerializingTests extends AbstractWireSerializingTestCase<DeleteSynonymRuleAction.Request> {
+
+    @Override
+    protected Writeable.Reader<DeleteSynonymRuleAction.Request> instanceReader() {
+        return DeleteSynonymRuleAction.Request::new;
+    }
+
+    @Override
+    protected DeleteSynonymRuleAction.Request createTestInstance() {
+        return new DeleteSynonymRuleAction.Request(randomIdentifier(), randomIdentifier());
+    }
+
+    @Override
+    protected DeleteSynonymRuleAction.Request mutateInstance(DeleteSynonymRuleAction.Request instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleActionResponseSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymRuleActionResponseSerializingTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersResponse;
+import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersResponseTests;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+public class DeleteSynonymRuleActionResponseSerializingTests extends AbstractWireSerializingTestCase<DeleteSynonymRuleAction.Response> {
+
+    @Override
+    protected Writeable.Reader<DeleteSynonymRuleAction.Response> instanceReader() {
+        return DeleteSynonymRuleAction.Response::new;
+    }
+
+    @Override
+    protected DeleteSynonymRuleAction.Response createTestInstance() {
+        Map<String, ReloadAnalyzersResponse.ReloadDetails> reloadedIndicesDetails = ReloadAnalyzersResponseTests
+            .createRandomReloadDetails();
+        AcknowledgedResponse acknowledgedResponse = AcknowledgedResponse.of(randomBoolean());
+        return new DeleteSynonymRuleAction.Response(
+            acknowledgedResponse,
+            new ReloadAnalyzersResponse(10, 10, 0, null, reloadedIndicesDetails)
+        );
+    }
+
+    @Override
+    protected DeleteSynonymRuleAction.Response mutateInstance(DeleteSynonymRuleAction.Response instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    public void testToXContent() throws IOException {
+        Map<String, ReloadAnalyzersResponse.ReloadDetails> reloadedIndicesNodes = Collections.singletonMap(
+            "index",
+            new ReloadAnalyzersResponse.ReloadDetails("index", Collections.singleton("nodeId"), Collections.singleton("my_analyzer"))
+        );
+        ReloadAnalyzersResponse reloadAnalyzersResponse = new ReloadAnalyzersResponse(10, 5, 0, null, reloadedIndicesNodes);
+        AcknowledgedResponse acknowledgedResponse = AcknowledgedResponse.of(true);
+        DeleteSynonymsAction.Response response = new DeleteSynonymsAction.Response(acknowledgedResponse, reloadAnalyzersResponse);
+
+        String output = Strings.toString(response);
+        assertEquals(XContentHelper.stripWhitespace("""
+            {
+              "acknowledged": true,
+              "reload_analyzers_details": {
+                "_shards": {
+                  "total": 10,
+                  "successful": 5,
+                  "failed": 0
+                },
+                "reload_details": [
+                  {
+                    "index": "index",
+                    "reloaded_analyzers": [ "my_analyzer" ],
+                    "reloaded_node_ids": [ "nodeId" ]
+                  }
+                ]
+              }
+            }"""), output);
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -71,6 +71,7 @@ public class Constants {
         "cluster:admin/synonyms/get",
         "cluster:admin/synonyms/put",
         "cluster:admin/synonyms_sets/get",
+        "cluster:admin/synonym_rules/delete",
         "cluster:admin/synonym_rules/get",
         "cluster:admin/synonym_rules/put",
         "cluster:admin/settings/update",


### PR DESCRIPTION
Include a DELETE synonym rule endpoint:

`DELETE /_synonyms/<synonym_set>/<synonym_rule>`

Response:

```json
{
    "acknowledged": true,
    "reload_analyzers_details": {
        "_shards": {
            "total": 0,
            "successful": 0,
            "failed": 0
        },
        "reload_details": []
    }
}
```

There are currently some duplicated classes that I would like to refactor, but I'll do that on a separate PR.