### PR TITLE
[8.9] Avoid getStateForMasterService where possible (#97304)

### DIFF
--- a/docs/changelog/97304.yaml
+++ b/docs/changelog/97304.yaml
@@ -1,0 +1,5 @@
+pr: 97304
+summary: Avoid `getStateForMasterService` where possible
+area: Cluster Coordination
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Avoid getStateForMasterService where possible (#97304)