### PR TITLE
Document the access field in responses for cross-cluster API keys

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-cross-cluster-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-cross-cluster-api-key.asciidoc
@@ -77,7 +77,9 @@ permissions in this entry apply.
 
 NOTE: No explicit <<security-privileges,privileges>> should be specified for either search
 or replication access. The creation process automatically converts the `access` specification
-to a role descriptor which has relevant privileges assigned accordingly.
+to a <<api-key-role-descriptors,role descriptor>> which has relevant privileges assigned accordingly.
+The `access` value as well as its corresponding `role_descriptors` are returned in responses of
+<<security-api-get-api-key,Get API keys API>> and <<security-api-query-api-key,Query API keys API>>.
 
 NOTE: Unlike <<api-key-role-descriptors,REST API keys>>, a cross-cluster API key
 does not capture permissions of the authenticated user. The API key's effective
@@ -217,6 +219,24 @@ A successful call returns a JSON structure that contains the information of the 
             "enabled": true
           }
         }
+      },
+      "access": {  <8>
+        "search": [
+          {
+            "names": [
+              "logs*"
+            ],
+            "allow_restricted_indices": false
+          }
+        ],
+        "replication": [
+          {
+            "names": [
+              "archive*"
+            ],
+            "allow_restricted_indices": false
+          }
+        ]
       }
     }
   ]
@@ -235,6 +255,7 @@ It is `cross_cluster_replication` if only cross-cluster replication is required.
 Or both, if search and replication are required.
 <6> The indices privileges corresponding to the required cross-cluster search access.
 <7> The indices privileges corresponding to the required cross-cluster replication access.
+<8> The `access` corresponds to the value specified at API key creation time.
 
 
 To use the generated API key, configure it as the cluster credential as part of an API key based remote cluster configuration.

--- a/x-pack/docs/en/rest-api/security/update-cross-cluster-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/update-cross-cluster-api-key.asciidoc
@@ -161,6 +161,16 @@ A successful call returns a JSON structure that contains the information of the 
             "enabled": true
           }
         }
+      },
+      "access": {  <2>
+        "search": [
+          {
+            "names": [
+              "logs*"
+            ],
+            "allow_restricted_indices": false
+          }
+        ]
       }
     }
   ]
@@ -169,6 +179,7 @@ A successful call returns a JSON structure that contains the information of the 
 // NOTCONSOLE
 <1> Role descriptor corresponding to the specified `access` scope at creation time.
 In this example, it grants cross cluster search permission for the `logs*` index pattern.
+<2> The `access` corresponds to the value specified at API key creation time.
 
 
 The following example updates the API key created above, assigning it new access scope and metadata:
@@ -243,6 +254,16 @@ and it will be:
             "enabled": true
           }
         }
+      },
+      "access": {  <2>
+        "replication": [
+          {
+            "names": [
+              "archive*"
+            ],
+            "allow_restricted_indices": false
+          }
+        ]
       }
     }
   ]
@@ -252,3 +273,4 @@ and it will be:
 <1> Role descriptor is updated to be the `access` scope specified at update time.
 In this example, it is updated to grant the cross cluster replication permission
 for the `archive*` index pattern.
+<2> The `access` corresponds to the value specified at API key update time.


### PR DESCRIPTION
Following the change in #97605, this PR adds necessary doc changes for the new access field in the responses.

Relates: #97605
