### PR TITLE
Add synonyms feature for test clusters (#97658)

### DIFF
--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -26,7 +26,7 @@ restResources {
 testClusters.configureEach {
   module ':modules:reindex'
   module ':modules:mapper-extras'
-  requiresFeature 'es.synonyms_feature_flag_enabled', Version.fromString("8.9.0")
+  requiresFeature 'es.synonyms_api_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 dependencies {

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 }
 
 testClusters.configureEach {
-  requiresFeature 'es.synonyms_feature_flag_enabled', Version.fromString("8.9.0")
+  requiresFeature 'es.synonyms_api_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonym_rule.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonym_rule.put.json
@@ -6,7 +6,7 @@
     },
     "stability": "experimental",
     "visibility": "feature_flag",
-    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "feature_flag": "es.synonyms_api_feature_flag_enabled",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete.json
@@ -6,7 +6,7 @@
     },
     "stability": "experimental",
     "visibility": "feature_flag",
-    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "feature_flag": "es.synonyms_api_feature_flag_enabled",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get.json
@@ -6,7 +6,7 @@
     },
     "stability": "experimental",
     "visibility": "feature_flag",
-    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "feature_flag": "es.synonyms_api_feature_flag_enabled",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.put.json
@@ -6,7 +6,7 @@
     },
     "stability": "experimental",
     "visibility": "feature_flag",
-    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "feature_flag": "es.synonyms_api_feature_flag_enabled",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms_sets.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms_sets.get.json
@@ -6,7 +6,7 @@
     },
     "stability": "experimental",
     "visibility": "feature_flag",
-    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "feature_flag": "es.synonyms_api_feature_flag_enabled",
     "headers": {
       "accept": [
         "application/json"

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -18,7 +18,7 @@ public enum FeatureFlag {
     TIME_SERIES_MODE("es.index_mode_feature_flag_registered=true", Version.fromString("8.0.0"), null),
     NEW_RCS_MODE("es.untrusted_remote_cluster_feature_flag_registered=true", Version.fromString("8.5.0"), null),
     DLM_ENABLED("es.dlm_feature_flag_enabled=true", Version.fromString("8.8.0"), null),
-    SYNONYMS_ENABLED("es.synonyms_feature_flag_enabled=true", Version.fromString("8.9.0"), null),
+    SYNONYMS_ENABLED("es.synonyms_api_feature_flag_enabled=true", Version.fromString("8.9.0"), null),
     QUERY_RULES_ENABLED("es.query_rules_feature_flag_enabled=true", Version.fromString("8.9.0"), null);
 
     public final String systemProperty;


### PR DESCRIPTION
Backport for #97658

Fix for #97334 where incorrect feature name was provided.

Correct more instances of synonyms_feature_flag_enabled for synonyms_api_feature_flag_enabled

Closes #96641, #97177