### PR TITLE
[8.8] Clarify keystore add-file command behavior (#97474)

### DIFF
--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -195,7 +195,8 @@ Values for multiple settings must be separated by carriage returns or newlines.
 
 You can add sensitive files, like authentication key files for Cloud plugins,
 using the `add-file` command. Settings and file paths are specified in pairs
-consisting of `setting path`.
+consisting of `setting path`. The value of the setting will be the binary contents
+of the file path at the time the file is added to the keystore.
 
 [source,sh]
 ----------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Clarify keystore add-file command behavior (#97474)