### PR TITLE
Fix to stop  aggregatable subojects from being multifields

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
@@ -220,11 +220,15 @@ public class ExtractedFields {
             if (Objects.equals(field, parent)) {
                 return false;
             }
+            if (isAggregatable(parent) && isAggregatable(field)) {
+                return false;
+            }
             Map<String, FieldCapabilities> parentFieldCaps = fieldsCapabilities.getField(parent);
             if (parentFieldCaps == null || (parentFieldCaps.size() == 1 && isNestedOrObject(parentFieldCaps))) {
                 // We check if the parent is an object or nested field. If so, it's not a multi field.
                 return false;
             }
+
             return true;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -885,7 +885,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
 
     public void testDetect_GivenMultiFieldAndParentIsRequired() {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("field_1", "keyword")
-            .addAggregatableField("field_1.keyword", "keyword")
+            .addAggregatableField("field_1.keyword", "keyword")// causing exception for assertion on line 900 below because it is not a multifield anymore due both this field and its parent above being aggregatable
             .addAggregatableField("field_2", "float")
             .build();
 
@@ -915,7 +915,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
 
     public void testDetect_GivenMultiFieldAndMultiFieldIsRequired() {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("field_1", "keyword")
-            .addAggregatableField("field_1.keyword", "keyword")
+            .addAggregatableField("field_1.keyword", "keyword") // causing exception for assertion on line 930 below because it is not a multifield anymore due both this field and its parent above being aggregatable
             .addAggregatableField("field_2", "float")
             .build();
 
@@ -1028,7 +1028,12 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             fieldCapabilities,
             Collections.emptyMap()
         );
-        Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
+        Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();// causing java.lang.IllegalArgumentException: cannot retrieve field [field_2] because it has no mappings
+        /*
+        at org.elasticsearch.xpack.ml.extractor.ExtractedFields$ExtractionMethodDetector.isAggregatable(ExtractedFields.java:196)
+        at org.elasticsearch.xpack.ml.extractor.ExtractedFields$ExtractionMethodDetector.isMultiField(ExtractedFields.java:223)
+        at org.elasticsearch.xpack.ml.extractor.ExtractedFields$ExtractionMethodDetector.detect(ExtractedFields.java:160)
+        */
 
         assertThat(fieldExtraction.v1().getAllFields(), hasSize(3));
         List<String> extractedFieldNames = fieldExtraction.v1()


### PR DESCRIPTION
Making the change recommended in https://github.com/elastic/elasticsearch/issues/88605 caused three tests to break. Two of them (`testDetect_GivenMultiFieldAndMultiFieldIsRequired` & `testDetect_GivenMultiFieldAndParentIsRequired`) seem to be directly due to no longer being multifields, and I think these tests likely just need to be changed to check for the new number of fields.

The third test that is failing is `testDetect_GivenParentAndMultiFieldBothAggregatable` due to `java.lang.IllegalArgumentException: cannot retrieve field [field_2] because it has no mappings`. However, I am not sure what the appropriate remedy for this test is. 