### PR TITLE
Avoid restarting `AsyncTaskMaintenanceService` in tests

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
@@ -99,11 +98,10 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
     }
 
     @Before
-    public void startMaintenanceService() {
+    public void unpauseMaintenanceService() {
         for (AsyncTaskMaintenanceService service : internalCluster().getDataNodeInstances(AsyncTaskMaintenanceService.class)) {
-            if (service.lifecycleState() == Lifecycle.State.STOPPED) {
+            if (service.unpause()) {
                 // force the service to start again
-                service.start();
                 ClusterState state = internalCluster().clusterService().state();
                 service.clusterChanged(new ClusterChangedEvent("noop", state, state));
             }
@@ -111,9 +109,9 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
     }
 
     @After
-    public void stopMaintenanceService() {
+    public void pauseMaintenanceService() {
         for (AsyncTaskMaintenanceService service : internalCluster().getDataNodeInstances(AsyncTaskMaintenanceService.class)) {
-            service.stop();
+            service.pause();
         }
     }
 
@@ -150,12 +148,12 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         DiscoveryNode node = clusterState.getState().nodes().get(searchId.getTaskId().getNodeId());
 
         // Temporarily stop garbage collection, making sure to wait for any in-flight tasks to complete
-        stopMaintenanceService();
+        pauseMaintenanceService();
         ensureAllSearchContextsReleased();
 
         internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {
         });
-        startMaintenanceService();
+        unpauseMaintenanceService();
         ensureYellow(ASYNC_RESULTS_INDEX, indexName);
     }
 


### PR DESCRIPTION
In #97553 we will forbid moving a lifecycle component from `STOPPED` to
`STARTED`, because we don't ever do this in production and there are
several places where to do so would be a bug. One of the few places we
do this transition today is in `AsyncSearchActionIT`. This commit
replaces the lifecycle transitions in that test suite with a
pause/unpause mechanism that does the same thing to the underlying
service.