### PR TITLE
Enable dlm feature flag in data stream tests

### DIFF
--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -53,7 +53,16 @@ if (BuildParams.inFipsJvm){
 }
 
 if (BuildParams.isSnapshotBuild() == false) {
+  tasks.named("test").configure {
+    systemProperty 'es.dlm_feature_flag_enabled', 'true'
+  }
   tasks.named("internalClusterTest").configure {
+    systemProperty 'es.dlm_feature_flag_enabled', 'true'
+  }
+  tasks.named("yamlRestTest").configure {
+    systemProperty 'es.dlm_feature_flag_enabled', 'true'
+  }
+  tasks.named("javaRestTest").configure {
     systemProperty 'es.dlm_feature_flag_enabled', 'true'
   }
 }


### PR DESCRIPTION
When we move the data stream lifecycle code from the `dlm` module to the `data-streams` one (https://github.com/elastic/elasticsearch/pull/97345/files#diff-ae6caffc7a2ab209609293083f2fef0e80c453c21556bb7a703cb7013a4bdda4), we forgot to enable the feature flag for all the tests. 

This PR fixes it and consequently fixes #97570

Closes: #97570