### PR TITLE
Add completion_time time field to async_search get and status response

### DIFF
--- a/docs/changelog/97700.yaml
+++ b/docs/changelog/97700.yaml
@@ -2,4 +2,5 @@ pr: 97700
 summary: Add `completion_time` time field to `async_search` get and status response
 area: Search
 type: enhancement
-issues: []
+issues:
+ - 88640

--- a/docs/changelog/97700.yaml
+++ b/docs/changelog/97700.yaml
@@ -1,0 +1,5 @@
+pr: 97700
+summary: Add `completion_time` time field to `async_search` get and status response
+area: Search
+type: enhancement
+issues: []

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -70,6 +70,7 @@ search results are returned as part of the
 // TESTRESPONSE[s/"is_running" : true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1584377890986/$body.expiration_time_in_millis/]
+// TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
 // TESTRESPONSE[s/"took" : 1122/"took": $body.response.took/]
 // TESTRESPONSE[s/"num_reduce_phases" : 0,//]
 // TESTRESPONSE[s/"total" : 562/"total": $body.response._shards.total/]
@@ -156,17 +157,18 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 --------------------------------------------------
 {
   "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
-  "is_partial" : true, <1>
-  "is_running" : true, <2>
+  "is_partial" : false, <1>
+  "is_running" : false, <2>
   "start_time_in_millis" : 1583945890986,
   "expiration_time_in_millis" : 1584377890986, <3>
+  "completion_time_in_millis" : 1583945903130, <4>
   "response" : {
     "took" : 12144,
     "timed_out" : false,
-    "num_reduce_phases" : 46, <4>
+    "num_reduce_phases" : 46, <5>
     "_shards" : {
       "total" : 562,
-      "successful" : 188, <5>
+      "successful" : 188, <6>
       "skipped" : 0,
       "failed" : 0
     },
@@ -178,7 +180,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
       "max_score" : null,
       "hits" : [ ]
     },
-    "aggregations" : { <6>
+    "aggregations" : { <7>
       "sale_date" :  {
         "buckets" : []
       }
@@ -191,6 +193,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 // TESTRESPONSE[s/"is_running" : true/"is_running" : false/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1584377890986/$body.expiration_time_in_millis/]
+// TESTRESPONSE[s/1583945903130/$body.completion_time_in_millis/]
 // TESTRESPONSE[s/"took" : 12144/"took": $body.response.took/]
 // TESTRESPONSE[s/"total" : 562/"total": $body.response._shards.total/]
 // TESTRESPONSE[s/"successful" : 188/"successful": $body.response._shards.successful/]
@@ -203,13 +206,14 @@ or was successfully completed on all shards. While the query is being
 executed, `is_partial` is always set to `true`
 <2> Whether the search is still being executed or it has completed
 <3> When the async search will expire
-<4> Indicates how many reductions of the results have been performed. If this
+<4> When the async search has finished, the completion_time is indicated (start_time + took)
+<5> Indicates how many reductions of the results have been performed. If this
 number increases compared to the last retrieved results, you can expect
 additional results included in the search response
-<5> Indicates how many shards have executed the query. Note that in order for
+<6> Indicates how many shards have executed the query. Note that in order for
 shard results to be included in the search response, they need to be reduced
 first.
-<6> Partial aggregations results, coming from the shards that have already
+<7> Partial aggregations results, coming from the shards that have already
 completed the execution of the query.
 
 The `wait_for_completion_timeout` parameter can also be provided when calling

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -365,6 +365,7 @@ The API returns the following response:
 // TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
+// TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
 // TESTRESPONSE[s/"num_reduce_phases": 0/"num_reduce_phases": "$body.response.num_reduce_phases"/]
 // TESTRESPONSE[s/"took": 1020/"took": "$body.response.took"/]
 // TESTRESPONSE[s/"total": 8/"total": $body.response._shards.total/]
@@ -465,19 +466,20 @@ Response:
   "is_running": false,
   "start_time_in_millis": 1685564911108,
   "expiration_time_in_millis": 1685996911108,
+  "completion_time_in_millis": 1685564938727,  <1>
   "response": {
     "took": 27619,
     "timed_out": false,
     "num_reduce_phases": 4,
     "_shards": {
       "total": 28,
-      "successful": 28,  <1>
+      "successful": 28,  <2>
       "skipped": 0,
       "failed": 0
     },
     "_clusters": {
       "total": 3,
-      "successful": 3,   <2>
+      "successful": 3,   <3>
       "skipped": 0
     },
     "hits": {
@@ -496,6 +498,7 @@ Response:
 // TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1685564911108/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1685996911108/$body.expiration_time_in_millis/]
+// TESTRESPONSE[s/1685564938727/$body.completion_time_in_millis/]
 // TESTRESPONSE[s/"took": 27619/"took": "$body.response.took"/]
 // TESTRESPONSE[s/"total": 28/"total": $body.response._shards.total/]
 // TESTRESPONSE[s/"successful": 28/"successful": $body.response._shards.successful/]
@@ -506,9 +509,10 @@ Response:
 // TESTRESPONSE[s/"hits": \[...list of hits here...\]/"hits": $body.response.hits.hits/]
 
 
-<1> The `_shards` section is now updated to show that 28 total shards
+<1> Once the search has finished, the completion_time is present.
+<2> The `_shards` section is now updated to show that 28 total shards
 were searched across all clusters and that all were successful.
-<2> The `_clusters` section shows that searches on all 3 clusters were successful.
+<3> The `_clusters` section shows that searches on all 3 clusters were successful.
 
 
 
@@ -592,6 +596,7 @@ the `wait_for_completion_timeout` duration (see <<async-search>>).
 // TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
+// TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
 // TESTRESPONSE[s/"num_reduce_phases": 0/"num_reduce_phases": "$body.response.num_reduce_phases"/]
 // TESTRESPONSE[s/"took": 1020/"took": "$body.response.took"/]
 // TESTRESPONSE[s/"total": 28/"total": $body.response._shards.total/]

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -155,9 +155,10 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_032 = registerTransportVersion(8_500_032, "a9a14bc6-c3f2-41d9-a3d8-c686bf2c901d");
     public static final TransportVersion V_8_500_033 = registerTransportVersion(8_500_033, "193ab7c4-a751-4cbd-a66a-2d7d56ccbc10");
     public static final TransportVersion V_8_500_034 = registerTransportVersion(8_500_034, "16871c8b-88ba-4432-980a-10fd9ecad2dc");
+    public static final TransportVersion V_8_500_035 = registerTransportVersion(8_500_035, "664dd6ce-3487-4fbd-81a9-af778b28be45");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_034);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_035);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -212,7 +212,7 @@ class MutableSearchResponse {
         } else {
             /*
              * Build the response, reducing aggs if we haven't already and
-             * storing the result of the reduction so we won't have to reduce
+             * storing the result of the reduction, so we won't have to reduce
              * the same aggregation results a second time if nothing has changed.
              * This does cost memory because we have a reference to the finally
              * reduced aggs sitting around which can't be GCed until we get an update.
@@ -253,6 +253,7 @@ class MutableSearchResponse {
                 false,
                 startTime,
                 expirationTime,
+                startTime + finalResponse.getTook().millis(),
                 finalResponse.getTotalShards(),
                 finalResponse.getSuccessfulShards(),
                 finalResponse.getSkippedShards(),
@@ -268,6 +269,7 @@ class MutableSearchResponse {
                 true,
                 startTime,
                 expirationTime,
+                null,
                 totalShards,
                 successfulShards,
                 skippedShards,
@@ -282,6 +284,7 @@ class MutableSearchResponse {
             true,
             startTime,
             expirationTime,
+            null,
             totalShards,
             successfulShards,
             skippedShards,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.async.AsyncResponse;
@@ -194,6 +195,10 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
         builder.timeField("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
 
         if (searchResponse != null) {
+            if (isRunning == false) {
+                TimeValue took = searchResponse.getTook();
+                builder.timeField("completion_time_in_millis", "completion_time", startTimeMillis + took.millis());
+            }
             builder.field("response");
             ChunkedToXContent.wrapAsToXContent(searchResponse).toXContent(builder, params);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -166,6 +166,18 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
         return expirationTimeMillis;
     }
 
+    /**
+     * @return completion time in millis if the search is finished running.
+     * Otherwise it will return null;
+     */
+    public Long getCompletionTime() {
+        if (searchResponse == null || isRunning) {
+            return null;
+        } else {
+            return getStartTime() + searchResponse.getTook().millis();
+        }
+    }
+
     @Override
     public AsyncSearchResponse withExpirationTime(long expirationTime) {
         return new AsyncSearchResponse(id, searchResponse, error, isPartial, isRunning, startTimeMillis, expirationTime);


### PR DESCRIPTION
Both the async_search response and status response objects now include a "completion_time_in_millis" 
entry in the XContent output if the search has completed successfully.

The completion_time is set as the start_time (already present) plus the 'took' time that is set in the 
SearchResponse object and only if the isRunning status == false since took is set even for in-progress searches.

We use the 'took' field because it is based on relative time, not absolute wall clock time which can go 
backwards due to NTP issues. See the comments in TransportSearchAction about the SearchTimeProvider 
for details.

Closes #88640 

