### PR TITLE
Verify no unnecessary shard movements

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
@@ -66,7 +66,8 @@ public class ClusterInfoSimulator {
             return shardSizes.get(ClusterInfo.shardIdentifierFromRouting(shard.shardId(), true));
         } else {
             // initializing new (empty?) primary
-            return shard.getExpectedShardSize();
+            var priorSize = shardSizes.get(ClusterInfo.shardIdentifierFromRouting(shard));
+            return priorSize != null ? Math.max(priorSize, shard.getExpectedShardSize()) : shard.getExpectedShardSize();
         }
     }
 


### PR DESCRIPTION
This change adds a test that simulates a life cycle of the cluster (in terms of creating/deleting indices) during a short interval of time. The goal of this test is to set up a reproduceable (with a seed) environment where we could investigate shard movements during balance calculation. This should allow us to better understand causes of the shard movements and minimize them in order to ensure cluster perform less rebalancing overall and is reconciled faster.
