### PR TITLE
[ML] Fix trained model API wait_for_completion

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
@@ -44,7 +44,7 @@ class ModelImporter {
     ModelImporter(Client client, String modelId, ModelPackageConfig packageConfig) {
         this.client = client;
         this.modelId = Objects.requireNonNull(modelId);
-        this.config = packageConfig;
+        this.config = Objects.requireNonNull(packageConfig);
     }
 
     public void doImport() throws URISyntaxException, IOException, ElasticsearchStatusException {

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelUploader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelUploader.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.packageloader.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.common.notifications.Level;
+import org.elasticsearch.xpack.core.ml.action.AuditMlNotificationAction;
+import org.elasticsearch.xpack.core.ml.action.PutTrainedModelDefinitionPartAction;
+import org.elasticsearch.xpack.core.ml.action.PutTrainedModelVocabularyAction;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig;
+import org.elasticsearch.xpack.core.ml.packageloader.action.LoadTrainedModelPackageAction.Request;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static org.elasticsearch.core.Strings.format;
+
+/**
+ * A helper class for abstracting out the use of the ModelLoaderUtils to make dependency injection testing easier.
+ */
+class ModelUploader {
+    private static final int DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+    private static final Logger logger = LogManager.getLogger(ModelUploader.class);
+    private final Client client;
+    private final String modelId;
+    private final ModelPackageConfig config;
+
+    ModelUploader(Client client, Request request) {
+        this.client = client;
+        this.modelId = request.getModelId();
+        this.config = request.getModelPackageConfig();
+    }
+
+    public void upload() throws URISyntaxException, IOException, ElasticsearchStatusException {
+        long size = config.getSize();
+
+        // Uploading other artefacts of the model first, that way the model is last and a simple search can be used to check if the
+        // download is complete
+        if (Strings.isNullOrEmpty(config.getVocabularyFile()) == false) {
+            uploadVocabulary();
+
+            writeDebugNotification(modelId, format("uploaded model vocabulary [%s]", config.getVocabularyFile()));
+        }
+
+        URI uri = ModelLoaderUtils.resolvePackageLocation(
+            config.getModelRepository(),
+            config.getPackagedModelId() + ModelLoaderUtils.MODEL_FILE_EXTENSION
+        );
+
+        InputStream modelInputStream = ModelLoaderUtils.getInputStreamFromModelRepository(uri);
+
+        ModelLoaderUtils.InputStreamChunker chunkIterator = new ModelLoaderUtils.InputStreamChunker(modelInputStream, DEFAULT_CHUNK_SIZE);
+
+        // simple round up
+        int totalParts = (int) ((size + DEFAULT_CHUNK_SIZE - 1) / DEFAULT_CHUNK_SIZE);
+
+        for (int part = 0; part < totalParts - 1; ++part) {
+            BytesArray definition = chunkIterator.next();
+
+            PutTrainedModelDefinitionPartAction.Request r = new PutTrainedModelDefinitionPartAction.Request(
+                modelId,
+                definition,
+                part,
+                size,
+                totalParts
+            );
+
+            client.execute(PutTrainedModelDefinitionPartAction.INSTANCE, r).actionGet();
+        }
+
+        // get the last part, this time verify the checksum and size
+        BytesArray definition = chunkIterator.next();
+
+        if (config.getSha256().equals(chunkIterator.getSha256()) == false) {
+            String message = format(
+                "Model sha256 checksums do not match, expected [%s] but got [%s]",
+                config.getSha256(),
+                chunkIterator.getSha256()
+            );
+
+            throw new ElasticsearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        if (config.getSize() != chunkIterator.getTotalBytesRead()) {
+            String message = format(
+                "Model size does not match, expected [%d] but got [%d]",
+                config.getSize(),
+                chunkIterator.getTotalBytesRead()
+            );
+
+            throw new ElasticsearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        PutTrainedModelDefinitionPartAction.Request r = new PutTrainedModelDefinitionPartAction.Request(
+            modelId,
+            definition,
+            totalParts - 1,
+            size,
+            totalParts
+        );
+
+        client.execute(PutTrainedModelDefinitionPartAction.INSTANCE, r).actionGet();
+        logger.debug(format("finished uploading model [%s] using [%d] parts", modelId, totalParts));
+    }
+
+    private void uploadVocabulary() throws URISyntaxException {
+        Tuple<List<String>, List<String>> vocabularyAndMerges = ModelLoaderUtils.loadVocabulary(
+            ModelLoaderUtils.resolvePackageLocation(config.getModelRepository(), config.getVocabularyFile())
+        );
+
+        PutTrainedModelVocabularyAction.Request r2 = new PutTrainedModelVocabularyAction.Request(
+            modelId,
+            vocabularyAndMerges.v1(),
+            vocabularyAndMerges.v2(),
+            List.of()
+        );
+
+        client.execute(PutTrainedModelVocabularyAction.INSTANCE, r2).actionGet();
+    }
+
+    private void writeDebugNotification(String modelId, String message) {
+        client.execute(
+            AuditMlNotificationAction.INSTANCE,
+            new AuditMlNotificationAction.Request(AuditMlNotificationAction.AuditType.INFERENCE, modelId, message, Level.INFO),
+            ActionListener.noop()
+        );
+
+        logger.debug(() -> format("[%s] %s", modelId, message));
+    }
+}

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -178,6 +178,8 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
                     modelId,
                     format("finished model upload after [%d] seconds", TimeUnit.NANOSECONDS.toSeconds(totalRuntimeNanos))
                 );
+                listener.onResponse(AcknowledgedResponse.TRUE);
+
             } catch (MalformedURLException e) {
                 logAndWriteNotificationAtError(modelId, format("Invalid URL [%s]", e));
             } catch (URISyntaxException e) {
@@ -187,7 +189,7 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
             }
         });
 
-        listener.onResponse(AcknowledgedResponse.TRUE);
+        // listener.onResponse(AcknowledgedResponse.TRUE);
     }
 
     private void logAndWriteNotificationAtError(String modelId, String message) {

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.packageloader.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -19,37 +20,27 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.common.notifications.Level;
 import org.elasticsearch.xpack.core.ml.action.AuditMlNotificationAction;
 import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
-import org.elasticsearch.xpack.core.ml.action.PutTrainedModelDefinitionPartAction;
-import org.elasticsearch.xpack.core.ml.action.PutTrainedModelVocabularyAction;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig;
 import org.elasticsearch.xpack.core.ml.packageloader.action.LoadTrainedModelPackageAction;
 import org.elasticsearch.xpack.core.ml.packageloader.action.LoadTrainedModelPackageAction.Request;
 import org.elasticsearch.xpack.ml.packageloader.MachineLearningPackageLoader;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 
 public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<Request, AcknowledgedResponse> {
-
-    private static final int DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
 
     private static final Logger logger = LogManager.getLogger(TransportLoadTrainedModelPackage.class);
 
@@ -81,133 +72,75 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
-        ModelPackageConfig modelPackageConfig = request.getModelPackageConfig();
-        String repository = modelPackageConfig.getModelRepository();
-        String modelId = request.getModelId();
-        long size = modelPackageConfig.getSize();
-        String packagedModelId = modelPackageConfig.getPackagedModelId();
+        ModelUploader modelUploader = new ModelUploader(client, request);
+        threadPool.executor(MachineLearningPackageLoader.UTILITY_THREAD_POOL_NAME)
+            .execute(() -> uploadModel(client, request, modelUploader, listener));
 
-        threadPool.executor(MachineLearningPackageLoader.UTILITY_THREAD_POOL_NAME).execute(() -> {
-            try {
-                final long relativeStartNanos = System.nanoTime();
-                logAndWriteNotificationAtInfo(modelId, "starting model upload");
-
-                URI uri = ModelLoaderUtils.resolvePackageLocation(repository, packagedModelId + ModelLoaderUtils.MODEL_FILE_EXTENSION);
-
-                // Uploading other artefacts of the model first, that way the model is last and a simple search can be used to check if the
-                // download is complete
-                if (Strings.isNullOrEmpty(modelPackageConfig.getVocabularyFile()) == false) {
-                    Tuple<List<String>, List<String>> vocabularyAndMerges = ModelLoaderUtils.loadVocabulary(
-                        ModelLoaderUtils.resolvePackageLocation(repository, modelPackageConfig.getVocabularyFile())
-                    );
-
-                    PutTrainedModelVocabularyAction.Request r2 = new PutTrainedModelVocabularyAction.Request(
-                        modelId,
-                        vocabularyAndMerges.v1(),
-                        vocabularyAndMerges.v2(),
-                        List.of()
-                    );
-                    client.execute(PutTrainedModelVocabularyAction.INSTANCE, r2).actionGet();
-
-                    logAndWriteNotificationAtDebug(
-                        modelId,
-                        format("uploaded model vocabulary [%s]", modelPackageConfig.getVocabularyFile())
-                    );
-                }
-
-                InputStream modelInputStream = ModelLoaderUtils.getInputStreamFromModelRepository(uri);
-
-                ModelLoaderUtils.InputStreamChunker chunkIterator = new ModelLoaderUtils.InputStreamChunker(
-                    modelInputStream,
-                    DEFAULT_CHUNK_SIZE
-                );
-
-                // simple round up
-                int totalParts = (int) ((size + DEFAULT_CHUNK_SIZE - 1) / DEFAULT_CHUNK_SIZE);
-
-                for (int part = 0; part < totalParts - 1; ++part) {
-                    BytesArray definition = chunkIterator.next();
-
-                    PutTrainedModelDefinitionPartAction.Request r = new PutTrainedModelDefinitionPartAction.Request(
-                        modelId,
-                        definition,
-                        part,
-                        size,
-                        totalParts
-                    );
-
-                    client.execute(PutTrainedModelDefinitionPartAction.INSTANCE, r).actionGet();
-                }
-
-                // get the last part, this time verify the checksum and size
-                BytesArray definition = chunkIterator.next();
-
-                if (modelPackageConfig.getSha256().equals(chunkIterator.getSha256()) == false) {
-                    String message = format(
-                        "Model sha256 checksums do not match, expected [%s] but got [%s]",
-                        modelPackageConfig.getSha256(),
-                        chunkIterator.getSha256()
-                    );
-                    logAndWriteNotificationAtError(modelId, message);
-                    return;
-                }
-
-                if (modelPackageConfig.getSize() != chunkIterator.getTotalBytesRead()) {
-                    String message = format(
-                        "Model size does not match, expected [%d] but got [%d]",
-                        modelPackageConfig.getSize(),
-                        chunkIterator.getTotalBytesRead()
-                    );
-                    logAndWriteNotificationAtError(modelId, message);
-                    return;
-                }
-
-                PutTrainedModelDefinitionPartAction.Request r = new PutTrainedModelDefinitionPartAction.Request(
-                    modelId,
-                    definition,
-                    totalParts - 1,
-                    size,
-                    totalParts
-                );
-
-                client.execute(PutTrainedModelDefinitionPartAction.INSTANCE, r).actionGet();
-                logger.debug(format("finished uploading model [%s] using [%d] parts", modelId, totalParts));
-
-                final long totalRuntimeNanos = System.nanoTime() - relativeStartNanos;
-                logAndWriteNotificationAtInfo(
-                    modelId,
-                    format("finished model upload after [%d] seconds", TimeUnit.NANOSECONDS.toSeconds(totalRuntimeNanos))
-                );
-                listener.onResponse(AcknowledgedResponse.TRUE);
-
-            } catch (MalformedURLException e) {
-                logAndWriteNotificationAtError(modelId, format("Invalid URL [%s]", e));
-            } catch (URISyntaxException e) {
-                logAndWriteNotificationAtError(modelId, format("Invalid URL syntax [%s]", e));
-            } catch (IOException e) {
-                logAndWriteNotificationAtError(modelId, format("IOException [%s]", e));
-            }
-        });
-
-        // listener.onResponse(AcknowledgedResponse.TRUE);
+        if (request.isWaitForCompletion() == false) {
+            listener.onResponse(AcknowledgedResponse.TRUE);
+        }
     }
 
-    private void logAndWriteNotificationAtError(String modelId, String message) {
-        writeNotification(modelId, message, Level.ERROR);
+    /**
+     * This is package scope so that we can test the logic directly.
+     * This should only be called from the masterOperation method and the tests
+     */
+    static void uploadModel(Client client, Request request, ModelUploader modelUploader, ActionListener<AcknowledgedResponse> listener) {
+        String modelId = request.getModelId();
+        final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+
+        try {
+            final long relativeStartNanos = System.nanoTime();
+
+            modelUploader.upload();
+
+            final long totalRuntimeNanos = System.nanoTime() - relativeStartNanos;
+            logAndWriteNotificationAtInfo(
+                client,
+                modelId,
+                format("finished model upload after [%d] seconds", TimeUnit.NANOSECONDS.toSeconds(totalRuntimeNanos))
+            );
+        } catch (ElasticsearchStatusException e) {
+            recordError(client, modelId, "%s", exceptionRef, e);
+        } catch (MalformedURLException e) {
+            recordError(client, modelId, "Invalid URL [%s]", exceptionRef, e);
+        } catch (URISyntaxException e) {
+            recordError(client, modelId, "Invalid URL syntax [%s]", exceptionRef, e);
+        } catch (IOException e) {
+            recordError(client, modelId, "IOException [%s]", exceptionRef, e);
+        } catch (Exception e) {
+            recordError(client, modelId, "Exception [%s]", exceptionRef, e);
+        } finally {
+            if (exceptionRef.get() != null) {
+                listener.onFailure(exceptionRef.get());
+            } else {
+                listener.onResponse(AcknowledgedResponse.TRUE);
+            }
+        }
+    }
+
+    private static void recordError(
+        Client client,
+        String modelId,
+        String messageFormatting,
+        AtomicReference<Exception> exceptionRef,
+        Exception e
+    ) {
+        logAndWriteNotificationAtError(client, modelId, format(messageFormatting, e));
+        exceptionRef.set(e);
+    }
+
+    private static void logAndWriteNotificationAtError(Client client, String modelId, String message) {
+        writeNotification(client, modelId, message, Level.ERROR);
         logger.error(format("[%s] %s", modelId, message));
     }
 
-    private void logAndWriteNotificationAtDebug(String modelId, String message) {
-        writeNotification(modelId, message, Level.INFO); // info is the lowest level
-        logger.debug(() -> format("[%s] %s", modelId, message));
-    }
-
-    private void logAndWriteNotificationAtInfo(String modelId, String message) {
-        writeNotification(modelId, message, Level.INFO);
+    private static void logAndWriteNotificationAtInfo(Client client, String modelId, String message) {
+        writeNotification(client, modelId, message, Level.INFO);
         logger.info(format("[%s] %s", modelId, message));
     }
 
-    private void writeNotification(String modelId, String message, Level level) {
+    private static void writeNotification(Client client, String modelId, String message, Level level) {
         client.execute(
             AuditMlNotificationAction.INSTANCE,
             new AuditMlNotificationAction.Request(AuditMlNotificationAction.AuditType.INFERENCE, modelId, message, level),

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtilsTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtilsTests.java
@@ -15,7 +15,18 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static org.hamcrest.core.Is.is;
+
 public class ModelLoaderUtilsTests extends ESTestCase {
+
+    public void testGetInputStreamFromModelRepositoryThrowsUnsupportedScheme() {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ModelLoaderUtils.getInputStreamFromModelRepository(new URI("unknown:/home/ml/package.ext"))
+        );
+
+        assertThat(e.getMessage(), is("unsupported scheme"));
+    }
 
     public void testResolvePackageLocationTrailingSlash() throws URISyntaxException {
         assertEquals(new URI("file:/home/ml/package.ext"), ModelLoaderUtils.resolvePackageLocation("file:///home/ml", "package.ext"));

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackageTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackageTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.packageloader.action;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.action.AuditMlNotificationAction;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfigTests;
+import org.elasticsearch.xpack.core.ml.packageloader.action.LoadTrainedModelPackageAction;
+import org.hamcrest.CoreMatchers;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+
+public class TransportLoadTrainedModelPackageTests extends ESTestCase {
+    private LoadTrainedModelPackageAction.Request loadModelReq;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        loadModelReq = createRequest("abc");
+    }
+
+    private LoadTrainedModelPackageAction.Request createRequest(String vocabFile) {
+        ModelPackageConfig config = new ModelPackageConfig.Builder(ModelPackageConfigTests.randomModulePackageConfig()).setVocabularyFile(
+            vocabFile
+        ).build();
+
+        return new LoadTrainedModelPackageAction.Request("id1", config, false);
+    }
+
+    public void testSendsFinishedUploadNotification() {
+        LoadTrainedModelPackageAction.Request req = createRequest(null);
+        ModelUploader uploader = mock(ModelUploader.class);
+        Client client = mock(Client.class);
+
+        TransportLoadTrainedModelPackage.uploadModel(client, req, uploader, ActionListener.noop());
+
+        ArgumentCaptor<AuditMlNotificationAction.Request> argument = ArgumentCaptor.forClass(AuditMlNotificationAction.Request.class);
+        verify(client).execute(eq(AuditMlNotificationAction.INSTANCE), argument.capture(), any());
+        assertThat(argument.getValue().getMessage(), CoreMatchers.containsString("finished model upload after"));
+    }
+
+    public void testSendsErrorNotificationForInternalError() throws URISyntaxException, IOException {
+        ElasticsearchStatusException exception = new ElasticsearchStatusException("exception", RestStatus.INTERNAL_SERVER_ERROR);
+
+        assertUploadCallsOnFailure(exception, "exception");
+    }
+
+    private void assertUploadCallsOnFailure(Exception exception, String message) throws URISyntaxException, IOException {
+        Client client = mock(Client.class);
+        ModelUploader uploader = createUploader(exception);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) mock(ActionListener.class);
+        TransportLoadTrainedModelPackage.uploadModel(client, loadModelReq, uploader, listener);
+
+        ArgumentCaptor<AuditMlNotificationAction.Request> argument = ArgumentCaptor.forClass(AuditMlNotificationAction.Request.class);
+        verify(client).execute(eq(AuditMlNotificationAction.INSTANCE), argument.capture(), any());
+        assertThat(argument.getValue().getMessage(), CoreMatchers.containsString(message));
+
+        verify(listener).onFailure(exception);
+    }
+
+    private ModelUploader createUploader(Exception exception) throws URISyntaxException, IOException {
+        ModelUploader uploader = mock(ModelUploader.class);
+        if (exception != null) {
+            doThrow(exception).when(uploader).upload();
+        }
+
+        return uploader;
+    }
+
+    public void testSendsErrorNotificationForMalformedURL() throws URISyntaxException, IOException {
+        MalformedURLException exception = new MalformedURLException("exception");
+
+        assertUploadCallsOnFailure(exception, "Invalid URL");
+    }
+
+    public void testSendsErrorNotificationForURISyntax() throws URISyntaxException, IOException {
+        URISyntaxException exception = mock(URISyntaxException.class);
+
+        assertUploadCallsOnFailure(exception, "Invalid URL syntax");
+    }
+
+    public void testSendsErrorNotificationForIOException() throws URISyntaxException, IOException {
+        IOException exception = mock(IOException.class);
+
+        assertUploadCallsOnFailure(exception, "IOException");
+    }
+
+    public void testSendsErrorNotificationForException() throws URISyntaxException, IOException {
+        RuntimeException exception = mock(RuntimeException.class);
+
+        assertUploadCallsOnFailure(exception, "Exception");
+    }
+
+    public void testCallsOnResponseWithAcknowledgedResponse() throws URISyntaxException, IOException {
+        Client client = mock(Client.class);
+        ModelUploader uploader = createUploader(null);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) mock(ActionListener.class);
+        TransportLoadTrainedModelPackage.uploadModel(client, loadModelReq, uploader, listener);
+
+        verify(listener).onResponse(AcknowledgedResponse.TRUE);
+    }
+}

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackageTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackageTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfigTests;
 import org.elasticsearch.xpack.core.ml.packageloader.action.LoadTrainedModelPackageAction;
 import org.hamcrest.CoreMatchers;
+import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -29,8 +30,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
-import org.junit.Before;
 
 public class TransportLoadTrainedModelPackageTests extends ESTestCase {
     private LoadTrainedModelPackageAction.Request loadModelReq;


### PR DESCRIPTION
This PR will fix the `wait_for_completion=true` query parameter to wait to return an HTTP response until loading the model into the elasticsearch index.

## Testing

Setting `wait_for_completion=true` should block while the ~400 mb file is saved to elasticsearch

```
curl --location --request PUT 'http://localhost:9200/_ml/trained_models/.elser_model_1?wait_for_completion=true' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic ZWxhc3RpYzpwYXNzd29yZA==' \
--data '{"input":{"field_names":["text_field"]}}'
```

Setting `wait_for_completion=false` should return immediately and the upload will run in the background