### PR TITLE
Making it possible to remove nodes info from enrich stats response

### DIFF
--- a/docs/changelog/97472.yaml
+++ b/docs/changelog/97472.yaml
@@ -1,0 +1,5 @@
+pr: 97472
+summary: Making it possible to remove nodes info from enrich stats response
+area: Stats
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -20,10 +20,8 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
 
@@ -141,8 +139,13 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
                 totalRemoteRequestsTotal += stats.remoteRequestsTotal;
                 totalExecutedSearchesTotal += stats.executedSearchesTotal;
             }
-            return new CoordinatorStats("N/A", totalQueueSize, totalRemoteRequestsCurrent,
-                totalRemoteRequestsTotal, totalExecutedSearchesTotal);
+            return new CoordinatorStats(
+                "N/A",
+                totalQueueSize,
+                totalRemoteRequestsCurrent,
+                totalRemoteRequestsTotal,
+                totalExecutedSearchesTotal
+            );
         }
 
         private static CacheStats rollupCacheStats(List<CacheStats> cacheStatsList) {
@@ -231,11 +234,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
 
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                if (params.paramAsBoolean("show_node_info", true)) {
-                    builder.field("node_id", nodeId);
-                } else {
-                    builder.field("node_id", "N/A");
-                }
+                builder.field("node_id", nodeId);
                 builder.field("queue_size", queueSize);
                 builder.field("remote_requests_current", remoteRequestsCurrent);
                 builder.field("remote_requests_total", remoteRequestsTotal);
@@ -356,11 +355,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
 
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                if (params.paramAsBoolean("show_node_info", true)) {
-                    builder.field("node_id", nodeId);
-                } else {
-                    builder.field("node_id", "N/A");
-                }
+                builder.field("node_id", nodeId);
                 builder.field("count", count);
                 builder.field("hits", hits);
                 builder.field("misses", misses);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -97,30 +97,31 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
             }
             builder.endArray();
             builder.startArray("coordinator_stats");
-            if (params.paramAsBoolean("show_node_info", true)) {
+            boolean redactNodeInfo = "serverless".equals(params.param("responseRestricted"));
+            if (redactNodeInfo) {
+                builder.startObject();
+                rollupCoordinatorStats(coordinatorStats).toXContent(builder, params);
+                builder.endObject();
+            } else {
                 for (CoordinatorStats entry : coordinatorStats) {
                     builder.startObject();
                     entry.toXContent(builder, params);
                     builder.endObject();
                 }
-            } else {
-                builder.startObject();
-                rollupCoordinatorStats(coordinatorStats).toXContent(builder, params);
-                builder.endObject();
             }
             builder.endArray();
             if (cacheStats != null) {
                 builder.startArray("cache_stats");
-                if (params.paramAsBoolean("show_node_info", true)) {
+                if (redactNodeInfo) {
+                    builder.startObject();
+                    rollupCacheStats(cacheStats).toXContent(builder, params);
+                    builder.endObject();
+                } else {
                     for (CacheStats cacheStat : cacheStats) {
                         builder.startObject();
                         cacheStat.toXContent(builder, params);
                         builder.endObject();
                     }
-                } else {
-                    builder.startObject();
-                    rollupCacheStats(cacheStats).toXContent(builder, params);
-                    builder.endObject();
                 }
                 builder.endArray();
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -390,4 +390,5 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
             }
         }
     }
+
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsActionTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.enrich.action;
+
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction.Response;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class EnrichStatsActionTests extends ESTestCase {
+
+    public void testFilterNodesFromResponse() throws IOException {
+        int numberOfNodes = randomIntBetween(3, 20);
+        List<Response.ExecutingPolicy> executingPolicies = new ArrayList<>();
+        List<Response.CoordinatorStats> coordinatorStats = new ArrayList<>();
+        List<Response.CacheStats> cacheStats = new ArrayList<>();
+        for (int i = 0; i < numberOfNodes; i++) {
+            String nodeId = randomAlphaOfLength(20);
+            coordinatorStats.add(
+                new Response.CoordinatorStats(
+                    nodeId,
+                    randomIntBetween(0, 1000),
+                    randomIntBetween(0, 1000),
+                    randomLongBetween(0, 100000),
+                    randomLongBetween(0, 100000)
+                )
+            );
+            cacheStats.add(
+                new Response.CacheStats(
+                    nodeId,
+                    randomLongBetween(0, 100000),
+                    randomLongBetween(0, 100000),
+                    randomLongBetween(0, 10000),
+                    randomIntBetween(0, 100000)
+                )
+            );
+        }
+        Response response = new Response(executingPolicies, coordinatorStats, cacheStats);
+        // No params, we expect no filtering:
+        assertToXContentResults(response, ToXContent.EMPTY_PARAMS, numberOfNodes);
+        // responseRestricted=serverless, we expect coordinator stats and cache stats to be rolled up to a single object:
+        assertToXContentResults(response, new ToXContent.MapParams(Map.of(RestRequest.RESPONSE_RESTRICTED, "serverless")), 1);
+        // making sure we don't throw a NullPointerException
+        assertToXContentResults(response, new ToXContent.MapParams(Collections.singletonMap("responseRestricted", null)), numberOfNodes);
+        // wrong value for responseRestricted, we expect no filtering:
+        assertToXContentResults(
+            response,
+            new ToXContent.MapParams(Map.of(RestRequest.RESPONSE_RESTRICTED, randomAlphaOfLength(5))),
+            numberOfNodes
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertToXContentResults(Response response, ToXContent.Params toXContentParams, int expectedNumberOfNodes)
+        throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, toXContentParams);
+        Map<String, Object> responseMap = createParser(builder).map();
+        List<Object> coordinatorStatsList = (List<Object>) responseMap.get("coordinator_stats");
+        assertThat(coordinatorStatsList.size(), equalTo(expectedNumberOfNodes));
+        List<Object> cacheStatsList = (List<Object>) responseMap.get("cache_stats");
+        assertThat(cacheStatsList.size(), equalTo(expectedNumberOfNodes));
+        if (expectedNumberOfNodes == 1) {
+            assertThat(((Map<String, String>) coordinatorStatsList.get(0)).get("node_id"), equalTo("N/A"));
+            assertThat(((Map<String, String>) cacheStatsList.get(0)).get("node_id"), equalTo("N/A"));
+        }
+    }
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -37,11 +36,6 @@ public class RestEnrichStatsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) throws IOException {
         final EnrichStatsAction.Request request = new EnrichStatsAction.Request();
         return channel -> client.execute(EnrichStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
-    }
-
-    @Override
-    protected Set<String> responseParams() {
-        return Set.of("show_node_info");
     }
 
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
@@ -15,7 +15,9 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -36,6 +38,11 @@ public class RestEnrichStatsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) throws IOException {
         final EnrichStatsAction.Request request = new EnrichStatsAction.Request();
         return channel -> client.execute(EnrichStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return Set.of("show_node_info");
     }
 
 }


### PR DESCRIPTION
This adds the ability to request that the _enrich/_stats response does not include node information. This not only means that the `node_id` is removed -- it also rolls up the stats for all nodes into one pseudo node so that information about the number of nodes is not leaked.
NOTE: DO NOT MERGE THIS. FOR DISCUSSION ONLY