### PR TITLE
[8.8] [DOCS] Add TOC to landing page (#97437)

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -11,6 +11,8 @@
 include::../Versions.asciidoc[]
 include::links.asciidoc[]
 
+include::landing-page.asciidoc[]
+
 include::intro.asciidoc[]
 
 include::release-notes/highlights.asciidoc[]

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -245,7 +245,7 @@
 window.addEventListener("DOMContentLoaded", (event) => {
   const left_col = document.getElementById("left_col")
   left_col.classList.remove('col-0')
-  left_col.classList.add("col-12", "order-2", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  left_col.classList.add("col-12", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
   const right_col = document.getElementById("right_col")
   right_col.classList.add('d-none')
   const middle_col = document.getElementById("middle_col")

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -1,3 +1,4 @@
+++++
 <style>
   * {
     box-sizing: border-box;
@@ -240,4 +241,19 @@
   </div>
 </div>
 
-<p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>
+<script>
+window.addEventListener("DOMContentLoaded", (event) => {
+  const left_col = document.getElementById("left_col")
+  left_col.classList.remove('col-0')
+  left_col.classList.add("col-12", "order-2", "col-md-4", "col-lg-3", "h-almost-full-md", "sticky-top-md")
+  const right_col = document.getElementById("right_col")
+  right_col.classList.add('d-none')
+  const middle_col = document.getElementById("middle_col")
+  middle_col.classList.remove("col-lg-7")
+  middle_col.classList.add("col-lg-9", "col-md-8")
+  const toc = middle_col.getElementsByClassName("toc")[0]
+  toc.remove()
+  left_col.appendChild(toc);
+});
+</script>
+++++


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Add TOC to landing page (#97437)](https://github.com/elastic/elasticsearch/pull/97437)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)