### PR TITLE
Makes lineal the calculation of IndicesQueryCache

### DIFF
--- a/docs/changelog/97600.yaml
+++ b/docs/changelog/97600.yaml
@@ -1,0 +1,6 @@
+pr: 97600
+summary: Makes lineal the calculation of `IndicesQueryCache`
+area: Stats
+type: bug
+issues:
+ - 97222

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -198,6 +198,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();
+        var queryCacheStatsMemoized = new CommonStats.QueryCacheStatsMemoized(indicesService.getIndicesQueryCache());
+
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {
                 cancellableTask.ensureNotCancelled();
@@ -220,7 +222,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                         new ShardStats(
                             indexShard.routingEntry(),
                             indexShard.shardPath(),
-                            CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, SHARD_STATS_FLAGS),
+                            CommonStats.getShardLevelStats(queryCacheStatsMemoized, indexShard, SHARD_STATS_FLAGS),
                             commitStats,
                             seqNoStats,
                             retentionLeaseStats,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -220,10 +220,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                         new ShardStats(
                             indexShard.routingEntry(),
                             indexShard.shardPath(),
-                            CommonStats.getShardLevelStats(
-                                () -> indicesService.getIndicesQueryCache().getStats(indexShard.shardId()),
-//                                indicesService.getIndicesQueryCache(),
-                                indexShard, SHARD_STATS_FLAGS),
+                            CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, SHARD_STATS_FLAGS),
                             commitStats,
                             seqNoStats,
                             retentionLeaseStats,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -220,7 +220,10 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                         new ShardStats(
                             indexShard.routingEntry(),
                             indexShard.shardPath(),
-                            CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, SHARD_STATS_FLAGS),
+                            CommonStats.getShardLevelStats(
+                                () -> indicesService.getIndicesQueryCache().getStats(indexShard.shardId()),
+//                                indicesService.getIndicesQueryCache(),
+                                indexShard, SHARD_STATS_FLAGS),
                             commitStats,
                             seqNoStats,
                             retentionLeaseStats,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.shard.ShardCountStats;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.index.warmer.WarmerStats;
+import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentFragment;
@@ -140,6 +141,10 @@ public class CommonStats implements Writeable, ToXContentFragment {
     /**
      * Filters the given flags for {@link CommonStatsFlags#SHARD_LEVEL} flags and calculates the corresponding statistics.
      */
+    public static CommonStats getShardLevelStats(IndicesQueryCache indicesQueryCache, IndexShard indexShard, CommonStatsFlags flags) {
+        return getShardLevelStats(() -> indicesQueryCache.getStats(indexShard.shardId()), indexShard, flags);
+    }
+
     public static CommonStats getShardLevelStats(
         Supplier<QueryCacheStats> queryCacheStatsSupplier,
         IndexShard indexShard,
@@ -164,7 +169,6 @@ public class CommonStats implements Writeable, ToXContentFragment {
                     case Refresh -> stats.refresh = indexShard.refreshStats();
                     case Flush -> stats.flush = indexShard.flushStats();
                     case Warmer -> stats.warmer = indexShard.warmerStats();
-                    // case QueryCache -> stats.queryCache = indicesQueryCache.getStats(indexShard.shardId());
                     case QueryCache -> stats.queryCache = queryCacheStatsSupplier.get();
                     case FieldData -> stats.fieldData = indexShard.fieldDataStats(flags.fieldDataFields());
                     case Completion -> stats.completion = indexShard.completionStats(flags.completionDataFields());

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -109,7 +109,10 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             assert task instanceof CancellableTask;
             IndexService indexService = indicesService.indexServiceSafe(shardRouting.shardId().getIndex());
             IndexShard indexShard = indexService.getShard(shardRouting.shardId().id());
-            CommonStats commonStats = CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, request.flags());
+            CommonStats commonStats = CommonStats.getShardLevelStats(
+                () -> indicesService.getIndicesQueryCache().getStats(indexShard.shardId()),
+//                indicesService.getIndicesQueryCache(),
+                indexShard, request.flags());
             CommitStats commitStats;
             SeqNoStats seqNoStats;
             RetentionLeaseStats retentionLeaseStats;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -109,10 +109,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             assert task instanceof CancellableTask;
             IndexService indexService = indicesService.indexServiceSafe(shardRouting.shardId().getIndex());
             IndexShard indexShard = indexService.getShard(shardRouting.shardId().id());
-            CommonStats commonStats = CommonStats.getShardLevelStats(
-                () -> indicesService.getIndicesQueryCache().getStats(indexShard.shardId()),
-//                indicesService.getIndicesQueryCache(),
-                indexShard, request.flags());
+            CommonStats commonStats = CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, request.flags());
             CommitStats commitStats;
             SeqNoStats seqNoStats;
             RetentionLeaseStats retentionLeaseStats;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -109,7 +109,11 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             assert task instanceof CancellableTask;
             IndexService indexService = indicesService.indexServiceSafe(shardRouting.shardId().getIndex());
             IndexShard indexShard = indexService.getShard(shardRouting.shardId().id());
-            CommonStats commonStats = CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, request.flags());
+            CommonStats commonStats = CommonStats.getShardLevelStats(
+                new CommonStats.QueryCacheStatsMemoized(indicesService.getIndicesQueryCache()),
+                indexShard,
+                request.flags()
+            );
             CommitStats commitStats;
             SeqNoStats seqNoStats;
             RetentionLeaseStats retentionLeaseStats;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -100,7 +100,7 @@ public class IndicesQueryCache implements QueryCache, Closeable {
             stats.put(entry.getKey(), stat);
         }
 
-        for (var entry: stats.entrySet()) {
+        for (var entry : stats.entrySet()) {
             final var shardStats = entry.getValue();
             final var weight = totalSize == 0 ? 1d / stats.size() : ((double) shardStats.getCacheSize()) / totalSize;
             final var additionalRamBytesUsed = Math.round(weight * sharedRamBytesUsed);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -537,7 +537,11 @@ public class IndicesService extends AbstractLifecycleComponent
                 new ShardStats(
                     indexShard.routingEntry(),
                     indexShard.shardPath(),
-                    CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, flags),
+                    CommonStats.getShardLevelStats(
+                        () -> indicesService.getIndicesQueryCache().getStats(indexShard.shardId()),
+//                        indicesService.getIndicesQueryCache(),
+                        indexShard,
+                        flags),
                     commitStats,
                     seqNoStats,
                     retentionLeaseStats,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -114,7 +114,7 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
         ShardStats shardStats = new ShardStats(
             shardRouting,
             new ShardPath(false, path, path, shardRouting.shardId()),
-            CommonStats.getShardLevelStats(null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store)),
+            CommonStats.getShardLevelStats(() -> null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store)),
             null,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -114,7 +114,7 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
         ShardStats shardStats = new ShardStats(
             shardRouting,
             new ShardPath(false, path, path, shardRouting.shardId()),
-            CommonStats.getShardLevelStats(() -> null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store)),
+            CommonStats.getShardLevelStats(null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store)),
             null,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/stats/CommonStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/stats/CommonStatsTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.indices.stats;
+
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesQueryCache;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CommonStatsTests extends ESTestCase {
+
+    public void testQueryCacheStatsCalculatorIsLazilyInitialized() {
+        var mockedIndicesQueryCache = mock(IndicesQueryCache.class);
+        var queryCacheStatsMemoized = new CommonStats.QueryCacheStatsMemoized(mockedIndicesQueryCache);
+
+        for (int i = 0; i < randomIntBetween(2, 1000); i++) {
+            queryCacheStatsMemoized.get(new ShardId(randomAlphaOfLength(5), randomAlphaOfLength(5), randomIntBetween(1, 100)));
+        }
+
+        verify(mockedIndicesQueryCache, times(1)).getGeneralStats();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -72,7 +72,6 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
@@ -110,6 +109,7 @@ import org.elasticsearch.index.store.StoreUtils;
 import org.elasticsearch.index.translog.TestTranslog;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogStats;
+import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
@@ -1611,7 +1611,11 @@ public class IndexShardTests extends IndexShardTestCase {
         ShardStats stats = new ShardStats(
             shard.routingEntry(),
             shard.shardPath(),
-            CommonStats.getShardLevelStats(QueryCacheStats::new, shard, new CommonStatsFlags()),
+            CommonStats.getShardLevelStats(
+                new CommonStats.QueryCacheStatsMemoized(new IndicesQueryCache(Settings.EMPTY)),
+                shard,
+                new CommonStatsFlags()
+            ),
             shard.commitStats(),
             shard.seqNoStats(),
             shard.getRetentionLeaseStats(),

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -72,6 +72,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
@@ -109,7 +110,6 @@ import org.elasticsearch.index.store.StoreUtils;
 import org.elasticsearch.index.translog.TestTranslog;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogStats;
-import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
@@ -1611,7 +1611,9 @@ public class IndexShardTests extends IndexShardTestCase {
         ShardStats stats = new ShardStats(
             shard.routingEntry(),
             shard.shardPath(),
-            CommonStats.getShardLevelStats(new IndicesQueryCache(Settings.EMPTY), shard, new CommonStatsFlags()),
+            CommonStats.getShardLevelStats(QueryCacheStats::new,
+//                new IndicesQueryCache(Settings.EMPTY),
+                shard, new CommonStatsFlags()),
             shard.commitStats(),
             shard.seqNoStats(),
             shard.getRetentionLeaseStats(),

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1611,9 +1611,7 @@ public class IndexShardTests extends IndexShardTestCase {
         ShardStats stats = new ShardStats(
             shard.routingEntry(),
             shard.shardPath(),
-            CommonStats.getShardLevelStats(QueryCacheStats::new,
-//                new IndicesQueryCache(Settings.EMPTY),
-                shard, new CommonStatsFlags()),
+            CommonStats.getShardLevelStats(QueryCacheStats::new, shard, new CommonStatsFlags()),
             shard.commitStats(),
             shard.seqNoStats(),
             shard.getRetentionLeaseStats(),

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -529,6 +529,8 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         final IndicesService mockIndicesService = mock(IndicesService.class);
         final IndexService indexService = mock(IndexService.class);
 
+        when(mockIndicesService.getIndicesQueryCache()).thenReturn(mock(IndicesQueryCache.class));
+
         // generate fake shards and their responses
         for (int i = 0; i < shardCount; ++i) {
             final IndexShard shard = mock(IndexShard.class);

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -91,6 +91,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -538,18 +540,15 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
 
                 shardStats.add(successfulShardStats);
 
-                when(mockIndicesService.indexShardStats(mockIndicesService, shard, CommonStatsFlags.ALL)).thenReturn(successfulShardStats);
+                when(mockIndicesService.indexShardStats(any(), eq(shard), eq(CommonStatsFlags.ALL))).thenReturn(successfulShardStats);
             } else {
-                when(mockIndicesService.indexShardStats(mockIndicesService, shard, CommonStatsFlags.ALL)).thenThrow(expectedException);
+                when(mockIndicesService.indexShardStats(any(), eq(shard), eq(CommonStatsFlags.ALL))).thenThrow(expectedException);
             }
         }
 
         when(mockIndicesService.iterator()).thenReturn(Collections.singleton(indexService).iterator());
         when(indexService.iterator()).thenReturn(shards.iterator());
         when(indexService.index()).thenReturn(index);
-
-        // real one, which has a logger defined
-        final IndicesService indicesService = getIndicesService();
 
         final Map<Index, List<IndexShardStats>> indexStats = IndicesService.statsByShard(mockIndicesService, CommonStatsFlags.ALL);
 


### PR DESCRIPTION
As per #97222, the calculation of `IndicesQueryCache` is computationally expensive due to some internal loops. Reading the current code, it'd be hard to simplify the calculation, without a big refactor. This is a ~sad and hacky~ attempt to give a solution to the current situation (Draft PR 😉), so users won't be affected by this `O(n^2)` loop.

~In strange case that this solution suffices in the short term, we can apply the same idea to the following classes, which are still using the old approach [TransportClusterStatsAction.java](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java) & [TransportClusterStatsAction.java](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java)~ Last night, in a dream, I came up with his `memoized` solution, which I applied to these 2 classes.

closes #97222