### PR TITLE
Updating health APIs and cat recovery API to INTERNAL for serverless

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
@@ -11,6 +11,8 @@ package org.elasticsearch.health;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 
@@ -19,6 +21,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
+@ServerlessScope(Scope.INTERNAL)
 public class RestGetHealthAction extends BaseRestHandler {
 
     private static final String VERBOSE_PARAM = "verbose";

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatRecoveryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatRecoveryAction.java
@@ -23,6 +23,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestResponseListener;
 
@@ -38,6 +40,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  * in a string format, designed to be used at the command line. An Index can
  * be specified to limit output to a particular index or indices.
  */
+@ServerlessScope(Scope.INTERNAL)
 public class RestCatRecoveryAction extends AbstractCatAction {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -14,6 +14,8 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestResponseListener;
 
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
+@ServerlessScope(Scope.INTERNAL)
 public class RestHealthAction extends AbstractCatAction {
 
     @Override


### PR DESCRIPTION
Changing access in serverless mode from BLOCKED to INTERNAL for the following:
/_health_report
/_health_report/{indicator}
/_cat/health
/_cat/recovery
/_cat/recovery/{index}