### PR TITLE
[8.9] [DOCS] Clarify that dense vectors can be created with ES (#97636)

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -20,9 +20,11 @@ Common use cases for kNN include:
 === Prerequisites
 
 * To run a kNN search, you must be able to convert your data into meaningful
-vector values. You create these vectors outside of {es} and add them to
-documents as <<dense-vector,`dense_vector`>> field values. Queries are
-represented as vectors with the same dimension.
+vector values. You can
+{ml-docs}/ml-nlp-text-emb-vector-search-example.html[create these vectors using
+a natural language processing (NLP) model in {es}], or generate them outside
+{es}. Vectors can be added to documents as <<dense-vector,`dense_vector`>> field
+values. Queries are represented as vectors with the same dimension.
 +
 Design your vectors so that the closer a document's vector is to a query vector,
 based on a similarity metric, the better its match.


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [DOCS] Clarify that dense vectors can be created with ES (#97636)