### PR TITLE
Changing watcher to disable cookies in shared http client

### DIFF
--- a/docs/changelog/97591.yaml
+++ b/docs/changelog/97591.yaml
@@ -1,0 +1,5 @@
+pr: 97591
+summary: Changing watcher to disable cookies in shared http client
+area: Watcher
+type: bug
+issues: []

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -137,7 +137,7 @@ public class HttpClient implements Closeable {
         clientBuilder.setMaxConnTotal(MAX_CONNECTIONS);
         /*
          * This client will potentially be used by multiple users. We do not want it to keep any state like cookies, because that will
-         * result in that state unexpectedlky being shared across all users.
+         * result in that state unexpectedly being shared across all users.
          */
         clientBuilder.disableCookieManagement();
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -135,6 +135,12 @@ public class HttpClient implements Closeable {
         clientBuilder.evictExpiredConnections();
         clientBuilder.setMaxConnPerRoute(MAX_CONNECTIONS);
         clientBuilder.setMaxConnTotal(MAX_CONNECTIONS);
+        /*
+         * This client will potentially be used by multiple users. We do not want it to keep any state like cookies, because that will
+         * result in that state unexpectedlky being shared across all users.
+         */
+        clientBuilder.disableCookieManagement();
+
         clientBuilder.setRedirectStrategy(new DefaultRedirectStrategy() {
             @Override
             public boolean isRedirected(org.apache.http.HttpRequest request, org.apache.http.HttpResponse response, HttpContext context)


### PR DESCRIPTION
Watcher uses a single apache http client to make all outgoing connections. This client is shared by any user of the watcher API, as well as scheduled watches. Currently this client supports cookies. A cookie set for one user will be shared by all users. Watcher is meant to be used with stateless http requests, so cookies don't offer any advantage. But it could cause problems if they are shared across users.