### PR TITLE
Loosening the amount of time Retry2Tests.testAwaitClose() waits for Retry2.awaitClose() to complete

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/bulk/Retry2Tests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/Retry2Tests.java
@@ -209,7 +209,8 @@ public class Retry2Tests extends ESTestCase {
             long stopTimeNanos = System.nanoTime();
             long runtimeMillis = TimeValue.timeValueNanos((stopTimeNanos - startTimeNanos)).millis();
             assertThat(runtimeMillis, greaterThanOrEqualTo(waitTimeMillis));
-            assertThat(runtimeMillis, lessThanOrEqualTo(2 * waitTimeMillis));
+            // A sanity check that it didn't take an extremely long time to complete:
+            assertThat(runtimeMillis, lessThanOrEqualTo(TimeValue.timeValueSeconds(1).millis()));
         }
     }
 


### PR DESCRIPTION
In Retry2Tests.testAwaitClose() we assert that `awaitClose()` takes at least `waitTimeMillis`, and then we assert that it completes in less than `2 * waitTimeMillis`. The latter check is just meant to make sure that it's not taking an extraordinary amount of time. Every once in a while (very rarely) this assertion fails because the call take a few more milliseconds than expected (in #97170 it takes 53ms when the limit is set to 48ms).  This small of a difference is not important, and possibly due to the build machine being busy or doing a GC. This commit changes the test to assert that the method completes within a second instead.
Closes #97170