### PR TITLE
Do not use auto_expand_replica in mget yaml rest tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/40_routing.yml
@@ -8,11 +8,6 @@ routing:
             index:
               number_of_shards: 5
               number_of_routing_shards: 5
-              auto_expand_replicas: 0-1
-
-  - do:
-      cluster.health:
-          wait_for_status: green
 
   - do:
       index:
@@ -51,14 +46,9 @@ requires routing:
           settings:
             index:
               number_of_shards: 5
-              auto_expand_replicas: 0-1
           mappings:
             _routing:
               required: true
-
-  - do:
-      cluster.health:
-        wait_for_status: green
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
@@ -9,11 +9,6 @@
           settings:
             index:
               refresh_interval: -1
-              auto_expand_replicas: 0-1
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:


### PR DESCRIPTION
As described in the issue, the change in https://github.com/elastic/elasticsearch/pull/96763 
has made the MixedClusterClientYamlTestSuiteIT for `mget` fail very 
often. For now, let's take the same approach that we have for `get.`

Closes https://github.com/elastic/elasticsearch/issues/97236
