### PR TITLE
Update data stream lifecycle telemetry

### DIFF
--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.core.action.XPackUsageFeatureAction.DATA_LIFECYCLE;
+import static org.elasticsearch.xpack.core.action.XPackUsageFeatureAction.DATA_STREAM_LIFECYCLE;
 import static org.hamcrest.Matchers.equalTo;
 
 public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
@@ -150,7 +150,7 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
         double averageRetention,
         boolean defaultRolloverUsed
     ) throws Exception {
-        XPackUsageFeatureResponse response = client().execute(DATA_LIFECYCLE, new XPackUsageRequest()).get();
+        XPackUsageFeatureResponse response = client().execute(DATA_STREAM_LIFECYCLE, new XPackUsageRequest()).get();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder = response.getUsage().toXContent(builder, ToXContent.EMPTY_PARAMS);
         Tuple<XContentType, Map<String, Object>> tuple = XContentHelper.convertToMap(
@@ -203,7 +203,7 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
         @Override
         public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
             List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>();
-            actions.add(new ActionPlugin.ActionHandler<>(DATA_LIFECYCLE, DataLifecycleUsageTransportAction.class));
+            actions.add(new ActionPlugin.ActionHandler<>(DATA_STREAM_LIFECYCLE, DataStreamLifecycleUsageTransportAction.class));
             return actions;
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NamedDiff;
-import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
@@ -39,8 +38,8 @@ import org.elasticsearch.xpack.core.application.EnterpriseSearchFeatureSetUsage;
 import org.elasticsearch.xpack.core.archive.ArchiveFeatureSetUsage;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
-import org.elasticsearch.xpack.core.datastreams.DataLifecycleFeatureSetUsage;
 import org.elasticsearch.xpack.core.datastreams.DataStreamFeatureSetUsage;
+import org.elasticsearch.xpack.core.datastreams.DataStreamLifecycleFeatureSetUsage;
 import org.elasticsearch.xpack.core.downsample.DownsampleIndexerAction;
 import org.elasticsearch.xpack.core.enrich.EnrichFeatureSetUsage;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
@@ -549,13 +548,11 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
             ),
             // Data Streams
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_STREAMS, DataStreamFeatureSetUsage::new),
-            DataStreamLifecycle.isEnabled()
-                ? new NamedWriteableRegistry.Entry(
-                    XPackFeatureSet.Usage.class,
-                    XPackField.DATA_LIFECYCLE,
-                    DataLifecycleFeatureSetUsage::new
-                )
-                : null,
+            new NamedWriteableRegistry.Entry(
+                XPackFeatureSet.Usage.class,
+                XPackField.DATA_STREAM_LIFECYCLE,
+                DataStreamLifecycleFeatureSetUsage::new
+            ),
             // Data Tiers
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_TIERS, DataTiersFeatureSetUsage::new),
             // Archive

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -66,7 +66,7 @@ public final class XPackField {
     /** Name constant for the data streams feature. */
     public static final String DATA_STREAMS = "data_streams";
     /** Name constant for the data stream lifecycle feature. */
-    public static final String DATA_LIFECYCLE = "data_lifecycle";
+    public static final String DATA_STREAM_LIFECYCLE = "data_lifecycle";
     /** Name constant for the data tiers feature. */
     public static final String DATA_TIERS = "data_tiers";
     /** Name constant for the aggregate_metric plugin. */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -76,8 +75,8 @@ import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.cluster.routing.allocation.mapper.DataTierFieldMapper;
-import org.elasticsearch.xpack.core.action.DataLifecycleUsageTransportAction;
 import org.elasticsearch.xpack.core.action.DataStreamInfoTransportAction;
+import org.elasticsearch.xpack.core.action.DataStreamLifecycleUsageTransportAction;
 import org.elasticsearch.xpack.core.action.DataStreamUsageTransportAction;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
@@ -355,9 +354,7 @@ public class XPackPlugin extends XPackClientPlugin
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_TIERS, DataTiersUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_STREAMS, DataStreamUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackInfoFeatureAction.DATA_STREAMS, DataStreamInfoTransportAction.class));
-        if (DataStreamLifecycle.isEnabled()) {
-            actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_LIFECYCLE, DataLifecycleUsageTransportAction.class));
-        }
+        actions.add(new ActionHandler<>(XPackUsageFeatureAction.DATA_STREAM_LIFECYCLE, DataStreamLifecycleUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.HEALTH, HealthApiUsageTransportAction.class));
         actions.add(new ActionHandler<>(XPackUsageFeatureAction.REMOTE_CLUSTERS, RemoteClusterUsageTransportAction.class));
         return actions;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.xpack.core.XPackField;
 
@@ -46,7 +45,7 @@ public class XPackUsageFeatureAction extends ActionType<XPackUsageFeatureRespons
     public static final XPackUsageFeatureAction ENRICH = new XPackUsageFeatureAction(XPackField.ENRICH);
     public static final XPackUsageFeatureAction SEARCHABLE_SNAPSHOTS = new XPackUsageFeatureAction(XPackField.SEARCHABLE_SNAPSHOTS);
     public static final XPackUsageFeatureAction DATA_STREAMS = new XPackUsageFeatureAction(XPackField.DATA_STREAMS);
-    public static final XPackUsageFeatureAction DATA_LIFECYCLE = new XPackUsageFeatureAction(XPackField.DATA_LIFECYCLE);
+    public static final XPackUsageFeatureAction DATA_STREAM_LIFECYCLE = new XPackUsageFeatureAction(XPackField.DATA_STREAM_LIFECYCLE);
     public static final XPackUsageFeatureAction DATA_TIERS = new XPackUsageFeatureAction(XPackField.DATA_TIERS);
     public static final XPackUsageFeatureAction AGGREGATE_METRIC = new XPackUsageFeatureAction(XPackField.AGGREGATE_METRIC);
     public static final XPackUsageFeatureAction ARCHIVE = new XPackUsageFeatureAction(XPackField.ARCHIVE);
@@ -59,7 +58,7 @@ public class XPackUsageFeatureAction extends ActionType<XPackUsageFeatureRespons
         ANALYTICS,
         CCR,
         DATA_STREAMS,
-        DataStreamLifecycle.isEnabled() ? DATA_LIFECYCLE : null,
+        DATA_STREAM_LIFECYCLE,
         DATA_TIERS,
         EQL,
         FROZEN_INDICES,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
@@ -11,26 +11,31 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 
-public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSerializingTestCase<DataLifecycleFeatureSetUsage> {
+public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSerializingTestCase<DataStreamLifecycleFeatureSetUsage> {
 
     @Override
-    protected DataLifecycleFeatureSetUsage createTestInstance() {
-        return new DataLifecycleFeatureSetUsage(
-            new DataLifecycleFeatureSetUsage.LifecycleStats(
-                randomNonNegativeLong(),
-                randomNonNegativeLong(),
-                randomNonNegativeLong(),
-                randomDouble(),
-                randomBoolean()
+    protected DataStreamLifecycleFeatureSetUsage createTestInstance() {
+        return randomBoolean()
+            ? new DataStreamLifecycleFeatureSetUsage(
+                new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomDouble(),
+                    randomBoolean()
+                )
             )
-        );
+            : DataStreamLifecycleFeatureSetUsage.DISABLED;
     }
 
     @Override
-    protected DataLifecycleFeatureSetUsage mutateInstance(DataLifecycleFeatureSetUsage instance) {
+    protected DataStreamLifecycleFeatureSetUsage mutateInstance(DataStreamLifecycleFeatureSetUsage instance) {
+        if (instance.equals(DataStreamLifecycleFeatureSetUsage.DISABLED)) {
+            return new DataStreamLifecycleFeatureSetUsage(DataStreamLifecycleFeatureSetUsage.LifecycleStats.INITIAL);
+        }
         return switch (randomInt(4)) {
-            case 0 -> new DataLifecycleFeatureSetUsage(
-                new DataLifecycleFeatureSetUsage.LifecycleStats(
+            case 0 -> new DataStreamLifecycleFeatureSetUsage(
+                new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
                     randomValueOtherThan(instance.lifecycleStats.dataStreamsWithLifecyclesCount, ESTestCase::randomLong),
                     instance.lifecycleStats.minRetentionMillis,
                     instance.lifecycleStats.maxRetentionMillis,
@@ -38,8 +43,8 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
                     instance.lifecycleStats.defaultRolloverUsed
                 )
             );
-            case 1 -> new DataLifecycleFeatureSetUsage(
-                new DataLifecycleFeatureSetUsage.LifecycleStats(
+            case 1 -> new DataStreamLifecycleFeatureSetUsage(
+                new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
                     instance.lifecycleStats.dataStreamsWithLifecyclesCount,
                     randomValueOtherThan(instance.lifecycleStats.minRetentionMillis, ESTestCase::randomLong),
                     instance.lifecycleStats.maxRetentionMillis,
@@ -47,8 +52,8 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
                     instance.lifecycleStats.defaultRolloverUsed
                 )
             );
-            case 2 -> new DataLifecycleFeatureSetUsage(
-                new DataLifecycleFeatureSetUsage.LifecycleStats(
+            case 2 -> new DataStreamLifecycleFeatureSetUsage(
+                new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
                     instance.lifecycleStats.dataStreamsWithLifecyclesCount,
                     instance.lifecycleStats.minRetentionMillis,
                     randomValueOtherThan(instance.lifecycleStats.maxRetentionMillis, ESTestCase::randomLong),
@@ -56,8 +61,8 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
                     instance.lifecycleStats.defaultRolloverUsed
                 )
             );
-            case 3 -> new DataLifecycleFeatureSetUsage(
-                new DataLifecycleFeatureSetUsage.LifecycleStats(
+            case 3 -> new DataStreamLifecycleFeatureSetUsage(
+                new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
                     instance.lifecycleStats.dataStreamsWithLifecyclesCount,
                     instance.lifecycleStats.minRetentionMillis,
                     instance.lifecycleStats.maxRetentionMillis,
@@ -65,8 +70,8 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
                     instance.lifecycleStats.defaultRolloverUsed
                 )
             );
-            case 4 -> new DataLifecycleFeatureSetUsage(
-                new DataLifecycleFeatureSetUsage.LifecycleStats(
+            case 4 -> new DataStreamLifecycleFeatureSetUsage(
+                new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
                     instance.lifecycleStats.dataStreamsWithLifecyclesCount,
                     instance.lifecycleStats.minRetentionMillis,
                     instance.lifecycleStats.maxRetentionMillis,
@@ -79,8 +84,8 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
     }
 
     @Override
-    protected Writeable.Reader<DataLifecycleFeatureSetUsage> instanceReader() {
-        return DataLifecycleFeatureSetUsage::new;
+    protected Writeable.Reader<DataStreamLifecycleFeatureSetUsage> instanceReader() {
+        return DataStreamLifecycleFeatureSetUsage::new;
     }
 
 }


### PR DESCRIPTION
In this PR we change the way the feature flag is used to disable, enable data stream lifecycle telemetry.

The initial approach used the feature flag to completely hide the data stream lifecycle code. When the flag was disabled the code was like it never existed. But this code includes wire communication, the named writable `DataLifecycleFeatureSetUsage` which has minimum supported version `TransportVersion.V_8_500_006`. 

The above will break the following mixed cluster combo in the tests: `8.9.0` (dlm flag disabled) and `8.10.0-SNAPSHOT` (dlm flag enabled). `8.9.0` will not be aware of `DataLifecycleFeatureSetUsage` but `8.10.0-SNAPSHOT` will expect that `DataLifecycleFeatureSetUsage` is supported in the `8.9.0` version and their communication will break.

In this PR, we do not hide the relative code behind the feature flag but we only use it to signal that the data lifecycle feature is not enabled:

```
   "data_lifecycle": {
        "available": true,
        "enabled": false
    },
```

Relates to: https://github.com/elastic/elasticsearch/pull/97425