### PR TITLE
Reduce legal Lifecycle transitions

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
+++ b/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
@@ -113,21 +113,12 @@ public final class Lifecycle {
     }
 
     public synchronized boolean moveToStarted() throws IllegalStateException {
-        return switch (state) {
-            case INITIALIZED -> {
-                state = State.STARTED;
-                yield true;
-            }
-            case STARTED -> false;
-            case STOPPED -> {
-                assert false : "STOPPED -> STARTED";
-                throw new IllegalStateException("Can't move to started state when stopped");
-            }
-            case CLOSED -> {
-                assert false : "CLOSED -> STARTED";
-                throw new IllegalStateException("Can't move to started state when closed");
-            }
-        };
+        if (canMoveToStarted()) {
+            state = State.STARTED;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public boolean canMoveToStopped() throws IllegalStateException {
@@ -146,21 +137,12 @@ public final class Lifecycle {
     }
 
     public synchronized boolean moveToStopped() throws IllegalStateException {
-        return switch (state) {
-            case INITIALIZED -> {
-                assert false : "INITIALIZED -> STOPPED";
-                throw new IllegalStateException("Can't move to stopped state when not started");
-            }
-            case STARTED -> {
-                state = State.STOPPED;
-                yield true;
-            }
-            case STOPPED -> false;
-            case CLOSED -> {
-                assert false : "CLOSED -> STOPPED";
-                throw new IllegalStateException("Can't move to stopped state when closed");
-            }
-        };
+        if (canMoveToStopped()) {
+            state = State.STOPPED;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public boolean canMoveToClosed() throws IllegalStateException {
@@ -176,21 +158,12 @@ public final class Lifecycle {
     }
 
     public synchronized boolean moveToClosed() throws IllegalStateException {
-        return switch (state) {
-            case INITIALIZED -> {
-                state = State.CLOSED;
-                yield true;
-            }
-            case STARTED -> {
-                assert false : "STARTED -> CLOSED";
-                throw new IllegalStateException("Can't move directly from STARTED to CLOSED, must move to STOPPED first");
-            }
-            case STOPPED -> {
-                state = State.CLOSED;
-                yield true;
-            }
-            case CLOSED -> false;
-        };
+        if (canMoveToClosed()) {
+            state = State.CLOSED;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.component;
+
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+public class LifecycleTests extends ESTestCase {
+
+    public void testTransitions() {
+        doTransitionTest(false);
+        doTransitionTest(true);
+    }
+
+    private void doTransitionTest(boolean startBeforeClosing) {
+        final var lifecycle = new Lifecycle();
+
+        assertState(lifecycle, Lifecycle.State.INITIALIZED);
+        assertTrue(lifecycle.canMoveToStarted());
+        assertTrue(lifecycle.canMoveToClosed());
+
+        if (startBeforeClosing) {
+            assertTrue(lifecycle.moveToStarted());
+            assertState(lifecycle, Lifecycle.State.STARTED);
+            assertFalse(lifecycle.canMoveToStarted());
+            assertTrue(lifecycle.canMoveToStopped());
+
+            assertTrue(lifecycle.moveToStopped());
+            assertState(lifecycle, Lifecycle.State.STOPPED);
+            assertFalse(lifecycle.canMoveToStopped());
+            assertTrue(lifecycle.canMoveToClosed());
+        }
+
+        assertTrue(lifecycle.moveToClosed());
+        assertState(lifecycle, Lifecycle.State.CLOSED);
+        assertFalse(lifecycle.canMoveToClosed());
+    }
+
+    private static void assertState(Lifecycle lifecycle, Lifecycle.State expectedState) {
+        assertEquals(expectedState, lifecycle.state());
+        assertEquals(expectedState == Lifecycle.State.INITIALIZED, lifecycle.initialized());
+        assertEquals(expectedState == Lifecycle.State.STARTED, lifecycle.started());
+        assertEquals(expectedState == Lifecycle.State.STOPPED, lifecycle.stopped());
+        assertEquals(expectedState == Lifecycle.State.CLOSED, lifecycle.closed());
+        assertEquals(expectedState == Lifecycle.State.STOPPED || expectedState == Lifecycle.State.CLOSED, lifecycle.stoppedOrClosed());
+    }
+
+    public void testThreadSafety() {
+        final var lifecycle = new Lifecycle();
+
+        try (var testHarness = new ThreadSafetyTestHarness(between(1, 10))) {
+            assertState(lifecycle, Lifecycle.State.INITIALIZED);
+            testHarness.testTransition(lifecycle::moveToStarted);
+            assertState(lifecycle, Lifecycle.State.STARTED);
+            testHarness.testTransition(lifecycle::moveToStopped);
+            assertState(lifecycle, Lifecycle.State.STOPPED);
+            testHarness.testTransition(lifecycle::moveToClosed);
+            assertState(lifecycle, Lifecycle.State.CLOSED);
+        }
+    }
+
+    private static class ThreadSafetyTestHarness implements Releasable {
+        final int threads;
+        final CyclicBarrier barrier;
+        final ExecutorService executor;
+
+        ThreadSafetyTestHarness(int threads) {
+            this.threads = threads;
+            this.barrier = new CyclicBarrier(threads);
+            this.executor = EsExecutors.newScaling(
+                "test",
+                threads,
+                threads,
+                10,
+                TimeUnit.SECONDS,
+                true,
+                EsExecutors.daemonThreadFactory("test"),
+                new ThreadContext(Settings.EMPTY)
+            );
+        }
+
+        void testTransition(BooleanSupplier doTransition) {
+            final var transitioned = new AtomicBoolean();
+            PlainActionFuture.<Void, RuntimeException>get(fut -> {
+                try (var listeners = new RefCountingListener(fut)) {
+                    for (int i = 0; i < threads; i++) {
+                        executor.execute(ActionRunnable.run(listeners.acquire(), () -> {
+                            safeAwait(barrier);
+                            if (doTransition.getAsBoolean()) {
+                                assertTrue(transitioned.compareAndSet(false, true));
+                            }
+                        }));
+                    }
+                }
+            });
+            assertTrue(transitioned.get());
+        }
+
+        @Override
+        public void close() {
+            terminate(executor);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
@@ -112,27 +112,6 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
         }
     }
 
-    public void testBoundPortDoesntChange() throws Exception {
-        Environment tempEnv = newEnvironment(Settings.builder().put(ReadinessService.PORT.getKey(), 0).build());
-        ReadinessService tempService = new ReadinessService(clusterService, tempEnv);
-        tempService.start();
-        tempService.startListener();
-
-        ServerSocketChannel channel = tempService.serverChannel();
-        assertTrue(channel.isOpen());
-        assertTrue(tempService.boundAddress().publishAddress().getPort() > 0);
-
-        int port = tempService.boundAddress().publishAddress().getPort();
-
-        tempService.stop();
-        assertNull(tempService.serverChannel());
-        tempService.start();
-        tempService.startListener();
-        assertEquals(port, ((InetSocketAddress) tempService.serverChannel().getLocalAddress()).getPort());
-        tempService.stop();
-        tempService.close();
-    }
-
     public void testSocketChannelCreation() throws Exception {
         try (ServerSocketChannel channel = readinessService.setupSocket()) {
             assertTrue(channel.isOpen());
@@ -161,13 +140,12 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
         readinessService.close();
     }
 
-    public void testStopWithoutStart() {
+    public void testCloseWithoutStart() {
         assertTrue(ReadinessService.enabled(env));
         assertFalse(readinessService.ready());
         assertNull(readinessService.serverChannel());
-        readinessService.stop();
-        assertFalse(readinessService.ready());
         readinessService.close();
+        assertFalse(readinessService.ready());
     }
 
     public void testTCPProbe() throws Exception {


### PR DESCRIPTION
Today `Lifecycle` permits transitions from `STOPPED` back to `STARTED`,
ignores transitions from `INITIALIZED` to `STOPPED`, and only throws an
`IllegalStateException` on an invalid transition. In fact in production
we never restart a `STOPPED` component (and there are several places
where we assume this), we can easily avoid stopping all `INITIALIZED`
components, and invalid lifecycle transitions should result in test
failures.

This commit tightens up the permitted transitions and adds assertions to
cause test failures for invalid transitions.