### PR TITLE
[8.9] adjust t-digest compression for MedianAbsoluteDeviationIT (#97680)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -131,7 +131,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
     private static MedianAbsoluteDeviationAggregationBuilder randomBuilder() {
         final MedianAbsoluteDeviationAggregationBuilder builder = new MedianAbsoluteDeviationAggregationBuilder("mad");
         if (randomBoolean()) {
-            builder.compression(randomDoubleBetween(20, 1000, false));
+            builder.compression(randomDoubleBetween(25, 1000, false));
         }
         return builder;
     }


### PR DESCRIPTION
Backports the following commits to 8.9:
 - adjust t-digest compression for MedianAbsoluteDeviationIT (#97680)