### PR TITLE
Add `shard_stats.total_count` column description to /_cat/nodes docs.

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -315,6 +315,9 @@ Time spent in suggest, such as `0`.
 `suggest.total`, `suto`, `suggestTotal`::
 Number of suggest operations, such as `0`.
 
+`shard_stats.total_count`, `sstc`, `shardStatsTotalCount`::
+Number of shards assigned.
+
 `mappings.total_count`, `mtc`, `mappingsTotalCount`::
 Number of mappings, including <<runtime,runtime>> and <<object,object>> fields.
 


### PR DESCRIPTION
This column was implemented previously but not added to the docs. It might be helpful to list it when troubleshooting cluster balance.
