### PR TITLE
Adds unix nanoseconds date formatter 

### DIFF
--- a/docs/changelog/97492.yaml
+++ b/docs/changelog/97492.yaml
@@ -1,5 +1,6 @@
 pr: 97492
-summary: Adds unix nanoseconds date formatter
+summary: Add support unix nanoseconds to the date formatter
 area: Ingest Node
 type: feature
-issues: []
+issues:
+  - 86106

--- a/docs/changelog/97492.yaml
+++ b/docs/changelog/97492.yaml
@@ -1,0 +1,5 @@
+pr: 97492
+summary: Adds unix nanoseconds date formatter
+area: Ingest Node
+type: feature
+issues: []

--- a/docs/reference/ingest/processors/date.asciidoc
+++ b/docs/reference/ingest/processors/date.asciidoc
@@ -17,7 +17,7 @@ in the same order they were defined as part of the processor definition.
 | Name                   | Required  | Default             | Description
 | `field`                | yes       | -                   | The field to get the date from.
 | `target_field`         | no        | @timestamp          | The field that will hold the parsed date.
-| `formats`              | yes       | -                   | An array of the expected date formats. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
+| `formats`              | yes       | -                   | An array of the expected date formats. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, UNIX_NS, or TAI64N.
 | `timezone`             | no        | UTC                 | The timezone to use when parsing the date. Supports <<template-snippets,template snippets>>.
 | `locale`               | no        | ENGLISH             | The locale to use when parsing the date, relevant when parsing month names or week days. Supports <<template-snippets,template snippets>>.
 | `output_format`        | no        | `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` | The format to use when writing the date to `target_field`. Must be a valid <<mapping-date-format,java time pattern>>.

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -54,6 +54,24 @@ enum DateFormat {
             return date -> Instant.ofEpochMilli(Long.parseLong(date)).atZone(timezone);
         }
     },
+    UnixNs {
+        @Override
+        Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
+            return date -> {
+                var parts = date.split("\\.");
+                if (parts.length > 2) {
+                    throw new IllegalArgumentException("failed to parse date field [" + date + "] with format [UNIX_NS]");
+                }
+                try {
+                    var seconds = Long.parseLong(parts[0]);
+                    var nanoseconds = parts.length == 2 ? Long.parseLong(parts[1]) : 0;
+                    return Instant.ofEpochSecond(seconds, nanoseconds).atZone(timezone);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("failed to parse date field [" + date + "] with format [UNIX_NS]");
+                }
+            };
+        }
+    },
     Tai64n {
         @Override
         Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
@@ -130,6 +148,7 @@ enum DateFormat {
             case "ISO8601" -> Iso8601;
             case "UNIX" -> Unix;
             case "UNIX_MS" -> UnixMs;
+            case "UNIX_NS" -> UnixNs;
             case "TAI64N" -> Tai64n;
             default -> Java;
         };

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -206,9 +206,53 @@ public class DateFormatTests extends ESTestCase {
         );
     }
 
+    public void testUnixNanoseconds() {
+        assertEquals(
+            DateFormat.UnixNs.getFunction(null, ZoneOffset.ofHours(2), null).apply("1688548995").toString(),
+            "2023-07-05T11:23:15+02:00"
+        );
+
+        assertEquals(
+            DateFormat.UnixNs.getFunction(null, ZoneOffset.ofHours(2), null).apply("1688548995.987654321").toString(),
+            "2023-07-05T11:23:15.987654321+02:00"
+        );
+        {
+            var invalidNs = randomAlphaOfLength(10) + "." + randomLongBetween(10000, 99999999);
+            assertEquals(
+                expectThrows(
+                    IllegalArgumentException.class,
+                    () -> DateFormat.UnixNs.getFunction(null, ZoneOffset.ofHours(2), null).apply(invalidNs)
+                ).getMessage(),
+                "failed to parse date field [" + invalidNs + "] with format [UNIX_NS]"
+            );
+        }
+        {
+            var invalidNs = randomLongBetween(10000, 99999999) + "." + randomAlphaOfLength(10);
+            assertEquals(
+                expectThrows(
+                    IllegalArgumentException.class,
+                    () -> DateFormat.UnixNs.getFunction(null, ZoneOffset.ofHours(2), null).apply(invalidNs)
+                ).getMessage(),
+                "failed to parse date field [" + invalidNs + "] with format [UNIX_NS]"
+            );
+        }
+        {
+            var invalidNs = randomIntBetween(1000, 50000) + "." + randomIntBetween(1000, 50000) + "." + randomIntBetween(1000, 50000);
+            assertEquals(
+                expectThrows(
+                    IllegalArgumentException.class,
+                    () -> DateFormat.UnixNs.getFunction(null, ZoneOffset.ofHours(2), null).apply(invalidNs)
+                ).getMessage(),
+                "failed to parse date field [" + invalidNs + "] with format [UNIX_NS]"
+            );
+        }
+    }
+
     public void testFromString() {
         assertThat(DateFormat.fromString("UNIX_MS"), equalTo(DateFormat.UnixMs));
         assertThat(DateFormat.fromString("unix_ms"), equalTo(DateFormat.Java));
+        assertThat(DateFormat.fromString("UNIX_NS"), equalTo(DateFormat.UnixNs));
+        assertThat(DateFormat.fromString("unix_ns"), equalTo(DateFormat.Java));
         assertThat(DateFormat.fromString("UNIX"), equalTo(DateFormat.Unix));
         assertThat(DateFormat.fromString("unix"), equalTo(DateFormat.Java));
         assertThat(DateFormat.fromString("ISO8601"), equalTo(DateFormat.Iso8601));

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
@@ -152,6 +152,13 @@ teardown:
                   "target_field" : "date_target_7",
                   "formats" : [ "ISO8601" ]
                 }
+              },
+              {
+                "date" : {
+                  "field" : "date_source_8",
+                  "target_field" : "date_target_8",
+                  "formats" : [ "UNIX_NS" ]
+                }
               }
             ]
           }
@@ -162,7 +169,16 @@ teardown:
         index: test
         id: "1"
         pipeline: "my_pipeline"
-        body: { date_source_1: "2018-02-05T13:44:56.657+0100", date_source_2: "2017-04-04 13:43:09 +0200", date_source_3: "10/Aug/2018:09:45:56 +0200", date_source_4: "1", date_source_5: "1", date_source_6: "4000000050d506482dbdf024", date_source_7: "2018-02-05T13:44:56.657+0100" }
+        body: {
+          date_source_1: "2018-02-05T13:44:56.657+0100",
+          date_source_2: "2017-04-04 13:43:09 +0200",
+          date_source_3: "10/Aug/2018:09:45:56 +0200",
+          date_source_4: "1",
+          date_source_5: "1",
+          date_source_6: "4000000050d506482dbdf024",
+          date_source_7: "2018-02-05T13:44:56.657+0100",
+          date_source_8: "1688548995.987654321"
+      }
 
   - do:
       get:
@@ -182,6 +198,7 @@ teardown:
   - match: { _source.date_target_6: "2012-12-22T01:00:46.767Z" }
   - match: { _source.date_source_7: "2018-02-05T13:44:56.657+0100" }
   - match: { _source.date_target_7: "2018-02-05T12:44:56.657Z" }
+  - match: { _source.date_target_8: "2023-07-05T09:23:15.987Z" }
 
 
 ---


### PR DESCRIPTION
A new DateFormatter under the id `UNIX_NS` to parse dates in the format 
seconds + nanoseconds are added. The new formatter accepts inputs with
the following formats:

* `13121312` -> only seconds
* `13121312.1231321` -> seconds + nanoseconds

Also added more tests and randomness to them whenever was possible

closes #86106 