### PR TITLE
Add Setting to optionally use mmap for shared cache IO

### DIFF
--- a/docs/changelog/97581.yaml
+++ b/docs/changelog/97581.yaml
@@ -1,0 +1,5 @@
+pr: 97581
+summary: Add Setting to optionally use mmap for shared cache IO
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
@@ -25,7 +25,8 @@ public class BlobCachePlugin extends Plugin implements ExtensiblePlugin {
             SharedBlobCacheService.SHARED_CACHE_RECOVERY_RANGE_SIZE_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING,
             SharedBlobCacheService.SHARED_CACHE_DECAY_INTERVAL_SETTING,
-            SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING
+            SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING,
+            SharedBlobCacheService.SHARED_CACHE_MMAP
         );
     }
 }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -237,6 +237,12 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         Setting.Property.NodeScope
     );
 
+    public static final Setting<Boolean> SHARED_CACHE_MMAP = Setting.boolSetting(
+        SHARED_CACHE_SETTINGS_PREFIX + "mmap",
+        false,
+        Setting.Property.NodeScope
+    );
+
     private static final Logger logger = LogManager.getLogger(SharedBlobCacheService.class);
 
     private final ConcurrentHashMap<RegionKey<KeyType>, Entry<CacheFileRegion>> keyMapping;
@@ -300,7 +306,14 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         this.minTimeDelta = SHARED_CACHE_MIN_TIME_DELTA_SETTING.get(settings).millis();
         freqs = new Entry[maxFreq];
         try {
-            sharedBytes = new SharedBytes(numRegions, regionSize, environment, writeBytes::add, readBytes::add);
+            sharedBytes = new SharedBytes(
+                numRegions,
+                regionSize,
+                environment,
+                writeBytes::add,
+                readBytes::add,
+                SHARED_CACHE_MMAP.get(settings)
+            );
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -300,7 +300,6 @@ public class SharedBytes extends AbstractRefCounted {
             if (mmap) {
                 bytesWritten = src.remaining();
                 mappedByteBuffer.put(Math.toIntExact(position - pageStart), src, src.position(), bytesWritten);
-                mappedByteBuffer.force();
                 src.position(src.position() + bytesWritten);
             } else {
                 bytesWritten = fileChannel.write(src, position);

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -23,6 +23,7 @@ import org.elasticsearch.preallocate.Preallocate;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,7 +67,9 @@ public class SharedBytes extends AbstractRefCounted {
     private final IntConsumer writeBytes;
     private final IntConsumer readBytes;
 
-    SharedBytes(int numRegions, long regionSize, NodeEnvironment environment, IntConsumer writeBytes, IntConsumer readBytes)
+    private final boolean mmap;
+
+    SharedBytes(int numRegions, long regionSize, NodeEnvironment environment, IntConsumer writeBytes, IntConsumer readBytes, boolean mmap)
         throws IOException {
         this.numRegions = numRegions;
         this.regionSize = regionSize;
@@ -84,9 +87,21 @@ public class SharedBytes extends AbstractRefCounted {
             }
         }
         this.path = cacheFile;
+        this.mmap = mmap;
         this.ios = new IO[numRegions];
+        if (mmap) {
+            int regionsPerMmap = Math.toIntExact(ByteSizeValue.ofGb(1).getBytes() / regionSize);
+            int mapSize = Math.toIntExact(regionsPerMmap * regionSize);
+            for (int i = 0; i < ; i++) {
+
+            }
+            fileChannel.map(FileChannel.MapMode.READ_WRITE, pageStart, regionSize)
+        }
         for (int i = 0; i < numRegions; i++) {
-            ios[i] = new IO(i);
+            ios[i] = new IO(i, null);
+        }
+        if (mmap) {
+            fileChannel.close();
         }
         this.writeBytes = writeBytes;
         this.readBytes = readBytes;
@@ -238,14 +253,25 @@ public class SharedBytes extends AbstractRefCounted {
 
         private final long pageStart;
 
-        private IO(final int sharedBytesPos) {
+        private final MappedByteBuffer mappedByteBuffer;
+
+        private IO(final int sharedBytesPos, MappedByteBuffer mappedByteBuffer) {
             pageStart = getPhysicalOffset(sharedBytesPos);
+            this.mappedByteBuffer = mappedByteBuffer;
         }
 
         @SuppressForbidden(reason = "Use positional reads on purpose")
         public int read(ByteBuffer dst, long position) throws IOException {
             checkOffsets(position, dst.remaining());
-            final int bytesRead = fileChannel.read(dst, position);
+            final int bytesRead;
+            if (mmap) {
+                bytesRead = dst.remaining();
+                int startPosition = dst.position();
+                dst.put(startPosition, mappedByteBuffer, Math.toIntExact(position - pageStart), bytesRead)
+                    .position(startPosition + bytesRead);
+            } else {
+                bytesRead = fileChannel.read(dst, position);
+            }
             readBytes.accept(bytesRead);
             return bytesRead;
         }
@@ -256,7 +282,15 @@ public class SharedBytes extends AbstractRefCounted {
             assert position % PAGE_SIZE == 0;
             assert src.remaining() % PAGE_SIZE == 0;
             checkOffsets(position, src.remaining());
-            final int bytesWritten = fileChannel.write(src, position);
+            final int bytesWritten;
+            if (mmap) {
+                bytesWritten = src.remaining();
+                mappedByteBuffer.put(Math.toIntExact(position - pageStart), src, src.position(), bytesWritten);
+                mappedByteBuffer.force();
+                src.position(src.position() + bytesWritten);
+            } else {
+                bytesWritten = fileChannel.write(src, position);
+            }
             writeBytes.accept(bytesWritten);
             return bytesWritten;
         }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
@@ -31,7 +31,8 @@ public class SharedBytesTests extends ESTestCase {
                 randomIntBetween(1, 16) * 4096L,
                 nodeEnv,
                 ignored -> {},
-                ignored -> {}
+                ignored -> {},
+                randomBoolean()
             );
             final var sharedBytesPath = nodeEnv.nodeDataPaths()[0].resolve("shared_snapshot_cache");
             assertTrue(Files.exists(sharedBytesPath));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseFrozenSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseFrozenSearchableSnapshotsIntegTestCase.java
@@ -32,7 +32,7 @@ public abstract class BaseFrozenSearchableSnapshotsIntegTestCase extends BaseSea
                         : new ByteSizeValue(randomIntBetween(1, 1000), ByteSizeUnit.BYTES).getStringRep()
                     : randomBoolean() ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB).getStringRep()
                     : new RatioValue(randomDoubleBetween(0.0d, 0.1d, false)).toString() // only use up to 0.1% disk to be friendly.
-            );
+            ).put(SharedBlobCacheService.SHARED_CACHE_MMAP.getKey(), randomBoolean());
         }
 
         return builder.build();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -86,6 +86,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
             .put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), rangeSize)
             .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
+            .put(SharedBlobCacheService.SHARED_CACHE_MMAP.getKey(), randomBoolean())
             .put("path.home", createTempDir())
             .build();
         final Environment environment = TestEnvironment.newEnvironment(settings);


### PR DESCRIPTION
Relatively crude but working implementation that allows access to the shared bytes using mmap for both reads and writes. This only deals with the IO side of things and does not yet using the memory map directly in the index inputs, so it's still doing more reads and memory copy than necessary through the buffered index input.
It's still interesting to use this for benchmarking early on and getting an understanding of how mmap will start to behave under the levels of concurrency and throughput that we are looking to subject the cache to.

Splits the cache file in 1GB maps (could do larger on newer JVMs but doesn't really matter much I think) and manually dispatches to either the `mmap` or `pread` implementations according to the flag (for 2 implementations this is apparently faster than bimorphic dispatch but it doesn't matter much).

The code is unchanged so long as the mmap setting isn't used except for a tiny bit of extra overhead from checking the boolean flag and some code size increases, so I think we could merge this to `main` to enable using it downstream in experiments and just leave the setting undocumented without worrying to much about the safety of this for the time being. This does pass all tests in a hot loop though on both OSX and Linux, ran them for 1h+ :)