### PR TITLE
Create IndexNameGenerator utility in server

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/IndexNameGenerator.java
+++ b/server/src/main/java/org/elasticsearch/common/IndexNameGenerator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.indices.InvalidIndexNameException;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+
+/**
+ * Generates valid Elasticsearch index names.
+ */
+public final class IndexNameGenerator {
+
+    static final String ILLEGAL_INDEXNAME_CHARS_REGEX = "[/:\"*?<>|# ,\\\\]+";
+    static final int MAX_GENERATED_UUID_LENGTH = 4;
+
+    private IndexNameGenerator() {}
+
+    /**
+     * This generates a valid unique index name by using the provided prefix, appended with a generated UUID, and the index name.
+     */
+    public static String generateValidIndexName(String prefix, String indexName) {
+        String randomUUID = generateValidIndexSuffix(UUIDs::randomBase64UUID);
+        randomUUID = randomUUID.substring(0, Math.min(randomUUID.length(), MAX_GENERATED_UUID_LENGTH));
+        return prefix + randomUUID + "-" + indexName;
+    }
+
+    /**
+     *
+     * @param randomGenerator
+     * @return
+     */
+    public static String generateValidIndexSuffix(Supplier<String> randomGenerator) {
+        String randomSuffix = randomGenerator.get().toLowerCase(Locale.ROOT);
+        randomSuffix = randomSuffix.replaceAll(ILLEGAL_INDEXNAME_CHARS_REGEX, "");
+        if (randomSuffix.length() == 0) {
+            throw new IllegalArgumentException("unable to generate random index name suffix");
+        }
+
+        return randomSuffix;
+    }
+
+    /**
+     * Validates the provided index name against the provided cluster state. This checks the index name for invalid characters
+     * and that it doesn't clash with existing indices or aliases.
+     * Returns null for valid indices.
+     */
+    @Nullable
+    public static ActionRequestValidationException validateGeneratedIndexName(String generatedIndexName, ClusterState state) {
+        ActionRequestValidationException err = new ActionRequestValidationException();
+        try {
+            MetadataCreateIndexService.validateIndexOrAliasName(generatedIndexName, InvalidIndexNameException::new);
+        } catch (InvalidIndexNameException e) {
+            err.addValidationError(e.getMessage());
+        }
+        if (state.routingTable().hasIndex(generatedIndexName) || state.metadata().hasIndex(generatedIndexName)) {
+            err.addValidationError("the index name we generated [" + generatedIndexName + "] already exists");
+        }
+        if (state.metadata().hasAlias(generatedIndexName)) {
+            err.addValidationError("the index name we generated [" + generatedIndexName + "] already exists as alias");
+        }
+
+        if (err.validationErrors().size() > 0) {
+            return err;
+        } else {
+            return null;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/IndexNameGeneratorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/IndexNameGeneratorTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.TestShardRoutingRoleStrategies;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.indices.InvalidIndexNameException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Locale;
+
+import static org.elasticsearch.common.IndexNameGenerator.ILLEGAL_INDEXNAME_CHARS_REGEX;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexSuffix;
+import static org.elasticsearch.common.IndexNameGenerator.validateGeneratedIndexName;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+public class IndexNameGeneratorTests extends ESTestCase {
+
+    public void testGenerateValidIndexName() {
+        String prefix = randomAlphaOfLengthBetween(5, 15);
+        String indexName = randomAlphaOfLengthBetween(5, 100);
+
+        String generatedValidIndexName = generateValidIndexName(prefix, indexName);
+        assertThat(generatedValidIndexName, startsWith(prefix));
+        assertThat(generatedValidIndexName, containsString(indexName));
+        try {
+            MetadataCreateIndexService.validateIndexOrAliasName(generatedValidIndexName, InvalidIndexNameException::new);
+        } catch (InvalidIndexNameException e) {
+            fail("generated index name [" + generatedValidIndexName + "] which is invalid due to [" + e.getDetailedMessage() + "]");
+        }
+    }
+
+    public void testGenerateValidIndexSuffix() {
+        {
+            String indexSuffix = generateValidIndexSuffix(() -> UUIDs.randomBase64UUID().toLowerCase(Locale.ROOT));
+            assertThat(indexSuffix, notNullValue());
+            assertThat(indexSuffix.length(), greaterThanOrEqualTo(1));
+            assertThat(indexSuffix.matches(ILLEGAL_INDEXNAME_CHARS_REGEX), is(false));
+        }
+
+        {
+            IllegalArgumentException illegalArgumentException = expectThrows(
+                IllegalArgumentException.class,
+                () -> generateValidIndexSuffix(() -> "****???><><>,# \\/:||")
+            );
+            assertThat(illegalArgumentException.getMessage(), is("unable to generate random index name suffix"));
+        }
+
+        {
+            assertThat(generateValidIndexSuffix(() -> "LegalChars|||# *"), is("legalchars"));
+        }
+    }
+
+    public void testValidateGeneratedIndexName() {
+        {
+            assertThat(
+                validateGeneratedIndexName(
+                    generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150)),
+                    ClusterState.EMPTY_STATE
+                ),
+                nullValue()
+            );
+        }
+
+        {
+            // index name is validated (invalid chars etc)
+            String generatedIndexName = generateValidIndexName("_prefix-", randomAlphaOfLengthBetween(5, 150));
+            assertThat(
+                validateGeneratedIndexName(generatedIndexName, ClusterState.EMPTY_STATE).validationErrors(),
+                containsInAnyOrder("Invalid index name [" + generatedIndexName + "], must not start with '_', '-', or '+'")
+            );
+        }
+
+        {
+            // index name is validated (invalid chars etc)
+            String generatedIndexName = generateValidIndexName("shrink-", "shrink-indexName-random###");
+            assertThat(
+                validateGeneratedIndexName(generatedIndexName, ClusterState.EMPTY_STATE).validationErrors(),
+                containsInAnyOrder("Invalid index name [" + generatedIndexName + "], must not contain '#'")
+            );
+        }
+
+        {
+            // generated index already exists as a standalone index
+            String generatedIndexName = generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150));
+            IndexMetadata indexMetadata = IndexMetadata.builder(generatedIndexName)
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(1, 5))
+                .build();
+            ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(Metadata.builder().put(indexMetadata, false))
+                .build();
+
+            ActionRequestValidationException validationException = validateGeneratedIndexName(generatedIndexName, clusterState);
+            assertThat(validationException, notNullValue());
+            assertThat(
+                validationException.validationErrors(),
+                containsInAnyOrder("the index name we generated [" + generatedIndexName + "] already exists")
+            );
+        }
+
+        {
+            // generated index name already exists as an index (cluster state routing table is also populated)
+            String generatedIndexName = generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150));
+            IndexMetadata indexMetadata = IndexMetadata.builder(generatedIndexName)
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(1, 5))
+                .build();
+            ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+                .routingTable(RoutingTable.builder(TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY).addAsNew(indexMetadata).build())
+                .metadata(Metadata.builder().put(indexMetadata, false))
+                .build();
+
+            ActionRequestValidationException validationException = validateGeneratedIndexName(generatedIndexName, clusterState);
+            assertThat(validationException, notNullValue());
+            assertThat(
+                validationException.validationErrors(),
+                containsInAnyOrder("the index name we generated [" + generatedIndexName + "] already exists")
+            );
+            ;
+        }
+
+        {
+            // generated index name already exists as an alias to another index
+            String generatedIndexName = generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150));
+            IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLengthBetween(10, 30))
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(1, 5))
+                .putAlias(AliasMetadata.builder(generatedIndexName).build())
+                .build();
+            ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(Metadata.builder().put(indexMetadata, false))
+                .build();
+
+            ActionRequestValidationException validationException = validateGeneratedIndexName(generatedIndexName, clusterState);
+            assertThat(validationException, notNullValue());
+            assertThat(
+                validationException.validationErrors(),
+                containsInAnyOrder("the index name we generated [" + generatedIndexName + "] already exists as alias")
+            );
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStep.java
@@ -13,16 +13,13 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState.Builder;
-import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
-import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.indices.InvalidIndexNameException;
 
-import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
+
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
+import static org.elasticsearch.common.IndexNameGenerator.validateGeneratedIndexName;
 
 /**
  * Generates a unique index name prefixing the original index name with the configured
@@ -35,8 +32,6 @@ public class GenerateUniqueIndexNameStep extends ClusterStateActionStep {
     private static final Logger logger = LogManager.getLogger(GenerateUniqueIndexNameStep.class);
 
     public static final String NAME = "generate-index-name";
-    static final String ILLEGAL_INDEXNAME_CHARS_REGEX = "[/:\"*?<>|# ,\\\\]+";
-    static final int MAX_GENERATED_UUID_LENGTH = 4;
 
     private final String prefix;
     private final BiFunction<String, Builder, Builder> lifecycleStateSetter;
@@ -98,28 +93,6 @@ public class GenerateUniqueIndexNameStep extends ClusterStateActionStep {
         );
     }
 
-    @Nullable
-    static ActionRequestValidationException validateGeneratedIndexName(String generatedIndexName, ClusterState state) {
-        ActionRequestValidationException err = new ActionRequestValidationException();
-        try {
-            MetadataCreateIndexService.validateIndexOrAliasName(generatedIndexName, InvalidIndexNameException::new);
-        } catch (InvalidIndexNameException e) {
-            err.addValidationError(e.getMessage());
-        }
-        if (state.routingTable().hasIndex(generatedIndexName) || state.metadata().hasIndex(generatedIndexName)) {
-            err.addValidationError("the index name we generated [" + generatedIndexName + "] already exists");
-        }
-        if (state.metadata().hasAlias(generatedIndexName)) {
-            err.addValidationError("the index name we generated [" + generatedIndexName + "] already exists as alias");
-        }
-
-        if (err.validationErrors().size() > 0) {
-            return err;
-        } else {
-            return null;
-        }
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -137,22 +110,4 @@ public class GenerateUniqueIndexNameStep extends ClusterStateActionStep {
         return Objects.hash(super.hashCode(), prefix);
     }
 
-    /**
-     * This generates a valid unique index name by using the provided prefix, appended with a generated UUID, and the index name.
-     */
-    static String generateValidIndexName(String prefix, String indexName) {
-        String randomUUID = generateValidIndexSuffix(UUIDs::randomBase64UUID);
-        randomUUID = randomUUID.substring(0, Math.min(randomUUID.length(), MAX_GENERATED_UUID_LENGTH));
-        return prefix + randomUUID + "-" + indexName;
-    }
-
-    static String generateValidIndexSuffix(Supplier<String> randomGenerator) {
-        String randomSuffix = randomGenerator.get().toLowerCase(Locale.ROOT);
-        randomSuffix = randomSuffix.replaceAll(ILLEGAL_INDEXNAME_CHARS_REGEX, "");
-        if (randomSuffix.length() == 0) {
-            throw new IllegalArgumentException("unable to generate random index name suffix");
-        }
-
-        return randomSuffix;
-    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.Map;
 
-import static org.elasticsearch.xpack.core.ilm.GenerateUniqueIndexNameStep.generateValidIndexName;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupTargetIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupTargetIndexStepTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.core.ilm.GenerateUniqueIndexNameStep.generateValidIndexName;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.newInstance;
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
 import static org.elasticsearch.xpack.core.ilm.DownsampleAction.DOWNSAMPLED_INDEX_PREFIX;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -163,7 +164,7 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
         lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
 
-        String downsampleIndex = GenerateUniqueIndexNameStep.generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
+        String downsampleIndex = generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
         lifecycleState.setDownsampleIndexName(downsampleIndex);
 
         IndexMetadata sourceIndexMetadata = IndexMetadata.builder(sourceIndexName)
@@ -213,7 +214,7 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
         lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
 
-        String downsampleIndex = GenerateUniqueIndexNameStep.generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
+        String downsampleIndex = generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
         lifecycleState.setDownsampleIndexName(downsampleIndex);
 
         IndexMetadata sourceIndexMetadata = IndexMetadata.builder(sourceIndexName)
@@ -255,7 +256,7 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
 
-        String downsampleIndex = GenerateUniqueIndexNameStep.generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
+        String downsampleIndex = generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
         lifecycleState.setDownsampleIndexName(downsampleIndex);
 
         IndexMetadata sourceIndexMetadata = IndexMetadata.builder(sourceIndexName)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStepTests.java
@@ -7,34 +7,19 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.TestShardRoutingRoleStrategies;
-import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState.Builder;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
-import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.indices.InvalidIndexNameException;
 
-import java.util.Locale;
 import java.util.function.BiFunction;
 
-import static org.elasticsearch.xpack.core.ilm.GenerateUniqueIndexNameStep.ILLEGAL_INDEXNAME_CHARS_REGEX;
-import static org.elasticsearch.xpack.core.ilm.GenerateUniqueIndexNameStep.generateValidIndexName;
-import static org.elasticsearch.xpack.core.ilm.GenerateUniqueIndexNameStep.generateValidIndexSuffix;
-import static org.elasticsearch.xpack.core.ilm.GenerateUniqueIndexNameStep.validateGeneratedIndexName;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 public class GenerateUniqueIndexNameStepTests extends AbstractStepTestCase<GenerateUniqueIndexNameStep> {
@@ -97,134 +82,6 @@ public class GenerateUniqueIndexNameStepTests extends AbstractStepTestCase<Gener
         );
         assertThat(executionState.shrinkIndexName(), containsString(indexName));
         assertThat(executionState.shrinkIndexName(), startsWith(generateUniqueIndexNameStep.prefix()));
-    }
-
-    public void testGenerateValidIndexName() {
-        String prefix = randomAlphaOfLengthBetween(5, 15);
-        String indexName = randomAlphaOfLengthBetween(5, 100);
-
-        String generatedValidIndexName = GenerateUniqueIndexNameStep.generateValidIndexName(prefix, indexName);
-        assertThat(generatedValidIndexName, startsWith(prefix));
-        assertThat(generatedValidIndexName, containsString(indexName));
-        try {
-            MetadataCreateIndexService.validateIndexOrAliasName(generatedValidIndexName, InvalidIndexNameException::new);
-        } catch (InvalidIndexNameException e) {
-            fail("generated index name [" + generatedValidIndexName + "] which is invalid due to [" + e.getDetailedMessage() + "]");
-        }
-    }
-
-    public void testGenerateValidIndexSuffix() {
-        {
-            String indexSuffix = generateValidIndexSuffix(() -> UUIDs.randomBase64UUID().toLowerCase(Locale.ROOT));
-            assertThat(indexSuffix, notNullValue());
-            assertThat(indexSuffix.length(), greaterThanOrEqualTo(1));
-            assertThat(indexSuffix.matches(ILLEGAL_INDEXNAME_CHARS_REGEX), is(false));
-        }
-
-        {
-            IllegalArgumentException illegalArgumentException = expectThrows(
-                IllegalArgumentException.class,
-                () -> generateValidIndexSuffix(() -> "****???><><>,# \\/:||")
-            );
-            assertThat(illegalArgumentException.getMessage(), is("unable to generate random index name suffix"));
-        }
-
-        {
-            assertThat(generateValidIndexSuffix(() -> "LegalChars|||# *"), is("legalchars"));
-        }
-    }
-
-    public void testValidateGeneratedIndexName() {
-        {
-            assertThat(
-                validateGeneratedIndexName(
-                    generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150)),
-                    ClusterState.EMPTY_STATE
-                ),
-                nullValue()
-            );
-        }
-
-        {
-            // index name is validated (invalid chars etc)
-            String generatedIndexName = generateValidIndexName("_prefix-", randomAlphaOfLengthBetween(5, 150));
-            assertThat(
-                validateGeneratedIndexName(generatedIndexName, ClusterState.EMPTY_STATE).validationErrors(),
-                containsInAnyOrder("Invalid index name [" + generatedIndexName + "], must not start with '_', '-', or '+'")
-            );
-        }
-
-        {
-            // index name is validated (invalid chars etc)
-            String generatedIndexName = generateValidIndexName("shrink-", "shrink-indexName-random###");
-            assertThat(
-                validateGeneratedIndexName(generatedIndexName, ClusterState.EMPTY_STATE).validationErrors(),
-                containsInAnyOrder("Invalid index name [" + generatedIndexName + "], must not contain '#'")
-            );
-        }
-
-        {
-            // generated index already exists as a standalone index
-            String generatedIndexName = generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150));
-            IndexMetadata indexMetadata = IndexMetadata.builder(generatedIndexName)
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(randomIntBetween(1, 5))
-                .numberOfReplicas(randomIntBetween(1, 5))
-                .build();
-            ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-                .metadata(Metadata.builder().put(indexMetadata, false))
-                .build();
-
-            ActionRequestValidationException validationException = validateGeneratedIndexName(generatedIndexName, clusterState);
-            assertThat(validationException, notNullValue());
-            assertThat(
-                validationException.validationErrors(),
-                containsInAnyOrder("the index name we generated [" + generatedIndexName + "] already exists")
-            );
-        }
-
-        {
-            // generated index name already exists as an index (cluster state routing table is also populated)
-            String generatedIndexName = generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150));
-            IndexMetadata indexMetadata = IndexMetadata.builder(generatedIndexName)
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(randomIntBetween(1, 5))
-                .numberOfReplicas(randomIntBetween(1, 5))
-                .build();
-            ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-                .routingTable(RoutingTable.builder(TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY).addAsNew(indexMetadata).build())
-                .metadata(Metadata.builder().put(indexMetadata, false))
-                .build();
-
-            ActionRequestValidationException validationException = validateGeneratedIndexName(generatedIndexName, clusterState);
-            assertThat(validationException, notNullValue());
-            assertThat(
-                validationException.validationErrors(),
-                containsInAnyOrder("the index name we generated [" + generatedIndexName + "] already exists")
-            );
-            ;
-        }
-
-        {
-            // generated index name already exists as an alias to another index
-            String generatedIndexName = generateValidIndexName(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 150));
-            IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLengthBetween(10, 30))
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(randomIntBetween(1, 5))
-                .numberOfReplicas(randomIntBetween(1, 5))
-                .putAlias(AliasMetadata.builder(generatedIndexName).build())
-                .build();
-            ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-                .metadata(Metadata.builder().put(indexMetadata, false))
-                .build();
-
-            ActionRequestValidationException validationException = validateGeneratedIndexName(generatedIndexName, clusterState);
-            assertThat(validationException, notNullValue());
-            assertThat(
-                validationException.validationErrors(),
-                containsInAnyOrder("the index name we generated [" + generatedIndexName + "] already exists as alias")
-            );
-        }
     }
 
     public void testParseOriginationDateFromGeneratedIndexName() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
 import static org.elasticsearch.xpack.core.ilm.ShrinkIndexNameSupplier.SHRUNKEN_INDEX_PREFIX;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -138,7 +139,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         lifecycleState.setAction(step.getKey().action());
         lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
-        String generatedShrunkenIndexName = GenerateUniqueIndexNameStep.generateValidIndexName(SHRUNKEN_INDEX_PREFIX, sourceIndexName);
+        String generatedShrunkenIndexName = generateValidIndexName(SHRUNKEN_INDEX_PREFIX, sourceIndexName);
         lifecycleState.setShrinkIndexName(generatedShrunkenIndexName);
         IndexMetadata sourceIndexMetadata = IndexMetadata.builder(sourceIndexName)
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, lifecycleName))


### PR DESCRIPTION
We'll need to generate index names as part of data stream lifecycles.
This moves the existing functionality we have in ILM to `server` so we can 
reuse it.