### PR TITLE
[CI] Fix PartialHitCountCollectorTests testCollectedHitCountEarlyTerminated

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/query/NonCountingTermQuery.java
+++ b/server/src/test/java/org/elasticsearch/search/query/NonCountingTermQuery.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FilterWeight;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+
+/**
+ * A {@link TermQuery} which does not retrieve hit count from Weight#count for reproducible tests.
+ * Using this query we will never early-terminate the collection phase because we can already
+ * get the document count from the term statistics of each segment.
+ */
+class NonCountingTermQuery extends TermQuery {
+
+    NonCountingTermQuery(Term term) {
+        super(term);
+    }
+
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        Weight w = super.createWeight(searcher, scoreMode, boost);
+        return new FilterWeight(w) {
+            public int count(LeafReaderContext context) throws IOException {
+                return -1;
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/query/PartialHitCountCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/PartialHitCountCollectorTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FilterWeight;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -27,7 +28,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.util.List;
 
 public class PartialHitCountCollectorTests extends ESTestCase {
 
@@ -105,33 +105,33 @@ public class PartialHitCountCollectorTests extends ESTestCase {
     }
 
     public void testCollectedHitCountEarlyTerminated() throws Exception {
-        Query query = new BooleanQuery.Builder().add(new TermQuery(new Term("string", "a1")), BooleanClause.Occur.SHOULD)
-            .add(new TermQuery(new Term("string", "b3")), BooleanClause.Occur.SHOULD)
-            .add(new TermQuery(new Term("string", "b6")), BooleanClause.Occur.SHOULD)
+        Query query = new BooleanQuery.Builder().add(termQuery(new Term("string", "a1")), BooleanClause.Occur.SHOULD)
+            .add(termQuery(new Term("string", "b3")), BooleanClause.Occur.SHOULD)
+            .add(termQuery(new Term("string", "b6")), BooleanClause.Occur.SHOULD)
             .build();
         // there's three docs matching the query: any totalHitsThreshold lower than 3 will trigger early termination
         int totalHitsThreshold = randomInt(2);
         PartialHitCountCollector partialHitCountCollector = new PartialHitCountCollector(totalHitsThreshold);
         searcher.search(query, partialHitCountCollector);
 
-        try {
-            assertEquals(totalHitsThreshold, partialHitCountCollector.getTotalHits());
-            assertTrue(partialHitCountCollector.hasEarlyTerminated());
-        } catch (AssertionError e) {
-            // if we get very unlucky with the document distribution, we can get more than one segment with only one document
-            // in this case early termination might not kick in because we never collect
-            // check if this was the case here and disregard error in that case
-            Weight weight = searcher.createWeight(query, ScoreMode.TOP_DOCS, 1.0f);
-            List<LeafReaderContext> leafContexts = searcher.getLeafContexts();
-            int totalHitsWithoutCollecting = 0;
-            for (LeafReaderContext leafContext : leafContexts) {
-                int count = weight.count(leafContext);
-                if (count != -1) {
-                    totalHitsWithoutCollecting += count;
-                }
+        assertEquals(totalHitsThreshold, partialHitCountCollector.getTotalHits());
+        assertTrue(partialHitCountCollector.hasEarlyTerminated());
+    }
+
+    /**
+     * Create a {@link TermQuery} which cannot terminate collection early
+     */
+    private TermQuery termQuery(Term term) {
+        return new TermQuery(term) {
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+
+                Weight w = super.createWeight(searcher, scoreMode, boost);
+                return new FilterWeight(w) {
+                    public int count(LeafReaderContext context) throws IOException {
+                        return -1;
+                    }
+                };
             }
-            assertTrue(totalHitsWithoutCollecting > totalHitsThreshold);
-            assertFalse(partialHitCountCollector.hasEarlyTerminated());
-        }
+        };
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/query/PartialHitCountCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/PartialHitCountCollectorTests.java
@@ -118,11 +118,13 @@ public class PartialHitCountCollectorTests extends ESTestCase {
     }
 
     /**
-     * A {@link TermQuery} which cannot terminate collection early
+     * A {@link TermQuery} which does not retrieve hit count from Weight#count for reproducible tests.
+     * Using this query we will never early-terminate the collection phase because we can already
+     * get the document count from the term statistics of each segment.
      */
-    public static class NonCountingTermQuery extends TermQuery {
+    static class NonCountingTermQuery extends TermQuery {
 
-        public NonCountingTermQuery(Term term) {
+        NonCountingTermQuery(Term term) {
             super(term);
         }
 

--- a/server/src/test/java/org/elasticsearch/search/query/PartialHitCountCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/PartialHitCountCollectorTests.java
@@ -12,17 +12,13 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.FilterWeight;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.test.ESTestCase;
@@ -115,27 +111,6 @@ public class PartialHitCountCollectorTests extends ESTestCase {
 
         assertEquals(totalHitsThreshold, partialHitCountCollector.getTotalHits());
         assertTrue(partialHitCountCollector.hasEarlyTerminated());
-    }
-
-    /**
-     * A {@link TermQuery} which does not retrieve hit count from Weight#count for reproducible tests.
-     * Using this query we will never early-terminate the collection phase because we can already
-     * get the document count from the term statistics of each segment.
-     */
-    static class NonCountingTermQuery extends TermQuery {
-
-        NonCountingTermQuery(Term term) {
-            super(term);
-        }
-
-        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-            Weight w = super.createWeight(searcher, scoreMode, boost);
-            return new FilterWeight(w) {
-                public int count(LeafReaderContext context) throws IOException {
-                    return -1;
-                }
-            };
-        }
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -77,6 +77,7 @@ import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchContextId;
+import org.elasticsearch.search.query.PartialHitCountCollectorTests.NonCountingTermQuery;
 import org.elasticsearch.search.rank.RankShardContext;
 import org.elasticsearch.search.rank.RankShardResult;
 import org.elasticsearch.search.sort.SortAndFormats;
@@ -434,8 +435,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
      */
     public void testTerminateAfterSize0NoHitCountShortcut() throws Exception {
         indexDocs();
-        BooleanQuery bq = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
-            .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+        BooleanQuery bq = new BooleanQuery.Builder().add(new NonCountingTermQuery(new Term("foo", "bar")), Occur.SHOULD)
+            .add(new NonCountingTermQuery(new Term("foo", "baz")), Occur.SHOULD)
             .build();
         {
             TestSearchContext context = createContext(newContextSearcher(reader), bq);

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -435,11 +435,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
      */
     public void testTerminateAfterSize0NoHitCountShortcut() throws Exception {
         indexDocs();
-        BooleanQuery bq = new BooleanQuery.Builder().add(new NonCountingTermQuery(new Term("foo", "bar")), Occur.SHOULD)
-            .add(new NonCountingTermQuery(new Term("foo", "baz")), Occur.SHOULD)
-            .build();
+        Query query = new NonCountingTermQuery(new Term("foo", "bar"));
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            TestSearchContext context = createContext(newContextSearcher(reader), query);
             context.terminateAfter(1);
             context.setSize(0);
             QueryPhase.executeQuery(context);
@@ -450,7 +448,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         }
         // test interaction between trackTotalHits and terminateAfter
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            TestSearchContext context = createContext(newContextSearcher(reader), query);
             context.terminateAfter(10);
             context.setSize(0);
             context.trackTotalHitsUpTo(-1);
@@ -461,7 +459,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            TestSearchContext context = createContext(newContextSearcher(reader), query);
             context.terminateAfter(10);
             context.setSize(0);
             // track total hits is lower than terminate_after
@@ -474,7 +472,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            TestSearchContext context = createContext(newContextSearcher(reader), query);
             context.terminateAfter(10);
             context.setSize(0);
             // track total hits is higher than terminate_after

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -77,7 +77,6 @@ import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchContextId;
-import org.elasticsearch.search.query.PartialHitCountCollectorTests.NonCountingTermQuery;
 import org.elasticsearch.search.rank.RankShardContext;
 import org.elasticsearch.search.rank.RankShardResult;
 import org.elasticsearch.search.sort.SortAndFormats;


### PR DESCRIPTION
For a particular document distribution (each of the three documents matching the boolean query
live in separate leave readers) we calculate the hit count without actually collecting. 
TotalHitCountCollector#getLeafCollector throws a CollectionTerminatedException(), which again shortcuts the PartialHitCountsCollectors collect() method to be called at all.
It should happen very rarely, and in that case we can check if the reason for not triggering the early termination
was that we can get the document count from the term statistics. Thats what this change proposes

Closes #97359