### PR TITLE
Ignore disk watermarks for index_only shards

### DIFF
--- a/docs/changelog/97556.yaml
+++ b/docs/changelog/97556.yaml
@@ -1,0 +1,5 @@
+pr: 97556
+summary: Ignore disk watermarks for `index_only` shards
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -42,7 +42,7 @@ public abstract class AllocationDecider {
     }
 
     /**
-     * Returns a {@link Decision} whether the given shard routing can be remain
+     * Returns a {@link Decision} whether the given shard routing can remain
      * on the given node. The default is {@link Decision#ALWAYS}.
      */
     public Decision canRemain(IndexMetadata indexMetadata, ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRouting.Role;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Strings;
@@ -466,7 +467,7 @@ public class DiskThresholdDecider extends AllocationDecider {
     }
 
     private static boolean ignoreDiskWatermarksForShard(RoutingAllocation allocation, ShardRouting shardRouting) {
-        return shardRouting.role().isPromotableToPrimary() || allocation.metadata().index(shardRouting.index()).ignoreDiskWatermarks();
+        return shardRouting.role() == Role.INDEX_ONLY || allocation.metadata().index(shardRouting.index()).ignoreDiskWatermarks();
     }
 
     private static DiskUsageWithRelocations getDiskUsage(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -389,7 +389,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (indexMetadata.ignoreDiskWatermarks() || ignoreDiskWatermarksForShard(allocation, shardRouting)) {
+        if (ignoreDiskWatermarksForShard(allocation, indexMetadata, shardRouting)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -464,6 +464,14 @@ public class DiskThresholdDecider extends AllocationDecider {
             "there is enough disk on this node for the shard to remain, free: [%s]",
             ByteSizeValue.ofBytes(freeBytes)
         );
+    }
+
+    private static boolean ignoreDiskWatermarksForShard(
+        RoutingAllocation allocation,
+        IndexMetadata indexMetadata,
+        ShardRouting shardRouting
+    ) {
+        return indexMetadata.ignoreDiskWatermarks() || ignoreDiskWatermarksForShard(allocation, shardRouting);
     }
 
     private static boolean ignoreDiskWatermarksForShard(RoutingAllocation allocation, ShardRouting shardRouting) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -190,7 +190,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (allocation.metadata().index(shardRouting.index()).ignoreDiskWatermarks()) {
+        if (ignoreDiskWatermarksForShard(allocation, shardRouting)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -348,7 +348,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (allocation.metadata().index(shardRouting.index()).ignoreDiskWatermarks()) {
+        if (ignoreDiskWatermarksForShard(allocation, shardRouting)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -388,7 +388,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (indexMetadata.ignoreDiskWatermarks()) {
+        if (indexMetadata.ignoreDiskWatermarks() || ignoreDiskWatermarksForShard(allocation, shardRouting)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -463,6 +463,10 @@ public class DiskThresholdDecider extends AllocationDecider {
             "there is enough disk on this node for the shard to remain, free: [%s]",
             ByteSizeValue.ofBytes(freeBytes)
         );
+    }
+
+    private static boolean ignoreDiskWatermarksForShard(RoutingAllocation allocation, ShardRouting shardRouting) {
+        return shardRouting.role().isPromotableToPrimary() || allocation.metadata().index(shardRouting.index()).ignoreDiskWatermarks();
     }
 
     private static DiskUsageWithRelocations getDiskUsage(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -191,7 +191,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (ignoreDiskWatermarksForShard(allocation, shardRouting)) {
+        if (ignoreDiskWatermarksForShard(shardRouting, allocation)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -349,7 +349,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (ignoreDiskWatermarksForShard(allocation, shardRouting)) {
+        if (ignoreDiskWatermarksForShard(shardRouting, allocation)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -389,7 +389,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             return decision;
         }
 
-        if (ignoreDiskWatermarksForShard(allocation, indexMetadata, shardRouting)) {
+        if (ignoreDiskWatermarksForShard(shardRouting, indexMetadata)) {
             return YES_DISK_WATERMARKS_IGNORED;
         }
 
@@ -466,16 +466,12 @@ public class DiskThresholdDecider extends AllocationDecider {
         );
     }
 
-    private static boolean ignoreDiskWatermarksForShard(
-        RoutingAllocation allocation,
-        IndexMetadata indexMetadata,
-        ShardRouting shardRouting
-    ) {
-        return indexMetadata.ignoreDiskWatermarks() || ignoreDiskWatermarksForShard(allocation, shardRouting);
+    private static boolean ignoreDiskWatermarksForShard(ShardRouting shardRouting, IndexMetadata indexMetadata) {
+        return shardRouting.role() == Role.INDEX_ONLY || indexMetadata.ignoreDiskWatermarks();
     }
 
-    private static boolean ignoreDiskWatermarksForShard(RoutingAllocation allocation, ShardRouting shardRouting) {
-        return shardRouting.role() == Role.INDEX_ONLY || allocation.metadata().index(shardRouting.index()).ignoreDiskWatermarks();
+    private static boolean ignoreDiskWatermarksForShard(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return ignoreDiskWatermarksForShard(shardRouting, allocation.metadata().index(shardRouting.index()));
     }
 
     private static DiskUsageWithRelocations getDiskUsage(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -928,7 +928,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
 
                 @Override
                 public ShardRouting.Role newReplicaRole() {
-                    return ShardRouting.Role.DEFAULT;
+                    throw new AssertionError("should not be called");
                 }
             }).addAsNew(metadata.index("test")).build())
             .nodes(DiscoveryNodes.builder().add(node))

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -904,9 +904,9 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         assertThat(decision.getExplanation(), containsString("disk watermarks are ignored on this index"));
     }
 
-    public void testDecidesYesIfPromotableShardRole() {
+    public void testDecidesYesForIndexOnlyShard() {
         final Metadata metadata = Metadata.builder()
-            .put(IndexMetadata.builder("test").settings(settings(IndexVersion.V_8_10_0)).numberOfShards(1).numberOfReplicas(0))
+            .put(IndexMetadata.builder("test").settings(settings(IndexVersion.current())).numberOfShards(1).numberOfReplicas(0))
             .build();
         final Index index = metadata.index("test").getIndex();
         ShardRouting shardRouting = ShardRouting.newUnassigned(
@@ -944,10 +944,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             Map.of()
         );
 
-        DiskThresholdDecider decider = new DiskThresholdDecider(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
-        );
+        DiskThresholdDecider decider = new DiskThresholdDecider(Settings.EMPTY, ClusterSettings.createBuiltInClusterSettings());
 
         RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),


### PR DESCRIPTION
This pull request changes the `DiskThresholdDecider` so that it ignores disk watermarks for shards with `index_only` role. 

The idea behind this change is to always be able to add such shards to indexing nodes and they can remain on nodes until a rebalance is executed after an autoscaling. To avoid running of disk space, indexing shards will report a more accurate estimate of their disk footprint (see linked PR and ES-5995) and we plan to add a service to monitor disk free space and to flush the largest shards in order to free up disk space (ES-6327) while throttling indexing (that would be a component similar to IndexingMemoryController)
 
ES-6305