### PR TITLE
Disable javadocs for benchmarks

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -21,6 +21,7 @@ base {
 }
 
 tasks.named("test").configure { enabled = false }
+tasks.named("javadoc").configure { enabled = false }
 
 configurations {
   expression


### PR DESCRIPTION
This commit disables javadocs for the benchmarks project, since the docs are not necessary or interesting, and cause warning noise in the build log output.