### PR TITLE
Log exception if publication fails at startup

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1570,6 +1570,16 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     lagDetector.setTrackedNodes(publishNodes);
                     publication.start(followersChecker.getFaultyNodes());
                 } catch (Exception e) {
+                    logger.warn(
+                        "publication of state version ["
+                            + clusterState.version()
+                            + "] in term ["
+                            + clusterState.term()
+                            + "] for ["
+                            + clusterStatePublicationEvent.getSummary()
+                            + "] failed to start",
+                        e
+                    );
                     assert currentPublication.isEmpty() : e; // should not fail after setting currentPublication
                     becomeCandidate("publish");
                 } finally {
@@ -1976,7 +1986,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
                     final FailedToCommitClusterStateException exception = new FailedToCommitClusterStateException(
                         Strings.format(
-                            "publication of cluster state version [%d] in term [%d] failed [committed={}]",
+                            "publication of cluster state version [%d] in term [%d] failed [committed=%s]",
                             publishRequest.getAcceptedState().version(),
                             publishRequest.getAcceptedState().term(),
                             committed

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1571,13 +1571,13 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     publication.start(followersChecker.getFaultyNodes());
                 } catch (Exception e) {
                     logger.warn(
-                        "publication of state version ["
+                        "failed to start publication of state version ["
                             + clusterState.version()
                             + "] in term ["
                             + clusterState.term()
                             + "] for ["
                             + clusterStatePublicationEvent.getSummary()
-                            + "] failed to start",
+                            + "]",
                         e
                     );
                     assert currentPublication.isEmpty() : e; // should not fail after setting currentPublication


### PR DESCRIPTION
It's a little surprising for a healthy and stable cluster to fail to
start a new publication, but today the leader just swallows the
exception and stands down. This commit records the exception in the logs
(and fixes another incorrectly-formatted log message).

Relates #97493