### PR TITLE
Enable Query Rules as technical preview

### DIFF
--- a/docs/changelog/97466.yaml
+++ b/docs/changelog/97466.yaml
@@ -1,0 +1,5 @@
+pr: 97466
+summary: Enable Query Rules as technical preview
+area: Application
+type: feature
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.delete.json
@@ -5,8 +5,7 @@
       "description": "Deletes a query ruleset."
     },
     "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "es.query_rules_feature_flag_enabled",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.get.json
@@ -5,8 +5,7 @@
       "description": "Returns the details about a query ruleset."
     },
     "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "es.query_rules_feature_flag_enabled",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.list.json
@@ -5,8 +5,7 @@
       "description": "Lists query rulesets."
     },
     "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "es.query_rules_feature_flag_enabled",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.put.json
@@ -5,8 +5,7 @@
       "description": "Creates or updates a query ruleset."
     },
     "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "es.query_rules_feature_flag_enabled",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -18,8 +18,7 @@ public enum FeatureFlag {
     TIME_SERIES_MODE("es.index_mode_feature_flag_registered=true", Version.fromString("8.0.0"), null),
     NEW_RCS_MODE("es.untrusted_remote_cluster_feature_flag_registered=true", Version.fromString("8.5.0"), null),
     DATA_STREAM_LIFECYCLE_ENABLED("es.dlm_feature_flag_enabled=true", Version.fromString("8.8.0"), null),
-    SYNONYMS_ENABLED("es.synonyms_feature_flag_enabled=true", Version.fromString("8.9.0"), null),
-    QUERY_RULES_ENABLED("es.query_rules_feature_flag_enabled=true", Version.fromString("8.9.0"), null);
+    SYNONYMS_ENABLED("es.synonyms_feature_flag_enabled=true", Version.fromString("8.9.0"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.IndicesService;
@@ -93,7 +92,6 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -118,8 +116,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
 
     private final boolean enabled;
 
-    private static final FeatureFlag QUERY_RULES_FEATURE_FLAG = new FeatureFlag("query_rules");
-
     public EnterpriseSearch(Settings settings) {
         this.enabled = XPackSettings.ENTERPRISE_SEARCH_ENABLED.get(settings);
     }
@@ -136,31 +132,24 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return List.of(usageAction, infoAction);
         }
 
-        final List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actionHandlers = new ArrayList<>(
-            List.of(
-                new ActionHandler<>(PutAnalyticsCollectionAction.INSTANCE, TransportPutAnalyticsCollectionAction.class),
-                new ActionHandler<>(GetAnalyticsCollectionAction.INSTANCE, TransportGetAnalyticsCollectionAction.class),
-                new ActionHandler<>(DeleteAnalyticsCollectionAction.INSTANCE, TransportDeleteAnalyticsCollectionAction.class),
-                new ActionHandler<>(PostAnalyticsEventAction.INSTANCE, TransportPostAnalyticsEventAction.class),
-                new ActionHandler<>(DeleteSearchApplicationAction.INSTANCE, TransportDeleteSearchApplicationAction.class),
-                new ActionHandler<>(GetSearchApplicationAction.INSTANCE, TransportGetSearchApplicationAction.class),
-                new ActionHandler<>(ListSearchApplicationAction.INSTANCE, TransportListSearchApplicationAction.class),
-                new ActionHandler<>(PutSearchApplicationAction.INSTANCE, TransportPutSearchApplicationAction.class),
-                new ActionHandler<>(QuerySearchApplicationAction.INSTANCE, TransportQuerySearchApplicationAction.class),
-                new ActionHandler<>(RenderSearchApplicationQueryAction.INSTANCE, TransportRenderSearchApplicationQueryAction.class),
-                usageAction,
-                infoAction
-            )
+        return List.of(
+            new ActionHandler<>(PutAnalyticsCollectionAction.INSTANCE, TransportPutAnalyticsCollectionAction.class),
+            new ActionHandler<>(GetAnalyticsCollectionAction.INSTANCE, TransportGetAnalyticsCollectionAction.class),
+            new ActionHandler<>(DeleteAnalyticsCollectionAction.INSTANCE, TransportDeleteAnalyticsCollectionAction.class),
+            new ActionHandler<>(PostAnalyticsEventAction.INSTANCE, TransportPostAnalyticsEventAction.class),
+            new ActionHandler<>(DeleteSearchApplicationAction.INSTANCE, TransportDeleteSearchApplicationAction.class),
+            new ActionHandler<>(GetSearchApplicationAction.INSTANCE, TransportGetSearchApplicationAction.class),
+            new ActionHandler<>(ListSearchApplicationAction.INSTANCE, TransportListSearchApplicationAction.class),
+            new ActionHandler<>(PutSearchApplicationAction.INSTANCE, TransportPutSearchApplicationAction.class),
+            new ActionHandler<>(QuerySearchApplicationAction.INSTANCE, TransportQuerySearchApplicationAction.class),
+            new ActionHandler<>(RenderSearchApplicationQueryAction.INSTANCE, TransportRenderSearchApplicationQueryAction.class),
+            new ActionHandler<>(DeleteQueryRulesetAction.INSTANCE, TransportDeleteQueryRulesetAction.class),
+            new ActionHandler<>(GetQueryRulesetAction.INSTANCE, TransportGetQueryRulesetAction.class),
+            new ActionHandler<>(ListQueryRulesetsAction.INSTANCE, TransportListQueryRulesetsAction.class),
+            new ActionHandler<>(PutQueryRulesetAction.INSTANCE, TransportPutQueryRulesetAction.class),
+            usageAction,
+            infoAction
         );
-
-        if (QUERY_RULES_FEATURE_FLAG.isEnabled()) {
-            actionHandlers.add(new ActionHandler<>(DeleteQueryRulesetAction.INSTANCE, TransportDeleteQueryRulesetAction.class));
-            actionHandlers.add(new ActionHandler<>(GetQueryRulesetAction.INSTANCE, TransportGetQueryRulesetAction.class));
-            actionHandlers.add(new ActionHandler<>(ListQueryRulesetsAction.INSTANCE, TransportListQueryRulesetsAction.class));
-            actionHandlers.add(new ActionHandler<>(PutQueryRulesetAction.INSTANCE, TransportPutQueryRulesetAction.class));
-        }
-
-        return Collections.unmodifiableList(actionHandlers);
     }
 
     @Override
@@ -178,29 +167,22 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return Collections.emptyList();
         }
 
-        final List<RestHandler> restHandlers = new ArrayList<>(
-            List.of(
-                new RestPutAnalyticsCollectionAction(getLicenseState()),
-                new RestGetAnalyticsCollectionAction(getLicenseState()),
-                new RestDeleteAnalyticsCollectionAction(getLicenseState()),
-                new RestPostAnalyticsEventAction(getLicenseState()),
-                new RestDeleteSearchApplicationAction(getLicenseState()),
-                new RestGetSearchApplicationAction(getLicenseState()),
-                new RestListSearchApplicationAction(getLicenseState()),
-                new RestPutSearchApplicationAction(getLicenseState()),
-                new RestQuerySearchApplicationAction(getLicenseState()),
-                new RestRenderSearchApplicationQueryAction(getLicenseState())
-            )
+        return List.of(
+            new RestPutAnalyticsCollectionAction(getLicenseState()),
+            new RestGetAnalyticsCollectionAction(getLicenseState()),
+            new RestDeleteAnalyticsCollectionAction(getLicenseState()),
+            new RestPostAnalyticsEventAction(getLicenseState()),
+            new RestDeleteSearchApplicationAction(getLicenseState()),
+            new RestGetSearchApplicationAction(getLicenseState()),
+            new RestListSearchApplicationAction(getLicenseState()),
+            new RestPutSearchApplicationAction(getLicenseState()),
+            new RestQuerySearchApplicationAction(getLicenseState()),
+            new RestRenderSearchApplicationQueryAction(getLicenseState()),
+            new RestDeleteQueryRulesetAction(getLicenseState()),
+            new RestGetQueryRulesetAction(getLicenseState()),
+            new RestListQueryRulesetsAction(getLicenseState()),
+            new RestPutQueryRulesetAction(getLicenseState())
         );
-
-        if (QUERY_RULES_FEATURE_FLAG.isEnabled()) {
-            restHandlers.add(new RestDeleteQueryRulesetAction(getLicenseState()));
-            restHandlers.add(new RestGetQueryRulesetAction(getLicenseState()));
-            restHandlers.add(new RestListQueryRulesetsAction(getLicenseState()));
-            restHandlers.add(new RestPutQueryRulesetAction(getLicenseState()));
-        }
-
-        return Collections.unmodifiableList(restHandlers);
     }
 
     @Override
@@ -238,14 +220,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        if (QUERY_RULES_FEATURE_FLAG.isEnabled()) {
-            return Arrays.asList(
-                SearchApplicationIndexService.getSystemIndexDescriptor(),
-                QueryRulesIndexService.getSystemIndexDescriptor()
-            );
-        } else {
-            return Collections.singletonList(SearchApplicationIndexService.getSystemIndexDescriptor());
-        }
+        return Arrays.asList(SearchApplicationIndexService.getSystemIndexDescriptor(), QueryRulesIndexService.getSystemIndexDescriptor());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -246,10 +246,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
 
     @Override
     public List<QuerySpec<?>> getQueries() {
-        if (QUERY_RULES_FEATURE_FLAG.isEnabled()) {
-            return singletonList(new QuerySpec<>(RuleQueryBuilder.NAME, RuleQueryBuilder::new, RuleQueryBuilder::fromXContent));
-        } else {
-            return Collections.emptyList();
-        }
+        return singletonList(new QuerySpec<>(RuleQueryBuilder.NAME, RuleQueryBuilder::new, RuleQueryBuilder::fromXContent));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -133,16 +133,21 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         }
 
         return List.of(
+            // Behavioral Analytics
             new ActionHandler<>(PutAnalyticsCollectionAction.INSTANCE, TransportPutAnalyticsCollectionAction.class),
             new ActionHandler<>(GetAnalyticsCollectionAction.INSTANCE, TransportGetAnalyticsCollectionAction.class),
             new ActionHandler<>(DeleteAnalyticsCollectionAction.INSTANCE, TransportDeleteAnalyticsCollectionAction.class),
             new ActionHandler<>(PostAnalyticsEventAction.INSTANCE, TransportPostAnalyticsEventAction.class),
+            
+            // Search Applications
             new ActionHandler<>(DeleteSearchApplicationAction.INSTANCE, TransportDeleteSearchApplicationAction.class),
             new ActionHandler<>(GetSearchApplicationAction.INSTANCE, TransportGetSearchApplicationAction.class),
             new ActionHandler<>(ListSearchApplicationAction.INSTANCE, TransportListSearchApplicationAction.class),
             new ActionHandler<>(PutSearchApplicationAction.INSTANCE, TransportPutSearchApplicationAction.class),
             new ActionHandler<>(QuerySearchApplicationAction.INSTANCE, TransportQuerySearchApplicationAction.class),
             new ActionHandler<>(RenderSearchApplicationQueryAction.INSTANCE, TransportRenderSearchApplicationQueryAction.class),
+            
+            // Query rules
             new ActionHandler<>(DeleteQueryRulesetAction.INSTANCE, TransportDeleteQueryRulesetAction.class),
             new ActionHandler<>(GetQueryRulesetAction.INSTANCE, TransportGetQueryRulesetAction.class),
             new ActionHandler<>(ListQueryRulesetsAction.INSTANCE, TransportListQueryRulesetsAction.class),

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -173,16 +173,21 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         }
 
         return List.of(
+            // Behavioral Analytics
             new RestPutAnalyticsCollectionAction(getLicenseState()),
             new RestGetAnalyticsCollectionAction(getLicenseState()),
             new RestDeleteAnalyticsCollectionAction(getLicenseState()),
             new RestPostAnalyticsEventAction(getLicenseState()),
+            
+            // Search Applications
             new RestDeleteSearchApplicationAction(getLicenseState()),
             new RestGetSearchApplicationAction(getLicenseState()),
             new RestListSearchApplicationAction(getLicenseState()),
             new RestPutSearchApplicationAction(getLicenseState()),
             new RestQuerySearchApplicationAction(getLicenseState()),
             new RestRenderSearchApplicationQueryAction(getLicenseState()),
+            
+            // Query rules
             new RestDeleteQueryRulesetAction(getLicenseState()),
             new RestGetQueryRulesetAction(getLicenseState()),
             new RestListQueryRulesetsAction(getLicenseState()),

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -138,7 +138,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             new ActionHandler<>(GetAnalyticsCollectionAction.INSTANCE, TransportGetAnalyticsCollectionAction.class),
             new ActionHandler<>(DeleteAnalyticsCollectionAction.INSTANCE, TransportDeleteAnalyticsCollectionAction.class),
             new ActionHandler<>(PostAnalyticsEventAction.INSTANCE, TransportPostAnalyticsEventAction.class),
-            
+
             // Search Applications
             new ActionHandler<>(DeleteSearchApplicationAction.INSTANCE, TransportDeleteSearchApplicationAction.class),
             new ActionHandler<>(GetSearchApplicationAction.INSTANCE, TransportGetSearchApplicationAction.class),
@@ -146,7 +146,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             new ActionHandler<>(PutSearchApplicationAction.INSTANCE, TransportPutSearchApplicationAction.class),
             new ActionHandler<>(QuerySearchApplicationAction.INSTANCE, TransportQuerySearchApplicationAction.class),
             new ActionHandler<>(RenderSearchApplicationQueryAction.INSTANCE, TransportRenderSearchApplicationQueryAction.class),
-            
+
             // Query rules
             new ActionHandler<>(DeleteQueryRulesetAction.INSTANCE, TransportDeleteQueryRulesetAction.class),
             new ActionHandler<>(GetQueryRulesetAction.INSTANCE, TransportGetQueryRulesetAction.class),
@@ -178,7 +178,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             new RestGetAnalyticsCollectionAction(getLicenseState()),
             new RestDeleteAnalyticsCollectionAction(getLicenseState()),
             new RestPostAnalyticsEventAction(getLicenseState()),
-            
+
             // Search Applications
             new RestDeleteSearchApplicationAction(getLicenseState()),
             new RestGetSearchApplicationAction(getLicenseState()),
@@ -186,7 +186,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             new RestPutSearchApplicationAction(getLicenseState()),
             new RestQuerySearchApplicationAction(getLicenseState()),
             new RestRenderSearchApplicationQueryAction(getLicenseState()),
-            
+
             // Query rules
             new RestDeleteQueryRulesetAction(getLicenseState()),
             new RestGetQueryRulesetAction(getLicenseState()),


### PR DESCRIPTION
We intend query rules to launch in 8.10 as technical preview, therefore we no longer need to gate this behind a feature flag. 