### PR TITLE
Mute failing test case

### DIFF
--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/80_transform.yml
@@ -36,6 +36,10 @@ teardown:
 
 ---
 "Index data on the remote cluster":
+  - skip:
+      version: "all"
+      reason: AwaitsFix https://github.com/elastic/elasticsearch/issues/97516
+
   - do:
       indices.create:
         index: remote_test_index


### PR DESCRIPTION
relates #97516

Mute 

```
':x-pack:plugin:transform:qa:multi-cluster-tests-with-security:remote-cluster' --tests "org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT.test {yaml=remote_cluster/80_transform/Index data on the remote cluster}"
```