### PR TITLE
Remove refresh_interval from default behavioral analytics event data streams settings.

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-settings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-settings.json
@@ -6,7 +6,6 @@
           "name": "behavioral_analytics-events-default_policy"
         },
         "codec": "best_compression",
-        "refresh_interval": "1s",
         "number_of_shards": 1,
         "number_of_replicas": 0,
         "auto_expand_replicas": "0-1",


### PR DESCRIPTION
Using the cluster default value instead of enforcing it into the templates.