### PR TITLE
Expose pid in new test clusters

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -72,6 +72,11 @@ public interface ClusterHandle extends Closeable {
     String getName(int index);
 
     /**
+     * Get the pid of the node for the given index.
+     */
+    long getPid(int index);
+
+    /**
      * Returns a comma-separated list of TCP transport endpoints for cluster. If this method is called on an unstarted cluster, the cluster
      * will be started. This method is thread-safe and subsequent calls will wait for cluster start and availability.
      *

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
@@ -96,6 +96,12 @@ public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends Cluste
     }
 
     @Override
+    public long getPid(int index) {
+        checkHandle();
+        return handle.getPid(index);
+    }
+
+    @Override
     public String getTransportEndpoints() {
         checkHandle();
         return handle.getTransportEndpoints();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -222,7 +222,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             return name;
         }
 
-        long getPid() {
+        public long getPid() {
             if (process == null) {
                 throw new IllegalStateException("Process has not been started, cannot get pid");
             }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -222,6 +222,13 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             return name;
         }
 
+        long getPid() {
+            if (process == null) {
+                throw new IllegalStateException("Process has not been started, cannot get pid");
+            }
+            return process.pid();
+        }
+
         public LocalNodeSpec getSpec() {
             return spec;
         }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -160,6 +160,11 @@ public class LocalClusterHandle implements ClusterHandle {
         return nodes.get(index).getName();
     }
 
+    @Override
+    public long getPid(int index) {
+        return nodes.get(index).getPid();
+    }
+
     public void stopNode(int index) {
         nodes.get(index).stop(false);
     }


### PR DESCRIPTION
Sometimes it is necessary for an integ test to poke at the Java process of Elasticsearch. This commit makes a node's pid available through ClusterHandle.