### PR TITLE
Remove "use stateless" feature flag

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -48,20 +48,13 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
 
     /**
      * Check if {@link #STATELESS_ENABLED_SETTING_NAME} is present and set to {@code true}, indicating that the node is
-     * part of a stateless deployment. When no settings are provided this method falls back to the value of the stateless feature flag;
-     * this is convenient for testing purpose as well as all behaviors that rely on node roles to be enabled/disabled by default when no
-     * settings are provided.
+     * part of a stateless deployment.
      *
      * @param settings the node settings
      * @return true if {@link #STATELESS_ENABLED_SETTING_NAME} is present and set
      */
     public static boolean isStateless(final Settings settings) {
-        if (settings.isEmpty() == false) {
-            return settings.getAsBoolean(STATELESS_ENABLED_SETTING_NAME, false);
-        } else {
-            // Fallback on stateless feature flag when no settings are provided
-            return DiscoveryNodeRole.hasStatelessFeatureFlag();
-        }
+        return settings.getAsBoolean(STATELESS_ENABLED_SETTING_NAME, false);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -29,20 +29,6 @@ import java.util.stream.Collectors;
 public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
 
     /**
-     * A feature flag to indicate if stateless is available or not. This is useful to enable stateless specific behavior like node roles
-     * enabled by default. Defaults to false.
-     */
-    private static final String USE_STATELESS_SYSTEM_PROPERTY = "es.use_stateless";
-    private static final Boolean USE_STATELESS_FEATURE_FLAG;
-    static {
-        final Boolean useStateless = Booleans.parseBoolean(System.getProperty(USE_STATELESS_SYSTEM_PROPERTY), false);
-        if (useStateless && Build.current().isSnapshot() == false) {
-            throw new IllegalArgumentException("Enabling stateless usage is only supported in snapshot builds");
-        }
-        USE_STATELESS_FEATURE_FLAG = useStateless;
-    }
-
-    /**
      * A feature flag to indicate if serverless is available or not. Defaults to false.
      */
     private static final String USE_SERVERLESS_SYSTEM_PROPERTY = "es.serverless";
@@ -176,11 +162,6 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         public boolean isEnabledByDefault(Settings settings) {
             return DiscoveryNode.isStateless(settings) == false;
         }
-
-        @Override
-        public void validateRoles(List<DiscoveryNodeRole> roles) {
-            ensureNoStatelessFeatureFlag(this);
-        }
     };
 
     /**
@@ -191,11 +172,6 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         @Override
         public boolean isEnabledByDefault(final Settings settings) {
             return DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE);
-        }
-
-        @Override
-        public void validateRoles(List<DiscoveryNodeRole> roles) {
-            ensureNoStatelessFeatureFlag(this);
         }
     };
 
@@ -208,11 +184,6 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         public boolean isEnabledByDefault(final Settings settings) {
             return DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE);
         }
-
-        @Override
-        public void validateRoles(List<DiscoveryNodeRole> roles) {
-            ensureNoStatelessFeatureFlag(this);
-        }
     };
 
     /**
@@ -223,11 +194,6 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         @Override
         public boolean isEnabledByDefault(final Settings settings) {
             return DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE);
-        }
-
-        @Override
-        public void validateRoles(List<DiscoveryNodeRole> roles) {
-            ensureNoStatelessFeatureFlag(this);
         }
     };
 
@@ -240,11 +206,6 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         public boolean isEnabledByDefault(final Settings settings) {
             return DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE);
         }
-
-        @Override
-        public void validateRoles(List<DiscoveryNodeRole> roles) {
-            ensureNoStatelessFeatureFlag(this);
-        }
     };
 
     /**
@@ -255,11 +216,6 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         @Override
         public boolean isEnabledByDefault(final Settings settings) {
             return DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE);
-        }
-
-        @Override
-        public void validateRoles(List<DiscoveryNodeRole> roles) {
-            ensureNoStatelessFeatureFlag(this);
         }
     };
 
@@ -416,17 +372,7 @@ public class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole> {
         return maybeGetRoleFromRoleName(roleName).orElseThrow(() -> new IllegalArgumentException("unknown role [" + roleName + "]"));
     }
 
-    public static boolean hasStatelessFeatureFlag() {
-        return USE_STATELESS_FEATURE_FLAG;
-    }
-
     public static boolean hasServerlessFeatureFlag() {
         return USE_SERVERLESS_FEATURE_FLAG;
-    }
-
-    private static void ensureNoStatelessFeatureFlag(DiscoveryNodeRole role) {
-        if (hasStatelessFeatureFlag()) {
-            throw new IllegalArgumentException("Role [" + role.roleName() + "] is only supported on non-stateless deployments");
-        }
     }
 }


### PR DESCRIPTION
This feature flag was introduced in the early days of stateless to enable different default node roles (legacy ones like data, data_content  or stateless ones) in tests/runs in case no explicit roles were set. At the time we had no decision on how things would be integrated, so we port over this flag in Elasticsearch.

It's been unused for quite some time now and it's confusing, so let's remove this. Stateless code already ensure that legacy node roles are not set when stateless is enabled.

