### PR TITLE
Increase accessibility of InternalMedianAbsoluteDeviation::computeMedianAbsoluteDeviation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviation.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 public class InternalMedianAbsoluteDeviation extends InternalNumericMetricsAggregation.SingleValue implements MedianAbsoluteDeviation {
 
-    static double computeMedianAbsoluteDeviation(TDigestState valuesSketch) {
+    public static double computeMedianAbsoluteDeviation(TDigestState valuesSketch) {
 
         if (valuesSketch.size() == 0) {
             return Double.NaN;


### PR DESCRIPTION
This commit increases the accessibility of computeMedianAbsoluteDeviation so that it can be used from outside of its package. Specifically, ESQL wants to reuse this functionality.