### PR TITLE
Add note on troubleshooting laggy cancellations

### DIFF
--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -6,7 +6,6 @@
 
 Returns the hot threads on each selected node in the cluster.
 
-
 [[cluster-nodes-hot-threads-api-request]]
 ==== {api-request-title}
 
@@ -53,7 +52,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 `threads`::
 		(Optional, integer) Specifies the number of hot threads to provide 
-		information for. Defaults to `3`.
+                information for. Defaults to `3`. If you are using this API for
+                troubleshooting, set this parameter to a large number (e.g.
+                `9999`) to get information about all the threads in the system.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -254,7 +254,7 @@ stop as soon as possible. To troubleshoot why a cancelled task does not
 complete promptly, use the list tasks API with the `?detailed` parameter to
 identify the other tasks the system is running and also use the
 <<cluster-nodes-hot-threads>> API to obtain detailed information about the work
-the system is doing instead of processing the cancellation.
+the system is doing instead of completing the cancelled task.
 
 ===== Task Grouping
 

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -245,11 +245,16 @@ POST _tasks/_cancel?nodes=nodeId1,nodeId2&actions=*reindex
 --------------------------------------------------
 
 A task may continue to run for some time after it has been cancelled because it
-may not be able to safely stop its current activity straight away. The list
-tasks API will continue to list these cancelled tasks until they complete. The
-`cancelled` flag in the response to the list tasks API indicates that the
-cancellation command has been processed and the task will stop as soon as
-possible.
+may not be able to safely stop its current activity straight away, or because
+{es} must complete its work on other tasks before it can process the
+cancellation. The list tasks API will continue to list these cancelled tasks
+until they complete. The `cancelled` flag in the response to the list tasks API
+indicates that the cancellation command has been processed and the task will
+stop as soon as possible. To troubleshoot why a cancelled task does not
+complete promptly, use the list tasks API with the `?detailed` parameter to
+identify the other tasks the system is running and also use the
+<<cluster-nodes-hot-threads>> API to obtain detailed information about the work
+the system is doing instead of processing the cancellation.
 
 ===== Task Grouping
 


### PR DESCRIPTION
Today we document that tasks may not react to cancellations immediately,
but in practice it's surprising to users and kind of a bug if they run
for too long after being cancelled. This commit adds a little extra
detail about the information to collect to troubleshoot such a
situation.