### PR TITLE
Change the way feature flag is used for the data stream lifecycle telemetry

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NamedDiff;
-import org.elasticsearch.cluster.metadata.DataLifecycle;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
@@ -549,13 +548,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
             ),
             // Data Streams
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_STREAMS, DataStreamFeatureSetUsage::new),
-            DataLifecycle.isEnabled()
-                ? new NamedWriteableRegistry.Entry(
-                    XPackFeatureSet.Usage.class,
-                    XPackField.DATA_LIFECYCLE,
-                    DataLifecycleFeatureSetUsage::new
-                )
-                : null,
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_LIFECYCLE, DataLifecycleFeatureSetUsage::new),
             // Data Tiers
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_TIERS, DataTiersFeatureSetUsage::new),
             // Archive

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.DataLifecycle;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -353,9 +352,7 @@ public class XPackPlugin extends XPackClientPlugin
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_TIERS, DataTiersUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_STREAMS, DataStreamUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackInfoFeatureAction.DATA_STREAMS, DataStreamInfoTransportAction.class));
-        if (DataLifecycle.isEnabled()) {
-            actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_LIFECYCLE, DataLifecycleUsageTransportAction.class));
-        }
+        actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_LIFECYCLE, DataLifecycleUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.HEALTH, HealthApiUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.REMOTE_CLUSTERS, RemoteClusterUsageTransportAction.class));
         return actions;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportAction.java
@@ -53,6 +53,11 @@ public class DataLifecycleUsageTransportAction extends XPackUsageFeatureTranspor
         ClusterState state,
         ActionListener<XPackUsageFeatureResponse> listener
     ) {
+        if (DataLifecycle.isEnabled() == false) {
+            listener.onResponse(new XPackUsageFeatureResponse(DataLifecycleFeatureSetUsage.DISABLED));
+            return;
+        }
+
         final Collection<DataStream> dataStreams = state.metadata().dataStreams().values();
         LongSummaryStatistics retentionStats = dataStreams.stream()
             .filter(ds -> ds.getLifecycle() != null)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.cluster.metadata.DataLifecycle;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.xpack.core.XPackField;
 
@@ -59,7 +58,7 @@ public class XPackUsageFeatureAction extends ActionType<XPackUsageFeatureRespons
         ANALYTICS,
         CCR,
         DATA_STREAMS,
-        DataLifecycle.isEnabled() ? DATA_LIFECYCLE : null,
+        DATA_LIFECYCLE,
         DATA_TIERS,
         EQL,
         FROZEN_INDICES,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataLifecycleFeatureSetUsage.java
@@ -20,11 +20,18 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class DataLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
+
+    public static final DataLifecycleFeatureSetUsage DISABLED = new DataLifecycleFeatureSetUsage();
     final LifecycleStats lifecycleStats;
 
     public DataLifecycleFeatureSetUsage(StreamInput input) throws IOException {
         super(input);
-        this.lifecycleStats = new LifecycleStats(input);
+        this.lifecycleStats = LifecycleStats.read(input);
+    }
+
+    private DataLifecycleFeatureSetUsage() {
+        super(XPackField.DATA_LIFECYCLE, true, false);
+        this.lifecycleStats = LifecycleStats.INITIAL;
     }
 
     public DataLifecycleFeatureSetUsage(LifecycleStats stats) {
@@ -46,13 +53,15 @@ public class DataLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
         super.innerXContent(builder, params);
-        builder.field("count", lifecycleStats.dataStreamsWithLifecyclesCount);
-        builder.field("default_rollover_used", lifecycleStats.defaultRolloverUsed);
-        builder.startObject("retention");
-        builder.field("minimum_millis", lifecycleStats.minRetentionMillis);
-        builder.field("maximum_millis", lifecycleStats.maxRetentionMillis);
-        builder.field("average_millis", lifecycleStats.averageRetentionMillis);
-        builder.endObject();
+        if (enabled) {
+            builder.field("count", lifecycleStats.dataStreamsWithLifecyclesCount);
+            builder.field("default_rollover_used", lifecycleStats.defaultRolloverUsed);
+            builder.startObject("retention");
+            builder.field("minimum_millis", lifecycleStats.minRetentionMillis);
+            builder.field("maximum_millis", lifecycleStats.maxRetentionMillis);
+            builder.field("average_millis", lifecycleStats.averageRetentionMillis);
+            builder.endObject();
+        }
     }
 
     @Override
@@ -62,7 +71,7 @@ public class DataLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
 
     @Override
     public int hashCode() {
-        return lifecycleStats.hashCode();
+        return Objects.hash(available, enabled, lifecycleStats);
     }
 
     @Override
@@ -74,10 +83,13 @@ public class DataLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
             return false;
         }
         DataLifecycleFeatureSetUsage other = (DataLifecycleFeatureSetUsage) obj;
-        return Objects.equals(lifecycleStats, other.lifecycleStats);
+        return available == other.available && enabled == other.enabled && Objects.equals(lifecycleStats, other.lifecycleStats);
     }
 
     public static class LifecycleStats implements Writeable {
+
+        public static final LifecycleStats INITIAL = new LifecycleStats(0, 0, 0, 0, true);
+
         final long dataStreamsWithLifecyclesCount;
         final long minRetentionMillis;
         final long maxRetentionMillis;
@@ -98,19 +110,11 @@ public class DataLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
             this.defaultRolloverUsed = defaultRolloverUsed;
         }
 
-        public LifecycleStats(StreamInput in) throws IOException {
+        public static LifecycleStats read(StreamInput in) throws IOException {
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_006)) {
-                this.dataStreamsWithLifecyclesCount = in.readVLong();
-                this.minRetentionMillis = in.readVLong();
-                this.maxRetentionMillis = in.readVLong();
-                this.averageRetentionMillis = in.readDouble();
-                this.defaultRolloverUsed = in.readBoolean();
+                return new LifecycleStats(in.readVLong(), in.readVLong(), in.readVLong(), in.readDouble(), in.readBoolean());
             } else {
-                this.dataStreamsWithLifecyclesCount = 0;
-                this.minRetentionMillis = 0;
-                this.maxRetentionMillis = 0;
-                this.averageRetentionMillis = 0.0;
-                this.defaultRolloverUsed = false;
+                return INITIAL;
             }
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataLifecycleFeatureSetUsageTests.java
@@ -15,19 +15,24 @@ public class DataLifecycleFeatureSetUsageTests extends AbstractWireSerializingTe
 
     @Override
     protected DataLifecycleFeatureSetUsage createTestInstance() {
-        return new DataLifecycleFeatureSetUsage(
-            new DataLifecycleFeatureSetUsage.LifecycleStats(
-                randomNonNegativeLong(),
-                randomNonNegativeLong(),
-                randomNonNegativeLong(),
-                randomDouble(),
-                randomBoolean()
+        return randomBoolean()
+            ? new DataLifecycleFeatureSetUsage(
+                new DataLifecycleFeatureSetUsage.LifecycleStats(
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomDouble(),
+                    randomBoolean()
+                )
             )
-        );
+            : DataLifecycleFeatureSetUsage.DISABLED;
     }
 
     @Override
     protected DataLifecycleFeatureSetUsage mutateInstance(DataLifecycleFeatureSetUsage instance) {
+        if (instance.equals(DataLifecycleFeatureSetUsage.DISABLED)) {
+            return new DataLifecycleFeatureSetUsage(DataLifecycleFeatureSetUsage.LifecycleStats.INITIAL);
+        }
         return switch (randomInt(4)) {
             case 0 -> new DataLifecycleFeatureSetUsage(
                 new DataLifecycleFeatureSetUsage.LifecycleStats(


### PR DESCRIPTION
In this PR we change the way the feature flag is used to disable, enable data stream lifecycle telemetry.

The initial approach used the feature flag to completely hide the data stream lifecycle code. When the flag was disabled the code was like it never existed. But this code includes wire communication, the named writable `DataLifecycleFeatureSetUsage` which has minimum supported version `TransportVersion.V_8_500_006`. 

The above will break the following mixed cluster combo in the tests: `8.9.0` (dlm flag disabled) and `8.10.0-SNAPSHOT` (dlm flag enabled). `8.9.0` will not be aware of `DataLifecycleFeatureSetUsage` but `8.10.0-SNAPSHOT` will expect that `DataLifecycleFeatureSetUsage` is supported in the `8.9.0` version and their communication will break.

In this PR, we do not hide the relative code behind the feature flag but we only use it to signal that the data lifecycle feature is not enabled:

```
   "data_lifecycle": {
        "available": true,
        "enabled": false
    },
```