### PR TITLE
[8.8] Fix docs for explaining unassigned shards (#97538)

### DIFF
--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -60,8 +60,9 @@ you might expect otherwise.
 ==== {api-request-body-title}
 
 `current_node`::
-    (Optional, string) Specifies the node ID or the name of the node to only 
-    explain a shard that is currently located on the specified node.
+    (Optional, string) Specifies the node ID or the name of the node currently
+    holding the shard to explain. To explain an unassigned shard, omit this
+    parameter.
 
 `index`::
     (Optional, string) Specifies the name of the index that you would like an 

--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -443,13 +443,10 @@ GET _cluster/allocation/explain?filter_path=index,node_allocation_decisions.node
 {
   "index": "my-index",
   "shard": 0,
-  "primary": false,
-  "current_node": "my-node"
+  "primary": false
 }
 ----
 // TEST[s/^/PUT my-index\n/]
-// TEST[s/"primary": false,/"primary": false/]
-// TEST[s/"current_node": "my-node"//]
 
 [discrete]
 [[fix-red-yellow-cluster-status]]

--- a/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
@@ -44,13 +44,10 @@ GET _cluster/allocation/explain?filter_path=index,node_allocation_decisions.node
 {
   "index": "my-index",
   "shard": 0,
-  "primary": false,
-  "current_node": "my-node"
+  "primary": false
 }
 ----
 // TEST[s/^/PUT my-index\n/]
-// TEST[s/"primary": false,/"primary": false/]
-// TEST[s/"current_node": "my-node"//]
 
 [discrete]
 [[fix-red-yellow-cluster-status]]


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix docs for explaining unassigned shards (#97538)