### PR TITLE
[8.9] Fix mapping parsing logic to determine synthetic source is active. (#97355)

### DIFF
--- a/docs/changelog/97355.yaml
+++ b/docs/changelog/97355.yaml
@@ -1,0 +1,6 @@
+pr: 97355
+summary: Fix mapping parsing logic to determine synthetic source is active
+area: "Mapping"
+type: bug
+issues:
+ - 97320

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -274,3 +274,80 @@ setup:
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._source.foo: "The Apache Software Foundation manages many projects including Lucene" }
   - match: { hits.hits.0.highlight.foo.0: "The Apache Software Foundation manages <em>many</em> projects including Lucene" }
+
+---
+synthetic_source:
+  - skip:
+      version: " - 8.3.99"
+      reason: synthetic source introduced in 8.4.0
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              foo:
+                type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: "Apache Lucene powers Elasticsearch"
+
+  - do:
+      search:
+        index: synthetic_source_test
+  - match: { "hits.total.value": 1 }
+  - match:
+      hits.hits.0._source:
+        foo: "Apache Lucene powers Elasticsearch"
+
+---
+tsdb:
+  - skip:
+      version: " - 8.9.99"
+      reason: bug fixed in 8.10.0
+
+  - do:
+      indices.create:
+        index: tsdb_test
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ dimension ]
+              time_series:
+                start_time: 2000-01-01T00:00:00Z
+                end_time: 2099-12-31T23:59:59Z
+          mappings:
+            properties:
+              dimension:
+                type: keyword
+                time_series_dimension: true
+              foo:
+                type: match_only_text
+
+  - do:
+      index:
+        index: tsdb_test
+        refresh: true
+        body:
+          "@timestamp": "2000-01-01T00:00:00Z"
+          dimension: "a"
+          foo: "Apache Lucene powers Elasticsearch"
+
+  - do:
+      search:
+        index: tsdb_test
+  - match: { "hits.total.value": 1 }
+  - match:
+      hits.hits.0._source:
+        "@timestamp" : "2000-01-01T00:00:00.000Z"
+        "dimension" : "a"
+        foo: "Apache Lucene powers Elasticsearch"

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -311,8 +311,8 @@ synthetic_source:
 ---
 tsdb:
   - skip:
-      version: " - 8.9.99"
-      reason: bug fixed in 8.10.0
+      version: " - 8.9.0"
+      reason: bug fixed in 8.9.1
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -114,6 +114,11 @@ public enum IndexMode {
 
         @Override
         public void validateSourceFieldMapper(SourceFieldMapper sourceFieldMapper) {}
+
+        @Override
+        public boolean isSyntheticSourceEnabled() {
+            return false;
+        }
     },
     TIME_SERIES("time_series") {
         @Override
@@ -206,6 +211,11 @@ public enum IndexMode {
             if (sourceFieldMapper.isSynthetic() == false) {
                 throw new IllegalArgumentException("time series indices only support synthetic source");
             }
+        }
+
+        @Override
+        public boolean isSyntheticSourceEnabled() {
+            return true;
         }
     };
 
@@ -300,7 +310,7 @@ public enum IndexMode {
 
     /**
      * @return the time range based on the provided index metadata and index mode implementation.
-     *         Otherwise <code>null</code> is returned.
+     * Otherwise <code>null</code> is returned.
      */
     @Nullable
     public abstract TimestampBounds getTimestampBound(IndexMetadata indexMetadata);
@@ -326,6 +336,11 @@ public enum IndexMode {
      * Validates the source field mapper
      */
     public abstract void validateSourceFieldMapper(SourceFieldMapper sourceFieldMapper);
+
+    /**
+     * @return whether synthetic source is the only allowed source mode.
+     */
+    public abstract boolean isSyntheticSourceEnabled();
 
     /**
      * Parse a string into an {@link IndexMode}.


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Fix mapping parsing logic to determine synthetic source is active. (#97355)