### PR TITLE
[8.9] Support for Byte and Short as vector tiles value tag (#97619)

### DIFF
--- a/docs/changelog/97619.yaml
+++ b/docs/changelog/97619.yaml
@@ -1,0 +1,6 @@
+pr: 97619
+summary: Support for Byte and Short as vector tiles features
+area: Geo
+type: bug
+issues:
+ - 97612

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vector-tile/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vector-tile/10_basic.yml
@@ -225,12 +225,17 @@ setup:
         zoom: 0
         body:
           runtime_mappings:
-            label_position:
+            label_position_lat:
               script:
                 GeoPoint point = doc['location'].getLabelPosition();
-                emit(point.getLat(), point.getLon());
-              type: geo_point
-          fields: [label_position]
+                emit(point.getLat());
+              type: double
+            label_position_lon:
+              script:
+                GeoPoint point = doc['location'].getLabelPosition();
+                emit(point.getLon());
+              type: double
+          fields: [label_position_lat, label_position_lon]
 
 ---
 "query field":

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
@@ -64,8 +64,16 @@ class VectorTileUtils {
             // guard for null values
             return;
         }
+        if (value instanceof Byte || value instanceof Short) {
+            // mvt does not support byte and short data types
+            value = ((Number) value).intValue();
+        }
         feature.addTags(layerProps.addKey(key));
-        feature.addTags(layerProps.addValue(value));
+        int valIndex = layerProps.addValue(value);
+        if (valIndex < 0) {
+            throw new IllegalArgumentException("Unsupported vector tile type for field [" + key + "] : " + value.getClass().getName());
+        }
+        feature.addTags(valIndex);
     }
 
     /**

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.vectortile.rest;
+
+import com.wdtinc.mapbox_vector_tile.VectorTile;
+import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class VectorTileUtilTests extends ESTestCase {
+
+    public void testAddPropertyToFeature() {
+        final MvtLayerProps layerProps = new MvtLayerProps();
+        final VectorTile.Tile.Feature.Builder featureBuilder = VectorTile.Tile.Feature.newBuilder();
+        // boolean
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "bool", true);
+        assertPropertyToFeature(layerProps, featureBuilder, 1);
+        // byte
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "byte", (byte) 1);
+        assertPropertyToFeature(layerProps, featureBuilder, 2);
+        // short
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "short", (short) 2);
+        assertPropertyToFeature(layerProps, featureBuilder, 3);
+        // integer
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "integer", 3);
+        assertPropertyToFeature(layerProps, featureBuilder, 4);
+        // long
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "long", 4L);
+        assertPropertyToFeature(layerProps, featureBuilder, 5);
+        // float
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "float", 5f);
+        assertPropertyToFeature(layerProps, featureBuilder, 6);
+        // double
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "double", 6d);
+        assertPropertyToFeature(layerProps, featureBuilder, 7);
+        // string
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "string", "7");
+        assertPropertyToFeature(layerProps, featureBuilder, 8);
+        // invalid
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "invalid", new Object())
+        );
+        assertThat(ex.getMessage(), containsString("Unsupported vector tile type for field [invalid]"));
+    }
+
+    private void assertPropertyToFeature(MvtLayerProps layerProps, VectorTile.Tile.Feature.Builder featureBuilder, int numProps) {
+        assertEquals(numProps, StreamSupport.stream(layerProps.getKeys().spliterator(), false).count());
+        assertEquals(numProps, StreamSupport.stream(layerProps.getVals().spliterator(), false).count());
+        assertEquals(2 * numProps, featureBuilder.getTagsCount());
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Support for Byte and Short as vector tiles value tag (#97619)