### PR TITLE
Made `_mvt` REST handler public in serverless

### DIFF
--- a/docs/changelog/97405.yaml
+++ b/docs/changelog/97405.yaml
@@ -1,0 +1,5 @@
+pr: 97405
+summary: Made `_mvt` REST handler public in serverless
+area: Geo
+type: enhancement
+issues: []

--- a/docs/changelog/97405.yaml
+++ b/docs/changelog/97405.yaml
@@ -1,5 +1,0 @@
-pr: 97405
-summary: Made `_mvt` REST handler public in serverless
-area: Geo
-type: enhancement
-issues: []

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -28,6 +28,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestResponseListener;
 import org.elasticsearch.search.SearchHit;
@@ -62,6 +64,7 @@ import static org.elasticsearch.transport.RemoteClusterAware.buildRemoteIndexNam
 /**
  * Main class handling a call to the _mvt API.
  */
+@ServerlessScope(Scope.PUBLIC)
 public class RestVectorTileAction extends BaseRestHandler {
 
     private static final String META_LAYER = "meta";


### PR DESCRIPTION
Apparently all REST API's need an explicit @ServerlessScope annotation in order to be public in serverless contexts. I labeled this `enhancement` because I found similar PRs for other search API's what added this annotation as an enhancement.