### PR TITLE
adjust t-digest compression for MedianAbsoluteDeviationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -131,7 +131,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
     private static MedianAbsoluteDeviationAggregationBuilder randomBuilder() {
         final MedianAbsoluteDeviationAggregationBuilder builder = new MedianAbsoluteDeviationAggregationBuilder("mad");
         if (randomBoolean()) {
-            builder.compression(randomDoubleBetween(20, 1000, false));
+            builder.compression(randomDoubleBetween(25, 1000, false));
         }
         return builder;
     }


### PR DESCRIPTION
The test has become flaky after the changes on t-digest algorithm. It seems it can have slightly more error for lower compression values, therefore let's change the lower value from 20 to 25.

fixes https://github.com/elastic/elasticsearch/issues/97577