### PR TITLE
Fix string interpolation in StringTemplatePluginTest

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginTest.groovy
@@ -35,12 +35,12 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = ["Type" : "Int", "type" : "int"]
-              it.inputFile = new File(projectDir, "src/main/p/X-Box.java.st")
+              it.inputFile = file("src/main/p/X-Box.java.st")
               it.outputFile = "p/IntBox.java"
             }
             template {
               it.properties = ["Type" : "Long", "type" : "long"]
-              it.inputFile = new File(projectDir, "src/main/p/X-Box.java.st")
+              it.inputFile = file("src/main/p/X-Box.java.st")
               it.outputFile = "p/LongBox.java"
             }
           }
@@ -90,7 +90,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = ["Red" : "true", "Blue" : "", "Green" : "true"]
-              it.inputFile = new File(projectDir, "src/main/Color.txt.st")
+              it.inputFile = file("src/main/Color.txt.st")
               it.outputFile = "Color.txt"
             }
           }
@@ -126,7 +126,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = [:] // no properties
-              it.inputFile = new File(projectDir, "src/main/Token.txt.st")
+              it.inputFile = file("src/main/Token.txt.st")
               it.outputFile = "Token.txt"
             }
           }
@@ -162,7 +162,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = [:] // no properties
-              it.inputFile = new File(projectDir, "src/main/UpToDate.txt.st")
+              it.inputFile = file("src/main/UpToDate.txt.st")
               it.outputFile = "UpToDate.txt"
             }
           }
@@ -198,7 +198,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = [:] // no properties
-              it.inputFile = new File(projectDir, "src/main/Message.txt.st")
+              it.inputFile = file("src/main/Message.txt.st")
               it.outputFile = "Message.txt"
             }
           }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginTest.groovy
@@ -35,12 +35,12 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = ["Type" : "Int", "type" : "int"]
-              it.inputFile = new File("${projectDir}/src/main/p/X-Box.java.st")
+              it.inputFile = new File(projectDir, "src/main/p/X-Box.java.st")
               it.outputFile = "p/IntBox.java"
             }
             template {
               it.properties = ["Type" : "Long", "type" : "long"]
-              it.inputFile = new File("${projectDir}/src/main/p/X-Box.java.st")
+              it.inputFile = new File(projectDir, "src/main/p/X-Box.java.st")
               it.outputFile = "p/LongBox.java"
             }
           }
@@ -90,7 +90,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = ["Red" : "true", "Blue" : "", "Green" : "true"]
-              it.inputFile = new File("${projectDir}/src/main/Color.txt.st")
+              it.inputFile = new File(projectDir, "src/main/Color.txt.st")
               it.outputFile = "Color.txt"
             }
           }
@@ -126,7 +126,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = [:] // no properties
-              it.inputFile = new File("${projectDir}/src/main/Token.txt.st")
+              it.inputFile = new File(projectDir, "src/main/Token.txt.st")
               it.outputFile = "Token.txt"
             }
           }
@@ -162,7 +162,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = [:] // no properties
-              it.inputFile = new File("${projectDir}/src/main/UpToDate.txt.st")
+              it.inputFile = new File(projectDir, "src/main/UpToDate.txt.st")
               it.outputFile = "UpToDate.txt"
             }
           }
@@ -198,7 +198,7 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
           tasks.named("stringTemplates").configure {
             template {
               it.properties = [:] // no properties
-              it.inputFile = new File("${projectDir}/src/main/Message.txt.st")
+              it.inputFile = new File(projectDir, "src/main/Message.txt.st")
               it.outputFile = "Message.txt"
             }
           }


### PR DESCRIPTION
This commit rearranges the string interpolation in StringTemplatePluginTest, which is problematic on Windows.

closes #97494