### PR TITLE
[8.9] Fix mixed-cluster test failure for top_hits aggregation (#97515)

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/top_hits.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/top_hits.yml
@@ -723,6 +723,9 @@ synthetic _source:
 
 ---
 runtime fields:
+  - skip:
+      version: " - 8.9.1"
+      reason:  "bugfix #97460 added in 8.9.1"
   - do:
       search:
         index: test


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Fix mixed-cluster test failure for top_hits aggregation (#97515)