### PR TITLE
Test fix, ensure watcher history is green before searching

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -61,14 +61,11 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
             )
             .get();
         assertThat(putWatchResponse.isCreated(), is(true));
+        ensureGreen(".watcher-history*");
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(".watcher-history*").get();
+        assertThat(refreshResponse.getStatus(), equalTo(RestStatus.OK));
 
         assertBusy(() -> {
-            RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(".watcher-history*").get();
-            assertThat(refreshResponse.getStatus(), equalTo(RestStatus.OK));
-            if (refreshResponse.getShardFailures().length > 0) {
-                logger.warn(refreshResponse.getShardFailures());
-            }
-            assertThat(refreshResponse.getSuccessfulShards(), equalTo(refreshResponse.getTotalShards()));
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, is(greaterThanOrEqualTo(1L)));
         }, 30, TimeUnit.SECONDS);


### PR DESCRIPTION
We tried to fix https://github.com/elastic/elasticsearch/issues/93633 in https://github.com/elastic/elasticsearch/pull/97595, but as @andreidan kindly explained in https://github.com/elastic/elasticsearch/pull/97595#discussion_r1260975408, some of our assumptions were wrong. This PR addresses the problem in a better way by ensuring the watcher history has allocated all its shards before refreshing and querying.