### PR TITLE
[NLP] Support the different mask tokens used by NLP models for Fill Mask

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -955,7 +955,7 @@ BERT-style tokenization is to be performed with the enclosed settings.
 end::inference-config-nlp-tokenization-bert[]
 
 tag::inference-config-nlp-tokenization-bert-ja[]
-experimental:[] BERT-style tokenization for Japanese text is to be performed 
+experimental:[] BERT-style tokenization for Japanese text is to be performed
 with the enclosed settings.
 end::inference-config-nlp-tokenization-bert-ja[]
 
@@ -1124,6 +1124,10 @@ tag::inference-config-results-field[]
 The field that is added to incoming documents to contain the inference
 prediction. Defaults to `predicted_value`.
 end::inference-config-results-field[]
+
+tag::inference-config-mask-token[]
+The string/token which will be removed from incoming documents and replaced with the inference prediction(s). Each model and tokenizer has a predefined mask token which cannot be changed. In a response, this field contains the mask token for the specified model/tokenizer. Thus, it is recommended not to set this value in requests. However, if this field is present in a request, its value must match the predefined value for that model/tokenizer, otherwise the request will fail.
+end::inference-config-mask-token[]
 
 tag::inference-config-results-field-processor[]
 The field that is added to incoming documents to contain the inference

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1126,7 +1126,7 @@ prediction. Defaults to `predicted_value`.
 end::inference-config-results-field[]
 
 tag::inference-config-mask-token[]
-The string/token which will be removed from incoming documents and replaced with the inference prediction(s). Each model and tokenizer has a predefined mask token which cannot be changed. In a response, this field contains the mask token for the specified model/tokenizer. Thus, it is recommended not to set this value in requests. However, if this field is present in a request, its value must match the predefined value for that model/tokenizer, otherwise the request will fail.
+The string/token which will be removed from incoming documents and replaced with the inference prediction(s). In a response, this field contains the mask token for the specified model/tokenizer. Each model and tokenizer has a predefined mask token which cannot be changed. Thus, it is recommended not to set this value in requests. However, if this field is present in a request, its value must match the predefined value for that model/tokenizer, otherwise the request will fail.
 end::inference-config-mask-token[]
 
 tag::inference-config-results-field-processor[]

--- a/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
@@ -41,8 +41,7 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
 +
 You can get information for multiple trained models in a single API request by
-using a comma-separated list of model IDs or a wildca
-rd expression.
+using a comma-separated list of model IDs or a wildcard expression.
 
 [[ml-get-trained-models-query-params]]
 == {api-query-parms-title}
@@ -174,6 +173,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-fill-mask]
 .Properties of fill_mask inference
 [%collapsible%open]
 ======
+`mask_token`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-mask-token]
+
 `tokenization`::::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
@@ -304,9 +307,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-vocabulary
 (Required, string)
 The index where the vocabulary is stored.
 =======
-`mask_token`::::
-(Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-mask-token]
 ======
 
 `ner`::::

--- a/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
@@ -41,7 +41,8 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
 +
 You can get information for multiple trained models in a single API request by
-using a comma-separated list of model IDs or a wildcard expression.
+using a comma-separated list of model IDs or a wildca
+rd expression.
 
 [[ml-get-trained-models-query-params]]
 == {api-query-parms-title}
@@ -166,7 +167,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
 ======
-
 `fill_mask`::::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-fill-mask]
@@ -304,6 +304,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-vocabulary
 (Required, string)
 The index where the vocabulary is stored.
 =======
+`mask_token`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-mask-token]
 ======
 
 `ner`::::

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenization.java
@@ -20,6 +20,8 @@ public class BertJapaneseTokenization extends Tokenization {
 
     public static final ParseField NAME = new ParseField("bert_ja");
 
+    public static final String MASK_TOKEN = "[MASK]";
+
     public static ConstructingObjectParser<BertJapaneseTokenization, Void> createJpParser(boolean ignoreUnknownFields) {
         ConstructingObjectParser<BertJapaneseTokenization, Void> parser = new ConstructingObjectParser<>(
             "bert_japanese_tokenization",
@@ -59,6 +61,11 @@ public class BertJapaneseTokenization extends Tokenization {
 
     XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         return builder;
+    }
+
+    @Override
+    public String getMaskToken() {
+        return MASK_TOKEN;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenization.java
@@ -21,6 +21,8 @@ public class BertTokenization extends Tokenization {
 
     public static final ParseField NAME = new ParseField("bert");
 
+    public static final String MASK_TOKEN = "[MASK]";
+
     public static ConstructingObjectParser<BertTokenization, Void> createParser(boolean ignoreUnknownFields) {
         ConstructingObjectParser<BertTokenization, Void> parser = new ConstructingObjectParser<>(
             "bert_tokenization",
@@ -65,6 +67,11 @@ public class BertTokenization extends Tokenization {
 
     XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         return builder;
+    }
+
+    @Override
+    public String getMaskToken() {
+        return MASK_TOKEN;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenization.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 public class MPNetTokenization extends Tokenization {
 
     public static final ParseField NAME = new ParseField("mpnet");
+    public static final String MASK_TOKEN = "<mask>";
 
     public static ConstructingObjectParser<MPNetTokenization, Void> createParser(boolean ignoreUnknownFields) {
         ConstructingObjectParser<MPNetTokenization, Void> parser = new ConstructingObjectParser<>(
@@ -65,6 +66,11 @@ public class MPNetTokenization extends Tokenization {
 
     XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         return builder;
+    }
+
+    @Override
+    public String getMaskToken() {
+        return MASK_TOKEN;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenization.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 public class RobertaTokenization extends Tokenization {
     public static final String NAME = "roberta";
+    public static final String MASK_TOKEN = "<mask>";
     private static final boolean DEFAULT_ADD_PREFIX_SPACE = false;
 
     private static final ParseField ADD_PREFIX_SPACE = new ParseField("add_prefix_space");
@@ -97,6 +98,11 @@ public class RobertaTokenization extends Tokenization {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(addPrefixSpace);
+    }
+
+    @Override
+    public String getMaskToken() {
+        return MASK_TOKEN;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/Tokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/Tokenization.java
@@ -143,6 +143,8 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
         }
     }
 
+    public abstract String getMaskToken();
+
     abstract XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException;
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/XLMRobertaTokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/XLMRobertaTokenization.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 public class XLMRobertaTokenization extends Tokenization {
     public static final String NAME = "xlm_roberta";
+    public static final String MASK_TOKEN = "<mask>";
 
     public static ConstructingObjectParser<XLMRobertaTokenization, Void> createParser(boolean ignoreUnknownFields) {
         ConstructingObjectParser<XLMRobertaTokenization, Void> parser = new ConstructingObjectParser<>(
@@ -79,6 +80,11 @@ public class XLMRobertaTokenization extends Tokenization {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+    }
+
+    @Override
+    public String getMaskToken() {
+        return MASK_TOKEN;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigTests.java
@@ -115,18 +115,15 @@ public class FillMaskConfigTests extends InferenceConfigItemTestCase<FillMaskCon
         Integer numTopClasses = randomBoolean() ? null : randomInt();
 
         String resultsField = randomBoolean() ? null : randomAlphaOfLength(5);
-        try {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             FillMaskConfig fmc = new FillMaskConfig.Builder().setVocabularyConfig(vocabularyConfig)
                 .setTokenization(tokenization)
                 .setNumTopClasses(numTopClasses)
                 .setResultsField(resultsField)
                 .setMaskToken("not a real mask token")
                 .build();
+        });
 
-            throw new Exception("Test failed, fake mask token should have caused exception");
-        } catch (IllegalArgumentException ignored) {
-
-        }
     }
 
     public void testCreateBuilderWithNullMaskToken() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigTests.java
@@ -75,4 +75,81 @@ public class FillMaskConfigTests extends InferenceConfigItemTestCase<FillMaskCon
             randomBoolean() ? null : randomAlphaOfLength(5)
         );
     }
+
+    public void testCreateBuilder() {
+
+        VocabularyConfig vocabularyConfig = randomBoolean() ? null : VocabularyConfigTests.createRandom();
+
+        Tokenization tokenization = randomBoolean()
+            ? null
+            : randomFrom(
+                BertTokenizationTests.createRandom(),
+                MPNetTokenizationTests.createRandom(),
+                RobertaTokenizationTests.createRandom()
+            );
+
+        Integer numTopClasses = randomBoolean() ? null : randomInt();
+
+        String resultsField = randomBoolean() ? null : randomAlphaOfLength(5);
+
+        new FillMaskConfig.Builder().setVocabularyConfig(vocabularyConfig)
+            .setTokenization(tokenization)
+            .setNumTopClasses(numTopClasses)
+            .setResultsField(resultsField)
+            .setMaskToken(tokenization == null ? null : tokenization.getMaskToken())
+            .build();
+    }
+
+    public void testCreateBuilderWithException() throws Exception {
+
+        VocabularyConfig vocabularyConfig = randomBoolean() ? null : VocabularyConfigTests.createRandom();
+
+        Tokenization tokenization = randomBoolean()
+            ? null
+            : randomFrom(
+                BertTokenizationTests.createRandom(),
+                MPNetTokenizationTests.createRandom(),
+                RobertaTokenizationTests.createRandom()
+            );
+
+        Integer numTopClasses = randomBoolean() ? null : randomInt();
+
+        String resultsField = randomBoolean() ? null : randomAlphaOfLength(5);
+        try {
+            FillMaskConfig fmc = new FillMaskConfig.Builder().setVocabularyConfig(vocabularyConfig)
+                .setTokenization(tokenization)
+                .setNumTopClasses(numTopClasses)
+                .setResultsField(resultsField)
+                .setMaskToken("not a real mask token")
+                .build();
+
+            throw new Exception("Test failed, fake mask token should have caused exception");
+        } catch (IllegalArgumentException ignored) {
+
+        }
+    }
+
+    public void testCreateBuilderWithNullMaskToken() {
+
+        VocabularyConfig vocabularyConfig = randomBoolean() ? null : VocabularyConfigTests.createRandom();
+
+        Tokenization tokenization = randomBoolean()
+            ? null
+            : randomFrom(
+                BertTokenizationTests.createRandom(),
+                MPNetTokenizationTests.createRandom(),
+                RobertaTokenizationTests.createRandom()
+            );
+
+        Integer numTopClasses = randomBoolean() ? null : randomInt();
+
+        String resultsField = randomBoolean() ? null : randomAlphaOfLength(5);
+
+        new FillMaskConfig.Builder().setVocabularyConfig(vocabularyConfig)
+            .setTokenization(tokenization)
+            .setNumTopClasses(numTopClasses)
+            .setResultsField(resultsField)
+            .build();
+    }
+
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.inference.nlp.NlpTask;
@@ -39,7 +40,7 @@ public class BertTokenizer extends NlpTokenizer {
     public static final String SEPARATOR_TOKEN = "[SEP]";
     public static final String PAD_TOKEN = "[PAD]";
     public static final String CLASS_TOKEN = "[CLS]";
-    public static final String MASK_TOKEN = "[MASK]";
+    public static final String MASK_TOKEN = BertTokenization.MASK_TOKEN;
 
     private static final Set<String> NEVER_SPLIT = Set.of(MASK_TOKEN);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/MPNetTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/MPNetTokenizer.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.inference.nlp.tokenizers;
 
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.MPNetTokenization;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 
 import java.util.Collections;
@@ -26,7 +27,7 @@ public class MPNetTokenizer extends BertTokenizer {
     public static final String SEPARATOR_TOKEN = "</s>";
     public static final String PAD_TOKEN = "<pad>";
     public static final String CLASS_TOKEN = "<s>";
-    public static final String MASK_TOKEN = "<mask>";
+    public static final String MASK_TOKEN = MPNetTokenization.MASK_TOKEN;
     private static final Set<String> NEVER_SPLIT = Set.of(MASK_TOKEN);
 
     protected MPNetTokenizer(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/RobertaTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/RobertaTokenizer.java
@@ -32,7 +32,7 @@ public class RobertaTokenizer extends NlpTokenizer {
     public static final String SEPARATOR_TOKEN = "</s>";
     public static final String PAD_TOKEN = "<pad>";
     public static final String CLASS_TOKEN = "<s>";
-    public static final String MASK_TOKEN = "<mask>";
+    public static final String MASK_TOKEN = RobertaTokenization.MASK_TOKEN;
 
     private static final Set<String> NEVER_SPLIT = Set.of(MASK_TOKEN);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/XLMRobertaTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/XLMRobertaTokenizer.java
@@ -34,7 +34,7 @@ public class XLMRobertaTokenizer extends NlpTokenizer {
     public static final String SEPARATOR_TOKEN = "</s>";
     public static final String PAD_TOKEN = "<pad>";
     public static final String CLASS_TOKEN = "<s>";
-    public static final String MASK_TOKEN = "<mask>";
+    public static final String MASK_TOKEN = XLMRobertaTokenization.MASK_TOKEN;
 
     private static final Set<String> NEVER_SPLIT = Set.of(MASK_TOKEN);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -135,6 +136,7 @@ public class RestGetTrainedModelsAction extends BaseRestHandler {
             Map<String, String> params = new HashMap<>(channel.request().params());
             defaultToXContentParamValues.forEach((k, v) -> params.computeIfAbsent(k, defaultToXContentParamValues::get));
             includes.forEach(include -> params.put(include, "true"));
+            params.put(ToXContentParams.FOR_INTERNAL_STORAGE, "false");
             response.toXContent(builder, new ToXContent.MapParams(params));
             return new RestResponse(getStatus(response), builder);
         }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -78,6 +78,125 @@ setup:
             "total_parts": 1
           }
 ---
+"Test getting and putting Fill Mask with two mask tokens, as well as exceptions caused by requests with the wrong token":
+  - do:
+      ml.put_trained_model:
+        model_id: "bert_fill_mask_model"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "fill_mask": {
+                "tokenization":{
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                }
+              }
+            }
+          }
+
+  - do:
+      ml.put_trained_model:
+        model_id: "roberta_fill_mask_model"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "fill_mask": {
+                "tokenization":{
+                  "roberta": {
+                    "with_special_tokens": false
+                  }
+                }
+              }
+            }
+          }
+  - do:
+      ml.put_trained_model:
+        model_id: "with_correct_mask_token"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "fill_mask": {
+                "tokenization":{
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                },
+                "mask_token": "[MASK]"
+              }
+            }
+          }
+  - do:
+      ml.put_trained_model:
+        model_id: "with_other_correct_mask_token"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "fill_mask": {
+                "tokenization":{
+                  "roberta": {
+                    "with_special_tokens": false
+                  }
+                },
+                "mask_token": "<mask>"
+              }
+            }
+          }
+  - do:
+      ml.get_trained_models:
+        model_id: "bert_fill_mask_model"
+  - match: {trained_model_configs.0.inference_config.fill_mask.mask_token: "[MASK]"}
+  - do:
+      ml.get_trained_models:
+        model_id: "roberta_fill_mask_model"
+  - match: {trained_model_configs.0.inference_config.fill_mask.mask_token: "<mask>"}
+  - do:
+      catch: /IllegalArgumentException. Mask token requested was \[<mask>\] but must be \[\[MASK\]\] for this model/
+      ml.put_trained_model:
+        model_id: "incorrect_mask_token"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "fill_mask": {
+                "tokenization":{
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                },
+                "mask_token": "<mask>"
+              }
+            }
+          }
+  - do:
+      catch: /IllegalArgumentException. Mask token requested was \[\[MASK\]\] but must be \[<mask>\] for this model/
+      ml.put_trained_model:
+        model_id: "incorrect_mask_token"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "fill_mask": {
+                "tokenization":{
+                  "roberta": {
+                    "with_special_tokens": false
+                  }
+                },
+                "mask_token": "[MASK]"
+              }
+            }
+          }
+---
 "Test start deployment fails with missing model definition":
 
   - do:


### PR DESCRIPTION
This change adds a `mask_token` field to the `GET _ml/trained_models` API, as an enhancement to support [kibana#159577](https://github.com/elastic/kibana/issues/159577). 

The `mask_token` field reveals the particular mask token for needed each model deployed. Below is an example `inference_config` component of the API response, with the new `mask_token` field within `fill_mask`.

```
      "inference_config": {
        "fill_mask": {
          "vocabulary": {
            "index": ".ml-inference-native-000001"
          },
          "tokenization": {
            "roberta": {
              "do_lower_case": false,
              "with_special_tokens": true,
              "max_sequence_length": 512,
              "truncate": "first",
              "span": -1,
              "add_prefix_space": false
            }
          },
          "num_top_classes": 5,
          "mask_token": "<mask>"
        }
      },
```