### PR TITLE
Add API for accessing node logs in test clusters framework

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -11,6 +11,7 @@ package org.elasticsearch.test.cluster;
 import org.elasticsearch.test.cluster.util.Version;
 
 import java.io.Closeable;
+import java.io.InputStream;
 
 /**
  * A handle to an {@link ElasticsearchCluster}.
@@ -127,4 +128,9 @@ public interface ClusterHandle extends Closeable {
      * Cleans up any resources created by this cluster.
      */
     void close();
+
+    /**
+     * Returns an {@link InputStream} for the given node log.
+     */
+    InputStream streamNodeLog(int index, LogType logType);
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -132,5 +132,5 @@ public interface ClusterHandle extends Closeable {
     /**
      * Returns an {@link InputStream} for the given node log.
      */
-    InputStream streamNodeLog(int index, LogType logType);
+    InputStream getNodeLog(int index, LogType logType);
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.cluster.util.Version;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.io.InputStream;
 import java.util.function.Supplier;
 
 public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends ClusterHandle> implements ElasticsearchCluster {
@@ -135,6 +136,12 @@ public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends Cluste
     public void upgradeToVersion(Version version) {
         checkHandle();
         handle.upgradeToVersion(version);
+    }
+
+    @Override
+    public InputStream streamNodeLog(int index, LogType logType) {
+        checkHandle();
+        return handle.streamNodeLog(index, logType);
     }
 
     private void checkHandle() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
@@ -139,9 +139,9 @@ public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends Cluste
     }
 
     @Override
-    public InputStream streamNodeLog(int index, LogType logType) {
+    public InputStream getNodeLog(int index, LogType logType) {
         checkHandle();
-        return handle.streamNodeLog(index, logType);
+        return handle.getNodeLog(index, logType);
     }
 
     private void checkHandle() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/LogType.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/LogType.java
@@ -9,16 +9,16 @@
 package org.elasticsearch.test.cluster;
 
 public enum LogType {
-    SERVER("elasticsearch.log"),
-    SERVER_JSON("elasticsearch_server.json");
+    SERVER("%s.log"),
+    SERVER_JSON("%s_server.json");
 
-    private final String filename;
+    private final String filenameFormat;
 
     LogType(String filenameFormat) {
-        this.filename = filenameFormat;
+        this.filenameFormat = filenameFormat;
     }
 
-    public String getFilename() {
-        return filename;
+    public String resolveFilename(String clusterName) {
+        return filenameFormat.formatted(clusterName);
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/LogType.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/LogType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.cluster;
+
+public enum LogType {
+    SERVER("elasticsearch.log"),
+    SERVER_JSON("elasticsearch_server.json");
+
+    private final String filename;
+
+    LogType(String filenameFormat) {
+        this.filename = filenameFormat;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+}

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -230,7 +230,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             return process.pid();
         }
 
-        public InputStream streamLog(LogType logType) {
+        public InputStream getLog(LogType logType) {
             Path logFile = logsDir.resolve(logType.getFilename());
             if (Files.exists(logFile)) {
                 try {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.test.cluster.ClusterFactory;
+import org.elasticsearch.test.cluster.LogType;
 import org.elasticsearch.test.cluster.local.LocalClusterSpec.LocalNodeSpec;
 import org.elasticsearch.test.cluster.local.distribution.DistributionDescriptor;
 import org.elasticsearch.test.cluster.local.distribution.DistributionResolver;
@@ -227,6 +228,20 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 throw new IllegalStateException("Process has not been started, cannot get pid");
             }
             return process.pid();
+        }
+
+        public InputStream streamLog(LogType logType) {
+            Path logFile = logsDir.resolve(logType.getFilename());
+            if (Files.exists(logFile)) {
+                try {
+                    return Files.newInputStream(logFile);
+                } catch (IOException e) {
+                    LOGGER.error("Failed to read log file of type '{}' for node {} at '{}'", logType, this, logFile);
+                    throw new RuntimeException(e);
+                }
+            }
+
+            throw new IllegalArgumentException("Log file " + logFile + " does not exist.");
         }
 
         public LocalNodeSpec getSpec() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -231,7 +231,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         }
 
         public InputStream getLog(LogType logType) {
-            Path logFile = logsDir.resolve(logType.getFilename());
+            Path logFile = logsDir.resolve(logType.resolveFilename(spec.getCluster().getName()));
             if (Files.exists(logFile)) {
                 try {
                     return Files.newInputStream(logFile);
@@ -369,6 +369,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             try {
                 // Write settings to elasticsearch.yml
                 Map<String, String> finalSettings = new HashMap<>();
+                finalSettings.put("cluster.name", spec.getCluster().getName());
                 finalSettings.put("node.name", name);
                 finalSettings.put("path.repo", repoDir.toString());
                 finalSettings.put("path.data", dataDir.toString());

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -11,12 +11,14 @@ package org.elasticsearch.test.cluster.local;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.test.cluster.ClusterHandle;
+import org.elasticsearch.test.cluster.LogType;
 import org.elasticsearch.test.cluster.local.LocalClusterFactory.Node;
 import org.elasticsearch.test.cluster.local.model.User;
 import org.elasticsearch.test.cluster.util.ExceptionUtils;
 import org.elasticsearch.test.cluster.util.Version;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.nio.file.Files;
@@ -167,6 +169,11 @@ public class LocalClusterHandle implements ClusterHandle {
 
     public void stopNode(int index) {
         nodes.get(index).stop(false);
+    }
+
+    @Override
+    public InputStream streamNodeLog(int index, LogType logType) {
+        return nodes.get(index).streamLog(logType);
     }
 
     protected void waitUntilReady() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -172,8 +172,8 @@ public class LocalClusterHandle implements ClusterHandle {
     }
 
     @Override
-    public InputStream streamNodeLog(int index, LogType logType) {
-        return nodes.get(index).streamLog(logType);
+    public InputStream getNodeLog(int index, LogType logType) {
+        return nodes.get(index).getLog(logType);
     }
 
     protected void waitUntilReady() {


### PR DESCRIPTION
Some tests need to assert on log messages in node logs. This adds an API for accessing test cluster node logs for this use case.