### PR TITLE
Expose logs dir in new test clusters

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -11,6 +11,7 @@ package org.elasticsearch.test.cluster;
 import org.elasticsearch.test.cluster.util.Version;
 
 import java.io.Closeable;
+import java.nio.file.Path;
 
 /**
  * A handle to an {@link ElasticsearchCluster}.
@@ -75,6 +76,11 @@ public interface ClusterHandle extends Closeable {
      * Get the pid of the node for the given index.
      */
     long getPid(int index);
+
+    /**
+     * Return the log directory of the node for the given index.
+     */
+    Path getLogsDir(int index);
 
     /**
      * Returns a comma-separated list of TCP transport endpoints for cluster. If this method is called on an unstarted cluster, the cluster

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.cluster.util.Version;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends ClusterHandle> implements ElasticsearchCluster {
@@ -99,6 +100,12 @@ public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends Cluste
     public long getPid(int index) {
         checkHandle();
         return handle.getPid(index);
+    }
+
+    @Override
+    public Path getLogsDir(int index) {
+        checkHandle();
+        return handle.getLogsDir(index);
     }
 
     @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -229,6 +229,10 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             return process.pid();
         }
 
+        public Path getLogsDir() {
+            return logsDir;
+        }
+
         public LocalNodeSpec getSpec() {
             return spec;
         }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -165,6 +165,11 @@ public class LocalClusterHandle implements ClusterHandle {
         return nodes.get(index).getPid();
     }
 
+    @Override
+    public Path getLogsDir(int index) {
+        return nodes.get(index).getLogsDir();
+    }
+
     public void stopNode(int index) {
         nodes.get(index).stop(false);
     }


### PR DESCRIPTION
Sometimes tests may need to inspect logs from ES. This commit adds a way to get the logs directory that was chosen by testclusters (relative to working dir).