### PR TITLE
Allow test clusters to specify additional jvm arguments

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterSpecBuilder.java
@@ -161,6 +161,7 @@ public abstract class AbstractLocalClusterSpecBuilder<T extends ElasticsearchClu
                 getKeystorePassword(),
                 getExtraConfigFiles(),
                 getSystemProperties(),
+                getJvmArgs(),
                 getSecrets()
             );
         }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -38,6 +38,7 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
     private final Map<String, Resource> keystoreFiles = new HashMap<>();
     private final Map<String, Resource> extraConfigFiles = new HashMap<>();
     private final Map<String, String> systemProperties = new HashMap<>();
+    private final List<String> jvmArgs = new ArrayList<>();
     private final Map<String, String> secrets = new HashMap<>();
     private DistributionType distributionType;
     private Version version;
@@ -216,6 +217,16 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
 
     public Map<String, String> getSystemProperties() {
         return inherit(() -> parent.getSystemProperties(), systemProperties);
+    }
+
+    @Override
+    public T jvmArg(String arg) {
+        this.jvmArgs.add(arg);
+        return cast(this);
+    }
+
+    public List<String> getJvmArgs() {
+        return inherit(() -> parent.getJvmArgs(), jvmArgs);
     }
 
     @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -635,6 +635,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                     .map(p -> p.replace("${ES_PATH_CONF}", configDir.toString()))
                     .collect(Collectors.joining(" "));
             }
+            String jvmArgs = String.join(" ", spec.getJvmArgs());
 
             String debugArgs = "";
             if (Boolean.getBoolean(TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP)) {
@@ -649,6 +650,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 + " "
                 + featureFlagProperties
                 + systemProperties
+                + jvmArgs
                 + debugArgs);
 
             return environment;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -83,6 +83,7 @@ public class LocalClusterSpec implements ClusterSpec {
         private final String keystorePassword;
         private final Map<String, Resource> extraConfigFiles;
         private final Map<String, String> systemProperties;
+        private final List<String> jvmArgs;
         private final Map<String, String> secrets;
         private Version version;
 
@@ -104,6 +105,7 @@ public class LocalClusterSpec implements ClusterSpec {
             String keystorePassword,
             Map<String, Resource> extraConfigFiles,
             Map<String, String> systemProperties,
+            List<String> jvmArgs,
             Map<String, String> secrets
         ) {
             this.cluster = cluster;
@@ -123,6 +125,7 @@ public class LocalClusterSpec implements ClusterSpec {
             this.keystorePassword = keystorePassword;
             this.extraConfigFiles = extraConfigFiles;
             this.systemProperties = systemProperties;
+            this.jvmArgs = jvmArgs;
             this.secrets = secrets;
         }
 
@@ -180,6 +183,10 @@ public class LocalClusterSpec implements ClusterSpec {
 
         public Map<String, String> getSystemProperties() {
             return systemProperties;
+        }
+
+        public List<String> getJvmArgs() {
+            return jvmArgs;
         }
 
         public Map<String, String> getSecrets() {
@@ -299,6 +306,7 @@ public class LocalClusterSpec implements ClusterSpec {
                         n.keystorePassword,
                         n.extraConfigFiles,
                         n.systemProperties,
+                        n.jvmArgs,
                         n.secrets
                     )
                 )

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
@@ -126,4 +126,9 @@ interface LocalSpecBuilder<T extends LocalSpecBuilder<?>> {
      * Adds a system property to node JVM arguments.
      */
     T systemProperty(String property, String value);
+
+    /**
+     * Adds an additional command line argument to node JVM arguments.
+     */
+    T jvmArg(String arg);
 }


### PR DESCRIPTION
Somet special tests like die-with-dignity need to pass additional jvm arguments (exit on OOM). This commit adds a new jvmArg to the cluster spec for the new test clusters infra.