### PR TITLE
Ensure the watcher history exists before we check its status

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.xpack.core.watcher.history.HistoryStoreField;
 import org.elasticsearch.xpack.core.watcher.transport.actions.put.PutWatchRequestBuilder;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;
@@ -61,10 +62,9 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
             )
             .get();
         assertThat(putWatchResponse.isCreated(), is(true));
+        ensureGreen(HistoryStoreField.DATA_STREAM);
 
         assertBusy(() -> {
-            indexExists(".watcher-history*");
-            ensureGreen(".watcher-history*");
             RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(".watcher-history*").get();
             assertThat(refreshResponse.getStatus(), equalTo(RestStatus.OK));
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -61,11 +61,12 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
             )
             .get();
         assertThat(putWatchResponse.isCreated(), is(true));
-        ensureGreen(".watcher-history*");
-        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(".watcher-history*").get();
-        assertThat(refreshResponse.getStatus(), equalTo(RestStatus.OK));
 
         assertBusy(() -> {
+            indexExists(".watcher-history*");
+            ensureGreen(".watcher-history*");
+            RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(".watcher-history*").get();
+            assertThat(refreshResponse.getStatus(), equalTo(RestStatus.OK));
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, is(greaterThanOrEqualTo(1L)));
         }, 30, TimeUnit.SECONDS);


### PR DESCRIPTION
Third and hopefully last follow up to fix https://github.com/elastic/elasticsearch/issues/93633. In https://github.com/elastic/elasticsearch/pull/97617 we introduced a check to see if the watcher history index is green. However, because we are using a wildcard and not the exact name of the index, the cluster health API returns green when the index does not exist. 

To address this we introduce one more check `indexExists(".watcher-history*");`. We ensure that the index exists first and then we use the cluster health to verify that it's green.