### PR TITLE
[Profiling] Add field Symbfile.file.id_str to profiling-returnpads-private mapping

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
@@ -38,7 +38,7 @@
            'binary' type fields don't allow using 'index: true'.
            The value is stored in its binary form (byte array).
            Not readable or writeable via JSON (CBOR and SMILE only).
-            */
+           */
           "type": "keyword",
           "index": true,
           "doc_values": false,

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
@@ -34,7 +34,20 @@
           "store": false
         },
         "Symbfile.file.id": {
-          /* 'binary' type fields don't allow using 'index: true'. */
+          /*
+           'binary' type fields don't allow using 'index: true'.
+           The value is stored in its binary form (byte array).
+           Not readable or writeable via JSON (CBOR and SMILE only).
+            */
+          "type": "keyword",
+          "index": true,
+          "doc_values": false,
+          "store": false
+        },
+        "Symbfile.file.id_str": {
+          /*
+           The value is stored as base64 encoded string to allow JSON queries.
+           */
           "type": "keyword",
           "index": true,
           "doc_values": false,


### PR DESCRIPTION
In order to read and write the file ID via JSON, we need its base64 representation in the mapping.