### PR TITLE
[DOCS] Clarify that dense vectors can be created with ES

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -20,12 +20,13 @@ Common use cases for kNN include:
 === Prerequisites
 
 * To run a kNN search, you must be able to convert your data into meaningful
-vector values. You create these vectors outside of {es} and add them to
-documents as <<dense-vector,`dense_vector`>> field values. Queries are
-represented as vectors with the same dimension.
-+
-Design your vectors so that the closer a document's vector is to a query vector,
-based on a similarity metric, the better its match.
+vector values. You can
+{ml-docs}/ml-nlp-text-emb-vector-search-example.html[create these vectors using
+a natural language processing (NLP) model in {es}], or generate them outside
+{es}, and add them to documents as <<dense-vector,`dense_vector`>> field values.
+Queries are represented as vectors with the same dimension. + Design your
+vectors so that the closer a document's vector is to a query vector, based on a
+similarity metric, the better its match.
 
 * To complete the steps in this guide, you must have the following
 <<privileges-list-indices,index privileges>>:

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -23,8 +23,8 @@ Common use cases for kNN include:
 vector values. You can
 {ml-docs}/ml-nlp-text-emb-vector-search-example.html[create these vectors using
 a natural language processing (NLP) model in {es}], or generate them outside
-{es}, and add them to documents as <<dense-vector,`dense_vector`>> field values.
-Queries are represented as vectors with the same dimension.
+{es}. Vectors can be added to documents as <<dense-vector,`dense_vector`>> field
+values. Queries are represented as vectors with the same dimension.
 +
 Design your vectors so that the closer a document's vector is to a query vector,
 based on a similarity metric, the better its match.

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -24,9 +24,10 @@ vector values. You can
 {ml-docs}/ml-nlp-text-emb-vector-search-example.html[create these vectors using
 a natural language processing (NLP) model in {es}], or generate them outside
 {es}, and add them to documents as <<dense-vector,`dense_vector`>> field values.
-Queries are represented as vectors with the same dimension. + Design your
-vectors so that the closer a document's vector is to a query vector, based on a
-similarity metric, the better its match.
+Queries are represented as vectors with the same dimension.
++
+Design your vectors so that the closer a document's vector is to a query vector,
+based on a similarity metric, the better its match.
 
 * To complete the steps in this guide, you must have the following
 <<privileges-list-indices,index privileges>>:


### PR DESCRIPTION
The kNN docs currently state about dense vectors that: "You create these vectors outside of Elasticsearch". However, you can also create them in ES using an NLP model. This PR clarifies that, with a link to [an example in the Machine Learning documentation](https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-text-emb-vector-search-example.html).

/cc @addytripathi