### PR TITLE
Make terminate_after early termination friendly

### DIFF
--- a/docs/changelog/97540.yaml
+++ b/docs/changelog/97540.yaml
@@ -1,0 +1,6 @@
+pr: 97540
+summary: Make `terminate_after` early termination friendly
+area: Search
+type: bug
+issues:
+ - 97269

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -478,7 +478,10 @@ The response will not contain any hits as the `size` was set to `0`. The
 matching documents, or greater than `0` meaning that there were at least
 as many documents matching the query when it was early terminated.
 Also if the query was terminated early, the `terminated_early` flag will
-be set to `true` in the response.
+be set to `true` in the response. There are queries for which total hits
+counting can be retrieved directly from the index statistics, which is much
+faster as it does not require executing the query. In those situations,
+`terminate_after` is not honored as no collection is performed.
 
 [source,console-result]
 --------------------------------------------------

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -478,10 +478,11 @@ The response will not contain any hits as the `size` was set to `0`. The
 matching documents, or greater than `0` meaning that there were at least
 as many documents matching the query when it was early terminated.
 Also if the query was terminated early, the `terminated_early` flag will
-be set to `true` in the response. There are queries for which total hits
-counting can be retrieved directly from the index statistics, which is much
-faster as it does not require executing the query. In those situations,
-`terminate_after` is not honored as no collection is performed.
+be set to `true` in the response. Some queries are able to retrieve the hits
+count directly from the index statistics, which is much faster as it does
+not require executing the query. In those situations, no documents are
+collected, the returned `total.hits` will be higher than `terminate_after`,
+and `terminated_early` will be set to `false`.
 
 [source,console-result]
 --------------------------------------------------
@@ -506,8 +507,8 @@ faster as it does not require executing the query. In those situations,
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"took": 3/"took": $body.took/]
+// TESTRESPONSE[s/"terminated_early": true/"terminated_early": $body.terminated_early/]
 // TESTRESPONSE[s/"value": 1/"value": $body.hits.total.value/]
-// TESTRESPONSE[s/"relation": "eq"/"relation": $body.hits.total.relation/]
 
 The `took` time in the response contains the milliseconds that this request
 took for processing, beginning quickly after the node received the query, up

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhaseCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhaseCollector.java
@@ -140,23 +140,12 @@ final class QueryPhaseCollector implements Collector {
 
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
-        applyTerminateAfter();
         Bits postFilterBits = getPostFilterBits(context);
 
         if (aggsCollector == null) {
-            LeafCollector tdlc = null;
-            try {
-                tdlc = topDocsCollector.getLeafCollector(context);
-            } catch (@SuppressWarnings("unused") CollectionTerminatedException e) {
-                // TODO we keep on collecting although we have nothing to collect (there is no top docs nor aggs leaf collector).
-                // The reason is only to set the early terminated flag to the QueryResult like some tests expect. This needs fixing.
-                if (terminateAfter == 0) {
-                    throw e;
-                }
-            }
-            final LeafCollector topDocsLeafCollector = tdlc;
+            final LeafCollector topDocsLeafCollector = topDocsCollector.getLeafCollector(context);
             if (postFilterBits == null && terminateAfter == 0 && minScore == null) {
-                // no need to wrap if we just need to collect unfiltered docs through leaf collector
+                // no need to wrap if we just need to collect unfiltered docs through leaf collector.
                 // aggs collector was not originally provided so the overall score mode is that of the top docs collector
                 return topDocsLeafCollector;
             }
@@ -177,19 +166,14 @@ final class QueryPhaseCollector implements Collector {
         } catch (@SuppressWarnings("unused") CollectionTerminatedException e) {
             // aggs collector does not need this segment, but the top docs collector may.
             if (topDocsLeafCollector == null) {
-                // TODO we keep on collecting although we have nothing to collect (there is no top docs nor aggs leaf collector).
-                // The reason is only to set the early terminated flag to the QueryResult. We should fix this.
-                if (terminateAfter == 0) {
-                    throw e;
-                }
+                throw e;
             }
         }
         final LeafCollector aggsLeafCollector = alf;
 
-        if (topDocsLeafCollector == null && terminateAfter == 0 && minScore == null) {
-            // top docs collector early terminated, we can avoid wrapping as long as we don't need to apply terminate_after and min_score.
-            // post_filter does not matter because it's not applied to aggs collection anyways. terminate_after matters only until we
-            // address the different TODOs around needless collection to honour terminate_after after early termination.
+        if (topDocsLeafCollector == null && minScore == null) {
+            // top docs collector early terminated, we can avoid wrapping as long as we don't need to apply min_score.
+            // post_filter and terminate_after do not matter because they not applied to aggs collection anyways.
             // aggs don't support skipping low scoring hits, so we can rely on setMinCompetitiveScore being a no-op already.
             return aggsLeafCollector;
         }
@@ -223,60 +207,32 @@ final class QueryPhaseCollector implements Collector {
 
     private class TopDocsLeafCollector implements LeafCollector {
         private final Bits postFilterBits;
-        private LeafCollector topDocsLeafCollector;
+        private final LeafCollector topDocsLeafCollector;
         private Scorable scorer;
 
         TopDocsLeafCollector(Bits postFilterBits, LeafCollector topDocsLeafCollector) {
+            assert topDocsLeafCollector != null;
+            assert postFilterBits != null || terminateAfter > 0 || minScore != null;
             this.postFilterBits = postFilterBits;
             this.topDocsLeafCollector = topDocsLeafCollector;
         }
 
         @Override
         public void setScorer(Scorable scorer) throws IOException {
-            if (cacheScores) {
-                scorer = ScoreCachingWrappingScorer.wrap(scorer);
-            }
-            if (terminateAfter > 0) {
-                scorer = new FilterScorable(scorer) {
-                    @Override
-                    public void setMinCompetitiveScore(float minScore) {
-                        // Ignore calls to setMinCompetitiveScore when terminate_after is used, otherwise early termination
-                        // of total hits tracking makes it impossible to terminate after.
-                        // TODO the reason is only to set the early terminated flag to the QueryResult. We should fix this.
-                    }
-                };
-            }
-            if (topDocsLeafCollector != null) {
-                topDocsLeafCollector.setScorer(scorer);
-            }
+            topDocsLeafCollector.setScorer(scorer);
             this.scorer = scorer;
         }
 
         @Override
         public DocIdSetIterator competitiveIterator() throws IOException {
-            if (topDocsLeafCollector != null) {
-                return topDocsLeafCollector.competitiveIterator();
-            }
-            return null;
+            return topDocsLeafCollector.competitiveIterator();
         }
 
         @Override
         public void collect(int doc) throws IOException {
             if (shouldCollectTopDocs(doc, scorer, postFilterBits)) {
                 numCollected++;
-                if (topDocsLeafCollector != null) {
-                    try {
-                        topDocsLeafCollector.collect(doc);
-                    } catch (@SuppressWarnings("unused") CollectionTerminatedException e) {
-                        topDocsLeafCollector = null;
-                        // TODO we keep on collecting although we have nothing to collect (there is no top docs nor aggs leaf
-                        // collector).
-                        // The reason is only to set the early terminated flag to the QueryResult. We should fix this.
-                        if (terminateAfter == 0) {
-                            throw e;
-                        }
-                    }
-                }
+                topDocsLeafCollector.collect(doc);
             }
         }
     }
@@ -288,6 +244,7 @@ final class QueryPhaseCollector implements Collector {
         private Scorable scorer;
 
         CompositeLeafCollector(Bits postFilterBits, LeafCollector topDocsLeafCollector, LeafCollector aggsLeafCollector) {
+            assert topDocsLeafCollector != null || aggsLeafCollector != null;
             this.postFilterBits = postFilterBits;
             this.topDocsLeafCollector = topDocsLeafCollector;
             this.aggsLeafCollector = aggsLeafCollector;
@@ -318,6 +275,8 @@ final class QueryPhaseCollector implements Collector {
         @Override
         public void collect(int doc) throws IOException {
             if (shouldCollectTopDocs(doc, scorer, postFilterBits)) {
+                // we keep on counting and checking the terminate_after threshold so that we can terminate aggs collection
+                // even if top docs collection early terminated
                 numCollected++;
                 if (topDocsLeafCollector != null) {
                     try {
@@ -326,12 +285,7 @@ final class QueryPhaseCollector implements Collector {
                         topDocsLeafCollector = null;
                         // top docs collector does not need this segment, but the aggs collector may.
                         if (aggsLeafCollector == null) {
-                            // TODO we keep on collecting although we have nothing to collect (there is no top docs nor aggs leaf
-                            // collector).
-                            // The reason is only to set the early terminated flag to the QueryResult. We should fix this.
-                            if (terminateAfter == 0) {
-                                throw e;
-                            }
+                            throw e;
                         }
                     }
                 }
@@ -345,12 +299,7 @@ final class QueryPhaseCollector implements Collector {
                         aggsLeafCollector = null;
                         // aggs collector does not need this segment, but the top docs collector may.
                         if (topDocsLeafCollector == null) {
-                            // TODO we keep on collecting although we have nothing to collect (there is no top docs nor aggs leaf
-                            // collector).
-                            // The reason is only to set the early terminated flag to the QueryResult. We should fix this.
-                            if (terminateAfter == 0) {
-                                throw e;
-                            }
+                            throw e;
                         }
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhaseCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhaseCollector.java
@@ -140,6 +140,7 @@ final class QueryPhaseCollector implements Collector {
 
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+        applyTerminateAfter();
         Bits postFilterBits = getPostFilterBits(context);
 
         if (aggsCollector == null) {

--- a/server/src/test/java/org/elasticsearch/search/query/NonCountingTermQuery.java
+++ b/server/src/test/java/org/elasticsearch/search/query/NonCountingTermQuery.java
@@ -29,10 +29,11 @@ class NonCountingTermQuery extends TermQuery {
         super(term);
     }
 
+    @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
         Weight w = super.createWeight(searcher, scoreMode, boost);
         return new FilterWeight(w) {
-            public int count(LeafReaderContext context) throws IOException {
+            public int count(LeafReaderContext context) {
                 return -1;
             }
         };

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseCollectorTests.java
@@ -948,8 +948,22 @@ public class QueryPhaseCollectorTests extends ESTestCase {
 
     public void testSetMinCompetitiveScoreIsEnabledTopDocsOnly() throws IOException {
         // without aggs no need to disable set min competitive score
+        Weight filterWeight = null;
+        int terminateAfter = 0;
+        Float minScore = null;
+        if (randomBoolean()) {
+            if (randomBoolean()) {
+                filterWeight = new MatchAllDocsQuery().createWeight(searcher, ScoreMode.TOP_DOCS, 1f);
+            }
+            if (randomBoolean()) {
+                terminateAfter = randomIntBetween(1, Integer.MAX_VALUE);
+            }
+            if (randomBoolean()) {
+                minScore = 0f;
+            }
+        }
         TopScoresCollector topDocs = new TopScoresCollector();
-        Collector queryPhaseCollector = new QueryPhaseCollector(topDocs, null, 0, null, null);
+        Collector queryPhaseCollector = new QueryPhaseCollector(topDocs, filterWeight, terminateAfter, null, minScore);
         LeafReaderContext leafReaderContext = searcher.getLeafContexts().get(0);
         LeafCollector leafCollector = queryPhaseCollector.getLeafCollector(leafReaderContext);
         MinCompetitiveScoreScorable scorer = new MinCompetitiveScoreScorable();
@@ -959,9 +973,24 @@ public class QueryPhaseCollectorTests extends ESTestCase {
     }
 
     public void testSetMinCompetitiveScoreIsDisabledWithAggs() throws IOException {
+        Weight filterWeight = null;
+        int terminateAfter = 0;
+        Float minScore = null;
+        if (randomBoolean()) {
+            if (randomBoolean()) {
+                TermQuery termQuery = new TermQuery(new Term("field2", "value"));
+                filterWeight = termQuery.createWeight(searcher, ScoreMode.TOP_DOCS, 1f);
+            }
+            if (randomBoolean()) {
+                terminateAfter = randomIntBetween(1, Integer.MAX_VALUE);
+            }
+            if (randomBoolean()) {
+                minScore = randomFloat();
+            }
+        }
         TopScoresCollector topDocs = new TopScoresCollector();
         Collector aggs = new MockCollector(randomBoolean() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES);
-        Collector queryPhaseCollector = new QueryPhaseCollector(topDocs, null, 0, aggs, null);
+        Collector queryPhaseCollector = new QueryPhaseCollector(topDocs, filterWeight, terminateAfter, aggs, minScore);
         LeafReaderContext leafReaderContext = searcher.getLeafContexts().get(0);
         LeafCollector leafCollector = queryPhaseCollector.getLeafCollector(leafReaderContext);
         MinCompetitiveScoreScorable scorer = new MinCompetitiveScoreScorable();
@@ -1051,24 +1080,6 @@ public class QueryPhaseCollectorTests extends ESTestCase {
         LeafCollector leafCollector = queryPhaseCollector.getLeafCollector(context);
         leafCollector.competitiveIterator();
         assertTrue(mockCollector.competitiveIteratorCalled);
-    }
-
-    public void testCompetitiveIteratorNoAggsCollectionTerminated() throws IOException {
-        // use a post_filter so that we wrap the top docs leaf collector, as this test verifies that
-        // the wrapper calls competitiveIterator when appropriated
-        Weight postFilterWeight = searcher.createWeight(new MatchAllDocsQuery(), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
-        MockCollector mockCollector = new MockCollector(randomFrom(ScoreMode.values()));
-        TerminateAfterCollector terminateAfterCollector = new TerminateAfterCollector(mockCollector, 1);
-        QueryPhaseCollector queryPhaseCollector = new QueryPhaseCollector(terminateAfterCollector, postFilterWeight, 0, null, null);
-        LeafReaderContext context = searcher.getLeafContexts().get(0);
-        LeafCollector leafCollector = queryPhaseCollector.getLeafCollector(context);
-        leafCollector.competitiveIterator();
-        assertTrue(mockCollector.competitiveIteratorCalled);
-        mockCollector.competitiveIteratorCalled = false;
-        leafCollector.collect(0);
-        expectThrows(CollectionTerminatedException.class, () -> leafCollector.collect(1));
-        leafCollector.competitiveIterator();
-        assertFalse(mockCollector.competitiveIteratorCalled);
     }
 
     public void testCompetitiveIteratorWithAggs() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -351,92 +351,61 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     /**
-     * Test the terminate after functionality when no hits are collected (size is set to 0) and the total hit count is
-     * shortcut by {@link org.apache.lucene.search.TotalHitCountCollector} using {@link Weight#count(LeafReaderContext)}.
-     * A match all query is used to leverage the hit count shortcut as it enables retrieving the count from the index statistics.
+     * Test the terminate after functionality when no hits are collected (size is set to 0) and the total hit count is shortcut by
+     * {@link org.apache.lucene.search.TotalHitCountCollector} using {@link Weight#count(LeafReaderContext)}. A match all query is used
+     * to leverage the hit count shortcut as it enables retrieving the count from the index statistics. Terminate_after has no effect as
+     * there is no collection effectively. It is fine that the total hit count is higher than the provided threshold in this case.
      */
     public void testTerminateAfterSize0HitCountShortcut() throws Exception {
-        indexDocs();
+        int numDocs = indexDocs();
         {
-            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 1), new MatchAllDocsQuery());
+            TestSearchContext context = createContext(noCollectionContextSearcher(reader), new MatchAllDocsQuery());
             context.terminateAfter(1);
             context.setSize(0);
             QueryPhase.addCollectorsAndSearch(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(getExpectedTotalHitCountWithShortcut(reader, 1)));
+            assertFalse(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
         // test interaction between trackTotalHits and terminateAfter
         {
-            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            TestSearchContext context = createContext(noCollectionContextSearcher(reader), new MatchAllDocsQuery());
             context.terminateAfter(10);
             context.setSize(0);
             context.trackTotalHitsUpTo(-1);
             QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
+            assertFalse(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
         {
-            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            TestSearchContext context = createContext(noCollectionContextSearcher(reader), new MatchAllDocsQuery());
             context.terminateAfter(10);
             context.setSize(0);
-            // track total hits is lower than terminate_after
-            context.trackTotalHitsUpTo(randomIntBetween(1, 9));
+            // terminate_after is not honored, no matter the value of track_total_hits.
+            context.trackTotalHitsUpTo(randomIntBetween(1, Integer.MAX_VALUE));
             QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
+            assertFalse(context.queryResult().terminatedEarly());
             // Given that total hit count does not require collection, PartialHitCountCollector does not early terminate.
-            // The overall search, and consequently the total hit count collection, will early terminate based on the terminate_after value
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(getExpectedTotalHitCountWithShortcut(reader, 10)));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
-        {
-            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
-            context.terminateAfter(10);
-            context.setSize(0);
-            // track total hits is greater than terminate_after but lower than the number of docs
-            context.trackTotalHitsUpTo(randomIntBetween(11, Integer.MAX_VALUE));
-            QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(getExpectedTotalHitCountWithShortcut(reader, 10)));
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
-        }
-    }
-
-    /**
-     * Computes the expected early terminated hit count when retrieved from {@link Weight#count(LeafReaderContext)}, given the
-     * <code>totalHitsThreshold</code>.
-     * {@link org.apache.lucene.search.TotalHitCountCollector} (used when size==0) shortcuts total hit count via
-     * {@link Weight#count(LeafReaderContext)} segment by segment. When that happens, {@link PartialHitCountCollector} will detect that
-     * the threshold is reached at the beginning of the following leaf collection. That means that the returned total hit count may be
-     * higher than <code>terminate_after</code> or <code>track_total_hits</code> (yet lower than the number of docs).
-     */
-    private static long getExpectedTotalHitCountWithShortcut(IndexReader reader, int totalHitsThreshold) {
-        int total = 0;
-        for (LeafReaderContext leaf : reader.leaves()) {
-            total += leaf.reader().numDocs();
-            if (total >= totalHitsThreshold) {
-                break;
-            }
-        }
-        return total;
     }
 
     /**
      * Test the terminate after functionality when no hits are collected (size is set to 0) and the
      * total hit count cannot be shortcut using {@link Weight#count(LeafReaderContext)}.
-     * We use a boolean query with two optional clauses, which makes it impossible to shortcut the total hit count. This test also
-     * requires disabling the query cache otherwise the count could be cached from previous runs and cause different behaviour.
+     * We use a special term query that doesn't expose doc count via Weight#count, which makes it impossible to shortcut the hit count.
+     * This test also requires disabling the query cache or the count could be cached from previous runs and cause different behaviour.
      */
     public void testTerminateAfterSize0NoHitCountShortcut() throws Exception {
         indexDocs();
         Query query = new NonCountingTermQuery(new Term("foo", "bar"));
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), query);
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 1), query);
             context.terminateAfter(1);
             context.setSize(0);
             QueryPhase.executeQuery(context);
@@ -447,25 +416,26 @@ public class QueryPhaseTests extends IndexShardTestCase {
         }
         // test interaction between trackTotalHits and terminateAfter
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), query);
+            TestSearchContext context = createContext(noCollectionContextSearcher(reader), query);
             context.terminateAfter(10);
             context.setSize(0);
+            // not tracking total hits makes the hit count collection early terminate, in which case terminate_after can't be honored
             context.trackTotalHitsUpTo(-1);
             QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
+            assertFalse(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
         {
-            TestSearchContext context = createContext(newContextSearcher(reader), query);
+            // track total hits is lower than terminate_after, hit count collection early terminates, terminate_after is not honored
+            int trackTotalHits = randomIntBetween(1, 9);
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, trackTotalHits), query);
             context.terminateAfter(10);
             context.setSize(0);
-            // track total hits is lower than terminate_after
-            int trackTotalHits = randomIntBetween(1, 9);
             context.trackTotalHitsUpTo(trackTotalHits);
             QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
+            assertFalse(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) trackTotalHits));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
@@ -474,7 +444,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
             TestSearchContext context = createContext(newContextSearcher(reader), query);
             context.terminateAfter(10);
             context.setSize(0);
-            // track total hits is higher than terminate_after
+            // track total hits is higher than terminate_after, in which case collection effectively terminates after 10 documents
             context.trackTotalHitsUpTo(randomIntBetween(11, Integer.MAX_VALUE));
             QueryPhase.executeQuery(context);
             assertTrue(context.queryResult().terminatedEarly());
@@ -488,6 +458,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
      * Test the terminate after functionality when hits are collected (size is greater than 0) and the
      * total hit count is shortcut using {@link TopDocsCollectorManagerFactory#shortcutTotalHitCount(IndexReader, Query)}
      * A match all query is used to leverage the hit count shortcut as it enables retrieving the count from the index statistics.
+     * Note that track_total_hits is effectively ignored in this case, and the hit count threshold applied is instead <code>size</code>.
      */
     public void testTerminateAfterWithHitsHitCountShortcut() throws Exception {
         int numDocs = indexDocs();
@@ -503,6 +474,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         {
             TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 1), new MatchAllDocsQuery());
             context.terminateAfter(1);
+            // default track_total_hits, size 1: terminate_after kicks in first
             context.setSize(1);
             QueryPhase.addCollectorsAndSearch(context);
             assertTrue(context.queryResult().terminatedEarly());
@@ -514,6 +486,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         {
             TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
             context.terminateAfter(7);
+            // total hits tracking disabled but 10 hits need to be collected, terminate_after is lower than size, so it kicks in first
             context.setSize(10);
             context.trackTotalHitsUpTo(-1);
             QueryPhase.executeQuery(context);
@@ -525,10 +498,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         {
             TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
             context.terminateAfter(7);
-            // size is greater than terminate_after
+            // size is greater than terminate_after (track_total_hits does not matter): terminate_after kicks in first
             context.setSize(10);
-            // track_total_hits is lower than terminate_after
-            context.trackTotalHitsUpTo(randomIntBetween(1, 6));
+            context.trackTotalHitsUpTo(randomIntBetween(1, Integer.MAX_VALUE));
             QueryPhase.executeQuery(context);
             assertTrue(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
@@ -536,30 +508,19 @@ public class QueryPhaseTests extends IndexShardTestCase {
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
         }
         {
-            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
+            int size = randomIntBetween(1, 6);
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, size), new MatchAllDocsQuery());
             context.terminateAfter(7);
-            // size is lower than terminate_after
-            context.setSize(5);
-            // track_total_hits is also lower than terminate_after
-            context.trackTotalHitsUpTo(randomIntBetween(1, 6));
+            // size is lower than terminate_after, track_total_hits does not matter: low scoring hits are skipped via
+            // setMinCompetitiveScore,
+            // terminate_after can't be honored as collection is entirely skipped after collecting the needed amount of hits
+            context.setSize(size);
+            context.trackTotalHitsUpTo(randomIntBetween(1, Integer.MAX_VALUE));
             QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
+            assertFalse(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(5));
-        }
-        {
-            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
-            context.terminateAfter(7);
-            context.setSize(10);
-            // track_total_hits is greater than terminate_after
-            context.trackTotalHitsUpTo(randomIntBetween(8, Integer.MAX_VALUE));
-            QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            // this is from our own shortcutTotalHitCount, which does not early terminate based on track_total_hits
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(size));
         }
     }
 


### PR DESCRIPTION
There are situations in which the terminate_after functionality causes the collection to keep on going although there is nothing to collect, with the only goal of incrementing the counter of collected docs and eventually early terminating which sets the `terminated_early` flag in the search response to true.

When docs collection early terminates, we should rather honor the corresponding `CollectionTerminatedException` that is thrown, and adjust expectations around the fact that `terminate_after` affects actual collection of documents, meaning that it can't be honored if the threshold has not been reached by the team the collection early terminates for other reasons.

This commit adjust the QueryPhaseCollector behavior to do that, which allows for some additional simplifications.

Aside note: before this change, `terminate_after` was honored in-between segments when size is set to `0` and the hit count can be retrieved from the index statistics, meaning that the hit count would be greater than the `terminate_after` but lower than the number of docs as not all segments were seen. The behavior when size is greater than `0` was different as the hit count that is shortcut in Elasticsearch includes all segments at all times. This change makes the two consistent in that size==0 will also expose count from all segments and won't be early terminated.


Closes #97269