### PR TITLE
[DOCS] Update Elastic GeoIP service link

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -15,9 +15,11 @@ CC BY-SA 4.0 license. It automatically downloads these databases if your nodes c
 * `ingest.geoip.downloader.eager.download` is set to true
 * your cluster has at least one pipeline with a `geoip` processor
 
-{es} automatically downloads updates for these databases from the Elastic GeoIP endpoint:
-https://geoip.elastic.co/v1/database. To get download statistics for these
-updates, use the <<geoip-stats-api,GeoIP stats API>>.
+{es} automatically downloads updates for these databases from the Elastic GeoIP
+endpoint:
+https://geoip.elastic.co/v1/database?elastic_geoip_service_tos=agree[https://geoip.elastic.co/v1/database].
+To get download statistics for these updates, use the <<geoip-stats-api,GeoIP
+stats API>>.
 
 If your cluster can't connect to the Elastic GeoIP endpoint or you want to
 manage your own updates, see <<manage-geoip-database-updates>>.


### PR DESCRIPTION
Adds TOS-related query parameters to the Elastic GeoIP link in the [GeoIP ingest processor docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/geoip-processor.html). The current link returns a 400 HTTP status.