### PR TITLE
Move slow FieldData#toString(...) logic to where it is needed

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -297,28 +297,15 @@ public enum FieldData {
      */
     public static SortedBinaryDocValues toString(final SortedSetDocValues values) {
         return new SortedBinaryDocValues() {
-            private int count = 0;
 
             @Override
             public boolean advanceExact(int doc) throws IOException {
-                if (values.advanceExact(doc) == false) {
-                    return false;
-                }
-                for (int i = 0;; ++i) {
-                    if (values.nextOrd() == SortedSetDocValues.NO_MORE_ORDS) {
-                        count = i;
-                        break;
-                    }
-                }
-                // reset the iterator on the current doc
-                boolean advanced = values.advanceExact(doc);
-                assert advanced;
-                return true;
+                return values.advanceExact(doc);
             }
 
             @Override
             public int docValueCount() {
-                return count;
+                return values.docValueCount();
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -412,7 +411,11 @@ public final class FlattenedFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
             failIfNoDocValues();
-            return new KeyedFlattenedFieldData.Builder(name(), key, (dv, n) -> new FlattenedDocValuesField(FieldData.toString(dv), n));
+            return new KeyedFlattenedFieldData.Builder(
+                name(),
+                key,
+                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.toString(dv), n)
+            );
         }
 
         @Override
@@ -716,7 +719,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return new SortedSetOrdinalsIndexFieldData.Builder(
                 name(),
                 CoreValuesSourceType.KEYWORD,
-                (dv, n) -> new FlattenedDocValuesField(FieldData.toString(dv), n)
+                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.toString(dv), n)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -414,7 +414,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return new KeyedFlattenedFieldData.Builder(
                 name(),
                 key,
-                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.inefficient(dv), n)
+                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.preComputeDocValueCount(dv), n)
             );
         }
 
@@ -719,7 +719,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return new SortedSetOrdinalsIndexFieldData.Builder(
                 name(),
                 CoreValuesSourceType.KEYWORD,
-                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.inefficient(dv), n)
+                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.preComputeDocValueCount(dv), n)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -414,7 +414,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return new KeyedFlattenedFieldData.Builder(
                 name(),
                 key,
-                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.toString(dv), n)
+                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.inefficient(dv), n)
             );
         }
 
@@ -719,7 +719,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return new SortedSetOrdinalsIndexFieldData.Builder(
                 name(),
                 CoreValuesSourceType.KEYWORD,
-                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.toString(dv), n)
+                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.inefficient(dv), n)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -411,11 +412,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
             failIfNoDocValues();
-            return new KeyedFlattenedFieldData.Builder(
-                name(),
-                key,
-                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.preComputeDocValueCount(dv), n)
-            );
+            return new KeyedFlattenedFieldData.Builder(name(), key, (dv, n) -> new FlattenedDocValuesField(FieldData.toString(dv), n));
         }
 
         @Override
@@ -719,7 +716,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return new SortedSetOrdinalsIndexFieldData.Builder(
                 name(),
                 CoreValuesSourceType.KEYWORD,
-                (dv, n) -> new FlattenedDocValuesField(KeyedFlattenedLeafFieldData.preComputeDocValueCount(dv), n)
+                (dv, n) -> new FlattenedDocValuesField(FieldData.toString(dv), n)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldData.java
@@ -85,7 +85,7 @@ public class KeyedFlattenedLeafFieldData implements LeafOrdinalsFieldData {
 
     @Override
     public SortedBinaryDocValues getBytesValues() {
-        return toString(getOrdinalsValues());
+        return inefficient(getOrdinalsValues());
     }
 
     /**
@@ -252,7 +252,17 @@ public class KeyedFlattenedLeafFieldData implements LeafOrdinalsFieldData {
         }
     }
 
-    public static SortedBinaryDocValues toString(final SortedSetDocValues values) {
+    /**
+     * Note: If {@link SortedSetDocValues#docValueCount()} is equal to the number of ordinals returned by
+     * {@link SortedSetDocValues#nextOrd()} then use {@link org.elasticsearch.index.fielddata.FieldData#toString(SortedSetDocValues)}
+     * instead of this implementation.
+     *
+     * @return a {@link SortedBinaryDocValues} instance that wraps a {@link SortedSetDocValues} instance that pre-computes doc count
+     * when advancing to a docId that matches. This is needed in some cases when the {@link SortedSetDocValues#docValueCount()} returns
+     * a count that is <b>not</b> equal to number of ordinals (via {@link SortedSetDocValues#nextOrd()}. This requires advancing the
+     * provided {@link SortedSetDocValues} twice.
+     */
+    static SortedBinaryDocValues inefficient(final SortedSetDocValues values) {
         return new SortedBinaryDocValues() {
             private int count = 0;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedLeafFieldData.java
@@ -85,7 +85,7 @@ public class KeyedFlattenedLeafFieldData implements LeafOrdinalsFieldData {
 
     @Override
     public SortedBinaryDocValues getBytesValues() {
-        return inefficient(getOrdinalsValues());
+        return preComputeDocValueCount(getOrdinalsValues());
     }
 
     /**
@@ -262,7 +262,7 @@ public class KeyedFlattenedLeafFieldData implements LeafOrdinalsFieldData {
      * a count that is <b>not</b> equal to number of ordinals (via {@link SortedSetDocValues#nextOrd()}. This requires advancing the
      * provided {@link SortedSetDocValues} twice.
      */
-    static SortedBinaryDocValues inefficient(final SortedSetDocValues values) {
+    static SortedBinaryDocValues preComputeDocValueCount(final SortedSetDocValues values) {
         return new SortedBinaryDocValues() {
             private int count = 0;
 


### PR DESCRIPTION
Change FieldData#toString(...) to delegate to SortedSetDocValues#docValueCount() instead of computing it in the advanceExact(...) method.

In some cases it is needed to pre-compute doc value count, because the number of ordinals is dynamic. For example in the case of flattened field. This logic is moved to `KeyedFlattenedLeafFieldData`, the only place where it is needed.

As part of profiling downsampling, advancing twice showed up as part of rolling up label fields. 
However for almost all these label fields, pre-computing doc value count isn't needed.

Relates to #97141