### PR TITLE
[DOCS] Add docs for EQL missing events

### DIFF
--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -249,6 +249,87 @@ GET /my-data-stream/_eql/search
 ----
 // TEST[setup:sec_logs]
 
+Use `!` to match <<eql-missing-events,missing events>>: events in a sequence
+that do not meet a condition within a given timespan:
+
+[source,console]
+----
+GET /my-data-stream/_eql/search
+{
+  "query": """
+    sequence with maxspan=1d
+      [ process where process.name == "cmd.exe" ]
+      ![ process where stringContains(process.command_line, "ocx") ]
+      [ file where stringContains(file.name, "scrobj.dll") ]
+  """
+}
+----
+// TEST[setup:sec_logs]
+
+Missing events are indicated in the response as `missing": true`:
+
+[source,console-result]
+----
+{
+  ...
+  "hits": {
+    "total": ...,
+    "sequences": [
+      {
+        "events": [
+          {
+            "_index": ".ds-my-data-stream-2023.07.04-000001",
+            "_id": "AnpTIYkBrVQ2QEgsWg94",
+            "_source": {
+              "@timestamp": "2099-12-07T11:06:07.000Z",
+              "event": {
+                "category": "process",
+                "id": "cMyt5SZ2",
+                "sequence": 3
+              },
+              "process": {
+                "pid": 2012,
+                "name": "cmd.exe",
+                "executable": "C:\\Windows\\System32\\cmd.exe"
+              }
+            }
+          },
+          {
+            "missing": true
+          },
+          {
+            "_index": ".ds-my-data-stream-2023.07.04-000001",
+            "_id": "BHpTIYkBrVQ2QEgsWg94",
+            "_source": {
+              "@timestamp": "2099-12-07T11:07:10.000Z",
+              "event": {
+                "category": "file",
+                "id": "tZ1NWVOs",
+                "sequence": 5
+              },
+              "process": {
+                "pid": 2012,
+                "name": "regsvr32.exe",
+                "executable": "C:\\Windows\\System32\\regsvr32.exe"
+              },
+              "file": {
+                "path": "C:\\Windows\\System32\\scrobj.dll",
+                "name": "scrobj.dll"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+----
+// TESTRESPONSE[s/  \.\.\.\n/"is_partial": false, "is_running": false, "took": $body.took, "timed_out": false,/]
+// TESTRESPONSE[s/"total": \.\.\.,/"total": { "value": 1, "relation": "eq" },/]
+// TESTRESPONSE[s/"_index": ".ds-my-data-stream-2023.07.04-000001"/"_index": $body.hits.sequences.0.events.0._index/]
+// TESTRESPONSE[s/"_id": "AnpTIYkBrVQ2QEgsWg94"/"_id": $body.hits.sequences.0.events.0._id/]
+// TESTRESPONSE[s/"_id": "BHpTIYkBrVQ2QEgsWg94"/"_id": $body.hits.sequences.0.events.2._id/]
+
 Use the <<eql-by-keyword,`by` keyword>> to match events that share the
 same field values:
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -575,6 +575,40 @@ sequence with maxspan=15m
 ----
 
 [discrete]
+[[eql-missing-events]]
+==== Missing events
+
+Use `!` to match missing events: events in a timespan-constrained sequence that
+do not meet a given condition.
+
+[source,eql]
+----
+sequence with maxspan=1h
+  [ event_category_1 where condition_1 ]
+  ![ event_category_2 where condition_2 ]
+  [ event_category_3 where condition_3 ]
+  ...
+----
+
+Missing event clauses can be used at the beginning, at the end, and/or in the
+middle of a sequence, in any combination with positive event clauses. A sequence
+can have multiple missing event clauses, but needs to have at least one positive
+clause. <<eql-with-maxspan-keywords,`with maxspan`>> is mandatory when missing
+event clauses are present.
+
+
+*Example* +
+The following sequence query finds logon events that are not followed within 5
+seconds by a logoff event.
+
+[source,eql]
+----
+sequence by host.name, user.name with maxspan=5s
+  [ authentication where event.code : "4624" ]
+  ![ authentication where event.code : "4647" ]
+----
+
+[discrete]
 [[eql-by-keyword]]
 ==== `by` keyword
 


### PR DESCRIPTION
This PR adds documentation for EQL missing events (https://github.com/elastic/elasticsearch/pull/92348)