### PR TITLE
Increase accessibility of GrokCaptureType

### DIFF
--- a/libs/grok/src/main/java/org/elasticsearch/grok/GrokCaptureConfig.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/GrokCaptureConfig.java
@@ -43,7 +43,7 @@ public final class GrokCaptureConfig {
     /**
      * The type defined for the field in the pattern.
      */
-    GrokCaptureType type() {
+    public GrokCaptureType type() {
         return type;
     }
 

--- a/libs/grok/src/main/java/org/elasticsearch/grok/GrokCaptureType.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/GrokCaptureType.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 /**
  * The type defined for the field in the pattern.
  */
-enum GrokCaptureType {
+public enum GrokCaptureType {
     STRING {
         @Override
         <T> T nativeExtracter(int[] backRefs, NativeExtracterMap<T> map) {


### PR DESCRIPTION
This commit increases the accessibility of GrokCaptureType so that it can be used from outside of its package. Specifically, ESQL wants to access the type from the configuration.