### PR TITLE
[Synthetics]Added privileges for synthetics API key generation

### DIFF
--- a/docs/changelog/97510.yaml
+++ b/docs/changelog/97510.yaml
@@ -1,0 +1,5 @@
+pr: 97510
+summary: "[Synthetics]Added privileges for synthetics API key generation"
+area: Authentication
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -807,7 +807,6 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // Synthetics API key for synthetics saas service
                 RoleDescriptor.IndicesPrivileges.builder().indices("synthetics-*").privileges("auto_configure", "read", "write").build(),
 
-
                 // Data telemetry reads mappings, metadata and stats of indices
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -804,6 +804,10 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*").privileges("read", "read_cross_cluster").build(),
 
+                // Synthetics API key for synthetics saas service
+                RoleDescriptor.IndicesPrivileges.builder().indices("synthetics-*").privileges("auto_configure", "read", "write").build(),
+
+
                 // Data telemetry reads mappings, metadata and stats of indices
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -805,7 +805,10 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*").privileges("read", "read_cross_cluster").build(),
 
                 // Synthetics API key for synthetics saas service
-                RoleDescriptor.IndicesPrivileges.builder().indices("synthetics-*").privileges("auto_configure", "read", "write").build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("synthetics-http-*", "synthetics-icmp-*", "synthetics-tcp-*", "synthetics-browser*")
+                    .privileges("auto_configure", "read", "write")
+                    .build(),
 
                 // Data telemetry reads mappings, metadata and stats of indices
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),


### PR DESCRIPTION
This change makes migrating Synthetics privileges seamless, where it currently is not, and can cause Synthetics checks to break across the upgrade from `< 8.8 -> 8.8+`. In `8.8+` we need additional privileges for reads from the `synthetics-*` index. To accomplish this we invalidated user API keys on upgrade, and asked them in the release notes to please visit the synthetics app as an admin to have this silently turned on in the background.

This was bad for a few reasons:

1. Synthetics would silently stop working on upgrade
2. People often don't read release notes
3. Users don't necessarily view the synthetics app soon after upgrade, and then, not necessarily with a superuser.

This change gives read access to those indices to the `kibana_system` user negating the need to invalidate.