### PR TITLE
[Profiling] Fix off-by-one error in test assert

### DIFF
--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/TransportGetProfilingActionTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/TransportGetProfilingActionTests.java
@@ -47,7 +47,7 @@ public class TransportGetProfilingActionTests extends ESTestCase {
     public void testRandomLengthListGreaterThanSliceCount() {
         int slices = randomIntBetween(1, 16);
         // To ensure that we can actually slice the list
-        List<String> input = randomList(slices, 20000, () -> "s");
+        List<String> input = randomList(slices + 1, 20000, () -> "s");
         List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
         assertEquals(slices, sliced.size());
     }


### PR DESCRIPTION
The test case `testRandomLengthListGreaterThanSliceCount` is supposed to test behavior of a list slice implementation when the input list contains more elements than desired slices. However, there was an off-by-one error so sometimes the input list was exactly the same size as the desired number of slices and thus the assertion was wrong. With this commit we ensure that the input list is always larger than the desired number of slices.