### PR TITLE
Add an accessor that retrieves the SortedBinaryDocValues from BaseKeywordDocValuesField.

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/field/BaseKeywordDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/BaseKeywordDocValuesField.java
@@ -132,4 +132,8 @@ public abstract class BaseKeywordDocValuesField extends AbstractScriptFieldFacto
             }
         };
     }
+
+    public SortedBinaryDocValues bytesValues() {
+        return input;
+    }
 }


### PR DESCRIPTION
This commit adds an accessor that retrieves the SortedBinaryDocValues from a BaseKeywordDocValuesField. This allows to iterator over the values as BytesRefs.