### PR TITLE
Synonyms - Fixes error when no ID is specified

### DIFF
--- a/docs/changelog/97426.yaml
+++ b/docs/changelog/97426.yaml
@@ -1,5 +1,0 @@
-pr: 97426
-summary: Synonyms - Fixes error when no ID is specified
-area: Analysis
-type: bug
-issues: []

--- a/docs/changelog/97426.yaml
+++ b/docs/changelog/97426.yaml
@@ -1,0 +1,5 @@
+pr: 97426
+summary: Synonyms - Fixes error when no ID is specified
+area: Analysis
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -22,8 +22,8 @@ setup:
       synonyms.get:
         synonyms_set: test-update-synonyms
 
-  - length: { synonyms_set.0.id: 20 }
-  - length: { synonyms_set.1.id: 20 }
+  - is_true: synonyms_set.0.id
+  - is_true: synonyms_set.1.id
 
 ---
 "Create and Update synonyms set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -5,6 +5,9 @@ setup:
 
 ---
 "Create synonyms with no ID creates ID automatically":
+  - skip:
+      version: " - 8.9.99"
+      reason: Fixed for 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-update-synonyms

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -4,6 +4,25 @@ setup:
       reason: Introduced in 8.9.0
 
 ---
+"Create synonyms with no ID creates ID automatically":
+  - do:
+      synonyms.put:
+        synonyms_set: test-update-synonyms
+        body:
+          synonyms_set:
+            - synonyms: "hello, hi"
+            - synonyms: "bye => goodbye"
+
+  - match: { result: "created" }
+
+  - do:
+      synonyms.get:
+        synonyms_set: test-update-synonyms
+
+  - length: { synonyms_set.0.id: 20 }
+  - length: { synonyms_set.1.id: 20 }
+
+---
 "Create and Update synonyms set":
   - do:
       synonyms.put:

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymRule.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymRule.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.synonyms;
 
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -43,7 +44,7 @@ public class SynonymRule implements Writeable, ToXContentObject {
     private final String id;
 
     public SynonymRule(@Nullable String id, String synonyms) {
-        this.id = id;
+        this.id = Objects.requireNonNullElse(id, UUIDs.base64UUID());
         this.synonyms = synonyms;
     }
 

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.Preference;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -356,11 +355,7 @@ public class SynonymsManagementAPIService {
     // Retrieves the internal synonym rule ID to store it in the index. As the same synonym rule ID
     // can be used in different synonym sets, we prefix the ID with the synonym set to avoid collisions
     private static String internalSynonymRuleId(String synonymsSetId, String synonymRuleId) {
-        if (synonymRuleId == null) {
-            synonymRuleId = UUIDs.base64UUID();
-        }
-        final String id = synonymsSetId + SYNONYM_RULE_ID_SEPARATOR + synonymRuleId;
-        return id;
+        return synonymsSetId + SYNONYM_RULE_ID_SEPARATOR + synonymRuleId;
     }
 
     static Settings settings() {


### PR DESCRIPTION
When synonyms have no ID specified, they have no ID when retrieved via GET operations. This fixes the issue.