### PR TITLE
[DOCS] Add TOC to landing page

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -11,6 +11,8 @@
 include::../Versions.asciidoc[]
 include::links.asciidoc[]
 
+include::landing-page.asciidoc[]
+
 include::intro.asciidoc[]
 
 include::release-notes/highlights.asciidoc[]

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -1,3 +1,5 @@
+[subs=attributes+]
+++++
 <style>
   * {
     box-sizing: border-box;
@@ -240,4 +242,19 @@
   </div>
 </div>
 
-<p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>
+<script>
+window.addEventListener("DOMContentLoaded", (event) => {
+  const left_col = document.getElementById("left_col")
+  left_col.classList.remove('col-0')
+  left_col.classList.add("col-12", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  const right_col = document.getElementById("right_col")
+  right_col.classList.add('d-none')
+  const middle_col = document.getElementById("middle_col")
+  middle_col.classList.remove("col-lg-7")
+  middle_col.classList.add("col-lg-9", "col-md-8")
+  const toc = middle_col.getElementsByClassName("toc")[0]
+  toc.remove()
+  left_col.appendChild(toc);
+});
+</script>
+++++

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -1,4 +1,3 @@
-[subs=attributes+]
 ++++
 <style>
   * {

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -245,7 +245,7 @@
 window.addEventListener("DOMContentLoaded", (event) => {
   const left_col = document.getElementById("left_col")
   left_col.classList.remove('col-0')
-  left_col.classList.add("col-12", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  left_col.classList.add("col-12", "order-2", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
   const right_col = document.getElementById("right_col")
   right_col.classList.add('d-none')
   const middle_col = document.getElementById("middle_col")


### PR DESCRIPTION
### Summary
- Adds the TOC to the Elasticsearch docs landing page. Removes the right sidebar from the landing page.
- Removes the "View all Elastic docs" link from the bottom of the landing page

### Screenshots

<details><summary><b>Before</b></summary>

![elasticsearch-before](https://github.com/elastic/elasticsearch/assets/40268737/502b36d1-060e-4f99-9f6a-0c90ea6b87ce)

</details> 

<details><summary><b>After</b></summary>

![elasticsearch-after](https://github.com/elastic/elasticsearch/assets/40268737/ffe76e33-c2dc-41c7-ad9d-75ef5c761be2)

</details> 