### PR TITLE
[DOCS] Fix keystore add-file examples

### DIFF
--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -199,7 +199,7 @@ consisting of `setting path`.
 
 [source,sh]
 ----------------------------------------------------------------
-bin/elasticsearch-keystore add-file the.setting.name.to.set /path/example-file.json
+bin/elasticsearch-keystore add-file the.setting.name.to.set /path/example-file.txt
 ----------------------------------------------------------------
 
 You can add multiple files with the `add-file` command:
@@ -207,8 +207,8 @@ You can add multiple files with the `add-file` command:
 [source,sh]
 ----------------------------------------------------------------
 bin/elasticsearch-keystore add-file \
-  the.setting.name.to.set /path/example-file.json \
-  the.other.setting.name.to.set /path/other-example-file.json
+  the.setting.name.to.set /path/example-file.txt \
+  the.other.setting.name.to.set /path/other-example-file.txt
 ----------------------------------------------------------------
 
 If the {es} keystore is password protected, you are prompted to enter the


### PR DESCRIPTION
Updates the `bin/elasticsearch-keystore add-file` examples to use a `.txt` file rather than JSON. 

~No secure setting in Elasticsearch uses JSON as a value.~
Edit: Aside from `gcs.client.default.credentials_file`, no other secure settings in Elasticsearch uses JSON as a value.

Closes https://github.com/elastic/elasticsearch/issues/97459

### Example
If `example-file.json` contains:

```JSON
{ "foo" : "bar" }
```

Then the following command:

```sh
./bin/elasticsearch-keystore add-file s3.client.default.access_key /path/example-file.json
```

Would create the following setting value:

```
s3.client.default.access_key : { "foo" : "bar" }`
```

A `.txt` file containing an authentication key is more realistic.