### PR TITLE
Avoid restarting `MonitoringService` in tests

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
@@ -190,6 +190,20 @@ public class MonitoringService extends AbstractLifecycleComponent {
         }
     }
 
+    // exposed for tests
+    public void unpause() {
+        synchronized (lifecycle) {
+            doStart();
+        }
+    }
+
+    // exposed for tests
+    public void pause() {
+        synchronized (lifecycle) {
+            doStop();
+        }
+    }
+
     @Override
     protected void doClose() {
         logger.debug("monitoring service is closing");

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
@@ -85,10 +85,6 @@ public class MonitoringServiceTests extends ESTestCase {
         assertBusy(() -> assertFalse(monitoringService.isStarted()));
         assertFalse(monitoringService.isMonitoringActive());
 
-        monitoringService.start();
-        assertBusy(() -> assertTrue(monitoringService.isStarted()));
-        assertTrue(monitoringService.isMonitoringActive());
-
         monitoringService.close();
         assertBusy(() -> assertFalse(monitoringService.isStarted()));
         assertFalse(monitoringService.isMonitoringActive());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/test/MonitoringIntegTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/test/MonitoringIntegTestCase.java
@@ -97,11 +97,11 @@ public abstract class MonitoringIntegTestCase extends ESIntegTestCase {
     }
 
     protected void startMonitoringService() {
-        internalCluster().getInstances(MonitoringService.class).forEach(MonitoringService::start);
+        internalCluster().getInstances(MonitoringService.class).forEach(MonitoringService::unpause);
     }
 
     protected void stopMonitoringService() {
-        internalCluster().getInstances(MonitoringService.class).forEach(MonitoringService::stop);
+        internalCluster().getInstances(MonitoringService.class).forEach(MonitoringService::pause);
     }
 
     protected void wipeMonitoringIndices() throws Exception {


### PR DESCRIPTION
In #97553 we will forbid moving a lifecycle component from `STOPPED` to
`STARTED`, because we don't ever do this in production and there are
several places where to do so would be a bug. One of the few places we
do this transition today is in `MonitoringIntegTestCase`. This commit
replaces the lifecycle transitions in that test suite with a
pause/unpause mechanism that does the same thing to the underlying
service.
