### PR TITLE
[DOCS] Adds deployment_id as an option to query_vector_builder

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -357,9 +357,8 @@ the dense vectors from the input data,
 * the text embedding NLP model deployment must be started.
 =====================
 
-Reference the deployed text embedding model (`model_id`) or the model deployment 
-(`deployment_id`) in the `query_vector_builder` object and provide the search 
-query as `model_text`:
+Reference the deployed text embedding model or the model deployment in the 
+`query_vector_builder` object and provide the search query as `model_text`:
 
 [source,js]
 ----
@@ -384,8 +383,8 @@ query as `model_text`:
 <1> The {nlp} task to perform. It must be `text_embedding`.
 <2> The ID of the text embedding model to use to generate the dense vectors from
 the query string. Use the same model that generated the embeddings from the
-input text in the index you search against. You can also use `deployment_id` 
-instead of `model_id`. 
+input text in the index you search against. You can also provide the value of
+the `deployment_id` in the `model_id` argument. 
 <3> The query string from which the model generates the dense vector
 representation.
 

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -357,8 +357,9 @@ the dense vectors from the input data,
 * the text embedding NLP model deployment must be started.
 =====================
 
-Reference the deployed text embedding model in the `query_vector_builder` object
-and provide the search query as `model_text`:
+Reference the deployed text embedding model (`model_id`) or the model deployment 
+(`deployment_id`) in the `query_vector_builder` object and provide the search 
+query as `model_text`:
 
 [source,js]
 ----
@@ -383,7 +384,8 @@ and provide the search query as `model_text`:
 <1> The {nlp} task to perform. It must be `text_embedding`.
 <2> The ID of the text embedding model to use to generate the dense vectors from
 the query string. Use the same model that generated the embeddings from the
-input text in the index you search against.
+input text in the index you search against. You can also use `deployment_id` 
+instead of `model_id`. 
 <3> The query string from which the model generates the dense vector
 representation.
 

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -383,8 +383,8 @@ Reference the deployed text embedding model or the model deployment in the
 <1> The {nlp} task to perform. It must be `text_embedding`.
 <2> The ID of the text embedding model to use to generate the dense vectors from
 the query string. Use the same model that generated the embeddings from the
-input text in the index you search against. You can also provide the value of
-the `deployment_id` in the `model_id` argument. 
+input text in the index you search against. You can use the value of the 
+`deployment_id` instead in the `model_id` argument. 
 <3> The query string from which the model generates the dense vector
 representation.
 


### PR DESCRIPTION
## Overview

This PR mentions that the value of the `deployment_id` can also be referenced in the `model_id` argument of the `query_vector_builder`.