### PR TITLE
Add simulated latency plugin

### DIFF
--- a/test/external-modules/latency-simulating-directory/build.gradle
+++ b/test/external-modules/latency-simulating-directory/build.gradle
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+esplugin {
+  description 'A test module that simulates latencies in lucene IndexInputs'
+  classname 'org.elasticsearch.test.inputlatency.InputLatencyPlugin'
+}
+
+apply plugin: 'elasticsearch.internal-cluster-test'

--- a/test/external-modules/latency-simulating-directory/src/main/java/org/elasticsearch/test/inputlatency/InputLatencyPlugin.java
+++ b/test/external-modules/latency-simulating-directory/src/main/java/org/elasticsearch/test/inputlatency/InputLatencyPlugin.java
@@ -17,6 +17,10 @@ import org.elasticsearch.plugins.Plugin;
 
 import java.util.List;
 
+/**
+ * Supplies a directory wrapper that simulates networks latencies when loading lucene
+ * directory files from disk
+ */
 public class InputLatencyPlugin extends Plugin {
 
     private static final Logger log = LogManager.getLogger(InputLatencyPlugin.class);

--- a/test/external-modules/latency-simulating-directory/src/main/java/org/elasticsearch/test/inputlatency/InputLatencyPlugin.java
+++ b/test/external-modules/latency-simulating-directory/src/main/java/org/elasticsearch/test/inputlatency/InputLatencyPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.inputlatency;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.List;
+
+public class InputLatencyPlugin extends Plugin {
+
+    private static final Logger log = LogManager.getLogger(InputLatencyPlugin.class);
+
+    /** Setting for enabling or disabling simulated object store latencies. Defaults to false. */
+    public static final Setting<Boolean> INPUT_LATENCY_ENABLED = Setting.boolSetting(
+        "input.latency.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
+
+    private final boolean enabled;
+
+    public InputLatencyPlugin(Settings settings) {
+        this.enabled = INPUT_LATENCY_ENABLED.get(settings);
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(INPUT_LATENCY_ENABLED);
+    }
+
+    @Override
+    public void onIndexModule(IndexModule indexModule) {
+        if (enabled) {
+            log.debug("Enabling input latency simulation plugin");
+            indexModule.setDirectoryWrapper(new SimulatedLatencyDirectoryWrapper(filename -> {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("Thread interrupted");
+                }
+            }));
+        }
+    }
+}

--- a/test/external-modules/latency-simulating-directory/src/main/java/org/elasticsearch/test/inputlatency/SimulatedLatencyDirectoryWrapper.java
+++ b/test/external-modules/latency-simulating-directory/src/main/java/org/elasticsearch/test/inputlatency/SimulatedLatencyDirectoryWrapper.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.inputlatency;
+
+import org.apache.lucene.store.BufferedIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.index.IndexModule;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.function.Consumer;
+
+public class SimulatedLatencyDirectoryWrapper implements IndexModule.DirectoryWrapper {
+
+    private final Consumer<String> delayer;
+
+    public SimulatedLatencyDirectoryWrapper(Consumer<String> delayer) {
+        this.delayer = delayer;
+    }
+
+    @Override
+    public Directory wrap(Directory directory, ShardRouting shardRouting) {
+        if (directory instanceof NIOFSDirectory niofsDir) {
+            return new FilterDirectory(niofsDir) {
+                @Override
+                public IndexInput openInput(String name, IOContext context) throws IOException {
+                    Path path = niofsDir.getDirectory().resolve(name);
+                    FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
+                    boolean success = false;
+                    try {
+                        final DelayingNIOFSIndexInput indexInput = new DelayingNIOFSIndexInput(
+                            "NIOFSIndexInput(path=\"" + path + "\")",
+                            fc,
+                            context
+                        );
+                        success = true;
+                        return indexInput;
+                    } finally {
+                        if (success == false) {
+                            IOUtils.closeWhileHandlingException(fc);
+                        }
+                    }
+                }
+            };
+        } else {
+            throw new IllegalStateException("Can only wrap NIOFSDirectory");
+        }
+    }
+
+    final class DelayingNIOFSIndexInput extends BufferedIndexInput {
+        /** The maximum chunk size for reads of 16384 bytes. */
+        private static final int CHUNK_SIZE = 16384;
+
+        /** the file channel we will read from */
+        protected final FileChannel channel;
+        /** is this instance a clone and hence does not own the file to close it */
+        boolean isClone = false;
+        /** start offset: non-zero in the slice case */
+        protected final long off;
+        /** end offset (start+length) */
+        protected final long end;
+
+        public DelayingNIOFSIndexInput(String resourceDesc, FileChannel fc, IOContext context) throws IOException {
+            super(resourceDesc, context);
+            this.channel = fc;
+            this.off = 0L;
+            this.end = fc.size();
+        }
+
+        public DelayingNIOFSIndexInput(String resourceDesc, FileChannel fc, long off, long length, int bufferSize) {
+            super(resourceDesc, bufferSize);
+            this.channel = fc;
+            this.off = off;
+            this.end = off + length;
+            this.isClone = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!isClone) {
+                channel.close();
+            }
+        }
+
+        @Override
+        public DelayingNIOFSIndexInput clone() {
+            DelayingNIOFSIndexInput clone = (DelayingNIOFSIndexInput) super.clone();
+            clone.isClone = true;
+            return clone;
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            if (offset < 0 || length < 0 || offset + length > this.length()) {
+                throw new IllegalArgumentException(
+                    "slice() "
+                        + sliceDescription
+                        + " out of bounds: offset="
+                        + offset
+                        + ",length="
+                        + length
+                        + ",fileLength="
+                        + this.length()
+                        + ": "
+                        + this
+                );
+            }
+            return new DelayingNIOFSIndexInput(getFullSliceDescription(sliceDescription), channel, off + offset, length, getBufferSize());
+        }
+
+        @Override
+        public final long length() {
+            return end - off;
+        }
+
+        @Override
+        protected void readInternal(ByteBuffer b) throws IOException {
+
+            // Add a delay here to simulate pulling data from the blob store
+            delayer.accept(this.toString());
+
+            long pos = getFilePointer() + off;
+
+            if (pos + b.remaining() > end) {
+                throw new EOFException("read past EOF: " + this);
+            }
+
+            try {
+                int readLength = b.remaining();
+                while (readLength > 0) {
+                    final int toRead = Math.min(CHUNK_SIZE, readLength);
+                    b.limit(b.position() + toRead);
+                    assert b.remaining() == toRead;
+                    final int i = channel.read(b, pos);
+                    if (i < 0) {
+                        // be defensive here, even though we checked before hand, something could have changed
+                        throw new EOFException("read past EOF: " + this + " buffer: " + b + " chunkLen: " + toRead + " end: " + end);
+                    }
+                    assert i > 0
+                        : "FileChannel.read with non zero-length bb.remaining() must always read at least "
+                            + "one byte (FileChannel is in blocking mode, see spec of ReadableByteChannel)";
+                    pos += i;
+                    readLength -= i;
+                }
+                assert readLength == 0;
+            } catch (IOException ioe) {
+                throw new IOException(ioe.getMessage() + ": " + this, ioe);
+            }
+        }
+
+        @Override
+        protected void seekInternal(long pos) throws IOException {
+            if (pos > length()) {
+                throw new EOFException("read past EOF: pos=" + pos + " vs length=" + length() + ": " + this);
+            }
+        }
+    }
+
+}

--- a/test/external-modules/latency-simulating-directory/src/test/java/org/elasticsearch/test/inputlatency/SimulatedLatencyDirectoryWrapperTests.java
+++ b/test/external-modules/latency-simulating-directory/src/test/java/org/elasticsearch/test/inputlatency/SimulatedLatencyDirectoryWrapperTests.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static org.hamcrest.Matchers.greaterThan;
 
-public class TestSimulatedLatencyDirectoryWrapper extends ESTestCase {
+public class SimulatedLatencyDirectoryWrapperTests extends ESTestCase {
 
     public void testBufferRunnableIsCalled() throws IOException {
         Settings build = Settings.builder()

--- a/test/external-modules/latency-simulating-directory/src/test/java/org/elasticsearch/test/inputlatency/TestSimulatedLatencyDirectoryWrapper.java
+++ b/test/external-modules/latency-simulating-directory/src/test/java/org/elasticsearch/test/inputlatency/TestSimulatedLatencyDirectoryWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.inputlatency;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.English;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.store.FsDirectoryFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class TestSimulatedLatencyDirectoryWrapper extends ESTestCase {
+
+    public void testBufferRunnableIsCalled() throws IOException {
+        Settings build = Settings.builder()
+            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.name().toLowerCase(Locale.ROOT))
+            .build();
+        Map<String, LongAdder> counters = new HashMap<>();
+        SimulatedLatencyDirectoryWrapper wrapper = new SimulatedLatencyDirectoryWrapper(filename -> {
+            counters.computeIfAbsent(filename, n -> new LongAdder()).increment();
+        });
+        try (
+            Directory directory = wrapper.wrap(newDirectory(build), null);
+            RandomIndexWriter w = new RandomIndexWriter(random(), directory)
+        ) {
+            // index a bunch of docs, then do some searches and check that the counters map is updated.
+            Document doc = new Document();
+            for (int i = 0; i < 200; i++) {
+                doc.clear();
+                doc.add(new TextField("text", English.intToEnglish(i), Field.Store.NO));
+                doc.add(new IntField("int", i, Field.Store.NO));
+                doc.add(new DoubleField("double", i * 1.5f, Field.Store.NO));
+                w.addDocument(doc);
+            }
+
+            w.commit();
+            w.flush();
+
+            IndexReader reader = DirectoryReader.open(directory);
+            IndexSearcher searcher = new IndexSearcher(reader);
+
+            counters.clear();
+
+            searcher.search(new TermQuery(new Term("text", "four")), 10);
+            assertThat(counters.size(), greaterThan(0));
+
+            reader.close();
+        }
+    }
+
+    private Directory newDirectory(Settings settings) throws IOException {
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("foo", settings);
+        Path tempDir = createTempDir().resolve(idxSettings.getUUID()).resolve("0");
+        Files.createDirectories(tempDir);
+        ShardPath path = new ShardPath(false, tempDir, tempDir, new ShardId(idxSettings.getIndex(), 0));
+        return new FsDirectoryFactory().newDirectory(idxSettings, path);
+    }
+
+}


### PR DESCRIPTION
This adds a test module to elasticsearch allowing benchmark test to simulate
a network delay when reading data from a lucene directory.  The simulated delay
is enabled by setting `input.latency.enabled=true` in a node's `elasticsearch.yml`
file.  This only works with `niofs` or `hybridfs` store types.

The module forks an NIOFSIndexInput, and inserts a 50ms sleep whenever the input
asks to refill its buffer from the file system.