### PR TITLE
Handling IOException from Windows in cleanup method of GeoIpDownloaderIT

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -662,7 +662,25 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
                 try {
                     IOUtils.rm(path);
                 } catch (IOException e) {
-                    throw new UncheckedIOException(e);
+                    /*
+                     * If the test is emulating Windows mode then it will throw an IOException if something has an open file handle to this
+                     * directory. ConfigDatabases adds a FileWatcher that lists the contents of this directory every 5 seconds. If the
+                     * timing is unlucky a directory listing can happen just as we are attempting to do this delete. In that case we wait a
+                     * small amount of time and retry once. If it fails a second time then something more serious is going on so we bail
+                     * out.
+                     */
+                    if (path.getFileSystem().provider().getScheme().equals("windows://") && e.getMessage().contains("access denied")) {
+                        logger.debug("Caught an IOException, will sleep and try deleting again", e);
+                        safeSleep(500);
+                        try {
+                            IOUtils.rm(path);
+                        } catch (IOException e2) {
+                            throw new UncheckedIOException(e2);
+                        }
+                    } else {
+                        throw new UncheckedIOException(e);
+                    }
+
                 }
             });
 


### PR DESCRIPTION
GeoIpDownloaderIT sometimes uses the WindowsFS (from Lucene) that throws an java.io.IOException when deleting a directory if there is an open handle to that directory (as tracked in WindowsFS). GeoIpDownloaderIT deletes the databases from the config directory on cleanup. Unfortunately there is a FileWatcher that calls listFiles() on this directory every 5 seconds (initialized in ConfigDatabases.init() when the IngestGeoIpPlugin is initializing). When listFiles() is called, it opens a file handle in WindowsFS, does a directory listing, and then closes/removes the file handle. Every once in a while that happens at just the wrong time -- when we are deleting the directory in the cleanup method of the test. So WindowsFS sees that there is an open file handle and blows up.
This PR checks the IOException if it happens when deleting the databases directory. If it is running in Windows mode then it waits a short time and tries to delete the databases directory again.
Closes #97082