### PR TITLE
Synonyms API - allow empty rulesests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
 
 ---
 "Create and Update synonyms set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -30,6 +30,23 @@ setup:
   - length: { reload_analyzers_details.reload_details: 0 }
 
 ---
+"Create empty synonyms set":
+  - do:
+      synonyms.put:
+        synonyms_set: test-empty-synonyms
+        body:
+          synonyms_set: []
+
+  - match: { result: "created" }
+
+  - do:
+      synonyms.get:
+        synonyms_set: test-empty-synonyms
+
+  - match: { count: 0 }
+  - match: { synonyms_set: [] }
+
+---
 "Validation fails tests":
   - do:
       catch: /\[synonyms\] field can't be empty/

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-get-synonyms

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-get-synonyms

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-synonyms-3

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-synonyms

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -89,3 +89,27 @@ setup:
           id: "test-id-1"
         - synonyms: "test => check"
           id: "test-id-2"
+
+---
+"Delete synonym rules - delete all synonym rules leave an empty synonym set":
+  - do:
+      synonym_rule.delete:
+        synonyms_set: test-synonyms
+        synonym_rule: test-id-1
+
+  - do:
+      synonym_rule.delete:
+        synonyms_set: test-synonyms
+        synonym_rule: test-id-2
+
+  - do:
+      synonym_rule.delete:
+        synonyms_set: test-synonyms
+        synonym_rule: test-id-3
+
+  - do:
+      synonyms.get:
+        synonyms_set: test-synonyms
+
+  - match: { count: 0 }
+  - match: { synonyms_set: [] }

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -66,14 +66,12 @@ public class SynonymsManagementAPIService {
     public static final String SYNONYMS_INDEX_NAME_PATTERN = ".synonyms-*";
     public static final String SYNONYMS_INDEX_CONCRETE_NAME = ".synonyms-1";
     public static final String SYNONYMS_ALIAS_NAME = ".synonyms";
-
     public static final String SYNONYMS_FEATURE_NAME = "synonyms";
     // Stores the synonym set the rule belongs to
     public static final String SYNONYMS_SET_FIELD = "synonyms_set";
     // Stores the synonym rule
     public static final String SYNONYMS_FIELD = SynonymRule.SYNONYMS_FIELD.getPreferredName();
     // Field that stores either SYNONYM_RULE_OBJECT_TYPE or SYNONYM_SET_OBJECT_TYPE
-
     private static final String OBJECT_TYPE_FIELD = "type";
     // Identifies synonym rule objects stored in the index
     private static final String SYNONYM_RULE_OBJECT_TYPE = "synonym_rule";
@@ -166,6 +164,7 @@ public class SynonymsManagementAPIService {
         client.prepareSearch(SYNONYMS_ALIAS_NAME)
             .setSize(0)
             .addAggregation(
+                // Retrieves synonym rules for each synonym set, excluding the synonym set object type
                 new FilterAggregationBuilder(RULESET_FILTER_AGG_NAME, QueryBuilders.termQuery(OBJECT_TYPE_FIELD, SYNONYM_RULE_OBJECT_TYPE))
                     .subAggregation(
                         new TermsAggregationBuilder(SYNONYM_SETS_AGG_NAME).field(SYNONYMS_SET_FIELD)
@@ -205,7 +204,7 @@ public class SynonymsManagementAPIService {
 
     public void getSynonymSetRules(String synonymSetId, int from, int size, ActionListener<PagedResult<SynonymRule>> listener) {
         checkSynonymSetExists(synonymSetId, listener.delegateFailure((existsListener, response) -> {
-            // Retrieves query rules, excluding the synonym set object type
+            // Retrieves synonym rules, excluding the synonym set object type
             client.prepareSearch(SYNONYMS_ALIAS_NAME)
                 .setQuery(
                     QueryBuilders.boolQuery()

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -253,7 +253,7 @@ public class SynonymsManagementAPIService {
             // Insert as bulk requests
             BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
             try {
-                if (created == false) {
+                if (created) {
                     // Insert synonym set object
                     bulkRequestBuilder.add(createSynonymSetIndexRequest(synonymSetId));
                 }

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -63,9 +63,10 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
  * Manages synonyms performing operations on the system index
  */
 public class SynonymsManagementAPIService {
-    public static final String SYNONYMS_INDEX_NAME_PATTERN = ".synonyms-*";
-    public static final String SYNONYMS_INDEX_CONCRETE_NAME = ".synonyms-1";
-    public static final String SYNONYMS_ALIAS_NAME = ".synonyms";
+    private static final String SYNONYMS_INDEX_NAME_PATTERN = ".synonyms-*";
+    private static final int SYNONYMS_INDEX_FORMAT = 2;
+    private static final String SYNONYMS_INDEX_CONCRETE_NAME = ".synonyms-" + SYNONYMS_INDEX_FORMAT;
+    private static final String SYNONYMS_ALIAS_NAME = ".synonyms";
     public static final String SYNONYMS_FEATURE_NAME = "synonyms";
     // Stores the synonym set the rule belongs to
     public static final String SYNONYMS_SET_FIELD = "synonyms_set";
@@ -77,11 +78,11 @@ public class SynonymsManagementAPIService {
     private static final String SYNONYM_RULE_OBJECT_TYPE = "synonym_rule";
     // Identifies synonym set objects stored in the index
     private static final String SYNONYM_SET_OBJECT_TYPE = "synonym_set";
-    public static final String SYNONYM_RULE_ID_SEPARATOR = "|";
-    public static final String SYNONYM_SETS_AGG_NAME = "synonym_sets_aggr";
+    private static final String SYNONYM_RULE_ID_SEPARATOR = "|";
     public static final int MAX_SYNONYMS_SETS = 10_000;
-    public static final String SYNONYM_RULE_ID_FIELD = SynonymRule.ID_FIELD.getPreferredName();
-    public static final String RULESET_FILTER_AGG_NAME = "ruleset_filter";
+    private static final String SYNONYM_RULE_ID_FIELD = SynonymRule.ID_FIELD.getPreferredName();
+    private static final String SYNONYM_SETS_AGG_NAME = "synonym_sets_aggr";
+    private static final String RULESET_FILTER_AGG_NAME = "ruleset_filter";
 
     private final Client client;
 
@@ -91,6 +92,7 @@ public class SynonymsManagementAPIService {
         .setDescription("Synonyms index for synonyms managed through APIs")
         .setPrimaryIndex(SYNONYMS_INDEX_CONCRETE_NAME)
         .setAliasName(SYNONYMS_ALIAS_NAME)
+        .setIndexFormat(SYNONYMS_INDEX_FORMAT)
         .setMappings(mappings())
         .setSettings(settings())
         .setVersionMetaKey("version")
@@ -443,6 +445,7 @@ public class SynonymsManagementAPIService {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+            .put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), SYNONYMS_INDEX_FORMAT)
             .build();
     }
 

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -410,6 +410,7 @@ public class SynonymsManagementAPIService {
                     );
                     return;
                 }
+                reloadAnalyzers(synonymSetId, deleteRulesListener, AcknowledgedResponse.of(true));
             }));
         }));
     }


### PR DESCRIPTION
Allows empty rulesets.

Previously, we checked the number of synonym rules for a synonym set; if it was 0, then the synonym set did not exist. That prevented an empty synonym set to exist.

This PR includes a new document to be stored in the synonyms index, that represents the synonym set itself. A new field that stores the object type (synonym rule or synonym set) is included. This approach seemed better than creating a separate index to store synonym set objects, at the expense of filtering on the correct object type on operations that retrieve the synonym rules.