### PR TITLE
Clarify keystore add-file command behavior

### DIFF
--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -195,7 +195,8 @@ Values for multiple settings must be separated by carriage returns or newlines.
 
 You can add sensitive files, like authentication key files for Cloud plugins,
 using the `add-file` command. Settings and file paths are specified in pairs
-consisting of `setting path`.
+consisting of `setting path`. The value of the setting will be the binary contents
+of the file path at the time the file is added to the keystore.
 
 [source,sh]
 ----------------------------------------------------------------


### PR DESCRIPTION
This commit adds a little more explanation to what add-file does on the keystore.

Closes #97459. For related conversation, see https://github.com/elastic/elasticsearch/pull/97465.