### PR TITLE
Improve assertion re. appliers reading applied state

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -351,9 +351,14 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 clusterApplierService.state();
                 error.set(new AssertionError("successfully sampled state"));
             } catch (AssertionError e) {
-                if (e.getMessage().contains("should not be called by a cluster state applier") == false) {
-                    error.set(e);
+                final var message = e.getMessage();
+                if (message.contains("On the cluster applier thread")
+                    && message.contains("you must use ClusterChangedEvent#state()")
+                    && message.contains("almost certainly a bug to read the latest-applied state")
+                    && message.contains("the new state has been committed at this point but is not yet applied")) {
+                    return;
                 }
+                error.set(e);
             }
         });
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -351,11 +351,12 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 clusterApplierService.state();
                 error.set(new AssertionError("successfully sampled state"));
             } catch (AssertionError e) {
-                final var message = e.getMessage();
-                if (message.contains("On the cluster applier thread")
-                    && message.contains("you must use ClusterChangedEvent#state()")
-                    && message.contains("almost certainly a bug to read the latest-applied state")
-                    && message.contains("the new state has been committed at this point but is not yet applied")) {
+                // NB not a string constant shared between implementation and test, because the content of this message is important and
+                // mustn't be changed inadvertently.
+                if (e.getMessage().equals("""
+                    On the cluster applier thread you must use ClusterChangedEvent#state() and ClusterChangedEvent#previousState() instead \
+                    of ClusterApplierService#state(). It is almost certainly a bug to read the latest-applied state from within a cluster \
+                    applier since the new state has been committed at this point but is not yet applied.""")) {
                     return;
                 }
                 error.set(e);


### PR DESCRIPTION
Calling `ClusterApplierService#state()` from within a cluster applier is
almost certainly a bug, and trips an assertion, but the explanatory
message is not very clear. This commit improves the message.