### PR TITLE
Make use of ActionListener.delegateFailureAndWrap in more spots

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportRethrottleAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportRethrottleAction.java
@@ -101,10 +101,10 @@ public class TransportRethrottleAction extends TransportTasksAction<BulkByScroll
             subRequest.setRequestsPerSecond(newRequestsPerSecond / runningSubtasks);
             subRequest.setTargetParentTaskId(new TaskId(localNodeId, task.getId()));
             logger.debug("rethrottling children of task [{}] to [{}] requests per second", task.getId(), subRequest.getRequestsPerSecond());
-            client.execute(RethrottleAction.INSTANCE, subRequest, ActionListener.wrap(r -> {
+            client.execute(RethrottleAction.INSTANCE, subRequest, listener.delegateFailureAndWrap((l, r) -> {
                 r.rethrowFailures("Rethrottle");
-                listener.onResponse(task.taskInfoGivenSubtaskInfo(localNodeId, r.getTasks()));
-            }, listener::onFailure));
+                l.onResponse(task.taskInfoGivenSubtaskInfo(localNodeId, r.getTasks()));
+            }));
         } else {
             logger.debug("children of task [{}] are already finished, nothing to rethrottle", task.getId());
             listener.onResponse(task.taskInfo(localNodeId, true));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/TransportRethrottleActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/TransportRethrottleActionTests.java
@@ -33,10 +33,12 @@ import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.theInstance;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TransportRethrottleActionTests extends ESTestCase {
     private int slices;
@@ -65,6 +67,7 @@ public class TransportRethrottleActionTests extends ESTestCase {
         float newRequestsPerSecond = randomValueOtherThanMany(f -> f <= 0, () -> randomFloat());
         @SuppressWarnings("unchecked")
         ActionListener<TaskInfo> listener = mock(ActionListener.class);
+        when(listener.delegateFailureAndWrap(any())).thenCallRealMethod();
 
         TransportRethrottleAction.rethrottle(logger, localNodeId, client, task, newRequestsPerSecond, listener);
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1139,13 +1139,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         RepositoryData newRepoData,
         ActionListener<DeleteResult> listener
     ) {
-        final GroupedActionListener<DeleteResult> groupedListener = new GroupedActionListener<>(2, ActionListener.wrap(deleteResults -> {
-            DeleteResult deleteResult = DeleteResult.ZERO;
-            for (DeleteResult result : deleteResults) {
-                deleteResult = deleteResult.add(result);
-            }
-            listener.onResponse(deleteResult);
-        }, listener::onFailure));
+        final GroupedActionListener<DeleteResult> groupedListener = new GroupedActionListener<>(
+            2,
+            listener.delegateFailureAndWrap((delegate, deleteResults) -> {
+                DeleteResult deleteResult = DeleteResult.ZERO;
+                for (DeleteResult result : deleteResults) {
+                    deleteResult = deleteResult.add(result);
+                }
+                delegate.onResponse(deleteResult);
+            })
+        );
 
         final Executor executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
         final List<String> staleRootBlobs = staleRootBlobs(newRepoData, rootBlobs.keySet());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStep.java
@@ -136,12 +136,12 @@ public class SwapAliasesAndDeleteSourceIndexStep extends AsyncActionStep {
             );
         });
 
-        client.admin().indices().aliases(aliasesRequest, ActionListener.wrap(response -> {
+        client.admin().indices().aliases(aliasesRequest, listener.delegateFailureAndWrap((delegate, response) -> {
             if (response.isAcknowledged() == false) {
                 logger.warn("aliases swap from [{}] to [{}] response was not acknowledged", sourceIndexName, targetIndex);
             }
-            listener.onResponse(null);
-        }, listener::onFailure));
+            delegate.onResponse(null);
+        }));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UpdateSettingsStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UpdateSettingsStep.java
@@ -47,7 +47,7 @@ public class UpdateSettingsStep extends AsyncActionStep {
         ).settings(settings);
         getClient().admin()
             .indices()
-            .updateSettings(updateSettingsRequest, ActionListener.wrap(response -> listener.onResponse(null), listener::onFailure));
+            .updateSettings(updateSettingsRequest, listener.delegateFailureAndWrap((l, response) -> l.onResponse(null)));
     }
 
     public Settings getSettings() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -179,11 +179,11 @@ public class ElasticsearchMappings {
                         ML_ORIGIN,
                         PutMappingAction.INSTANCE,
                         putMappingRequest,
-                        ActionListener.wrap(response -> {
+                        listener.delegateFailureAndWrap((l, response) -> {
                             if (response.isAcknowledged()) {
-                                listener.onResponse(true);
+                                l.onResponse(true);
                             } else {
-                                listener.onFailure(
+                                l.onFailure(
                                     new ElasticsearchException(
                                         "Attempt to put missing mapping in indices "
                                             + Arrays.toString(indicesThatRequireAnUpdate)
@@ -191,7 +191,7 @@ public class ElasticsearchMappings {
                                     )
                                 );
                             }
-                        }, listener::onFailure)
+                        })
                     );
                 } else {
                     logger.trace("Mappings are up to date.");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -132,6 +132,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
             );
 
         listener = mock(ActionListener.class);
+        when(listener.delegateFailureAndWrap(any())).thenCallRealMethod();
 
         createRequestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
         aliasesRequestCaptor = ArgumentCaptor.forClass(IndicesAliasesRequest.class);
@@ -179,6 +180,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
         InOrder inOrder = inOrder(client, listener);
         inOrder.verify(client).execute(same(PutComposableIndexTemplateAction.INSTANCE), any(), any());
         inOrder.verify(listener).onResponse(true);
+        verify(listener).delegateFailureAndWrap(any());
     }
 
     public void testInstallIndexTemplateIfRequired_GivenComposableTemplateExists() throws UnknownHostException {
@@ -245,6 +247,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
         InOrder inOrder = inOrder(client, listener);
         inOrder.verify(client).execute(same(PutComposableIndexTemplateAction.INSTANCE), any(), any());
         inOrder.verify(listener).onResponse(true);
+        verify(listener).delegateFailureAndWrap(any());
     }
 
     public void testCreateStateIndexAndAliasIfNecessary_CleanState() throws UnknownHostException {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -125,28 +125,31 @@ public class MlDeprecationChecker implements DeprecationChecker {
         getModelSnapshots.setPageParams(new PageParams(0, 50));
         getModelSnapshots.setSort(ModelSnapshot.MIN_VERSION.getPreferredName());
 
-        ActionListener<Void> getModelSnaphots = ActionListener.wrap(
-            _unused -> components.client()
-                .execute(GetModelSnapshotsAction.INSTANCE, getModelSnapshots, ActionListener.wrap(modelSnapshots -> {
-                    modelSnapshots.getResources()
-                        .results()
-                        .forEach(modelSnapshot -> checkModelSnapshot(modelSnapshot).ifPresent(issues::add));
-                    deprecationIssueListener.onResponse(new CheckResult(getName(), issues));
-                }, deprecationIssueListener::onFailure)),
-            deprecationIssueListener::onFailure
+        ActionListener<Void> getModelSnaphots = deprecationIssueListener.delegateFailureAndWrap(
+            (deprecationIssueListenerDelegate, _unused) -> components.client()
+                .execute(
+                    GetModelSnapshotsAction.INSTANCE,
+                    getModelSnapshots,
+                    deprecationIssueListenerDelegate.delegateFailureAndWrap((delegate, modelSnapshots) -> {
+                        modelSnapshots.getResources()
+                            .results()
+                            .forEach(modelSnapshot -> checkModelSnapshot(modelSnapshot).ifPresent(issues::add));
+                        delegate.onResponse(new CheckResult(getName(), issues));
+                    })
+                )
         );
 
         components.client()
             .execute(
                 GetDatafeedsAction.INSTANCE,
                 new GetDatafeedsAction.Request(GetDatafeedsAction.ALL),
-                ActionListener.wrap(datafeedsResponse -> {
+                getModelSnaphots.delegateFailureAndWrap((delegate, datafeedsResponse) -> {
                     for (DatafeedConfig df : datafeedsResponse.getResponse().results()) {
                         checkDataFeedAggregations(df, components.xContentRegistry()).ifPresent(issues::add);
                         checkDataFeedQuery(df, components.xContentRegistry()).ifPresent(issues::add);
                     }
-                    getModelSnaphots.onResponse(null);
-                }, deprecationIssueListener::onFailure)
+                    delegate.onResponse(null);
+                })
             );
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
@@ -33,9 +33,12 @@ public class TransformDeprecationChecker implements DeprecationChecker {
 
         PageParams startPage = new PageParams(0, PageParams.DEFAULT_SIZE);
         List<DeprecationIssue> issues = new ArrayList<>();
-        recursiveGetTransformsAndCollectDeprecations(components, issues, startPage, ActionListener.wrap(allIssues -> {
-            deprecationIssueListener.onResponse(new CheckResult(getName(), allIssues));
-        }, deprecationIssueListener::onFailure));
+        recursiveGetTransformsAndCollectDeprecations(
+            components,
+            issues,
+            startPage,
+            deprecationIssueListener.delegateFailureAndWrap((l, allIssues) -> l.onResponse(new CheckResult(getName(), allIssues)))
+        );
     }
 
     @Override
@@ -53,17 +56,18 @@ public class TransformDeprecationChecker implements DeprecationChecker {
         request.setPageParams(page);
         request.setAllowNoResources(true);
 
-        components.client().execute(GetTransformAction.INSTANCE, request, ActionListener.wrap(getTransformResponse -> {
-            for (TransformConfig config : getTransformResponse.getTransformConfigurations()) {
-                issues.addAll(config.checkForDeprecations(components.xContentRegistry()));
-            }
-            if (getTransformResponse.getTransformConfigurationCount() >= (page.getFrom() + page.getSize())) {
-                PageParams nextPage = new PageParams(page.getFrom() + page.getSize(), PageParams.DEFAULT_SIZE);
-                recursiveGetTransformsAndCollectDeprecations(components, issues, nextPage, listener);
-            } else {
-                listener.onResponse(issues);
-            }
+        components.client()
+            .execute(GetTransformAction.INSTANCE, request, listener.delegateFailureAndWrap((delegate, getTransformResponse) -> {
+                for (TransformConfig config : getTransformResponse.getTransformConfigurations()) {
+                    issues.addAll(config.checkForDeprecations(components.xContentRegistry()));
+                }
+                if (getTransformResponse.getTransformConfigurationCount() >= (page.getFrom() + page.getSize())) {
+                    PageParams nextPage = new PageParams(page.getFrom() + page.getSize(), PageParams.DEFAULT_SIZE);
+                    recursiveGetTransformsAndCollectDeprecations(components, issues, nextPage, delegate);
+                } else {
+                    delegate.onResponse(issues);
+                }
 
-        }, listener::onFailure));
+            }));
     }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
@@ -166,10 +166,7 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
                 try {
                     ActionListener<ExecuteEnrichPolicyStatus> listener;
                     if (request.isWaitForCompletion()) {
-                        listener = ActionListener.wrap(
-                            result -> actionListener.onResponse(new Response(result)),
-                            actionListener::onFailure
-                        );
+                        listener = actionListener.delegateFailureAndWrap((l, result) -> l.onResponse(new Response(result)));
                     } else {
                         listener = ActionListener.wrap(
                             result -> LOGGER.debug("successfully executed policy [{}]", request.getName()),

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
@@ -87,11 +87,11 @@ public class TransportPutEnrichPolicyAction extends AcknowledgedTransportMasterN
             privRequest.clusterPrivileges(Strings.EMPTY_ARRAY);
             privRequest.indexPrivileges(privileges);
 
-            ActionListener<HasPrivilegesResponse> wrappedListener = ActionListener.wrap(r -> {
+            ActionListener<HasPrivilegesResponse> wrappedListener = listener.delegateFailureAndWrap((delegate, r) -> {
                 if (r.isCompleteMatch()) {
-                    putPolicy(request, listener);
+                    putPolicy(request, delegate);
                 } else {
-                    listener.onFailure(
+                    delegate.onFailure(
                         Exceptions.authorizationError(
                             "unable to store policy because no indices match with the " + "specified index patterns {}",
                             request.getPolicy().getIndices(),
@@ -99,7 +99,7 @@ public class TransportPutEnrichPolicyAction extends AcknowledgedTransportMasterN
                         )
                     );
                 }
-            }, listener::onFailure);
+            });
             client.execute(HasPrivilegesAction.INSTANCE, privRequest, wrappedListener);
         } else {
             putPolicy(request, listener);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlUsageTransportAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlUsageTransportAction.java
@@ -58,7 +58,7 @@ public class EqlUsageTransportAction extends XPackUsageFeatureTransportAction {
         EqlStatsRequest eqlRequest = new EqlStatsRequest();
         eqlRequest.includeStats(true);
         eqlRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(EqlStatsAction.INSTANCE, eqlRequest, ActionListener.wrap(r -> {
+        client.execute(EqlStatsAction.INSTANCE, eqlRequest, listener.delegateFailureAndWrap((delegate, r) -> {
             List<Counters> countersPerNode = r.getNodes()
                 .stream()
                 .map(EqlStatsResponse.NodeStatsResponse::getStats)
@@ -66,7 +66,7 @@ public class EqlUsageTransportAction extends XPackUsageFeatureTransportAction {
                 .collect(Collectors.toList());
             Counters mergedCounters = Counters.merge(countersPerNode);
             EqlFeatureSetUsage usage = new EqlFeatureSetUsage(mergedCounters.toNestedMap());
-            listener.onResponse(new XPackUsageFeatureResponse(usage));
-        }, listener::onFailure));
+            delegate.onResponse(new XPackUsageFeatureResponse(usage));
+        }));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sample/SampleIterator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sample/SampleIterator.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Stack;
 
 import static org.elasticsearch.action.ActionListener.runAfter;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.common.Strings.EMPTY_ARRAY;
 import static org.elasticsearch.xpack.eql.execution.assembler.SampleQueryRequest.COMPOSITE_AGG_NAME;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.prepareRequest;
@@ -147,7 +146,7 @@ public class SampleIterator implements Executable {
     }
 
     private void queryForCompositeAggPage(ActionListener<Payload> listener, final SampleQueryRequest request) {
-        client.query(request, wrap(r -> {
+        client.query(request, listener.delegateFailureAndWrap((delegate, r) -> {
             Aggregation a = r.getAggregations().get(COMPOSITE_AGG_NAME);
             if (a instanceof InternalComposite == false) {
                 throw new EqlIllegalArgumentException("Unexpected aggregation result type returned [{}]", a.getClass());
@@ -158,15 +157,15 @@ public class SampleIterator implements Executable {
             Page nextPage = new Page(composite, request);
             if (nextPage.size > 0) {
                 pushToStack(nextPage);
-                advance(listener);
+                advance(delegate);
             } else {
                 if (stack.size() > 0) {
-                    nextPage(listener, stack.pop());
+                    nextPage(delegate, stack.pop());
                 } else {
-                    payload(listener);
+                    payload(delegate);
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     protected void pushToStack(Page nextPage) {
@@ -210,7 +209,7 @@ public class SampleIterator implements Executable {
         }
 
         int initialSize = samples.size();
-        client.multiQuery(searches, ActionListener.wrap(r -> {
+        client.multiQuery(searches, listener.delegateFailureAndWrap((delegate, r) -> {
             List<List<SearchHit>> sample = new ArrayList<>(maxCriteria);
             MultiSearchResponse.Item[] response = r.getResponses();
             int docGroupsCounter = 1;
@@ -228,7 +227,7 @@ public class SampleIterator implements Executable {
                             samples.add(new Sample(sampleKeys.get(responseIndex / maxCriteria), match));
                         }
                         if (samples.size() == limit.limit()) {
-                            payload(listener);
+                            payload(delegate);
                             return;
                         }
                     }
@@ -244,8 +243,8 @@ public class SampleIterator implements Executable {
             // or it's just not the last page and we should advance
             var next = page.size == fetchSize ? page : stack.pop();
             log.trace("Final step... getting next page of the " + (next == page ? "current" : "previous") + " page");
-            nextPage(listener, next);
-        }, listener::onFailure));
+            nextPage(delegate, next);
+        }));
     }
 
     private void updateMemoryUsage() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
@@ -151,11 +151,11 @@ public class BasicQueryClient implements QueryClient {
             multiSearchBuilder.add(search);
         }
 
-        search(multiSearchBuilder.request(), ActionListener.wrap(r -> {
+        search(multiSearchBuilder.request(), listener.delegateFailureAndWrap((delegate, r) -> {
             for (MultiSearchResponse.Item item : r.getResponses()) {
                 // check for failures
                 if (item.isFailure()) {
-                    listener.onFailure(item.getFailure());
+                    delegate.onFailure(item.getFailure());
                     return;
                 }
                 // otherwise proceed
@@ -176,8 +176,8 @@ public class BasicQueryClient implements QueryClient {
                     });
                 }
             }
-            listener.onResponse(seq);
-        }, listener::onFailure));
+            delegate.onResponse(seq);
+        }));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -131,10 +131,10 @@ public class PITAwareQueryClient extends BasicQueryClient {
     private <Response> void openPIT(ActionListener<Response> listener, Runnable runnable) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).indicesOptions(IndexResolver.FIELD_CAPS_INDICES_OPTIONS)
             .keepAlive(keepAlive);
-        client.execute(OpenPointInTimeAction.INSTANCE, request, wrap(r -> {
+        client.execute(OpenPointInTimeAction.INSTANCE, request, listener.delegateFailureAndWrap((ignored, r) -> {
             pitId = r.getPointInTimeId();
             runnable.run();
-        }, listener::onFailure));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -56,21 +56,21 @@ public final class RuntimeUtils {
     private RuntimeUtils() {}
 
     public static ActionListener<SearchResponse> searchLogListener(ActionListener<SearchResponse> listener, Logger log) {
-        return ActionListener.wrap(response -> {
+        return listener.delegateFailureAndWrap((delegate, response) -> {
             ShardSearchFailure[] failures = response.getShardFailures();
             if (CollectionUtils.isEmpty(failures) == false) {
-                listener.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
+                delegate.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
                 return;
             }
             if (log.isTraceEnabled()) {
                 logSearchResponse(response, log);
             }
-            listener.onResponse(response);
-        }, listener::onFailure);
+            delegate.onResponse(response);
+        });
     }
 
     public static ActionListener<MultiSearchResponse> multiSearchLogListener(ActionListener<MultiSearchResponse> listener, Logger log) {
-        return ActionListener.wrap(items -> {
+        return listener.delegateFailureAndWrap((delegate, items) -> {
             for (MultiSearchResponse.Item item : items) {
                 Exception failure = item.getFailure();
                 SearchResponse response = item.getResponse();
@@ -82,15 +82,15 @@ public final class RuntimeUtils {
                     }
                 }
                 if (failure != null) {
-                    listener.onFailure(failure);
+                    delegate.onFailure(failure);
                     return;
                 }
                 if (log.isTraceEnabled()) {
                     logSearchResponse(response, log);
                 }
             }
-            listener.onResponse(items);
-        }, listener::onFailure);
+            delegate.onResponse(items);
+        });
     }
 
     private static void logSearchResponse(SearchResponse response, Logger logger) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -47,7 +47,6 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.ActionListener.runAfter;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.eql.execution.ExecutionUtils.copySource;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.addFilter;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.searchHits;
@@ -218,7 +217,7 @@ public class TumblingWindow implements Executable {
             }
 
             List<SearchRequest> queries = prepareQueryForMissingEvents(batchToCheck);
-            client.multiQuery(queries, wrap(p -> doCheckMissingEvents(batchToCheck, p, listener, next), listener::onFailure));
+            client.multiQuery(queries, listener.delegateFailureAndWrap((l, p) -> doCheckMissingEvents(batchToCheck, p, l, next)));
         }
     }
 
@@ -354,7 +353,7 @@ public class TumblingWindow implements Executable {
         log.trace("{}", matcher);
         log.trace("Querying base stage [{}] {}", stage, base.queryRequest());
 
-        client.query(base.queryRequest(), wrap(p -> baseCriterion(stage, p, listener), listener::onFailure));
+        client.query(base.queryRequest(), listener.delegateFailureAndWrap((l, p) -> baseCriterion(stage, p, l)));
     }
 
     /**
@@ -527,7 +526,7 @@ public class TumblingWindow implements Executable {
 
         log.trace("Querying until stage {}", request);
 
-        client.query(request, wrap(r -> {
+        client.query(request, listener.delegateFailureAndWrap((delegate, r) -> {
             List<SearchHit> hits = searchHits(r);
 
             log.trace("Found [{}] hits", hits.size());
@@ -540,7 +539,7 @@ public class TumblingWindow implements Executable {
 
             // keep running the query runs out of the results (essentially returns less than what we want)
             if (hits.size() == windowSize && request.after().before(window.end)) {
-                untilCriterion(window, listener, next);
+                untilCriterion(window, delegate, next);
             }
             // looks like this stage is done, move on
             else {
@@ -548,7 +547,7 @@ public class TumblingWindow implements Executable {
                 next.run();
             }
 
-        }, listener::onFailure));
+        }));
     }
 
     private void secondaryCriterion(WindowInfo window, int currentStage, ActionListener<Payload> listener) {
@@ -559,7 +558,7 @@ public class TumblingWindow implements Executable {
 
         log.trace("Querying (secondary) stage [{}] {}", criterion.stage(), request);
 
-        client.query(request, wrap(r -> {
+        client.query(request, listener.delegateFailureAndWrap((delegate, r) -> {
             List<SearchHit> hits = searchHits(r);
 
             // filter hits that are escaping the window (same timestamp but different tiebreaker)
@@ -593,7 +592,7 @@ public class TumblingWindow implements Executable {
 
                 // if the limit has been reached, return what's available
                 if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
-                    payload(listener);
+                    payload(delegate);
                     return;
                 }
 
@@ -611,19 +610,19 @@ public class TumblingWindow implements Executable {
             // keep running the query runs out of the results (essentially returns less than what we want)
             // however check if the window has been fully consumed
             if (hits.size() == windowSize && request.after().before(window.end)) {
-                secondaryCriterion(window, currentStage, listener);
+                secondaryCriterion(window, currentStage, delegate);
             }
             // looks like this stage is done, move on
             else {
                 // but first check is there are still candidates within the current window
                 if (nextPositiveStage > 0 && matcher.hasFollowingCandidates(criterion.stage())) {
-                    secondaryCriterion(window, nextPositiveStage, listener);
+                    secondaryCriterion(window, nextPositiveStage, delegate);
                 } else {
                     // otherwise, advance it
-                    tumbleWindow(window.baseStage, listener);
+                    tumbleWindow(window.baseStage, delegate);
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     /**

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -242,7 +242,7 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
                     cfg,
                     request.query(),
                     params,
-                    wrap(r -> listener.onResponse(createResponse(r, task.getExecutionId())), onFailure)
+                    listener.delegateFailureAndWrap((l, r) -> l.onResponse(createResponse(r, task.getExecutionId())))
                 ),
                 node -> transportService.sendRequest(
                     node,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 
 public class EqlSession {
@@ -83,7 +82,7 @@ public class EqlSession {
     }
 
     public void eql(String eql, ParserParams params, ActionListener<Results> listener) {
-        eqlExecutable(eql, params, wrap(e -> e.execute(this, map(listener, Results::fromPayload)), listener::onFailure));
+        eqlExecutable(eql, params, listener.delegateFailureAndWrap((l, e) -> e.execute(this, map(l, Results::fromPayload))));
     }
 
     public void eqlExecutable(String eql, ParserParams params, ActionListener<PhysicalPlan> listener) {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderAction.java
@@ -78,14 +78,14 @@ public class TransportPutSamlServiceProviderAction extends HandledTransportActio
             return;
         }
         logger.trace("Searching for existing ServiceProvider with id [{}] for [{}]", document.entityId, request);
-        index.findByEntityId(document.entityId, ActionListener.wrap(matchingDocuments -> {
+        index.findByEntityId(document.entityId, listener.delegateFailureAndWrap((delegate, matchingDocuments) -> {
             if (matchingDocuments.isEmpty()) {
                 // derive a document id from the entity id so that don't accidentally create duplicate entities due to a race condition
                 document.docId = deriveDocumentId(document);
                 // force a create in case there are concurrent requests. This way, if two nodes/threads are trying to create the SP at
                 // the same time, one will fail. That's not ideal, but it's better than having 1 silently overwrite the other.
                 logger.trace("No existing ServiceProvider for EntityID=[{}], writing new doc [{}]", document.entityId, document.docId);
-                writeDocument(document, DocWriteRequest.OpType.CREATE, request.getRefreshPolicy(), listener);
+                writeDocument(document, DocWriteRequest.OpType.CREATE, request.getRefreshPolicy(), delegate);
             } else if (matchingDocuments.size() == 1) {
                 final SamlServiceProviderDocument existingDoc = Iterables.get(matchingDocuments, 0).getDocument();
                 assert existingDoc.docId != null : "Loaded document with no doc id";
@@ -93,7 +93,7 @@ public class TransportPutSamlServiceProviderAction extends HandledTransportActio
                 document.setDocId(existingDoc.docId);
                 document.setCreated(existingDoc.created);
                 logger.trace("Found existing ServiceProvider for EntityID=[{}], writing to doc [{}]", document.entityId, document.docId);
-                writeDocument(document, DocWriteRequest.OpType.INDEX, request.getRefreshPolicy(), listener);
+                writeDocument(document, DocWriteRequest.OpType.INDEX, request.getRefreshPolicy(), delegate);
             } else {
                 logger.warn(
                     "Found multiple existing service providers in [{}] with entity id [{}] - [{}]",
@@ -101,11 +101,11 @@ public class TransportPutSamlServiceProviderAction extends HandledTransportActio
                     document.entityId,
                     matchingDocuments.stream().map(d -> d.getDocument().docId).collect(Collectors.joining(","))
                 );
-                listener.onFailure(
+                delegate.onFailure(
                     new IllegalStateException("Multiple service providers already exist with entity id [" + document.entityId + "]")
                 );
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void writeDocument(
@@ -130,8 +130,8 @@ public class TransportPutSamlServiceProviderAction extends HandledTransportActio
             document,
             opType,
             refreshPolicy,
-            ActionListener.wrap(
-                response -> listener.onResponse(
+            listener.delegateFailureAndWrap(
+                (l, response) -> l.onResponse(
                     new PutSamlServiceProviderResponse(
                         response.getId(),
                         response.getResult() == DocWriteResponse.Result.CREATED,
@@ -140,8 +140,7 @@ public class TransportPutSamlServiceProviderAction extends HandledTransportActio
                         document.entityId,
                         document.enabled
                     )
-                ),
-                listener::onFailure
+                )
             )
         );
     }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
@@ -166,12 +166,12 @@ public class TransportSamlInitiateSingleSignOnAction extends HandledTransportAct
     ) {
         User user = secondaryAuthentication.getUser();
         secondaryAuthentication.execute(ignore -> {
-            ActionListener<UserPrivilegeResolver.UserPrivileges> wrapped = ActionListener.wrap(userPrivileges -> {
+            ActionListener<UserPrivilegeResolver.UserPrivileges> wrapped = listener.delegateFailureAndWrap((delegate, userPrivileges) -> {
                 if (userPrivileges.hasAccess == false) {
-                    listener.onResponse(null);
+                    delegate.onResponse(null);
                 } else {
                     logger.debug("Resolved [{}] for [{}]", userPrivileges, user);
-                    listener.onResponse(
+                    delegate.onResponse(
                         new UserServiceAuthentication(
                             user.principal(),
                             user.fullName(),
@@ -181,7 +181,7 @@ public class TransportSamlInitiateSingleSignOnAction extends HandledTransportAct
                         )
                     );
                 }
-            }, listener::onFailure);
+            });
             privilegeResolver.resolve(serviceProvider.getPrivileges(), wrapped);
             return null;
         });

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ApplicationActionsResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ApplicationActionsResolver.java
@@ -37,6 +37,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.security.action.privilege.GetPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.privilege.GetPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
 import org.elasticsearch.xpack.idp.saml.sp.ServiceProviderDefaults;
 
 import java.io.IOException;
@@ -134,14 +135,14 @@ public class ApplicationActionsResolver extends AbstractLifecycleComponent {
     private void loadActions(String applicationName, ActionListener<Set<String>> listener) {
         final GetPrivilegesRequest request = new GetPrivilegesRequest();
         request.application(applicationName);
-        this.client.execute(GetPrivilegesAction.INSTANCE, request, ActionListener.wrap(response -> {
+        this.client.execute(GetPrivilegesAction.INSTANCE, request, listener.delegateFailureAndWrap((l, response) -> {
             final Set<String> fixedActions = Stream.of(response.privileges())
-                .map(p -> p.getActions())
+                .map(ApplicationPrivilegeDescriptor::getActions)
                 .flatMap(Collection::stream)
                 .filter(s -> s.indexOf('*') == -1)
                 .collect(Collectors.toUnmodifiableSet());
             cache.put(applicationName, fixedActions);
-            listener.onResponse(fixedActions);
-        }, listener::onFailure));
+            l.onResponse(fixedActions);
+        }));
     }
 }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
@@ -133,18 +133,18 @@ public class SamlIdentityProvider {
         boolean allowDisabled,
         ActionListener<SamlServiceProvider> listener
     ) {
-        serviceProviderResolver.resolve(spEntityId, ActionListener.wrap(sp -> {
+        serviceProviderResolver.resolve(spEntityId, listener.delegateFailureAndWrap((delegate, sp) -> {
             if (sp == null) {
                 logger.debug("No explicitly registered service provider exists for entityId [{}]", spEntityId);
-                resolveWildcardService(spEntityId, acs, listener);
+                resolveWildcardService(spEntityId, acs, delegate);
             } else if (allowDisabled == false && sp.isEnabled() == false) {
                 logger.info("Service provider [{}][{}] is not enabled", spEntityId, sp.getName());
-                listener.onResponse(null);
+                delegate.onResponse(null);
             } else {
                 logger.debug("Service provider for [{}] is [{}]", spEntityId, sp);
-                listener.onResponse(sp);
+                delegate.onResponse(sp);
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void resolveWildcardService(String spEntityId, String acs, ActionListener<SamlServiceProvider> listener) {

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
@@ -185,17 +185,16 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
             client.prepareSearchScroll(searchResponse.getScrollId())
                 .setScroll(TimeValue.timeValueMinutes(1L))
                 .execute(
-                    ActionListener.wrap(
-                        searchResponse1 -> handleFilteringSearchResponse(
+                    listener.delegateFailureAndWrap(
+                        (l, searchResponse1) -> handleFilteringSearchResponse(
                             searchResponse1,
                             pipelineSources,
                             explicitPipelineIds,
                             wildcardPipelinePatterns,
                             numberOfHitsSeenSoFar,
                             clearScroll,
-                            listener
-                        ),
-                        listener::onFailure
+                            l
+                        )
                     )
                 );
         }

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportPutPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportPutPipelineAction.java
@@ -36,11 +36,6 @@ public class TransportPutPipelineAction extends HandledTransportAction<PutPipeli
             .setId(request.id())
             .setSource(request.source(), request.xContentType())
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .execute(
-                ActionListener.wrap(
-                    indexResponse -> listener.onResponse(new PutPipelineResponse(indexResponse.status())),
-                    listener::onFailure
-                )
-            );
+            .execute(listener.delegateFailureAndWrap((l, indexResponse) -> l.onResponse(new PutPipelineResponse(indexResponse.status()))));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1905,7 +1905,7 @@ public class MachineLearning extends Plugin
         originClient.execute(
             SetUpgradeModeAction.INSTANCE,
             new SetUpgradeModeAction.Request(true),
-            ActionListener.wrap(r -> listener.onResponse(Collections.singletonMap("already_in_upgrade_mode", false)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, r) -> l.onResponse(Collections.singletonMap("already_in_upgrade_mode", false)))
         );
     }
 
@@ -1927,7 +1927,7 @@ public class MachineLearning extends Plugin
         originClient.execute(
             SetUpgradeModeAction.INSTANCE,
             new SetUpgradeModeAction.Request(false),
-            ActionListener.wrap(r -> listener.onResponse(r.isAcknowledged()), listener::onFailure)
+            listener.delegateFailureAndWrap((l, r) -> l.onResponse(r.isAcknowledged()))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
@@ -96,6 +96,6 @@ public class TransportClearDeploymentCacheAction extends TransportTasksAction<Tr
         TrainedModelDeploymentTask task,
         ActionListener<Response> listener
     ) {
-        task.clearCache(ActionListener.wrap(r -> listener.onResponse(new Response(true)), listener::onFailure));
+        task.clearCache(listener.delegateFailureAndWrap((l, r) -> l.onResponse(new Response(true))));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -156,68 +156,78 @@ public class TransportCloseJobAction extends TransportTasksAction<
                 tasksMetadata,
                 isForce,
                 null,
-                ActionListener.wrap(
-                    expandedJobIds -> validate(
+                listener.delegateFailureAndWrap(
+                    (delegate, expandedJobIds) -> validate(
                         expandedJobIds,
                         isForce,
                         tasksMetadata,
-                        ActionListener.wrap(
-                            response -> stopDatafeedsIfNecessary(response, isForce, timeout, tasksMetadata, ActionListener.wrap(bool -> {
-                                request.setOpenJobIds(response.openJobIds.toArray(new String[0]));
-                                if (response.openJobIds.isEmpty() && response.closingJobIds.isEmpty()) {
-                                    listener.onResponse(new CloseJobAction.Response(true));
-                                    return;
-                                }
-
-                                if (isForce) {
-                                    List<String> jobIdsToForceClose = new ArrayList<>(response.openJobIds);
-                                    jobIdsToForceClose.addAll(response.closingJobIds);
-                                    forceCloseJob(state, request, jobIdsToForceClose, listener);
-                                } else {
-                                    Set<String> executorNodes = new HashSet<>();
-                                    PersistentTasksCustomMetadata tasks = state.metadata().custom(PersistentTasksCustomMetadata.TYPE);
-                                    for (String resolvedJobId : request.getOpenJobIds()) {
-                                        PersistentTasksCustomMetadata.PersistentTask<?> jobTask = MlTasks.getJobTask(resolvedJobId, tasks);
-                                        if (jobTask == null) {
-                                            // This should not happen, because openJobIds was
-                                            // derived from the same tasks metadata as jobTask
-                                            String msg = "Requested job ["
-                                                + resolvedJobId
-                                                + "] be stopped, but job's task could not be found.";
-                                            assert jobTask != null : msg;
-                                            logger.error(msg);
-                                        } else if (jobTask.isAssigned()) {
-                                            executorNodes.add(jobTask.getExecutorNode());
-                                        } else {
-                                            // This is the easy case - the job is not currently assigned to a node, so can
-                                            // be gracefully stopped simply by removing its persistent task. (Usually a
-                                            // graceful stop cannot be achieved by simply removing the persistent task, but
-                                            // if the job has no running code then graceful/forceful are basically the same.)
-                                            // The listener here can be a no-op, as waitForJobClosed() already waits for
-                                            // these persistent tasks to disappear.
-                                            persistentTasksService.sendRemoveRequest(
-                                                jobTask.getId(),
-                                                ActionListener.wrap(
-                                                    r -> logger.trace(
-                                                        () -> format("[%s] removed task to close unassigned job", resolvedJobId)
-                                                    ),
-                                                    e -> logger.error(
-                                                        () -> format("[%s] failed to remove task to close unassigned job", resolvedJobId),
-                                                        e
-                                                    )
-                                                )
-                                            );
-                                        }
+                        delegate.delegateFailureAndWrap(
+                            (delegate2, response) -> stopDatafeedsIfNecessary(
+                                response,
+                                isForce,
+                                timeout,
+                                tasksMetadata,
+                                delegate2.delegateFailureAndWrap((delegate3, bool) -> {
+                                    request.setOpenJobIds(response.openJobIds.toArray(new String[0]));
+                                    if (response.openJobIds.isEmpty() && response.closingJobIds.isEmpty()) {
+                                        delegate3.onResponse(new CloseJobAction.Response(true));
+                                        return;
                                     }
-                                    request.setNodes(executorNodes.toArray(new String[0]));
 
-                                    normalCloseJob(state, task, request, response.openJobIds, response.closingJobIds, listener);
-                                }
-                            }, listener::onFailure)),
-                            listener::onFailure
+                                    if (isForce) {
+                                        List<String> jobIdsToForceClose = new ArrayList<>(response.openJobIds);
+                                        jobIdsToForceClose.addAll(response.closingJobIds);
+                                        forceCloseJob(state, request, jobIdsToForceClose, delegate3);
+                                    } else {
+                                        Set<String> executorNodes = new HashSet<>();
+                                        PersistentTasksCustomMetadata tasks = state.metadata().custom(PersistentTasksCustomMetadata.TYPE);
+                                        for (String resolvedJobId : request.getOpenJobIds()) {
+                                            PersistentTasksCustomMetadata.PersistentTask<?> jobTask = MlTasks.getJobTask(
+                                                resolvedJobId,
+                                                tasks
+                                            );
+                                            if (jobTask == null) {
+                                                // This should not happen, because openJobIds was
+                                                // derived from the same tasks metadata as jobTask
+                                                String msg = "Requested job ["
+                                                    + resolvedJobId
+                                                    + "] be stopped, but job's task could not be found.";
+                                                assert jobTask != null : msg;
+                                                logger.error(msg);
+                                            } else if (jobTask.isAssigned()) {
+                                                executorNodes.add(jobTask.getExecutorNode());
+                                            } else {
+                                                // This is the easy case - the job is not currently assigned to a node, so can
+                                                // be gracefully stopped simply by removing its persistent task. (Usually a
+                                                // graceful stop cannot be achieved by simply removing the persistent task, but
+                                                // if the job has no running code then graceful/forceful are basically the same.)
+                                                // The listener here can be a no-op, as waitForJobClosed() already waits for
+                                                // these persistent tasks to disappear.
+                                                persistentTasksService.sendRemoveRequest(
+                                                    jobTask.getId(),
+                                                    ActionListener.wrap(
+                                                        r -> logger.trace(
+                                                            () -> format("[%s] removed task to close unassigned job", resolvedJobId)
+                                                        ),
+                                                        e -> logger.error(
+                                                            () -> format(
+                                                                "[%s] failed to remove task to close unassigned job",
+                                                                resolvedJobId
+                                                            ),
+                                                            e
+                                                        )
+                                                    )
+                                                );
+                                            }
+                                        }
+                                        request.setNodes(executorNodes.toArray(new String[0]));
+
+                                        normalCloseJob(state, task, request, response.openJobIds, response.closingJobIds, delegate3);
+                                    }
+                                })
+                            )
                         )
-                    ),
-                    listener::onFailure
+                    )
                 )
             );
         }
@@ -283,12 +293,12 @@ public class TransportCloseJobAction extends TransportTasksAction<
         PersistentTasksCustomMetadata tasksMetadata,
         ActionListener<Boolean> listener
     ) {
-        datafeedConfigProvider.findDatafeedIdsForJobIds(jobIds.openJobIds, ActionListener.wrap(datafeedIds -> {
+        datafeedConfigProvider.findDatafeedIdsForJobIds(jobIds.openJobIds, listener.delegateFailureAndWrap((delegate, datafeedIds) -> {
             List<String> runningDatafeedIds = datafeedIds.stream()
                 .filter(datafeedId -> MlTasks.getDatafeedState(datafeedId, tasksMetadata) != DatafeedState.STOPPED)
                 .collect(Collectors.toList());
             if (runningDatafeedIds.isEmpty()) {
-                listener.onResponse(false);
+                delegate.onResponse(false);
             } else {
                 if (isForce) {
                     // A datafeed with an end time will gracefully close its job when it stops even if it was force stopped.
@@ -303,17 +313,13 @@ public class TransportCloseJobAction extends TransportTasksAction<
                     isolateDatafeeds(
                         jobIds.openJobIds,
                         runningDatafeedIds,
-                        ActionListener.wrap(
-                            r -> stopDatafeeds(runningDatafeedIds, true, timeout, listener),
-                            // As things stand this will never be called - see the comment in isolateDatafeeds() for why
-                            listener::onFailure
-                        )
+                        delegate.delegateFailureAndWrap((l, r) -> stopDatafeeds(runningDatafeedIds, true, timeout, l))
                     );
                 } else {
-                    stopDatafeeds(runningDatafeedIds, false, timeout, listener);
+                    stopDatafeeds(runningDatafeedIds, false, timeout, delegate);
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void stopDatafeeds(List<String> runningDatafeedIds, boolean isForce, TimeValue timeout, ActionListener<Boolean> listener) {
@@ -575,7 +581,7 @@ public class TransportCloseJobAction extends TransportTasksAction<
 
         final Set<String> movedJobs = ConcurrentCollections.newConcurrentSet();
 
-        ActionListener<CloseJobAction.Response> intermediateListener = ActionListener.wrap(response -> {
+        ActionListener<CloseJobAction.Response> intermediateListener = listener.delegateFailureAndWrap((delegate, response) -> {
             for (String jobId : movedJobs) {
                 PersistentTasksCustomMetadata.PersistentTask<?> jobTask = MlTasks.getJobTask(jobId, tasks);
                 persistentTasksService.sendRemoveRequest(
@@ -589,8 +595,8 @@ public class TransportCloseJobAction extends TransportTasksAction<
                     })
                 );
             }
-            listener.onResponse(response);
-        }, listener::onFailure);
+            delegate.onResponse(response);
+        });
 
         boolean noOpenJobsToClose = openJobIds.isEmpty();
         if (noOpenJobsToClose) {
@@ -599,9 +605,8 @@ public class TransportCloseJobAction extends TransportTasksAction<
             return;
         }
 
-        ActionListener<CloseJobAction.Response> finalListener = ActionListener.wrap(
-            r -> waitForJobClosed(request, waitForCloseRequest, r, intermediateListener, movedJobs),
-            listener::onFailure
+        ActionListener<CloseJobAction.Response> finalListener = intermediateListener.delegateFailureAndWrap(
+            (l, r) -> waitForJobClosed(request, waitForCloseRequest, r, l, movedJobs)
         );
         super.doExecute(task, request, finalListener);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCreateTrainedModelAssignmentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCreateTrainedModelAssignmentAction.java
@@ -75,7 +75,7 @@ public class TransportCreateTrainedModelAssignmentAction extends TransportMaster
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         trainedModelAssignmentClusterService.createNewModelAssignment(
             request.getTaskParams(),
-            ActionListener.wrap(trainedModelAssignment -> listener.onResponse(new Response(trainedModelAssignment)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, trainedModelAssignment) -> l.onResponse(new Response(trainedModelAssignment)))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteCalendarAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteCalendarAction.java
@@ -54,21 +54,27 @@ public class TransportDeleteCalendarAction extends HandledTransportAction<Delete
 
         final String calendarId = request.getCalendarId();
 
-        ActionListener<Calendar> calendarListener = ActionListener.wrap(calendar -> {
+        ActionListener<Calendar> calendarListener = listener.delegateFailureAndWrap((delegate, calendar) -> {
             // Delete calendar and events
             DeleteByQueryRequest dbqRequest = buildDeleteByQuery(calendarId);
-            executeAsyncWithOrigin(client, ML_ORIGIN, DeleteByQueryAction.INSTANCE, dbqRequest, ActionListener.wrap(response -> {
-                if (response.getDeleted() == 0) {
-                    listener.onFailure(new ResourceNotFoundException("No calendar with id [" + calendarId + "]"));
-                    return;
-                }
+            executeAsyncWithOrigin(
+                client,
+                ML_ORIGIN,
+                DeleteByQueryAction.INSTANCE,
+                dbqRequest,
+                delegate.delegateFailureAndWrap((delegate2, response) -> {
+                    if (response.getDeleted() == 0) {
+                        delegate2.onFailure(new ResourceNotFoundException("No calendar with id [" + calendarId + "]"));
+                        return;
+                    }
 
-                jobManager.updateProcessOnCalendarChanged(
-                    calendar.getJobIds(),
-                    ActionListener.wrap(r -> listener.onResponse(AcknowledgedResponse.TRUE), listener::onFailure)
-                );
-            }, listener::onFailure));
-        }, listener::onFailure);
+                    jobManager.updateProcessOnCalendarChanged(
+                        calendar.getJobIds(),
+                        delegate2.delegateFailureAndWrap((l, r) -> l.onResponse(AcknowledgedResponse.TRUE))
+                    );
+                })
+            );
+        });
 
         jobResultsProvider.calendar(calendarId, calendarListener);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -83,15 +83,13 @@ public class TransportDeleteDatafeedAction extends AcknowledgedTransportMasterNo
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        ActionListener<Boolean> finalListener = ActionListener.wrap(
+        ActionListener<Boolean> finalListener = listener.delegateFailureAndWrap(
             // use clusterService.state() here so that the updated state without the task is available
-            response -> datafeedManager.deleteDatafeed(request, clusterService.state(), listener),
-            listener::onFailure
+            (l, response) -> datafeedManager.deleteDatafeed(request, clusterService.state(), l)
         );
 
-        ActionListener<IsolateDatafeedAction.Response> isolateDatafeedHandler = ActionListener.wrap(
-            response -> removeDatafeedTask(request, state, finalListener),
-            listener::onFailure
+        ActionListener<IsolateDatafeedAction.Response> isolateDatafeedHandler = finalListener.delegateFailureAndWrap(
+            (l, response) -> removeDatafeedTask(request, state, l)
         );
 
         IsolateDatafeedAction.Request isolateDatafeedRequest = new IsolateDatafeedAction.Request(request.getDatafeedId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
@@ -56,16 +56,16 @@ public class TransportDeleteFilterAction extends HandledTransportAction<DeleteFi
     @Override
     protected void doExecute(Task task, DeleteFilterAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         final String filterId = request.getFilterId();
-        jobConfigProvider.findJobsWithCustomRules(ActionListener.wrap(jobs -> {
+        jobConfigProvider.findJobsWithCustomRules(listener.delegateFailureAndWrap((delegate, jobs) -> {
             List<String> currentlyUsedBy = findJobsUsingFilter(jobs, filterId);
             if (currentlyUsedBy.isEmpty() == false) {
-                listener.onFailure(
+                delegate.onFailure(
                     ExceptionsHelper.conflictStatusException(Messages.getMessage(Messages.FILTER_CANNOT_DELETE, filterId, currentlyUsedBy))
                 );
             } else {
-                deleteFilter(filterId, listener);
+                deleteFilter(filterId, delegate);
             }
-        }, listener::onFailure));
+        }));
     }
 
     private static List<String> findJobsUsingFilter(List<Job> jobs, String filterId) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
@@ -75,13 +75,13 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<
         ActionListener<EvaluateDataFrameAction.Response> listener
     ) {
         TaskId parentTaskId = new TaskId(clusterService.localNode().getId(), task.getId());
-        ActionListener<List<Void>> resultsListener = ActionListener.wrap(unused -> {
+        ActionListener<List<Void>> resultsListener = listener.delegateFailureAndWrap((delegate, unused) -> {
             EvaluateDataFrameAction.Response response = new EvaluateDataFrameAction.Response(
                 request.getEvaluation().getName(),
                 request.getEvaluation().getResults()
             );
-            listener.onResponse(response);
-        }, listener::onFailure);
+            delegate.onResponse(response);
+        });
 
         // Create an immutable collection of parameters to be used by evaluation metrics.
         EvaluationParameters parameters = new EvaluationParameters(maxBuckets.get());
@@ -139,13 +139,17 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<
                 SearchRequest searchRequest = new SearchRequest(request.getIndices()).source(searchSourceBuilder);
                 useSecondaryAuthIfAvailable(
                     securityContext,
-                    () -> client.execute(SearchAction.INSTANCE, searchRequest, ActionListener.wrap(searchResponse -> {
-                        evaluation.process(searchResponse);
-                        if (evaluation.hasAllResults() == false) {
-                            add(nextTask());
-                        }
-                        listener.onResponse(null);
-                    }, listener::onFailure))
+                    () -> client.execute(
+                        SearchAction.INSTANCE,
+                        searchRequest,
+                        listener.delegateFailureAndWrap((delegate, searchResponse) -> {
+                            evaluation.process(searchResponse);
+                            if (evaluation.hasAllResults() == false) {
+                                add(nextTask());
+                            }
+                            delegate.onResponse(null);
+                        })
+                    )
                 );
             };
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -138,18 +138,16 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
                 ).build();
                 extractedFieldsDetectorFactory.createFromSource(
                     config,
-                    ActionListener.wrap(
-                        extractedFieldsDetector -> explain(parentTaskId, config, extractedFieldsDetector, listener),
-                        listener::onFailure
+                    listener.delegateFailureAndWrap(
+                        (l, extractedFieldsDetector) -> explain(parentTaskId, config, extractedFieldsDetector, l)
                     )
                 );
             });
         } else {
             extractedFieldsDetectorFactory.createFromSource(
                 request.getConfig(),
-                ActionListener.wrap(
-                    extractedFieldsDetector -> explain(parentTaskId, request.getConfig(), extractedFieldsDetector, listener),
-                    listener::onFailure
+                listener.delegateFailureAndWrap(
+                    (l, extractedFieldsDetector) -> explain(parentTaskId, request.getConfig(), extractedFieldsDetector, l)
                 )
             );
         }
@@ -172,9 +170,8 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
             return;
         }
 
-        ActionListener<MemoryEstimation> memoryEstimationListener = ActionListener.wrap(
-            memoryEstimation -> listener.onResponse(new ExplainDataFrameAnalyticsAction.Response(fieldExtraction.v2(), memoryEstimation)),
-            listener::onFailure
+        ActionListener<MemoryEstimation> memoryEstimationListener = listener.delegateFailureAndWrap(
+            (l, memoryEstimation) -> l.onResponse(new ExplainDataFrameAnalyticsAction.Response(fieldExtraction.v2(), memoryEstimation))
         );
 
         estimateMemoryUsage(parentTaskId, config, fieldExtraction.v1(), memoryEstimationListener);
@@ -202,11 +199,8 @@ public class TransportExplainDataFrameAnalyticsAction extends HandledTransportAc
             estimateMemoryTaskId,
             config,
             extractorFactory,
-            ActionListener.wrap(
-                result -> listener.onResponse(
-                    new MemoryEstimation(result.getExpectedMemoryWithoutDisk(), result.getExpectedMemoryWithDisk())
-                ),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, result) -> l.onResponse(new MemoryEstimation(result.getExpectedMemoryWithoutDisk(), result.getExpectedMemoryWithDisk()))
             )
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -95,15 +95,15 @@ public class TransportFinalizeJobExecutionAction extends AcknowledgedTransportMa
                     ML_ORIGIN,
                     UpdateAction.INSTANCE,
                     updateRequest,
-                    ActionListener.wrap(updateResponse -> chainedListener.onResponse(null), chainedListener::onFailure)
+                    chainedListener.delegateFailureAndWrap((l, updateResponse) -> l.onResponse(null))
                 );
             });
         }
 
-        voidChainTaskExecutor.execute(ActionListener.wrap(aVoids -> {
+        voidChainTaskExecutor.execute(listener.delegateFailureAndWrap((l, aVoids) -> {
             logger.debug("finalized job [{}]", jobIdString);
-            listener.onResponse(AcknowledgedResponse.TRUE);
-        }, listener::onFailure));
+            l.onResponse(AcknowledgedResponse.TRUE);
+        }));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFlushJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFlushJobAction.java
@@ -66,10 +66,17 @@ public class TransportFlushJobAction extends TransportJobTaskAction<FlushJobActi
             timeRangeBuilder.endTime(request.getEnd());
         }
         paramsBuilder.forTimeRange(timeRangeBuilder.build());
-        processManager.flushJob(task, paramsBuilder.build(), ActionListener.wrap(flushAcknowledgement -> {
-            listener.onResponse(
-                new FlushJobAction.Response(true, flushAcknowledgement == null ? null : flushAcknowledgement.getLastFinalizedBucketEnd())
-            );
-        }, listener::onFailure));
+        processManager.flushJob(
+            task,
+            paramsBuilder.build(),
+            listener.delegateFailureAndWrap(
+                (l, flushAcknowledgement) -> l.onResponse(
+                    new FlushJobAction.Response(
+                        true,
+                        flushAcknowledgement == null ? null : flushAcknowledgement.getLastFinalizedBucketEnd()
+                    )
+                )
+            )
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -40,7 +40,7 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
 
     @Override
     protected void doExecute(Task task, GetBucketsAction.Request request, ActionListener<GetBucketsAction.Response> listener) {
-        jobManager.jobExists(request.getJobId(), null, ActionListener.wrap(ok -> {
+        jobManager.jobExists(request.getJobId(), null, listener.delegateFailureAndWrap((delegate, ok) -> {
             BucketsQueryBuilder query = new BucketsQueryBuilder().expand(request.isExpand())
                 .includeInterim(request.isExcludeInterim() == false)
                 .start(request.getStart())
@@ -61,14 +61,10 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
             jobResultsProvider.buckets(
                 request.getJobId(),
                 query,
-                q -> listener.onResponse(new GetBucketsAction.Response(q)),
-                listener::onFailure,
+                q -> delegate.onResponse(new GetBucketsAction.Response(q)),
+                delegate::onFailure,
                 client
             );
-
-        },
-            listener::onFailure
-
-        ));
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
@@ -46,7 +46,7 @@ public class TransportGetCalendarsAction extends HandledTransportAction<GetCalen
         CalendarQueryBuilder query = new CalendarQueryBuilder().pageParams(pageParams).calendarIdTokens(idTokens).sort(true);
         jobResultsProvider.calendars(
             query,
-            ActionListener.wrap(calendars -> listener.onResponse(new GetCalendarsAction.Response(calendars)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, calendars) -> l.onResponse(new GetCalendarsAction.Response(calendars)))
         );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
@@ -47,7 +47,7 @@ public class TransportGetCategoriesAction extends HandledTransportAction<GetCate
     @Override
     protected void doExecute(Task task, GetCategoriesAction.Request request, ActionListener<GetCategoriesAction.Response> listener) {
         TaskId parentTaskId = new TaskId(clusterService.localNode().getId(), task.getId());
-        jobManager.jobExists(request.getJobId(), parentTaskId, ActionListener.wrap(jobExists -> {
+        jobManager.jobExists(request.getJobId(), parentTaskId, listener.delegateFailureAndWrap((delegate, jobExists) -> {
             Integer from = request.getPageParams() != null ? request.getPageParams().getFrom() : null;
             Integer size = request.getPageParams() != null ? request.getPageParams().getSize() : null;
             jobResultsProvider.categoryDefinitions(
@@ -57,12 +57,12 @@ public class TransportGetCategoriesAction extends HandledTransportAction<GetCate
                 true,
                 from,
                 size,
-                r -> listener.onResponse(new GetCategoriesAction.Response(r)),
-                listener::onFailure,
+                r -> delegate.onResponse(new GetCategoriesAction.Response(r)),
+                delegate::onFailure,
                 (CancellableTask) task,
                 parentTaskId,
                 new ParentTaskAssigningClient(client, parentTaskId)
             );
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsAction.java
@@ -83,7 +83,7 @@ public class TransportGetDataFrameAnalyticsAction extends AbstractTransportGetRe
         searchResources(
             request,
             new TaskId(clusterService.localNode().getId(), task.getId()),
-            ActionListener.wrap(queryPage -> listener.onResponse(new GetDataFrameAnalyticsAction.Response(queryPage)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, queryPage) -> l.onResponse(new GetDataFrameAnalyticsAction.Response(queryPage)))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedRunningStateAction.java
@@ -106,10 +106,10 @@ public class TransportGetDatafeedRunningStateAction extends TransportTasksAction
         }
 
         // Do this to catch datafeed tasks that have been created but are currently not assigned to a node.
-        ActionListener<Response> taskResponseListener = ActionListener.wrap(actionResponses -> {
+        ActionListener<Response> taskResponseListener = listener.delegateFailureAndWrap((delegate, actionResponses) -> {
             Map<String, Response.RunningState> runningStateMap = actionResponses.getDatafeedRunningState();
             if (runningStateMap.size() == datafeedTasks.size()) {
-                listener.onResponse(actionResponses);
+                delegate.onResponse(actionResponses);
                 return;
             }
             List<Response> missingResponses = new ArrayList<>();
@@ -128,8 +128,8 @@ public class TransportGetDatafeedRunningStateAction extends TransportTasksAction
                         )
                 )
             );
-            listener.onResponse(Response.fromResponses(missingResponses));
-        }, listener::onFailure);
+            delegate.onResponse(Response.fromResponses(missingResponses));
+        });
 
         String[] nodesOfConcern = datafeedTasks.stream()
             .map(PersistentTasksCustomMetadata.PersistentTask::getExecutorNode)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -67,7 +67,7 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
         datafeedManager.getDatafeeds(
             request,
             parentTaskId,
-            ActionListener.wrap(datafeeds -> listener.onResponse(new GetDatafeedsAction.Response(datafeeds)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, datafeeds) -> l.onResponse(new GetDatafeedsAction.Response(datafeeds)))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
@@ -54,7 +54,7 @@ public class TransportGetFiltersAction extends AbstractTransportGetResourcesActi
         searchResources(
             request,
             new TaskId(clusterService.localNode().getId(), task.getId()),
-            ActionListener.wrap(filters -> listener.onResponse(new GetFiltersAction.Response(filters)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, filters) -> l.onResponse(new GetFiltersAction.Response(filters)))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -40,7 +40,7 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
 
     @Override
     protected void doExecute(Task task, GetInfluencersAction.Request request, ActionListener<GetInfluencersAction.Response> listener) {
-        jobManager.jobExists(request.getJobId(), null, ActionListener.wrap(jobExists -> {
+        jobManager.jobExists(request.getJobId(), null, listener.delegateFailureAndWrap((delegate, jobExists) -> {
             InfluencersQueryBuilder.InfluencersQuery query = new InfluencersQueryBuilder().includeInterim(
                 request.isExcludeInterim() == false
             )
@@ -55,10 +55,10 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
             jobResultsProvider.influencers(
                 request.getJobId(),
                 query,
-                page -> listener.onResponse(new GetInfluencersAction.Response(page)),
-                listener::onFailure,
+                page -> delegate.onResponse(new GetInfluencersAction.Response(page)),
+                delegate::onFailure,
                 client
             );
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -108,14 +108,13 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<
             tasks,
             true,
             parentTaskId,
-            ActionListener.wrap(expandedIds -> {
+            finalListener.delegateFailureAndWrap((delegate, expandedIds) -> {
                 request.setExpandedJobsIds(new ArrayList<>(expandedIds));
-                ActionListener<GetJobsStatsAction.Response> jobStatsListener = ActionListener.wrap(
-                    response -> gatherStatsForClosedJobs(request, response, parentTaskId, finalListener),
-                    finalListener::onFailure
+                ActionListener<GetJobsStatsAction.Response> jobStatsListener = delegate.delegateFailureAndWrap(
+                    (l, response) -> gatherStatsForClosedJobs(request, response, parentTaskId, l)
                 );
                 super.doExecute(task, request, jobStatsListener);
-            }, finalListener::onFailure)
+            })
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -75,7 +75,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<
         jobManager.jobExists(
             request.getJobId(),
             parentTaskId,
-            ActionListener.wrap(ok -> getModelSnapshots(request, parentTaskId, listener), listener::onFailure)
+            listener.delegateFailureAndWrap((l, ok) -> getModelSnapshots(request, parentTaskId, l))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -40,8 +40,7 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
 
     @Override
     protected void doExecute(Task task, GetRecordsAction.Request request, ActionListener<GetRecordsAction.Response> listener) {
-
-        jobManager.jobExists(request.getJobId(), null, ActionListener.wrap(jobExists -> {
+        jobManager.jobExists(request.getJobId(), null, listener.delegateFailureAndWrap((delegate, jobExists) -> {
             RecordsQueryBuilder query = new RecordsQueryBuilder().includeInterim(request.isExcludeInterim() == false)
                 .epochStart(request.getStart())
                 .epochEnd(request.getEnd())
@@ -53,10 +52,10 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
             jobResultsProvider.records(
                 request.getJobId(),
                 query,
-                page -> listener.onResponse(new GetRecordsAction.Response(page)),
-                listener::onFailure,
+                page -> delegate.onResponse(new GetRecordsAction.Response(page)),
+                delegate::onFailure,
                 client
             );
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilder.java
@@ -288,17 +288,17 @@ public class InferencePipelineAggregationBuilder extends AbstractPipelineAggrega
                     privRequest.indexPrivileges(new RoleDescriptor.IndicesPrivileges[] {});
                     privRequest.applicationPrivileges(new RoleDescriptor.ApplicationResourcePrivileges[] {});
 
-                    ActionListener<HasPrivilegesResponse> privResponseListener = ActionListener.wrap(r -> {
+                    ActionListener<HasPrivilegesResponse> privResponseListener = listener.delegateFailureAndWrap((delegate, r) -> {
                         if (r.isCompleteMatch()) {
-                            modelLoadAction.accept(client, listener);
+                            modelLoadAction.accept(client, delegate);
                         } else {
-                            listener.onFailure(
+                            delegate.onFailure(
                                 Exceptions.authorizationError(
                                     "user [" + username + "] does not have the privilege to get trained models so cannot use ml inference"
                                 )
                             );
                         }
-                    }, listener::onFailure);
+                    });
 
                     client.execute(HasPrivilegesAction.INSTANCE, privRequest, privResponseListener);
                 });

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
@@ -93,7 +93,7 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
                 }
             });
 
-            client.execute(GetTrainedModelsAction.INSTANCE, modelsAction, ActionListener.wrap(trainedModels -> {
+            client.execute(GetTrainedModelsAction.INSTANCE, modelsAction, listener.delegateFailureAndWrap((delegate, trainedModels) -> {
                 final List<TrainedModelConfig> trainedModelConfigs = trainedModels.getResources().results();
 
                 Set<String> potentialAnalyticsIds = new HashSet<>();
@@ -109,13 +109,13 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
                     restRequest,
                     2,
                     trainedModels.getResources().results(),
-                    listener
+                    delegate
                 );
 
                 client.execute(
                     GetTrainedModelsStatsAction.INSTANCE,
                     statsRequest,
-                    ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
+                    groupedListener.delegateFailureAndWrap((l, r) -> l.onResponse(r))
                 );
 
                 GetDataFrameAnalyticsAction.Request dataFrameAnalyticsRequest = new GetDataFrameAnalyticsAction.Request(requestIdPattern);
@@ -124,9 +124,9 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
                 client.execute(
                     GetDataFrameAnalyticsAction.INSTANCE,
                     dataFrameAnalyticsRequest,
-                    ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
+                    groupedListener.delegateFailureAndWrap((l, r) -> l.onResponse(r))
                 );
-            }, listener::onFailure));
+            }));
         };
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ml.rest.inference;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.core.RestApiVersion;
@@ -86,13 +85,12 @@ public class RestInferTrainedModelDeploymentAction extends BaseRestHandler {
             request,
             // This API is deprecated but refactoring makes it simpler to call
             // the new replacement API and swap in the old response.
-            ActionListener.wrap(response -> {
+            new RestToXContentListener<>(channel).delegateFailureAndWrap((l, response) -> {
                 InferTrainedModelDeploymentAction.Response oldResponse = new InferTrainedModelDeploymentAction.Response(
                     response.getInferenceResults()
                 );
-                new RestToXContentListener<>(channel).onResponse(oldResponse);
-            }, e -> new RestToXContentListener<>(channel).onFailure(e))
-
+                l.onResponse(oldResponse);
+            })
         );
     }
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsAction.java
@@ -112,10 +112,9 @@ public class TransportMonitoringMigrateAlertsAction extends TransportMasterNodeA
         ActionListener<MonitoringMigrateAlertsResponse> delegate
     ) {
         // Send failures to the final listener directly, and on success, fork to management thread and execute best effort alert removal
-        return ActionListener.wrap(
-            (response) -> threadPool.executor(ThreadPool.Names.MANAGEMENT)
-                .execute(ActionRunnable.wrap(delegate, (listener) -> afterSettingUpdate(listener, response))),
-            delegate::onFailure
+        return delegate.delegateFailureAndWrap(
+            (l, response) -> threadPool.executor(ThreadPool.Names.MANAGEMENT)
+                .execute(ActionRunnable.wrap(l, listener -> afterSettingUpdate(listener, response)))
         );
     }
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -929,16 +929,15 @@ public class HttpExporter extends Exporter {
         }
 
         if (migrationCoordinator.canInstall()) {
-            resource.checkAndPublishIfDirty(client, ActionListener.wrap((success) -> {
+            resource.checkAndPublishIfDirty(client, listener.delegateFailureAndWrap((delegate, success) -> {
                 if (success) {
                     final String name = "xpack.monitoring.exporters." + config.name();
-
-                    listener.onResponse(new HttpExportBulk(name, client, defaultParams, dateTimeFormatter, threadContext));
+                    delegate.onResponse(new HttpExportBulk(name, client, defaultParams, dateTimeFormatter, threadContext));
                 } else {
                     // we're not ready yet, so keep waiting
-                    listener.onResponse(null);
+                    delegate.onResponse(null);
                 }
-            }, listener::onFailure));
+            }));
         } else {
             // we're migrating right now, so keep waiting
             listener.onResponse(null);

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
@@ -135,14 +135,14 @@ public abstract class PublishableHttpResource extends HttpResource {
      */
     @Override
     protected final void doCheckAndPublish(final RestClient client, final ActionListener<ResourcePublishResult> listener) {
-        doCheck(client, ActionListener.wrap(exists -> {
+        doCheck(client, listener.delegateFailureAndWrap((l, exists) -> {
             if (exists) {
                 // it already exists, so we can skip publishing it
-                listener.onResponse(ResourcePublishResult.ready());
+                l.onResponse(ResourcePublishResult.ready());
             } else {
-                doPublish(client, listener);
+                doPublish(client, l);
             }
-        }, listener::onFailure));
+        }));
     }
 
     /**

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -141,7 +141,7 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
                     priorIndexVersions.toArray(new String[0]),
                     // the cluster state that we are operating on is a snapshot and won't reflect that the alias has just gone.
                     // Therefore, we use putIndex here which does not check for the existence of an alias
-                    ActionListener.wrap(r -> putIndex(index.getName(), index.getAlias(), listener), listener::onFailure)
+                    listener.delegateFailureAndWrap((l, r) -> putIndex(index.getName(), index.getAlias(), l))
                 );
             } else {
                 createIndex(state, index, listener);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -272,7 +272,7 @@ public class IndexResolver {
                     indexRequest.indicesOptions(FROZEN_INDICES_OPTIONS);
                 }
 
-                client.admin().indices().getIndex(indexRequest, wrap(indices -> {
+                client.admin().indices().getIndex(indexRequest, listener.delegateFailureAndWrap((delegate, indices) -> {
                     if (indices != null) {
                         for (String indexName : indices.getIndices()) {
                             boolean isFrozen = retrieveFrozenIndices
@@ -282,8 +282,8 @@ public class IndexResolver {
                             );
                         }
                     }
-                    resolveRemoteIndices(clusterWildcard, indexWildcards, javaRegex, retrieveFrozenIndices, indexInfos, listener);
-                }, listener::onFailure));
+                    resolveRemoteIndices(clusterWildcard, indexWildcards, javaRegex, retrieveFrozenIndices, indexInfos, delegate);
+                }));
             } else {
                 resolveRemoteIndices(clusterWildcard, indexWildcards, javaRegex, retrieveFrozenIndices, indexInfos, listener);
             }
@@ -363,7 +363,7 @@ public class IndexResolver {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, indicesOptions, runtimeMappings);
         client.fieldCaps(
             fieldRequest,
-            ActionListener.wrap(response -> listener.onResponse(mergedMappings(typeRegistry, indexWildcard, response)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response)))
         );
     }
 
@@ -379,7 +379,7 @@ public class IndexResolver {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, includeFrozen, runtimeMappings);
         client.fieldCaps(
             fieldRequest,
-            ActionListener.wrap(response -> listener.onResponse(mergedMappings(typeRegistry, indexWildcard, response)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response)))
         );
     }
 
@@ -586,17 +586,26 @@ public class IndexResolver {
         ActionListener<List<EsIndex>> listener
     ) {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, includeFrozen, runtimeMappings);
-        client.fieldCaps(fieldRequest, wrap(response -> {
-            client.admin().indices().getAliases(createGetAliasesRequest(response, includeFrozen), wrap(aliases -> {
-                listener.onResponse(separateMappings(typeRegistry, javaRegex, response, aliases.getAliases()));
-            }, ex -> {
-                if (ex instanceof IndexNotFoundException || ex instanceof ElasticsearchSecurityException) {
-                    listener.onResponse(separateMappings(typeRegistry, javaRegex, response, null));
-                } else {
-                    listener.onFailure(ex);
-                }
-            }));
-        }, listener::onFailure));
+        client.fieldCaps(
+            fieldRequest,
+            listener.delegateFailureAndWrap(
+                (delegate, response) -> client.admin()
+                    .indices()
+                    .getAliases(
+                        createGetAliasesRequest(response, includeFrozen),
+                        wrap(
+                            aliases -> delegate.onResponse(separateMappings(typeRegistry, javaRegex, response, aliases.getAliases())),
+                            ex -> {
+                                if (ex instanceof IndexNotFoundException || ex instanceof ElasticsearchSecurityException) {
+                                    delegate.onResponse(separateMappings(typeRegistry, javaRegex, response, null));
+                                } else {
+                                    delegate.onFailure(ex);
+                                }
+                            }
+                        )
+                    )
+            )
+        );
 
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
@@ -95,13 +95,13 @@ public abstract class AbstractTransportQlAsyncGetResultsAction<Response extends 
     protected void doExecute(Task task, GetAsyncResultRequest request, ActionListener<Response> listener) {
         DiscoveryNode node = resultsService.getNode(request.getId());
         if (node == null || resultsService.isLocalNode(node)) {
-            resultsService.retrieveResult(request, ActionListener.wrap(r -> {
+            resultsService.retrieveResult(request, listener.delegateFailureAndWrap((l, r) -> {
                 if (r.getException() != null) {
-                    listener.onFailure(r.getException());
+                    l.onFailure(r.getException());
                 } else {
-                    listener.onResponse(r.getResponse());
+                    l.onResponse(r.getResponse());
                 }
-            }, listener::onFailure));
+            }));
         } else {
             transportService.sendRequest(
                 node,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ActionListeners.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ActionListeners.java
@@ -21,6 +21,6 @@ public class ActionListeners {
      * Combination of {@link ActionListener#wrap(CheckedConsumer, Consumer)} and {@link ActionListener#map}
      */
     public static <T, Response> ActionListener<Response> map(ActionListener<T> delegate, CheckedFunction<Response, T, Exception> fn) {
-        return ActionListener.wrap(r -> delegate.onResponse(fn.apply(r)), delegate::onFailure);
+        return delegate.delegateFailureAndWrap((l, r) -> l.onResponse(fn.apply(r)));
     }
 }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -306,7 +306,7 @@ public class RollupIndexerStateTests extends ESTestCase {
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(threadPool, job, state, null) {
                 @Override
                 protected void onFinish(ActionListener<Void> listener) {
-                    super.onFinish(ActionListener.wrap(r -> { listener.onResponse(r); }, listener::onFailure));
+                    super.onFinish(listener.delegateFailureAndWrap((l, r) -> l.onResponse(r)));
                 }
 
                 @Override
@@ -362,10 +362,10 @@ public class RollupIndexerStateTests extends ESTestCase {
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(threadPool, job, state, null, spyStats) {
                 @Override
                 protected void onFinish(ActionListener<Void> listener) {
-                    super.onFinish(ActionListener.wrap(r -> {
-                        listener.onResponse(r);
+                    super.onFinish(listener.delegateFailureAndWrap((l, r) -> {
+                        l.onResponse(r);
                         isFinished.set(true);
-                    }, listener::onFailure));
+                    }));
                 }
             };
             final CountDownLatch latch = indexer.newLatch();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageTransportAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageTransportAction.java
@@ -146,31 +146,35 @@ public class SecurityUsageTransportAction extends XPackUsageFeatureTransportActi
             }
         };
 
-        final ActionListener<Map<String, Object>> rolesStoreUsageListener = ActionListener.wrap(rolesStoreUsage -> {
+        final ActionListener<Map<String, Object>> rolesStoreUsageListener = listener.delegateFailureAndWrap((l, rolesStoreUsage) -> {
             rolesUsageRef.set(rolesStoreUsage);
             doCountDown.run();
-        }, listener::onFailure);
+        });
 
-        final ActionListener<Map<String, Object>> roleMappingStoreUsageListener = ActionListener.wrap(nativeRoleMappingStoreUsage -> {
-            Map<String, Object> usage = singletonMap("native", nativeRoleMappingStoreUsage);
-            roleMappingUsageRef.set(usage);
-            doCountDown.run();
-        }, listener::onFailure);
+        final ActionListener<Map<String, Object>> roleMappingStoreUsageListener = listener.delegateFailureAndWrap(
+            (l, nativeRoleMappingStoreUsage) -> {
+                Map<String, Object> usage = singletonMap("native", nativeRoleMappingStoreUsage);
+                roleMappingUsageRef.set(usage);
+                doCountDown.run();
+            }
+        );
 
-        final ActionListener<Map<String, Object>> realmsUsageListener = ActionListener.wrap(realmsUsage -> {
+        final ActionListener<Map<String, Object>> realmsUsageListener = listener.delegateFailureAndWrap((l, realmsUsage) -> {
             realmsUsageRef.set(realmsUsage);
             doCountDown.run();
-        }, listener::onFailure);
+        });
 
-        final ActionListener<Map<String, Object>> userProfileUsageListener = ActionListener.wrap(userProfileUsage -> {
+        final ActionListener<Map<String, Object>> userProfileUsageListener = listener.delegateFailureAndWrap((l, userProfileUsage) -> {
             userProfileUsageRef.set(userProfileUsage);
             doCountDown.run();
-        }, listener::onFailure);
+        });
 
-        final ActionListener<Map<String, Object>> remoteClusterServerUsageListener = ActionListener.wrap(remoteClusterServerUsage -> {
-            remoteClusterServerUsageRef.set(remoteClusterServerUsage);
-            doCountDown.run();
-        }, listener::onFailure);
+        final ActionListener<Map<String, Object>> remoteClusterServerUsageListener = listener.delegateFailureAndWrap(
+            (l, remoteClusterServerUsage) -> {
+                remoteClusterServerUsageRef.set(remoteClusterServerUsage);
+                doCountDown.run();
+            }
+        );
 
         if (rolesStore == null || enabled == false) {
             rolesStoreUsageListener.onResponse(Collections.emptyMap());
@@ -204,8 +208,8 @@ public class SecurityUsageTransportAction extends XPackUsageFeatureTransportActi
     private void remoteClusterServerUsage(ActionListener<Map<String, Object>> listener) {
         if (TcpTransport.isUntrustedRemoteClusterEnabled()) {
             apiKeyService.crossClusterApiKeyUsageStats(
-                ActionListener.wrap(
-                    usage -> listener.onResponse(
+                listener.delegateFailureAndWrap(
+                    (l, usage) -> l.onResponse(
                         Map.of(
                             "available",
                             ADVANCED_REMOTE_CLUSTER_SECURITY_FEATURE.checkWithoutTracking(licenseState),
@@ -214,8 +218,7 @@ public class SecurityUsageTransportAction extends XPackUsageFeatureTransportActi
                             "api_keys",
                             usage
                         )
-                    ),
-                    listener::onFailure
+                    )
                 )
             );
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportDelegatePkiAuthenticationAction.java
@@ -101,12 +101,10 @@ public final class TransportDelegatePkiAuthenticationAction extends HandledTrans
                         delegateeAuthentication,
                         Map.of(),
                         false,
-                        ActionListener.wrap(tokenResult -> {
+                        listener.delegateFailureAndWrap((l, tokenResult) -> {
                             final TimeValue expiresIn = tokenService.getExpirationDelay();
-                            listener.onResponse(
-                                new DelegatePkiAuthenticationResponse(tokenResult.getAccessToken(), expiresIn, authentication)
-                            );
-                        }, listener::onFailure)
+                            l.onResponse(new DelegatePkiAuthenticationResponse(tokenResult.getAccessToken(), expiresIn, authentication));
+                        })
                     );
                 }, e -> {
                     logger.debug(() -> format("Delegated x509Token [%s] could not be authenticated", x509DelegatedToken), e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportGrantAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportGrantAction.java
@@ -64,12 +64,12 @@ public abstract class TransportGrantAction<Request extends GrantRequest, Respons
 
             final String runAsUsername = request.getGrant().getRunAsUsername();
 
-            final ActionListener<Authentication> authenticationListener = ActionListener.wrap(authentication -> {
+            final ActionListener<Authentication> authenticationListener = listener.delegateFailureAndWrap((delegate, authentication) -> {
                 if (authentication.isRunAs()) {
                     final String effectiveUsername = authentication.getEffectiveSubject().getUser().principal();
                     if (runAsUsername != null && false == runAsUsername.equals(effectiveUsername)) {
                         // runAs is ignored
-                        listener.onFailure(
+                        delegate.onFailure(
                             new ElasticsearchStatusException("the provided grant credentials do not support run-as", RestStatus.BAD_REQUEST)
                         );
                     } else {
@@ -80,23 +80,22 @@ public abstract class TransportGrantAction<Request extends GrantRequest, Respons
                             authentication,
                             AuthenticateAction.NAME,
                             AuthenticateRequest.INSTANCE,
-                            ActionListener.wrap(
-                                ignore2 -> doExecuteWithGrantAuthentication(task, request, authentication, listener),
-                                listener::onFailure
+                            delegate.delegateFailureAndWrap(
+                                (l, ignore2) -> doExecuteWithGrantAuthentication(task, request, authentication, l)
                             )
                         );
                     }
                 } else {
                     if (runAsUsername != null) {
                         // runAs is ignored
-                        listener.onFailure(
+                        delegate.onFailure(
                             new ElasticsearchStatusException("the provided grant credentials do not support run-as", RestStatus.BAD_REQUEST)
                         );
                     } else {
-                        doExecuteWithGrantAuthentication(task, request, authentication, listener);
+                        doExecuteWithGrantAuthentication(task, request, authentication, delegate);
                     }
                 }
-            }, listener::onFailure);
+            });
 
             if (runAsUsername != null) {
                 threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, runAsUsername);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkUpdateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkUpdateApiKeyAction.java
@@ -52,9 +52,8 @@ public final class TransportBulkUpdateApiKeyAction extends TransportBaseUpdateAp
     ) {
         resolver.resolveUserRoleDescriptors(
             authentication,
-            ActionListener.wrap(
-                roleDescriptors -> apiKeyService.updateApiKeys(authentication, request, roleDescriptors, listener),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, roleDescriptors) -> apiKeyService.updateApiKeys(authentication, request, roleDescriptors, l)
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateApiKeyAction.java
@@ -64,9 +64,8 @@ public final class TransportCreateApiKeyAction extends HandledTransportAction<Cr
             }
             resolver.resolveUserRoleDescriptors(
                 authentication,
-                ActionListener.wrap(
-                    roleDescriptors -> apiKeyService.createApiKey(authentication, request, roleDescriptors, listener),
-                    listener::onFailure
+                listener.delegateFailureAndWrap(
+                    (l, roleDescriptors) -> apiKeyService.createApiKey(authentication, request, roleDescriptors, l)
                 )
             );
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyAction.java
@@ -87,9 +87,8 @@ public final class TransportGrantApiKeyAction extends TransportGrantAction<Grant
     ) {
         resolver.resolveUserRoleDescriptors(
             authentication,
-            ActionListener.wrap(
-                roleDescriptors -> apiKeyService.createApiKey(authentication, request.getApiKeyRequest(), roleDescriptors, listener),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, roleDescriptors) -> apiKeyService.createApiKey(authentication, request.getApiKeyRequest(), roleDescriptors, l)
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateApiKeyAction.java
@@ -51,17 +51,13 @@ public final class TransportUpdateApiKeyAction extends TransportBaseUpdateApiKey
     ) {
         resolver.resolveUserRoleDescriptors(
             authentication,
-            ActionListener.wrap(
-                roleDescriptors -> apiKeyService.updateApiKeys(
+            listener.delegateFailureAndWrap(
+                (delegate, roleDescriptors) -> apiKeyService.updateApiKeys(
                     authentication,
                     BulkUpdateApiKeyRequest.wrap(request),
                     roleDescriptors,
-                    ActionListener.wrap(
-                        bulkResponse -> listener.onResponse(toSingleResponse(request.getId(), bulkResponse)),
-                        listener::onFailure
-                    )
-                ),
-                listener::onFailure
+                    delegate.delegateFailureAndWrap((l, bulkResponse) -> l.onResponse(toSingleResponse(request.getId(), bulkResponse)))
+                )
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateCrossClusterApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateCrossClusterApiKeyAction.java
@@ -57,7 +57,7 @@ public final class TransportUpdateCrossClusterApiKeyAction extends TransportBase
                 }
             },
             Set.of(),
-            ActionListener.wrap(bulkResponse -> listener.onResponse(toSingleResponse(request.getId(), bulkResponse)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, bulkResponse) -> l.onResponse(toSingleResponse(request.getId(), bulkResponse)))
         );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportDeletePrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportDeletePrivilegesAction.java
@@ -49,11 +49,10 @@ public class TransportDeletePrivilegesAction extends HandledTransportAction<Dele
             request.application(),
             names,
             request.getRefreshPolicy(),
-            ActionListener.wrap(
-                privileges -> listener.onResponse(
+            listener.delegateFailureAndWrap(
+                (l, privileges) -> l.onResponse(
                     new DeletePrivilegesResponse(privileges.getOrDefault(request.application(), Collections.emptyList()))
-                ),
-                listener::onFailure
+                )
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
@@ -55,7 +55,7 @@ public class TransportGetPrivilegesAction extends HandledTransportAction<GetPriv
         this.privilegeStore.getPrivileges(
             applications,
             names,
-            ActionListener.wrap(privileges -> listener.onResponse(new GetPrivilegesResponse(privileges)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, privileges) -> l.onResponse(new GetPrivilegesResponse(privileges)))
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
@@ -44,7 +44,7 @@ public class TransportPutPrivilegesAction extends HandledTransportAction<PutPriv
             this.privilegeStore.putPrivileges(
                 request.getPrivileges(),
                 request.getRefreshPolicy(),
-                ActionListener.wrap(created -> listener.onResponse(new PutPrivilegesResponse(created)), listener::onFailure)
+                listener.delegateFailureAndWrap((l, created) -> l.onResponse(new PutPrivilegesResponse(created)))
             );
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
@@ -70,14 +70,14 @@ public class TransportGetRolesAction extends HandledTransportAction<GetRolesRequ
             // specific roles were requested but they were built in only, no need to hit the store
             listener.onResponse(new GetRolesResponse(roles.toArray(new RoleDescriptor[roles.size()])));
         } else {
-            nativeRolesStore.getRoleDescriptors(rolesToSearchFor, ActionListener.wrap((retrievalResult) -> {
+            nativeRolesStore.getRoleDescriptors(rolesToSearchFor, listener.delegateFailureAndWrap((delegate, retrievalResult) -> {
                 if (retrievalResult.isSuccess()) {
                     roles.addAll(retrievalResult.getDescriptors());
-                    listener.onResponse(new GetRolesResponse(roles.toArray(new RoleDescriptor[roles.size()])));
+                    delegate.onResponse(new GetRolesResponse(roles.toArray(new RoleDescriptor[roles.size()])));
                 } else {
-                    listener.onFailure(retrievalResult.getFailure());
+                    delegate.onFailure(retrievalResult.getFailure());
                 }
-            }, listener::onFailure));
+            }));
         }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/ReservedRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/ReservedRoleMappingAction.java
@@ -90,7 +90,7 @@ public class ReservedRoleMappingAction implements ReservedClusterStateHandler<Li
             prevState.state(),
             prevState.keys(),
             l -> securityIndexRecoveryListener.addListener(
-                ActionListener.wrap(ignored -> nonStateTransform(requests, prevState, l), l::onFailure)
+                l.delegateFailureAndWrap((ll, ignored) -> nonStateTransform(requests, prevState, ll))
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
@@ -44,9 +44,11 @@ public class TransportGetRoleMappingsAction extends HandledTransportAction<GetRo
         } else {
             names = new HashSet<>(Arrays.asList(request.getNames()));
         }
-        this.roleMappingStore.getRoleMappings(names, ActionListener.wrap(mappings -> {
-            ExpressionRoleMapping[] array = mappings.toArray(new ExpressionRoleMapping[mappings.size()]);
-            listener.onResponse(new GetRoleMappingsResponse(array));
-        }, listener::onFailure));
+        this.roleMappingStore.getRoleMappings(
+            names,
+            listener.delegateFailureAndWrap(
+                (delegate, mappings) -> delegate.onResponse(new GetRoleMappingsResponse(mappings.toArray(new ExpressionRoleMapping[0])))
+            )
+        );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
@@ -44,7 +44,7 @@ public class TransportPutRoleMappingAction extends ReservedStateAwareHandledTran
     ) {
         roleMappingStore.putRoleMapping(
             request,
-            ActionListener.wrap(created -> listener.onResponse(new PutRoleMappingResponse(created)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, created) -> l.onResponse(new PutRoleMappingResponse(created)))
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -77,9 +77,9 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                     originatingAuthentication,
                     tokenMeta,
                     true,
-                    ActionListener.wrap(tokenResult -> {
+                    listener.delegateFailureAndWrap((delegate, tokenResult) -> {
                         final TimeValue expiresIn = tokenService.getExpirationDelay();
-                        listener.onResponse(
+                        delegate.onResponse(
                             new SamlAuthenticateResponse(
                                 authentication,
                                 tokenResult.getAccessToken(),
@@ -87,7 +87,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                                 expiresIn
                             )
                         );
-                    }, listener::onFailure)
+                    })
                 );
             }, e -> {
                 logger.debug(() -> "SamlToken [" + saml + "] could not be authenticated", e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
@@ -42,7 +42,7 @@ public class TransportDeleteServiceAccountTokenAction extends HandledTransportAc
     ) {
         serviceAccountService.deleteIndexToken(
             request,
-            ActionListener.wrap(found -> listener.onResponse(new DeleteServiceAccountTokenResponse(found)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, found) -> l.onResponse(new DeleteServiceAccountTokenResponse(found)))
         );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -161,7 +161,7 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
             originatingAuth,
             Collections.emptyMap(),
             includeRefreshToken,
-            ActionListener.wrap(tokenResult -> {
+            listener.delegateFailureAndWrap((delegate, tokenResult) -> {
                 final String scope = getResponseScopeValue(request.getScope());
                 final String base64AuthenticateResponse = (grantType == GrantType.KERBEROS) ? extractOutToken() : null;
                 final CreateTokenResponse response = new CreateTokenResponse(
@@ -172,8 +172,8 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
                     base64AuthenticateResponse,
                     authentication
                 );
-                listener.onResponse(response);
-            }, listener::onFailure)
+                delegate.onResponse(response);
+            })
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
@@ -34,9 +34,8 @@ public final class TransportInvalidateTokenAction extends HandledTransportAction
 
     @Override
     protected void doExecute(Task task, InvalidateTokenRequest request, ActionListener<InvalidateTokenResponse> listener) {
-        final ActionListener<TokensInvalidationResult> invalidateListener = ActionListener.wrap(
-            tokensInvalidationResult -> listener.onResponse(new InvalidateTokenResponse(tokensInvalidationResult)),
-            listener::onFailure
+        final ActionListener<TokensInvalidationResult> invalidateListener = listener.delegateFailureAndWrap(
+            (l, tokensInvalidationResult) -> l.onResponse(new InvalidateTokenResponse(tokensInvalidationResult))
         );
         if (Strings.hasText(request.getUserName()) || Strings.hasText(request.getRealmName())) {
             tokenService.invalidateActiveTokensForRealmAndUser(request.getRealmName(), request.getUserName(), invalidateListener);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
@@ -31,7 +31,7 @@ public class TransportRefreshTokenAction extends HandledTransportAction<CreateTo
 
     @Override
     protected void doExecute(Task task, CreateTokenRequest request, ActionListener<CreateTokenResponse> listener) {
-        tokenService.refreshToken(request.getRefreshToken(), ActionListener.wrap(tokenResult -> {
+        tokenService.refreshToken(request.getRefreshToken(), listener.delegateFailureAndWrap((delegate, tokenResult) -> {
             final String scope = getResponseScopeValue(request.getScope());
             final CreateTokenResponse response = new CreateTokenResponse(
                 tokenResult.getAccessToken(),
@@ -41,7 +41,7 @@ public class TransportRefreshTokenAction extends HandledTransportAction<CreateTo
                 null,
                 tokenResult.getAuthentication()
             );
-            listener.onResponse(response);
-        }, listener::onFailure));
+            delegate.onResponse(response);
+        }));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
@@ -69,12 +69,12 @@ public class TransportHasPrivilegesAction extends HandledTransportAction<HasPriv
 
         resolveApplicationPrivileges(
             request,
-            ActionListener.wrap(
-                applicationPrivilegeDescriptors -> authorizationService.checkPrivileges(
+            listener.delegateFailureAndWrap(
+                (delegate, applicationPrivilegeDescriptors) -> authorizationService.checkPrivileges(
                     authentication.getEffectiveSubject(),
                     request.getPrivilegesToCheck(),
                     applicationPrivilegeDescriptors,
-                    listener.map(privilegesCheckResult -> {
+                    delegate.map(privilegesCheckResult -> {
                         AuthorizationEngine.PrivilegesCheckResult.Details checkResultDetails = privilegesCheckResult.getDetails();
                         assert checkResultDetails != null : "runDetailedCheck is 'true' but the result has no details";
                         return new HasPrivilegesResponse(
@@ -85,8 +85,7 @@ public class TransportHasPrivilegesAction extends HandledTransportAction<HasPriv
                             checkResultDetails != null ? checkResultDetails.application() : Map.of()
                         );
                     })
-                ),
-                listener::onFailure
+                )
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealm.java
@@ -53,10 +53,12 @@ public class NativeRealm extends CachingUsernamePasswordRealm {
 
     @Override
     public void usageStats(ActionListener<Map<String, Object>> listener) {
-        super.usageStats(ActionListener.wrap(stats -> userStore.getUserCount(ActionListener.wrap(size -> {
-            stats.put("size", size);
-            listener.onResponse(stats);
-        }, listener::onFailure)), listener::onFailure));
+        super.usageStats(
+            listener.delegateFailureAndWrap((delegate, stats) -> userStore.getUserCount(delegate.delegateFailureAndWrap((l, size) -> {
+                stats.put("size", size);
+                l.onResponse(stats);
+            })))
+        );
     }
 
     // method is used for testing to verify cache expiration since expireAll is final

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
@@ -252,13 +252,13 @@ public final class KerberosRealm extends Realm implements CachingRealm {
         final ActionListener<AuthenticationResult<User>> listener
     ) {
         final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(username, null, Set.of(), metadata, this.config);
-        userRoleMapper.resolveRoles(userData, ActionListener.wrap(roles -> {
+        userRoleMapper.resolveRoles(userData, listener.delegateFailureAndWrap((delegate, roles) -> {
             final User computedUser = new User(username, roles.toArray(new String[roles.size()]), null, null, userData.getMetadata(), true);
             if (userPrincipalNameToUserCache != null) {
                 userPrincipalNameToUserCache.put(username, computedUser);
             }
-            listener.onResponse(AuthenticationResult.success(computedUser));
-        }, listener::onFailure));
+            delegate.onResponse(AuthenticationResult.success(computedUser));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolver.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.security.authc.ldap.support;
 
 import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.LDAPInterface;
-import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchScope;
 
 import org.apache.logging.log4j.Logger;
@@ -68,13 +67,13 @@ public class LdapMetadataResolver {
                 OBJECT_CLASS_PRESENCE_FILTER,
                 Math.toIntExact(timeout.seconds()),
                 ignoreReferralErrors,
-                ActionListener.wrap((SearchResultEntry entry) -> {
+                listener.delegateFailureAndWrap((l, entry) -> {
                     if (entry == null) {
-                        listener.onResponse(Map.of());
+                        l.onResponse(Map.of());
                     } else {
-                        listener.onResponse(toMap(entry::getAttribute));
+                        l.onResponse(toMap(entry::getAttribute));
                     }
-                }, listener::onFailure),
+                }),
                 this.attributeNames
             );
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapSession.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapSession.java
@@ -108,13 +108,13 @@ public class LdapSession implements Releasable {
 
     public void resolve(ActionListener<LdapUserData> listener) {
         logger.debug("Resolving LDAP groups + meta-data for user [{}]", userDn);
-        groups(ActionListener.wrap(groups -> {
+        groups(listener.delegateFailureAndWrap((delegate, groups) -> {
             logger.debug("Resolved {} LDAP groups [{}] for user [{}]", groups.size(), groups, userDn);
-            metadata(ActionListener.wrap(meta -> {
+            metadata(delegate.delegateFailureAndWrap((l, meta) -> {
                 logger.debug("Resolved {} meta-data fields [{}] for user [{}]", meta.size(), meta, userDn);
-                listener.onResponse(new LdapUserData(groups, meta));
-            }, listener::onFailure));
-        }, listener::onFailure));
+                l.onResponse(new LdapUserData(groups, meta));
+            }));
+        }));
     }
 
     public static class LdapUserData {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/RealmUserLookup.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/RealmUserLookup.java
@@ -45,13 +45,13 @@ public class RealmUserLookup {
     public void lookup(String principal, ActionListener<Tuple<User, Realm>> listener) {
         final IteratingActionListener<Tuple<User, Realm>, ? extends Realm> userLookupListener = new IteratingActionListener<>(
             listener,
-            (realm, lookupUserListener) -> realm.lookupUser(principal, ActionListener.wrap(foundUser -> {
+            (realm, lookupUserListener) -> realm.lookupUser(principal, lookupUserListener.delegateFailureAndWrap((delegate, foundUser) -> {
                 if (foundUser != null) {
-                    lookupUserListener.onResponse(new Tuple<>(foundUser, realm));
+                    delegate.onResponse(new Tuple<>(foundUser, realm));
                 } else {
-                    lookupUserListener.onResponse(null);
+                    delegate.onResponse(null);
                 }
-            }, lookupUserListener::onFailure)),
+            })),
             realms,
             threadContext
         );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
@@ -45,9 +45,8 @@ public class CompositeRoleMapper implements UserRoleMapper {
     public void resolveRoles(UserData user, ActionListener<Set<String>> listener) {
         GroupedActionListener<Set<String>> groupListener = new GroupedActionListener<>(
             delegates.size(),
-            ActionListener.wrap(
-                composite -> listener.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet())),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, composite) -> l.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet()))
             )
         );
         this.delegates.forEach(mapper -> mapper.resolveRoles(user, groupListener));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -322,7 +322,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
         if (securityIndex.isAvailable() == false) {
             reportStats(listener, Collections.emptyList());
         } else {
-            getMappings(ActionListener.wrap(mappings -> reportStats(listener, mappings), listener::onFailure));
+            getMappings(listener.delegateFailureAndWrap(NativeRoleMappingStore::reportStats));
         }
     }
 
@@ -366,7 +366,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
 
     @Override
     public void resolveRoles(UserData user, ActionListener<Set<String>> listener) {
-        getRoleMappings(null, ActionListener.wrap(mappings -> {
+        getRoleMappings(null, listener.delegateFailureAndWrap((delegate, mappings) -> {
             final ExpressionModel model = user.asModel();
             final Set<String> roles = mappings.stream()
                 .filter(ExpressionRoleMapping::isEnabled)
@@ -378,8 +378,8 @@ public class NativeRoleMappingStore implements UserRoleMapper {
                 })
                 .collect(Collectors.toSet());
             logger.debug("Mapping user [{}] to roles [{}]", user, roles);
-            listener.onResponse(roles);
-        }, listener::onFailure));
+            delegate.onResponse(roles);
+        }));
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
@@ -100,10 +100,10 @@ public final class IndicesAliasesRequestInterceptor implements RequestIntercepto
                 requestInfo,
                 authorizationInfo,
                 indexToAliasesMap,
-                wrapPreservingContext(ActionListener.wrap(authzResult -> {
+                wrapPreservingContext(listener.delegateFailureAndWrap((delegate, authzResult) -> {
                     if (authzResult.isGranted()) {
                         // do not audit success again
-                        listener.onResponse(null);
+                        delegate.onResponse(null);
                     } else {
                         auditTrail.accessDenied(
                             AuditUtil.extractRequestId(threadContext),
@@ -112,13 +112,13 @@ public final class IndicesAliasesRequestInterceptor implements RequestIntercepto
                             request,
                             authorizationInfo
                         );
-                        listener.onFailure(
+                        delegate.onFailure(
                             Exceptions.authorizationError(
                                 "Adding an alias is not allowed when the alias " + "has more permissions than any of the indices"
                             )
                         );
                     }
-                }, listener::onFailure), threadContext)
+                }), threadContext)
             );
         } else {
             listener.onResponse(null);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
@@ -75,9 +75,9 @@ public final class ResizeRequestInterceptor implements RequestInterceptor {
                 requestInfo,
                 authorizationInfo,
                 Collections.singletonMap(request.getSourceIndex(), Collections.singletonList(request.getTargetIndexRequest().index())),
-                wrapPreservingContext(ActionListener.wrap(authzResult -> {
+                wrapPreservingContext(listener.delegateFailureAndWrap((delegate, authzResult) -> {
                     if (authzResult.isGranted()) {
-                        listener.onResponse(null);
+                        delegate.onResponse(null);
                     } else {
                         auditTrail.accessDenied(
                             extractRequestId(threadContext),
@@ -86,13 +86,13 @@ public final class ResizeRequestInterceptor implements RequestInterceptor {
                             request,
                             authorizationInfo
                         );
-                        listener.onFailure(
+                        delegate.onFailure(
                             Exceptions.authorizationError(
                                 "Resizing an index is not allowed when the target index " + "has more permissions than the source index"
                             )
                         );
                     }
-                }, listener::onFailure), threadContext)
+                }), threadContext)
             );
         } else {
             listener.onResponse(null);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
@@ -20,9 +20,11 @@ import org.junit.Before;
 import java.util.Collections;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TransportDeleteServiceAccountTokenActionTests extends ESTestCase {
 
@@ -47,6 +49,7 @@ public class TransportDeleteServiceAccountTokenActionTests extends ESTestCase {
         );
         @SuppressWarnings("unchecked")
         final ActionListener<DeleteServiceAccountTokenResponse> listener = mock(ActionListener.class);
+        when(listener.delegateFailureAndWrap(any())).thenCallRealMethod();
         transportDeleteServiceAccountTokenAction.doExecute(mock(Task.class), request, listener);
         verify(serviceAccountService).deleteIndexToken(eq(request), anyActionListener());
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -347,10 +347,10 @@ public class AuthorizationServiceTests extends ESTestCase {
                 fieldPermissionsCache,
                 privilegesStore,
                 RESTRICTED_INDICES,
-                ActionListener.wrap(r -> {
+                listener.delegateFailureAndWrap((l, r) -> {
                     roleCache.put(names, r);
-                    listener.onResponse(r);
-                }, listener::onFailure)
+                    l.onResponse(r);
+                })
             );
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/action/SpatialUsageTransportAction.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/action/SpatialUsageTransportAction.java
@@ -59,7 +59,7 @@ public class SpatialUsageTransportAction extends XPackUsageFeatureTransportActio
         client.execute(
             SpatialStatsAction.INSTANCE,
             statsRequest,
-            ActionListener.wrap(r -> listener.onResponse(new XPackUsageFeatureResponse(new SpatialFeatureSetUsage(r))), listener::onFailure)
+            listener.delegateFailureAndWrap((l, r) -> l.onResponse(new XPackUsageFeatureResponse(new SpatialFeatureSetUsage(r))))
         );
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
@@ -75,9 +75,9 @@ public class PlanExecutor {
     ) {
         metrics.translate();
 
-        newSession(cfg).sqlExecutable(sql, params, wrap(exec -> {
+        newSession(cfg).sqlExecutable(sql, params, listener.delegateFailureAndWrap((delegate, exec) -> {
             if (exec instanceof EsQueryExec e) {
-                listener.onResponse(SourceGenerator.sourceBuilder(e.queryContainer(), cfg.filter(), cfg.pageSize()));
+                delegate.onResponse(SourceGenerator.sourceBuilder(e.queryContainer(), cfg.filter(), cfg.pageSize()));
             }
             // try to provide a better resolution of what failed
             else {
@@ -90,9 +90,9 @@ public class PlanExecutor {
                 } else {
                     message = "Cannot generate a query DSL";
                 }
-                listener.onFailure(new PlanningException(message + ", sql statement: [{}]", sql));
+                delegate.onFailure(new PlanningException(message + ", sql statement: [{}]", sql));
             }
-        }, listener::onFailure));
+        }));
     }
 
     public void sql(SqlConfiguration cfg, String sql, List<SqlTypedParamValue> params, ActionListener<Page> listener) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
@@ -124,17 +124,16 @@ public class SearchHitCursor implements Cursor {
 
         client.search(
             request,
-            ActionListener.wrap(
-                (SearchResponse response) -> handle(
+            listener.delegateFailureAndWrap(
+                (l, response) -> handle(
                     client,
                     response,
                     request.source(),
                     makeRowSet(response),
-                    listener,
+                    l,
                     includeFrozen,
                     allowPartialSearchResults
-                ),
-                listener::onFailure
+                )
             )
         );
     }
@@ -162,11 +161,7 @@ public class SearchHitCursor implements Cursor {
         SearchHitRowSet rowSet = makeRowSet.get();
 
         if (rowSet.hasRemaining() == false) {
-            closePointInTime(
-                client,
-                response.pointInTimeId(),
-                ActionListener.wrap(r -> listener.onResponse(Page.last(rowSet)), listener::onFailure)
-            );
+            closePointInTime(client, response.pointInTimeId(), listener.delegateFailureAndWrap((l, r) -> l.onResponse(Page.last(rowSet))));
         } else {
             updateSearchAfter(hits, source);
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Debug.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Debug.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.ActionListener.wrap;
 
 public class Debug extends Command {
 
@@ -80,11 +79,11 @@ public class Debug extends Command {
     @Override
     public void execute(SqlSession session, ActionListener<Page> listener) {
         switch (type) {
-            case ANALYZED -> session.debugAnalyzedPlan(plan, wrap(i -> handleInfo(i, listener), listener::onFailure));
+            case ANALYZED -> session.debugAnalyzedPlan(plan, listener.delegateFailureAndWrap((l, i) -> handleInfo(i, l)));
             case OPTIMIZED -> session.analyzedPlan(
                 plan,
                 true,
-                wrap(analyzedPlan -> handleInfo(session.optimizer().debugOptimize(analyzedPlan), listener), listener::onFailure)
+                listener.delegateFailureAndWrap((l, analyzedPlan) -> handleInfo(session.optimizer().debugOptimize(analyzedPlan), l))
             );
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
@@ -80,15 +80,16 @@ public class ShowColumns extends Command {
         idx = hasText(cat) && cat.equals(cluster) == false ? buildRemoteIndexName(cat, idx) : idx;
 
         boolean withFrozen = includeFrozen || session.configuration().includeFrozen();
-        session.indexResolver().resolveAsMergedMapping(idx, withFrozen, emptyMap(), ActionListener.wrap(indexResult -> {
-            List<List<?>> rows = emptyList();
-            if (indexResult.isValid()) {
-                rows = new ArrayList<>();
-                Version version = Version.fromId(session.configuration().version().id);
-                fillInRows(IndexCompatibility.compatible(indexResult, version).get().mapping(), null, rows);
-            }
-            listener.onResponse(of(session, rows));
-        }, listener::onFailure));
+        session.indexResolver()
+            .resolveAsMergedMapping(idx, withFrozen, emptyMap(), listener.delegateFailureAndWrap((delegate, indexResult) -> {
+                List<List<?>> rows = emptyList();
+                if (indexResult.isValid()) {
+                    rows = new ArrayList<>();
+                    Version version = Version.fromId(session.configuration().version().id);
+                    fillInRows(IndexCompatibility.compatible(indexResult, version).get().mapping(), null, rows);
+                }
+                delegate.onResponse(of(session, rows));
+            }));
     }
 
     static void fillInRows(Map<String, EsField> mapping, String prefix, List<List<?>> rows) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
@@ -68,14 +68,14 @@ public class ShowTables extends Command {
         boolean withFrozen = session.configuration().includeFrozen() || includeFrozen;
         // to avoid redundancy, indicate whether frozen fields are required by specifying the type
         EnumSet<IndexType> indexType = withFrozen ? IndexType.VALID_INCLUDE_FROZEN : IndexType.VALID_REGULAR;
-        session.indexResolver().resolveNames(cat, idx, regex, indexType, ActionListener.wrap(result -> {
-            listener.onResponse(
+        session.indexResolver().resolveNames(cat, idx, regex, indexType, listener.delegateFailureAndWrap((delegate, result) -> {
+            delegate.onResponse(
                 of(
                     session,
                     result.stream().map(t -> asList(t.cluster(), t.name(), t.type().toSql(), t.type().toNative())).collect(toList())
                 )
             );
-        }, listener::onFailure));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -144,8 +144,8 @@ public class SysTables extends Command {
                 idx,
                 regex,
                 tableTypes,
-                ActionListener.wrap(
-                    result -> listener.onResponse(
+                listener.delegateFailureAndWrap(
+                    (delegate, result) -> delegate.onResponse(
                         of(
                             session,
                             result.stream()
@@ -158,8 +158,7 @@ public class SysTables extends Command {
                                 .map(t -> asList(t.cluster(), null, t.name(), t.type().toSql(), EMPTY, null, null, null, null, null))
                                 .collect(toList())
                         )
-                    ),
-                    listener::onFailure
+                    )
                 )
             );
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/CommandExec.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/CommandExec.java
@@ -17,8 +17,6 @@ import org.elasticsearch.xpack.sql.session.SqlSession;
 import java.util.List;
 import java.util.Objects;
 
-import static org.elasticsearch.action.ActionListener.wrap;
-
 public class CommandExec extends LeafExec {
 
     private final Command command;
@@ -39,7 +37,7 @@ public class CommandExec extends LeafExec {
 
     @Override
     public void execute(SqlSession session, ActionListener<Page> listener) {
-        command.execute(session, wrap(listener::onResponse, listener::onFailure));
+        command.execute(session, listener.delegateFailureAndWrap((l, r) -> l.onResponse(r)));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
@@ -50,7 +50,7 @@ public class TransportSqlClearCursorAction extends HandledTransportAction<SqlCle
         Cursor cursor = Cursors.decodeFromStringWithZone(request.getCursor(), planExecutor.writeableRegistry()).v1();
         planExecutor.cleanCursor(
             cursor,
-            ActionListener.<Boolean>wrap(success -> listener.onResponse(new SqlClearCursorResponse(success)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, success) -> l.onResponse(new SqlClearCursorResponse(success)))
         );
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -182,7 +182,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
             planExecutor.nextPage(
                 cfg,
                 decoded.v1(),
-                wrap(p -> listener.onResponse(createResponse(request, decoded.v2(), null, p, task)), listener::onFailure)
+                listener.delegateFailureAndWrap((l, p) -> l.onResponse(createResponse(request, decoded.v2(), null, p, task)))
             );
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -84,10 +84,7 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
             cfg,
             request.query(),
             request.params(),
-            ActionListener.wrap(
-                searchSourceBuilder -> listener.onResponse(new SqlTranslateResponse(searchSourceBuilder)),
-                listener::onFailure
-            )
+            listener.delegateFailureAndWrap((l, searchSourceBuilder) -> l.onResponse(new SqlTranslateResponse(searchSourceBuilder)))
         );
     }
 }

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
@@ -68,10 +68,7 @@ public class CustomRoleMappingRealm extends Realm implements CachingRealm {
             return;
         }
         if (USERNAME.equals(username)) {
-            buildUser(
-                username,
-                ActionListener.wrap(u -> listener.onResponse(cache.computeIfAbsent(username, k -> u)), listener::onFailure)
-            );
+            buildUser(username, listener.delegateFailureAndWrap((l, u) -> l.onResponse(cache.computeIfAbsent(username, k -> u))));
         } else {
             listener.onResponse(null);
         }
@@ -81,7 +78,7 @@ public class CustomRoleMappingRealm extends Realm implements CachingRealm {
         final UserRoleMapper.UserData data = new UserRoleMapper.UserData(username, null, List.of(USER_GROUP), Map.of(), super.config);
         roleMapper.resolveRoles(
             data,
-            ActionListener.wrap(roles -> listener.onResponse(new User(username, roles.toArray(String[]::new))), listener::onFailure)
+            listener.delegateFailureAndWrap((l, roles) -> l.onResponse(new User(username, roles.toArray(String[]::new))))
         );
     }
 


### PR DESCRIPTION
Replacing more uses of ActionListener.wrap with delegateFailureAndWrap which has better performance through saving many capturing lambdas and redundant method references for `listener::onFailure`.
