### PR TITLE
Move the ReschedulingRunnable scheduling to a separate method

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -106,7 +106,9 @@ public interface Scheduler {
      *         not be interrupted.
      */
     default Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
-        return new ReschedulingRunnable(command, interval, executor, this, (e) -> {}, (e) -> {});
+        var runnable = new ReschedulingRunnable(command, interval, executor, this, (e) -> {}, (e) -> {});
+        runnable.start();
+        return runnable;
     }
 
     /**
@@ -171,7 +173,7 @@ public interface Scheduler {
         private volatile boolean run = true;
 
         /**
-         * Creates a new rescheduling runnable and schedules the first execution to occur after the interval specified
+         * Creates a new rescheduling runnable
          *
          * @param runnable the {@link Runnable} that should be executed periodically
          * @param interval the time interval between executions
@@ -192,6 +194,12 @@ public interface Scheduler {
             this.scheduler = scheduler;
             this.rejectionConsumer = rejectionConsumer;
             this.failureConsumer = failureConsumer;
+        }
+
+        /**
+         * Schedules the first execution of this runnable
+         */
+        void start() {
             scheduler.schedule(this, interval, executor);
         }
 

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -523,11 +523,13 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     @Override
     public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
-        return new ReschedulingRunnable(command, interval, executor, this, (e) -> {
+        var runnable = new ReschedulingRunnable(command, interval, executor, this, (e) -> {
             if (logger.isDebugEnabled()) {
                 logger.debug(() -> format("scheduled task [%s] was rejected on thread pool [%s]", command, executor), e);
             }
         }, (e) -> logger.warn(() -> format("failed to run scheduled task [%s] on thread pool [%s]", command, executor), e));
+        runnable.start();
+        return runnable;
     }
 
     protected final void stopCachedTimeThread() {

--- a/server/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
@@ -31,7 +31,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -76,7 +78,11 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
             (e) -> {},
             (e) -> {}
         );
-        // this call was made during construction of the runnable
+        // not scheduled yet
+        verify(threadPool, never()).schedule(any(), any(), any());
+
+        reschedulingRunnable.start();
+        // this call was made by start
         verify(threadPool, times(1)).schedule(reschedulingRunnable, delay, Names.GENERIC);
 
         // create a thread and start the runnable
@@ -263,6 +269,7 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
             (e) -> {},
             (e) -> {}
         );
+        reschedulingRunnable.start();
         assertTrue(reschedulingRunnable.isCancelled());
     }
 


### PR DESCRIPTION
This is to ensure the `this` does not escape the constructor