### PR TITLE
Fix timestamp as object at root level for APM Server

### DIFF
--- a/docs/changelog/97401.yaml
+++ b/docs/changelog/97401.yaml
@@ -1,0 +1,5 @@
+pr: 97401
+summary: Fix timestamp as object as root level in APM Server
+area: Data streams
+type: bug
+issues: []

--- a/docs/changelog/97401.yaml
+++ b/docs/changelog/97401.yaml
@@ -1,5 +1,5 @@
 pr: 97401
-summary: Fix timestamp as object as root level in APM Server
+summary: Accept timestamp as object at root level
 area: Data streams
 type: bug
 issues: []

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
@@ -235,6 +235,7 @@ Test general mockup ECS mappings:
                 "path": "/path/to/my/file",
                 "target_path": "/path/to/my/file"
               },
+              "code_signature.timestamp": "2023-07-05",
               "registry.data.strings": ["C:\\rta\\red_ttp\\bin\\myapp.exe"]
             },
             "error": {
@@ -378,6 +379,7 @@ Test general mockup ECS mappings:
   # testing the default mapping of string input fields to keyword if not matching any pattern
   - match: { .$idx0name.mappings.properties.start-timestamp.type: "keyword" }
   - match: { .$idx0name.mappings.properties.timestamp.properties.us.type: "long" }
+  - match: { .$idx0name.mappings.properties.parent.properties.code_signature.properties.timestamp.type: "date" }
   - match: { .$idx0name.mappings.properties.vulnerability.properties.score.properties.base.type: "float" }
   - match: { .$idx0name.mappings.properties.vulnerability.properties.score.properties.temporal.type: "float" }
   - match: { .$idx0name.mappings.properties.vulnerability.properties.score.properties.version.type: "keyword" }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
@@ -197,6 +197,7 @@ Test general mockup ECS mappings:
           {
             "start_timestamp": "not a date",
             "start-timestamp": "not a date",
+            "timestamp.us": 1688550340718000,
             "test": "mockup-ecs-log",
             "registry": {
               "data": {
@@ -376,6 +377,7 @@ Test general mockup ECS mappings:
   - match: { .$idx0name.mappings.properties.start_timestamp.type: "date" }
   # testing the default mapping of string input fields to keyword if not matching any pattern
   - match: { .$idx0name.mappings.properties.start-timestamp.type: "keyword" }
+  - match: { .$idx0name.mappings.properties.timestamp.properties.us.type: "long" }
   - match: { .$idx0name.mappings.properties.vulnerability.properties.score.properties.base.type: "float" }
   - match: { .$idx0name.mappings.properties.vulnerability.properties.score.properties.temporal.type: "float" }
   - match: { .$idx0name.mappings.properties.vulnerability.properties.score.properties.version.type: "keyword" }

--- a/x-pack/plugin/core/src/main/resources/ecs-dynamic-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/ecs-dynamic-mappings.json
@@ -124,7 +124,6 @@
               "type": "date"
             },
             "path_match": [
-              "timestamp",
               "*.timestamp",
               "*_timestamp",
               "*.not_after",


### PR DESCRIPTION
APM Server uses `timestamp.us` at documents root level. When sending data with such field to a `logs-*-*` data stream, indexing fails with: `failed to parse field [timestamp] of type [date] in document with id '<id>'`.
This happens because it clashes with the [ECS dynamic template](https://github.com/elastic/elasticsearch/blob/34268e19664346b3bfee35864e4210e27e398024/x-pack/plugin/core/src/main/resources/ecs-dynamic-mappings.json#L121-L145) that maps `timestamp` fields to a `date`.

The preferable solution would be to still automatically map such fields to `date` if they are of suitable candidate type (`string`, `long` or `double`). We would have relied on `match_mapping_type`, but this setting doesn't support multiple type values and creating multiple dynamic templates to same patterns with different `match_mapping_type` make them clash with each other. Two possible enhancements can work well for our purpose:
- make `match_mapping_type` support array of types
- add `unmatch_mapping_type`, which we would use to unmatch `object` type


For now, the quick fix would be to remove only the `path_match: timestamp` mapping, thus still support nested fields (like [`code_signature.timestamp`](https://www.elastic.co/guide/en/ecs/8.8/ecs-code_signature.html#field-code-signature-timestamp))