### PR TITLE
[Profiling] Propagate mget failures

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -285,7 +285,11 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
 
         public void onResponse(MultiGetResponse multiGetItemResponses) {
             for (MultiGetItemResponse trace : multiGetItemResponses) {
-                if (trace.isFailed() == false && trace.getResponse().isExists()) {
+                if (trace.isFailed()) {
+                    submitListener.onFailure(trace.getFailure().getFailure());
+                    return;
+                }
+                if (trace.getResponse().isExists()) {
                     String id = trace.getId();
                     // Duplicates are expected as we query multiple indices - do a quick pre-check before we deserialize a response
                     if (stackTracePerId.containsKey(id) == false) {
@@ -445,7 +449,11 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
 
         public void onStackFramesResponse(MultiGetResponse multiGetItemResponses) {
             for (MultiGetItemResponse frame : multiGetItemResponses) {
-                if (frame.isFailed() == false && frame.getResponse().isExists()) {
+                if (frame.isFailed()) {
+                    submitListener.onFailure(frame.getFailure().getFailure());
+                    return;
+                }
+                if (frame.getResponse().isExists()) {
                     // Duplicates are expected as we query multiple indices - do a quick pre-check before we deserialize a response
                     if (stackFrames.containsKey(frame.getId()) == false) {
                         stackFrames.putIfAbsent(frame.getId(), StackFrame.fromSource(frame.getResponse().getSource()));
@@ -457,7 +465,11 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
 
         public void onExecutableDetailsResponse(MultiGetResponse multiGetItemResponses) {
             for (MultiGetItemResponse executable : multiGetItemResponses) {
-                if (executable.isFailed() == false && executable.getResponse().isExists()) {
+                if (executable.isFailed()) {
+                    submitListener.onFailure(executable.getFailure().getFailure());
+                    return;
+                }
+                if (executable.getResponse().isExists()) {
                     // Duplicates are expected as we query multiple indices - do a quick pre-check before we deserialize a response
                     if (executables.containsKey(executable.getId()) == false) {
                         executables.put(executable.getId(), ObjectPath.eval("Executable.file.name", executable.getResponse().getSource()));


### PR DESCRIPTION
The Universal Profiling plugin uses the `mget` API internally to enrich profiling data. If the `mget` API fails to retrieve an item, it will not error but instead provide error details per item. Previously we have skipped such items leading to puzzling results e.g. when a user was lacking proper permissions (user would see an empty page instead of an error). With this commit we abort processing on the first failed item and return an appropriate error response.