### PR TITLE
[Profiling] Add initial support for upgrades

### DIFF
--- a/docs/changelog/97380.yaml
+++ b/docs/changelog/97380.yaml
@@ -1,0 +1,5 @@
+pr: 97380
+summary: "[Profiling] Add initial support for upgrades"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
@@ -24,6 +24,10 @@
       "_source": {
         "enabled": false
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
@@ -26,7 +26,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.events.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
@@ -13,6 +13,10 @@
       "_source": {
         "mode": "synthetic"
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
@@ -15,7 +15,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.executables.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json
@@ -21,7 +21,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.hosts.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json
@@ -19,6 +19,10 @@
       "_source": {
         "enabled": true
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -19,6 +19,10 @@
       "_source": {
         "enabled": false
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       /*
        We intentionally allow dynamic mappings for metrics. Which metrics are added is guarded by
        the collector and we want to allow adding new metrics over time. As this is a datastream,

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -21,7 +21,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.metrics.version}
       },
       /*
        We intentionally allow dynamic mappings for metrics. Which metrics are added is guarded by

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json
@@ -23,7 +23,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.stackframes.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json
@@ -21,6 +21,10 @@
       "_source": {
         "enabled": true
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json
@@ -19,6 +19,10 @@
       "_source": {
         "mode": "synthetic"
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json
@@ -21,7 +21,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.stacktraces.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json
@@ -19,7 +19,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.symbols.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json
@@ -17,6 +17,10 @@
       "_source": {
         "enabled": true
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
@@ -21,7 +21,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.returnpads.private.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
@@ -19,6 +19,10 @@
       "_source": {
         "enabled": true
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json
@@ -15,6 +15,10 @@
       "_source": {
         "mode": "synthetic"
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json
@@ -17,7 +17,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.sq.executables.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json
@@ -15,6 +15,10 @@
       "_source": {
         "mode": "synthetic"
       },
+      "_meta": {
+        "index-template-version": ${xpack.profiling.template.version},
+        "index-version": 1
+      },
       "dynamic": false,
       "properties": {
         "ecs.version": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json
@@ -17,7 +17,7 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": 1
+        "index-version": ${xpack.profiling.index.sq.leafframes.version}
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.RefCountingRunnable;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterIndexHealth;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.index.Index;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class AbstractProfilingPersistenceManager<T extends AbstractProfilingPersistenceManager.ProfilingIndexAbstraction>
+    implements
+        ClusterStateListener,
+        Closeable {
+    protected final Logger logger = LogManager.getLogger(getClass());
+
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+
+    private final ClusterService clusterService;
+    private volatile boolean templatesEnabled;
+
+    public AbstractProfilingPersistenceManager(ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    public void initialize() {
+        clusterService.addListener(this);
+    }
+
+    @Override
+    public void close() {
+        clusterService.removeListener(this);
+    }
+
+    public void setTemplatesEnabled(boolean templatesEnabled) {
+        this.templatesEnabled = templatesEnabled;
+    }
+
+    @Override
+    public final void clusterChanged(ClusterChangedEvent event) {
+        if (templatesEnabled == false) {
+            return;
+        }
+        // wait for the cluster state to be recovered
+        if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
+
+        // If this node is not a master node, exit.
+        if (event.state().nodes().isLocalNodeElectedMaster() == false) {
+            return;
+        }
+
+        if (event.state().nodes().getMaxNodeVersion().after(event.state().nodes().getSmallestNonClientNodeVersion())) {
+            logger.debug("Skipping up-to-date check as cluster has mixed versions");
+            return;
+        }
+
+        if (isAllResourcesCreated(event) == false) {
+            logger.trace("Skipping index creation; not all required resources are present yet");
+            return;
+        }
+
+        if (inProgress.compareAndSet(false, true)) {
+            // Only release the lock once all upgrade attempts have succeeded or failed.
+            try (var refs = new RefCountingRunnable(() -> inProgress.set(false))) {
+                ClusterState clusterState = event.state();
+                for (T index : getManagedIndices()) {
+                    Status status = getStatus(clusterState, index);
+                    if (status.actionable) {
+                        onStatus(clusterState, status, index, ActionListener.releasing(refs.acquire()));
+                    }
+                }
+            }
+        } else {
+            logger.trace("Skipping index creation as changes are already in progress");
+        }
+    }
+
+    protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
+        return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state());
+    }
+
+    /**
+     * Extracts the appropriate index metadata for a given index from the cluster state.
+     *
+     * @param state Current cluster state. Never <code>null</code>.
+     * @param index An index for which to retrieve index metadata. Never <code>null</code>.
+     * @return The corresponding index metadata or <code>null</code> if there are none.
+     */
+    protected abstract IndexMetadata indexMetadata(ClusterState state, T index);
+
+    /**
+     * @return An iterable of all indices that are managed by this instance.
+     */
+    protected abstract Iterable<T> getManagedIndices();
+
+    /**
+     * Handler that takes appropriate action for a certain index status.
+     *
+     * @param clusterState The current cluster state. Never <code>null</code>.
+     * @param status Status of the current index.
+     * @param index The current index.
+     * @param listener Listener to be called on completion / errors.
+     */
+    protected abstract void onStatus(ClusterState clusterState, Status status, T index, ActionListener<? super ActionResponse> listener);
+
+    private Status getStatus(ClusterState state, T index) {
+        IndexMetadata metadata = indexMetadata(state, index);
+        if (metadata != null) {
+            if (metadata.getState() == IndexMetadata.State.CLOSE) {
+                logger.warn(
+                    "Index [{}] is closed. This is likely to prevent Universal Profiling from functioning correctly",
+                    metadata.getIndex()
+                );
+                return Status.CLOSED;
+            }
+            final IndexRoutingTable routingTable = state.getRoutingTable().index(metadata.getIndex());
+            ClusterHealthStatus indexHealth = new ClusterIndexHealth(metadata, routingTable).getStatus();
+            if (indexHealth == ClusterHealthStatus.RED) {
+                logger.debug(
+                    "Index [{}] health status is RED, any pending mapping upgrades will wait until this changes",
+                    metadata.getIndex()
+                );
+                return Status.UNHEALTHY;
+            }
+            MappingMetadata mapping = metadata.mapping();
+            if (mapping != null) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> meta = (Map<String, Object>) mapping.sourceAsMap().get("_meta");
+                int currentIndexVersion;
+                int currentTemplateVersion;
+                if (meta == null) {
+                    logger.debug("Missing _meta field in mapping of index [{}], assuming initial version.", metadata.getIndex());
+                    currentIndexVersion = 1;
+                    currentTemplateVersion = 1;
+                } else {
+                    // we are extra defensive and treat any unexpected values as an unhealthy index which we won't touch.
+                    currentIndexVersion = getVersionField(metadata.getIndex(), meta, "index-version");
+                    currentTemplateVersion = getVersionField(metadata.getIndex(), meta, "index-template-version");
+                    if (currentIndexVersion == -1 || currentTemplateVersion == -1) {
+                        return Status.UNHEALTHY;
+                    }
+                }
+                if (index.getVersion() > currentIndexVersion) {
+                    return Status.NEEDS_VERSION_BUMP;
+                } else if (ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION > currentTemplateVersion) {
+                    // TODO 8.10+: Check if there are any pending migrations. If none are pending we can consider the index up to date.
+                    return Status.NEEDS_MAPPINGS_UPDATE;
+                } else {
+                    return Status.UP_TO_DATE;
+                }
+            } else {
+                logger.warn("No mapping found for existing index [{}]. Index cannot be migrated.", metadata.getIndex());
+                return Status.UNHEALTHY;
+            }
+        } else {
+            return Status.NEEDS_CREATION;
+        }
+    }
+
+    private int getVersionField(Index index, Map<String, Object> meta, String fieldName) {
+        Object value = meta.get(fieldName);
+        if (value instanceof Integer) {
+            return (int) value;
+        } else if (value == null) {
+            logger.warn("Metadata version field [{}] of index [{}] is empty.", fieldName, index);
+            return -1;
+        } else {
+            logger.warn(
+                "Expected metadata version field [{}] of index [{}] to contain an integer value but found [{}].",
+                fieldName,
+                index,
+                value
+            );
+            return -1;
+        }
+    }
+
+    enum Status {
+        CLOSED(false),
+        UNHEALTHY(false),
+        NEEDS_CREATION(true),
+        NEEDS_VERSION_BUMP(true),
+        UP_TO_DATE(false),
+        NEEDS_MAPPINGS_UPDATE(true);
+
+        /**
+         * Whether a status is for informational purposes only or whether it should be acted upon and may change cluster state.
+         */
+        private final boolean actionable;
+
+        Status(boolean actionable) {
+            this.actionable = actionable;
+        }
+    }
+
+    /**
+     * An index that is used by Universal Profiling.
+     */
+    interface ProfilingIndexAbstraction {
+        String getName();
+
+        int getVersion();
+    }
+}

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
@@ -180,18 +180,13 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         Object value = meta.get(fieldName);
         if (value instanceof Integer) {
             return (int) value;
-        } else if (value == null) {
+        }
+        if (value == null) {
             logger.warn("Metadata version field [{}] of index [{}] is empty.", fieldName, index);
             return -1;
-        } else {
-            logger.warn(
-                "Expected metadata version field [{}] of index [{}] to contain an integer value but found [{}].",
-                fieldName,
-                index,
-                value
-            );
-            return -1;
         }
+        logger.warn("Metadata version field [{}] of index [{}] is [{}] (expected an integer).", fieldName, index, value);
+        return -1;
     }
 
     enum Status {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
@@ -81,7 +81,7 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
             return;
         }
 
-        if (inProgress.compareAndSet(false, true)) {
+        if (inProgress.compareAndSet(false, true) == false) {
             logger.trace("Skipping index creation as changes are already in progress");
             return;
         }
@@ -141,10 +141,7 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         final IndexRoutingTable routingTable = state.getRoutingTable().index(metadata.getIndex());
         ClusterHealthStatus indexHealth = new ClusterIndexHealth(metadata, routingTable).getStatus();
         if (indexHealth == ClusterHealthStatus.RED) {
-            logger.debug(
-                "Index [{}] health status is RED, any pending mapping upgrades will wait until this changes",
-                metadata.getIndex()
-            );
+            logger.debug("Index [{}] health status is RED, any pending mapping upgrades will wait until this changes", metadata.getIndex());
             return Status.UNHEALTHY;
         }
         MappingMetadata mapping = metadata.mapping();

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingDataStreamManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingDataStreamManager.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiler;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
+import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
+import org.elasticsearch.action.datastreams.CreateDataStreamAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/**
+ * Creates all data streams that are required for using Elastic Universal Profiling.
+ */
+public class ProfilingDataStreamManager extends AbstractProfilingPersistenceManager<ProfilingDataStreamManager.ProfilingDataStream> {
+    public static final List<ProfilingDataStream> PROFILING_DATASTREAMS;
+
+    static {
+        List<ProfilingDataStream> dataStreams = new ArrayList<>(
+            EventsIndex.indexNames().stream().map(n -> ProfilingDataStream.of(n, 1)).toList()
+        );
+        dataStreams.add(ProfilingDataStream.of("profiling-metrics", 1));
+        dataStreams.add(ProfilingDataStream.of("profiling-hosts", 1));
+        PROFILING_DATASTREAMS = Collections.unmodifiableList(dataStreams);
+    }
+
+    private final ThreadPool threadPool;
+    private final Client client;
+
+    public ProfilingDataStreamManager(ThreadPool threadPool, Client client, ClusterService clusterService) {
+        super(clusterService);
+        this.threadPool = threadPool;
+        this.client = client;
+    }
+
+    @Override
+    protected void onStatus(
+        ClusterState clusterState,
+        Status status,
+        ProfilingDataStream index,
+        ActionListener<? super ActionResponse> listener
+    ) {
+        switch (status) {
+            case NEEDS_CREATION -> createDataStream(index, listener);
+            case NEEDS_VERSION_BUMP -> rolloverDataStream(index, listener);
+            default -> {
+                logger.debug("Skipping status change [{}] for data stream [{}].", status, index);
+                // ensure that listener is notified we're done
+                listener.onResponse(null);
+            }
+        }
+    }
+
+    protected IndexMetadata indexMetadata(ClusterState state, ProfilingDataStream dataStream) {
+        Map<String, DataStream> dataStreams = state.metadata().dataStreams();
+        if (dataStreams == null) {
+            return null;
+        }
+        DataStream ds = dataStreams.get(dataStream.getName());
+        if (ds == null) {
+            return null;
+        }
+        Index writeIndex = ds.getWriteIndex();
+        if (writeIndex == null) {
+            return null;
+        }
+        return state.metadata().index(writeIndex);
+    }
+
+    @Override
+    protected Iterable<ProfilingDataStream> getManagedIndices() {
+        return PROFILING_DATASTREAMS;
+    }
+
+    private void onDataStreamFailure(ProfilingDataStream dataStream, Exception ex) {
+        logger.error(() -> format("error for data stream [%s] for [%s]", dataStream, ClientHelper.PROFILING_ORIGIN), ex);
+    }
+
+    private void rolloverDataStream(final ProfilingDataStream dataStream, ActionListener<? super ActionResponse> listener) {
+        logger.debug("rolling over data stream [{}].", dataStream);
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            RolloverRequest request = new RolloverRequest(dataStream.getName(), null);
+            request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+            executeAsyncWithOrigin(
+                client.threadPool().getThreadContext(),
+                ClientHelper.PROFILING_ORIGIN,
+                request,
+                new ActionListener<RolloverResponse>() {
+                    @Override
+                    public void onResponse(RolloverResponse response) {
+                        if (response.isAcknowledged() == false) {
+                            logger.error(
+                                "error rolling over data stream [{}] for [{}], request was not acknowledged",
+                                dataStream,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        } else if (response.isShardsAcknowledged() == false) {
+                            logger.warn(
+                                "rolling over data stream [{}] for [{}], shards were not acknowledged",
+                                dataStream,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        } else if (response.isRolledOver() == false) {
+                            logger.warn("could not rollover data stream [{}] for [{}].", dataStream, ClientHelper.PROFILING_ORIGIN);
+                        } else {
+                            logger.debug(
+                                "rolled over data stream [{}] from [{}] to index [{}] for [{}].",
+                                dataStream,
+                                response.getOldIndex(),
+                                response.getNewIndex(),
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        }
+                        listener.onResponse(response);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onDataStreamFailure(dataStream, e);
+                        listener.onFailure(e);
+                    }
+                },
+                (req, l) -> client.admin().indices().rolloverIndex(req, l)
+            );
+        });
+    }
+
+    private void createDataStream(ProfilingDataStream dataStream, final ActionListener<? super ActionResponse> listener) {
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            CreateDataStreamAction.Request request = new CreateDataStreamAction.Request(dataStream.getName());
+            request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+            executeAsyncWithOrigin(
+                client.threadPool().getThreadContext(),
+                ClientHelper.PROFILING_ORIGIN,
+                request,
+                new ActionListener<AcknowledgedResponse>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse response) {
+                        if (response.isAcknowledged() == false) {
+                            logger.error(
+                                "error adding data stream [{}] for [{}], request was not acknowledged",
+                                dataStream,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        }
+                        listener.onResponse(response);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onDataStreamFailure(dataStream, e);
+                        listener.onFailure(e);
+                    }
+                },
+                (req, l) -> client.execute(CreateDataStreamAction.INSTANCE, req, l)
+            );
+        });
+    }
+
+    /**
+     * A datastream that is used by Universal Profiling.
+     */
+    static class ProfilingDataStream implements AbstractProfilingPersistenceManager.ProfilingIndexAbstraction {
+        private final String name;
+        private final int version;
+
+        public static ProfilingDataStream of(String name, int version) {
+            return new ProfilingDataStream(name, version);
+        }
+
+        private ProfilingDataStream(String name, int version) {
+            this.name = name;
+            this.version = version;
+        }
+
+        public ProfilingDataStream withVersion(int version) {
+            return new ProfilingDataStream(name, version);
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public int getVersion() {
+            return version;
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ProfilingDataStream that = (ProfilingDataStream) o;
+            return version == that.version && Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, version);
+        }
+    }
+}

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingDataStreamManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingDataStreamManager.java
@@ -41,10 +41,13 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
 
     static {
         List<ProfilingDataStream> dataStreams = new ArrayList<>(
-            EventsIndex.indexNames().stream().map(n -> ProfilingDataStream.of(n, 1)).toList()
+            EventsIndex.indexNames()
+                .stream()
+                .map(n -> ProfilingDataStream.of(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
+                .toList()
         );
-        dataStreams.add(ProfilingDataStream.of("profiling-metrics", 1));
-        dataStreams.add(ProfilingDataStream.of("profiling-hosts", 1));
+        dataStreams.add(ProfilingDataStream.of("profiling-metrics", ProfilingIndexTemplateRegistry.PROFILING_METRICS_VERSION));
+        dataStreams.add(ProfilingDataStream.of("profiling-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION));
         PROFILING_DATASTREAMS = Collections.unmodifiableList(dataStreams);
     }
 

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -375,13 +375,7 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
 
         @Override
         public String getName() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(indexPrefix());
-            if (generation != null) {
-                sb.append("-");
-                sb.append(generation);
-            }
-            return sb.toString();
+            return isKvIndex() ? String.format(Locale.ROOT, "%s-%s", indexPrefix(), generation) : indexPrefix();
         }
 
         public int getVersion() {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -41,10 +41,10 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<ProfilingIndexManager.ProfilingIndex> {
     // For testing
     public static final List<ProfilingIndex> PROFILING_INDICES = List.of(
-        ProfilingIndex.regular("profiling-returnpads-private", 1, OnVersionBump.IGNORE_OLD),
+        ProfilingIndex.regular("profiling-returnpads-private", 1, OnVersionBump.KEEP_OLD),
         ProfilingIndex.regular("profiling-sq-executables", 1, OnVersionBump.DELETE_OLD),
         ProfilingIndex.regular("profiling-sq-leafframes", 1, OnVersionBump.DELETE_OLD),
-        ProfilingIndex.regular("profiling-symbols-private", 1, OnVersionBump.IGNORE_OLD),
+        ProfilingIndex.regular("profiling-symbols-private", 1, OnVersionBump.KEEP_OLD),
         ProfilingIndex.kv("profiling-executables", 1),
         ProfilingIndex.kv("profiling-stackframes", 1),
         ProfilingIndex.kv("profiling-stacktraces", 1),
@@ -301,7 +301,7 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
 
     enum OnVersionBump {
         DELETE_OLD,
-        IGNORE_OLD
+        KEEP_OLD
     }
 
     /**
@@ -319,7 +319,7 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
 
         public static ProfilingIndex kv(String name, int version) {
             // K/V indices will age automatically as per the ILM policy, and we won't force-upgrade them on version bumps
-            return new ProfilingIndex(name, version, "000001", OnVersionBump.IGNORE_OLD);
+            return new ProfilingIndex(name, version, "000001", OnVersionBump.KEEP_OLD);
         }
 
         private ProfilingIndex(String namePrefix, int version, String generation, OnVersionBump onVersionBump) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -7,31 +7,30 @@
 
 package org.elasticsearch.xpack.profiler;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
+import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
 
-import java.io.Closeable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Objects;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
@@ -39,107 +38,186 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 /**
  * Creates all indices that are required for using Elastic Universal Profiling.
  */
-public class ProfilingIndexManager implements ClusterStateListener, Closeable {
-    private static final Logger logger = LogManager.getLogger(ProfilingIndexManager.class);
+public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<ProfilingIndexManager.ProfilingIndex> {
     // For testing
     public static final List<ProfilingIndex> PROFILING_INDICES = List.of(
-        ProfilingIndex.regular("profiling-returnpads-private"),
-        ProfilingIndex.regular("profiling-sq-executables"),
-        ProfilingIndex.regular("profiling-sq-leafframes"),
-        ProfilingIndex.regular("profiling-symbols-private"),
-        ProfilingIndex.kv("profiling-executables"),
-        ProfilingIndex.kv("profiling-stackframes"),
-        ProfilingIndex.kv("profiling-stacktraces"),
-        ProfilingIndex.kv("profiling-symbols-global")
+        ProfilingIndex.regular("profiling-returnpads-private", 1, OnVersionBump.IGNORE_OLD),
+        ProfilingIndex.regular("profiling-sq-executables", 1, OnVersionBump.DELETE_OLD),
+        ProfilingIndex.regular("profiling-sq-leafframes", 1, OnVersionBump.DELETE_OLD),
+        ProfilingIndex.regular("profiling-symbols-private", 1, OnVersionBump.IGNORE_OLD),
+        ProfilingIndex.kv("profiling-executables", 1),
+        ProfilingIndex.kv("profiling-stackframes", 1),
+        ProfilingIndex.kv("profiling-stacktraces", 1),
+        ProfilingIndex.kv("profiling-symbols-global", 1)
     );
 
     private final ThreadPool threadPool;
     private final Client client;
-    private final ClusterService clusterService;
-    private final ConcurrentMap<String, AtomicBoolean> creationInProgressPerIndex = new ConcurrentHashMap<>();
-    private volatile boolean templatesEnabled;
 
     public ProfilingIndexManager(ThreadPool threadPool, Client client, ClusterService clusterService) {
+        super(clusterService);
         this.threadPool = threadPool;
         this.client = client;
-        this.clusterService = clusterService;
-    }
-
-    public void initialize() {
-        clusterService.addListener(this);
     }
 
     @Override
-    public void close() {
-        clusterService.removeListener(this);
-    }
-
-    public void setTemplatesEnabled(boolean templatesEnabled) {
-        this.templatesEnabled = templatesEnabled;
-    }
-
-    @Override
-    public void clusterChanged(ClusterChangedEvent event) {
-        if (templatesEnabled == false) {
-            return;
-        }
-        // wait for the cluster state to be recovered
-        if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
-            return;
-        }
-
-        // If this node is not a master node, exit.
-        if (event.state().nodes().isLocalNodeElectedMaster() == false) {
-            return;
-        }
-
-        if (event.state().nodes().getMaxNodeVersion().after(event.state().nodes().getSmallestNonClientNodeVersion())) {
-            logger.debug("Skipping up-to-date check as cluster has mixed versions");
-            return;
-        }
-
-        // ensure that all resources are present that we need to create indices
-        if (isAllResourcesCreated(event) == false) {
-            logger.trace("Skipping index creation; not all required resources are present yet");
-            return;
-        }
-
-        addIndicesIfMissing(event.state());
-    }
-
-    protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
-        return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state());
-    }
-
-    private void addIndicesIfMissing(ClusterState state) {
-        Map<String, IndexMetadata> indicesMetadata = state.metadata().indices();
-        for (ProfilingIndex profilingIndex : PROFILING_INDICES) {
-            String index = profilingIndex.toString();
-            final AtomicBoolean creationInProgress = creationInProgressPerIndex.computeIfAbsent(index, key -> new AtomicBoolean(false));
-            if (creationInProgress.compareAndSet(false, true)) {
-                // Do a quick (exact) check first
-                boolean indexNeedsToBeCreated = indicesMetadata == null || indicesMetadata.get(index) == null;
-                // for K/V indices we must not create the index if a newer generation exists
-                if (indexNeedsToBeCreated && profilingIndex.isKvIndex()) {
-                    indexNeedsToBeCreated = indicesMetadata != null
-                        && indicesMetadata.keySet().stream().anyMatch(profilingIndex::isMatchWithoutGeneration) == false;
-                }
-                if (indexNeedsToBeCreated) {
-                    logger.debug("adding index [{}], because it doesn't exist", index);
-                    putIndex(index, profilingIndex.getAlias(), creationInProgress);
-                } else {
-                    logger.trace("not adding index [{}], because it already exists", index);
-                    creationInProgress.set(false);
-                }
+    protected void onStatus(
+        ClusterState clusterState,
+        Status status,
+        ProfilingIndex index,
+        ActionListener<? super ActionResponse> listener
+    ) {
+        switch (status) {
+            case NEEDS_CREATION -> createIndex(clusterState, index, listener);
+            case NEEDS_VERSION_BUMP -> bumpVersion(clusterState, index, listener);
+            default -> {
+                logger.debug("Skipping status change [{}] for index [{}].", status, index);
+                // ensure that listener is notified we're done
+                listener.onResponse(null);
             }
         }
     }
 
-    private void onPutIndexFailure(String index, Exception ex) {
+    @Override
+    protected IndexMetadata indexMetadata(ClusterState state, ProfilingIndex index) {
+        Map<String, IndexMetadata> indicesMetadata = state.metadata().indices();
+        if (indicesMetadata == null) {
+            return null;
+        }
+        IndexMetadata metadata = indicesMetadata.get(index.toString());
+        // prioritize the most recent generation from the current version
+        if (metadata == null && index.isKvIndex()) {
+            metadata = indicesMetadata.entrySet()
+                .stream()
+                .filter(e -> index.isMatchWithoutGeneration(e.getKey()))
+                // use the most recent index to make sure we use the most recent version info from the _meta field
+                .max(Comparator.comparingLong(e -> e.getValue().getCreationDate()))
+                .map(Map.Entry::getValue)
+                .orElse(null);
+        }
+
+        // attempt to find an index from an earlier generation
+        if (metadata == null) {
+            metadata = indicesMetadata.entrySet()
+                .stream()
+                .filter(e -> index.isMatchWithoutVersion(e.getKey()))
+                // use the most recent index to make sure we use the most recent version info from the _meta field
+                .max(Comparator.comparingLong(e -> e.getValue().getCreationDate()))
+                .map(Map.Entry::getValue)
+                .orElse(null);
+        }
+
+        return metadata;
+    }
+
+    private void bumpVersion(ClusterState state, ProfilingIndex index, ActionListener<? super ActionResponse> listener) {
+        if (index.getOnVersionBump() == OnVersionBump.DELETE_OLD) {
+            Map<String, IndexMetadata> indicesMetadata = state.metadata().indices();
+            List<String> priorIndexVersions = indicesMetadata.keySet()
+                .stream()
+                // ignore the current index and look only for old versions
+                .filter(Predicate.not(index::isFullMatch))
+                .filter(index::isMatchWithoutVersion)
+                .toList();
+            if (priorIndexVersions.isEmpty() == false) {
+                logger.debug("deleting indices [{}] on index version bump for [{}].", priorIndexVersions, index.getAlias());
+                deleteIndices(
+                    priorIndexVersions.toArray(new String[0]),
+                    // the cluster state that we are operating on is a snapshot and won't reflect that the alias has just gone.
+                    // Therefore, we use putIndex here which does not check for the existence of an alias
+                    ActionListener.wrap(r -> putIndex(index.getName(), index.getAlias(), listener), listener::onFailure)
+                );
+            } else {
+                createIndex(state, index, listener);
+            }
+        } else {
+            createIndex(state, index, listener);
+        }
+    }
+
+    @Override
+    protected Iterable<ProfilingIndex> getManagedIndices() {
+        return PROFILING_INDICES;
+    }
+
+    private void onCreateIndexFailure(String index, Exception ex) {
         logger.error(() -> format("error adding index [%s] for [%s]", index, ClientHelper.PROFILING_ORIGIN), ex);
     }
 
-    private void putIndex(final String index, final String alias, final AtomicBoolean creationCheck) {
+    private void createIndex(final ClusterState state, final ProfilingIndex index, final ActionListener<? super ActionResponse> listener) {
+        if (state.metadata().hasAlias(index.getAlias())) {
+            // there is an existing index from a prior version. Use the rollover API to move the write alias atomically. This has the
+            // following implications:
+            //
+            // * A new index will be created according to the currently installed version of the matching index template.
+            // * The write alias will point to that index.
+            // * The prior index will continue to be managed by ILM but will advance to the next phase after rollover. As
+            // rollover blocks phase transitions, the prior index may move a bit sooner than expected to the warm tier
+            // after version bumps; still all conditions need to be met, it's just that due to the earlier rollover, the
+            // condition will be reached sooner than without a version bump.
+            rolloverIndex(index.getName(), index.getAlias(), listener);
+        } else {
+            // newly create index
+            putIndex(index.getName(), index.getAlias(), listener);
+        }
+    }
+
+    private void rolloverIndex(final String newIndex, final String alias, ActionListener<? super ActionResponse> listener) {
+        logger.debug("rolling over to index [{}] for alias [{}].", newIndex, alias);
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            RolloverRequest request = new RolloverRequest(alias, newIndex);
+            request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+            executeAsyncWithOrigin(
+                client.threadPool().getThreadContext(),
+                ClientHelper.PROFILING_ORIGIN,
+                request,
+                new ActionListener<RolloverResponse>() {
+                    @Override
+                    public void onResponse(RolloverResponse response) {
+                        if (response.isAcknowledged() == false) {
+                            logger.error(
+                                "error rolling over index [{}] for [{}], request was not acknowledged",
+                                newIndex,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        } else if (response.isShardsAcknowledged() == false) {
+                            logger.warn(
+                                "rolling over index [{}] for [{}], shards were not acknowledged",
+                                newIndex,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        } else if (response.isRolledOver() == false) {
+                            logger.warn(
+                                "could not rollover alias [{}] to index [{}] for [{}].",
+                                alias,
+                                newIndex,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        } else {
+                            logger.debug(
+                                "rolled over alias [{}] from [{}] to index [{}] for [{}].",
+                                alias,
+                                response.getOldIndex(),
+                                response.getNewIndex(),
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        }
+                        listener.onResponse(response);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onCreateIndexFailure(newIndex, e);
+                        listener.onFailure(e);
+                    }
+                },
+                (req, l) -> client.admin().indices().rolloverIndex(req, l)
+            );
+        });
+    }
+
+    private void putIndex(final String index, final String alias, final ActionListener<? super ActionResponse> listener) {
         final Executor executor = threadPool.generic();
         executor.execute(() -> {
             CreateIndexRequest request = new CreateIndexRequest(index);
@@ -148,8 +226,8 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
                     Map<String, Object> sourceAsMap = Map.of("aliases", Map.of(alias, Map.of("is_write_index", true)));
                     request.source(sourceAsMap, LoggingDeprecationHandler.INSTANCE);
                 } catch (Exception ex) {
-                    creationCheck.set(false);
-                    onPutIndexFailure(index, ex);
+                    onCreateIndexFailure(index, ex);
+                    listener.onFailure(ex);
                     return;
                 }
             }
@@ -161,7 +239,6 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
                 new ActionListener<CreateIndexResponse>() {
                     @Override
                     public void onResponse(CreateIndexResponse response) {
-                        creationCheck.set(false);
                         if (response.isAcknowledged() == false) {
                             logger.error(
                                 "error adding index [{}] for [{}], request was not acknowledged",
@@ -171,41 +248,105 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
                         } else if (response.isShardsAcknowledged() == false) {
                             logger.warn("adding index [{}] for [{}], shards were not acknowledged", index, ClientHelper.PROFILING_ORIGIN);
                         }
+                        listener.onResponse(response);
                     }
 
                     @Override
                     public void onFailure(Exception e) {
-                        creationCheck.set(false);
-                        onPutIndexFailure(index, e);
+                        onCreateIndexFailure(index, e);
+                        listener.onFailure(e);
                     }
                 },
-                (req, listener) -> client.admin().indices().create(req, listener)
+                (req, l) -> client.admin().indices().create(req, l)
             );
         });
+    }
+
+    private void onDeleteIndexFailure(String[] indices, Exception ex) {
+        logger.error(() -> format("error deleting indices [%s] for [%s]", indices, ClientHelper.PROFILING_ORIGIN), ex);
+    }
+
+    private void deleteIndices(final String[] indices, final ActionListener<AcknowledgedResponse> listener) {
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            DeleteIndexRequest request = new DeleteIndexRequest(indices);
+            request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+            executeAsyncWithOrigin(
+                client.threadPool().getThreadContext(),
+                ClientHelper.PROFILING_ORIGIN,
+                request,
+                new ActionListener<AcknowledgedResponse>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse response) {
+                        if (response.isAcknowledged() == false) {
+                            logger.error(
+                                "error deleting indices [{}] for [{}], request was not acknowledged",
+                                indices,
+                                ClientHelper.PROFILING_ORIGIN
+                            );
+                        }
+                        listener.onResponse(response);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onDeleteIndexFailure(indices, e);
+                        listener.onFailure(e);
+                    }
+                },
+                (req, l) -> client.admin().indices().delete(req, l)
+            );
+        });
+    }
+
+    enum OnVersionBump {
+        DELETE_OLD,
+        IGNORE_OLD
     }
 
     /**
      * An index that is used by Universal Profiling.
      */
-    static class ProfilingIndex {
-        private final String name;
+    static class ProfilingIndex implements ProfilingIndexAbstraction {
+        private final String namePrefix;
+        private final int version;
         private final String generation;
+        private final OnVersionBump onVersionBump;
 
-        public static ProfilingIndex regular(String name) {
-            return new ProfilingIndex(name, null);
+        public static ProfilingIndex regular(String name, int version, OnVersionBump onVersionBump) {
+            return new ProfilingIndex(name, version, null, onVersionBump);
         }
 
-        public static ProfilingIndex kv(String name) {
-            return new ProfilingIndex(name, "000001");
+        public static ProfilingIndex kv(String name, int version) {
+            // K/V indices will age automatically as per the ILM policy, and we won't force-upgrade them on version bumps
+            return new ProfilingIndex(name, version, "000001", OnVersionBump.IGNORE_OLD);
         }
 
-        private ProfilingIndex(String namePrefix, String generation) {
-            this.name = namePrefix;
+        private ProfilingIndex(String namePrefix, int version, String generation, OnVersionBump onVersionBump) {
+            this.namePrefix = namePrefix;
+            this.version = version;
             this.generation = generation;
+            this.onVersionBump = onVersionBump;
+        }
+
+        public ProfilingIndex withVersion(int version) {
+            return new ProfilingIndex(namePrefix, version, generation, onVersionBump);
+        }
+
+        public ProfilingIndex withGeneration(String generation) {
+            return new ProfilingIndex(namePrefix, version, generation, onVersionBump);
+        }
+
+        public boolean isMatchWithoutVersion(String indexName) {
+            return indexName.startsWith("." + namePrefix);
         }
 
         public boolean isMatchWithoutGeneration(String indexName) {
             return indexName.startsWith(indexPrefix());
+        }
+
+        public boolean isFullMatch(String indexName) {
+            return toString().equals(indexName);
         }
 
         public boolean isKvIndex() {
@@ -213,15 +354,11 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
         }
 
         public String getAlias() {
-            return name;
-        }
-
-        private String indexPrefix() {
-            return String.format(Locale.ROOT, ".%s-v%03d", name, ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION);
+            return namePrefix;
         }
 
         @Override
-        public String toString() {
+        public String getName() {
             StringBuilder sb = new StringBuilder();
             sb.append(indexPrefix());
             if (generation != null) {
@@ -229,6 +366,43 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
                 sb.append(generation);
             }
             return sb.toString();
+        }
+
+        public int getVersion() {
+            return version;
+        }
+
+        public OnVersionBump getOnVersionBump() {
+            return onVersionBump;
+        }
+
+        private String indexPrefix() {
+            return String.format(Locale.ROOT, ".%s-v%03d", namePrefix, version);
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ProfilingIndex index = (ProfilingIndex) o;
+            return version == index.version
+                && Objects.equals(namePrefix, index.namePrefix)
+                && Objects.equals(generation, index.generation)
+                && onVersionBump == index.onVersionBump;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(namePrefix, version, generation, onVersionBump);
         }
     }
 }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -41,14 +41,30 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<ProfilingIndexManager.ProfilingIndex> {
     // For testing
     public static final List<ProfilingIndex> PROFILING_INDICES = List.of(
-        ProfilingIndex.regular("profiling-returnpads-private", 1, OnVersionBump.KEEP_OLD),
-        ProfilingIndex.regular("profiling-sq-executables", 1, OnVersionBump.DELETE_OLD),
-        ProfilingIndex.regular("profiling-sq-leafframes", 1, OnVersionBump.DELETE_OLD),
-        ProfilingIndex.regular("profiling-symbols-private", 1, OnVersionBump.KEEP_OLD),
-        ProfilingIndex.kv("profiling-executables", 1),
-        ProfilingIndex.kv("profiling-stackframes", 1),
-        ProfilingIndex.kv("profiling-stacktraces", 1),
-        ProfilingIndex.kv("profiling-symbols-global", 1)
+        ProfilingIndex.regular(
+            "profiling-returnpads-private",
+            ProfilingIndexTemplateRegistry.PROFILING_RETURNPADS_PRIVATE_VERSION,
+            OnVersionBump.KEEP_OLD
+        ),
+        ProfilingIndex.regular(
+            "profiling-sq-executables",
+            ProfilingIndexTemplateRegistry.PROFILING_SQ_EXECUTABLES_VERSION,
+            OnVersionBump.DELETE_OLD
+        ),
+        ProfilingIndex.regular(
+            "profiling-sq-leafframes",
+            ProfilingIndexTemplateRegistry.PROFILING_SQ_LEAFFRAMES_VERSION,
+            OnVersionBump.DELETE_OLD
+        ),
+        ProfilingIndex.regular(
+            "profiling-symbols-private",
+            ProfilingIndexTemplateRegistry.PROFILING_SYMBOLS_VERSION,
+            OnVersionBump.KEEP_OLD
+        ),
+        ProfilingIndex.kv("profiling-executables", ProfilingIndexTemplateRegistry.PROFILING_EXECUTABLES_VERSION),
+        ProfilingIndex.kv("profiling-stackframes", ProfilingIndexTemplateRegistry.PROFILING_STACKFRAMES_VERSION),
+        ProfilingIndex.kv("profiling-stacktraces", ProfilingIndexTemplateRegistry.PROFILING_STACKTRACES_VERSION),
+        ProfilingIndex.kv("profiling-symbols-global", ProfilingIndexTemplateRegistry.PROFILING_SYMBOLS_VERSION)
     );
 
     private final ThreadPool threadPool;

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
@@ -42,6 +42,18 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 1: initial
     public static final int INDEX_TEMPLATE_VERSION = 1;
 
+    // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
+    public static final int PROFILING_EVENTS_VERSION = 1;
+    public static final int PROFILING_EXECUTABLES_VERSION = 1;
+    public static final int PROFILING_METRICS_VERSION = 1;
+    public static final int PROFILING_HOSTS_VERSION = 1;
+    public static final int PROFILING_STACKFRAMES_VERSION = 1;
+    public static final int PROFILING_STACKTRACES_VERSION = 1;
+    public static final int PROFILING_SYMBOLS_VERSION = 1;
+    public static final int PROFILING_RETURNPADS_PRIVATE_VERSION = 1;
+    public static final int PROFILING_SQ_EXECUTABLES_VERSION = 1;
+    public static final int PROFILING_SQ_LEAFFRAMES_VERSION = 1;
+
     public static final String PROFILING_TEMPLATE_VERSION_VARIABLE = "xpack.profiling.template.version";
 
     private volatile boolean templatesEnabled;
@@ -96,13 +108,15 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
                 "profiling-events",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-events.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("events", PROFILING_EVENTS_VERSION)
             ),
             new IndexTemplateConfig(
                 "profiling-executables",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("executables", PROFILING_EXECUTABLES_VERSION)
             ),
             new IndexTemplateConfig(
                 "profiling-ilm",
@@ -120,31 +134,36 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
                 "profiling-metrics",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("metrics", PROFILING_METRICS_VERSION)
             ),
             new IndexTemplateConfig(
                 "profiling-hosts",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("hosts", PROFILING_HOSTS_VERSION)
             ),
             new IndexTemplateConfig(
                 "profiling-stackframes",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("stackframes", PROFILING_STACKFRAMES_VERSION)
             ),
             new IndexTemplateConfig(
                 "profiling-stacktraces",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("stacktraces", PROFILING_STACKTRACES_VERSION)
             ),
             new IndexTemplateConfig(
                 "profiling-symbols",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json",
                 INDEX_TEMPLATE_VERSION,
-                PROFILING_TEMPLATE_VERSION_VARIABLE
+                PROFILING_TEMPLATE_VERSION_VARIABLE,
+                indexVersion("symbols", PROFILING_SYMBOLS_VERSION)
             )
         )) {
             try {
@@ -157,6 +176,10 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
             }
         }
         COMPONENT_TEMPLATE_CONFIGS = Collections.unmodifiableMap(componentTemplates);
+    }
+
+    private static Map<String, String> indexVersion(String index, int version) {
+        return Map.of(String.format(Locale.ROOT, "xpack.profiling.index.%s.version", index), String.valueOf(version));
     }
 
     @Override
@@ -206,19 +229,22 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
             "profiling-returnpads-private",
             "/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json",
             INDEX_TEMPLATE_VERSION,
-            PROFILING_TEMPLATE_VERSION_VARIABLE
+            PROFILING_TEMPLATE_VERSION_VARIABLE,
+            indexVersion("returnpads.private", PROFILING_RETURNPADS_PRIVATE_VERSION)
         ),
         new IndexTemplateConfig(
             "profiling-sq-executables",
             "/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json",
             INDEX_TEMPLATE_VERSION,
-            PROFILING_TEMPLATE_VERSION_VARIABLE
+            PROFILING_TEMPLATE_VERSION_VARIABLE,
+            indexVersion("sq.executables", PROFILING_SQ_EXECUTABLES_VERSION)
         ),
         new IndexTemplateConfig(
             "profiling-sq-leafframes",
             "/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json",
             INDEX_TEMPLATE_VERSION,
-            PROFILING_TEMPLATE_VERSION_VARIABLE
+            PROFILING_TEMPLATE_VERSION_VARIABLE,
+            indexVersion("sq.leafframes", PROFILING_SQ_LEAFFRAMES_VERSION)
         ),
         new IndexTemplateConfig(
             "profiling-symbols-global",

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
@@ -62,6 +62,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     private final SetOnce<ProfilingIndexTemplateRegistry> registry = new SetOnce<>();
 
     private final SetOnce<ProfilingIndexManager> indexManager = new SetOnce<>();
+    private final SetOnce<ProfilingDataStreamManager> dataStreamManager = new SetOnce<>();
 
     public ProfilingPlugin(Settings settings) {
         this.settings = settings;
@@ -88,13 +89,15 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         logger.info("Profiling is {}", enabled ? "enabled" : "disabled");
         registry.set(new ProfilingIndexTemplateRegistry(settings, clusterService, threadPool, client, xContentRegistry));
         indexManager.set(new ProfilingIndexManager(threadPool, client, clusterService));
+        dataStreamManager.set(new ProfilingDataStreamManager(threadPool, client, clusterService));
         // set initial value
         updateTemplatesEnabled(PROFILING_TEMPLATES_ENABLED.get(settings));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_TEMPLATES_ENABLED, this::updateTemplatesEnabled);
         if (enabled) {
             registry.get().initialize();
             indexManager.get().initialize();
-            return List.of(registry.get(), indexManager.get());
+            dataStreamManager.get().initialize();
+            return List.of(registry.get(), indexManager.get(), dataStreamManager.get());
         } else {
             return Collections.emptyList();
         }
@@ -106,6 +109,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         }
         registry.get().setTemplatesEnabled(newValue);
         indexManager.get().setTemplatesEnabled(newValue);
+        dataStreamManager.get().setTemplatesEnabled(newValue);
     }
 
     @Override
@@ -162,5 +166,6 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     public void close() {
         registry.get().close();
         indexManager.get().close();
+        dataStreamManager.get().close();
     }
 }


### PR DESCRIPTION
With this commit we add support to specify upgrade behavior per index (or data stream) that is managed by the profiling plugin:

* Data streams and K/V indices will be rolled over: The prior write index will remain untouched and eventually be deleted according to the ILM policy.
* Regular indices may either be ignored or deleted on upgrades.