### PR TITLE
[8.9] Test fix: ensure watcher history is green before searching (#97617)

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -58,9 +58,11 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
             )
             .get();
         assertThat(putWatchResponse.isCreated(), is(true));
+        ensureGreen(".watcher-history*");
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(".watcher-history*").get();
+        assertThat(refreshResponse.getStatus(), equalTo(RestStatus.OK));
 
         assertBusy(() -> {
-            indicesAdmin().prepareRefresh(".watcher-history*").get();
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, is(greaterThanOrEqualTo(1L)));
         }, 30, TimeUnit.SECONDS);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Test fix: ensure watcher history is green before searching (#97617)](https://github.com/elastic/elasticsearch/pull/97617)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)