### PR TITLE
[ML] Fix to stop aggregatable subojects from being multifields, to support "subobjects": false

### DIFF
--- a/docs/changelog/97705.yaml
+++ b/docs/changelog/97705.yaml
@@ -1,0 +1,7 @@
+pr: 97705
+summary: "Fix to stop aggregatable subojects from being multifields, to support \"\
+  subobjects\": false"
+area: Machine Learning
+type: "bug, enhancement"
+issues:
+ - 88605

--- a/docs/changelog/97705.yaml
+++ b/docs/changelog/97705.yaml
@@ -1,6 +1,6 @@
 pr: 97705
-summary: "Fix to stop aggregatable subojects from being multifields, to support \"\
-  subobjects\": false"
+summary: "Fix to stop aggregatable subobjects from being considered multi-fields, to support \
+  `\"subobjects\": false` in data frame analytics"
 area: Machine Learning
 type: bug
 issues:

--- a/docs/changelog/97705.yaml
+++ b/docs/changelog/97705.yaml
@@ -2,6 +2,6 @@ pr: 97705
 summary: "Fix to stop aggregatable subojects from being multifields, to support \"\
   subobjects\": false"
 area: Machine Learning
-type: "bug, enhancement"
+type: bug
 issues:
  - 88605

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/ExtractedFields.java
@@ -225,6 +225,9 @@ public class ExtractedFields {
                 // We check if the parent is an object or nested field. If so, it's not a multi field.
                 return false;
             }
+            if (isAggregatable(parent) && isAggregatable(field)) {
+                return false;
+            }
             return true;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -897,18 +897,18 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         );
         Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
 
-        assertThat(fieldExtraction.v1().getAllFields(), hasSize(2));
+        assertThat(fieldExtraction.v1().getAllFields(), hasSize(3));
         List<String> extractedFieldNames = fieldExtraction.v1()
             .getAllFields()
             .stream()
             .map(ExtractedField::getName)
             .collect(Collectors.toList());
-        assertThat(extractedFieldNames, contains("field_1", "field_2"));
+        assertThat(extractedFieldNames, contains("field_1", "field_1.keyword", "field_2"));
 
         assertFieldSelectionContains(
             fieldExtraction.v2(),
             FieldSelection.included("field_1", Collections.singleton("keyword"), true, FieldSelection.FeatureType.CATEGORICAL),
-            FieldSelection.excluded("field_1.keyword", Collections.singleton("keyword"), "[field_1] is required instead"),
+            FieldSelection.included("field_1.keyword", Collections.singleton("keyword"), false, FieldSelection.FeatureType.CATEGORICAL),
             FieldSelection.included("field_2", Collections.singleton("float"), false, FieldSelection.FeatureType.NUMERICAL)
         );
     }
@@ -927,17 +927,17 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         );
         Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
 
-        assertThat(fieldExtraction.v1().getAllFields(), hasSize(2));
+        assertThat(fieldExtraction.v1().getAllFields(), hasSize(3));
         List<String> extractedFieldNames = fieldExtraction.v1()
             .getAllFields()
             .stream()
             .map(ExtractedField::getName)
             .collect(Collectors.toList());
-        assertThat(extractedFieldNames, contains("field_1.keyword", "field_2"));
+        assertThat(extractedFieldNames, contains("field_1", "field_1.keyword", "field_2"));
 
         assertFieldSelectionContains(
             fieldExtraction.v2(),
-            FieldSelection.excluded("field_1", Collections.singleton("keyword"), "[field_1.keyword] is required instead"),
+            FieldSelection.included("field_1", Collections.singleton("keyword"), false, FieldSelection.FeatureType.CATEGORICAL),
             FieldSelection.included("field_1.keyword", Collections.singleton("keyword"), true, FieldSelection.FeatureType.CATEGORICAL),
             FieldSelection.included("field_2", Collections.singleton("float"), false, FieldSelection.FeatureType.NUMERICAL)
         );
@@ -1029,23 +1029,18 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             Collections.emptyMap()
         );
         Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
-
-        assertThat(fieldExtraction.v1().getAllFields(), hasSize(3));
+        assertThat(fieldExtraction.v1().getAllFields(), hasSize(4));
         List<String> extractedFieldNames = fieldExtraction.v1()
             .getAllFields()
             .stream()
             .map(ExtractedField::getName)
             .collect(Collectors.toList());
-        assertThat(extractedFieldNames, contains("field_1", "field_2.double", "field_2.keyword"));
+        assertThat(extractedFieldNames, contains("field_1", "field_1.keyword", "field_2.double", "field_2.keyword"));
 
         assertFieldSelectionContains(
             fieldExtraction.v2(),
             FieldSelection.included("field_1", Collections.singleton("keyword"), false, FieldSelection.FeatureType.CATEGORICAL),
-            FieldSelection.excluded(
-                "field_1.keyword",
-                Collections.singleton("keyword"),
-                "[field_1] is preferred because it is aggregatable"
-            ),
+            FieldSelection.included("field_1.keyword", Collections.singleton("keyword"), false, FieldSelection.FeatureType.CATEGORICAL),
             FieldSelection.included("field_2.double", Collections.singleton("double"), true, FieldSelection.FeatureType.NUMERICAL),
             FieldSelection.included("field_2.keyword", Collections.singleton("float"), false, FieldSelection.FeatureType.NUMERICAL)
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -1581,9 +1581,8 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         assertThat(extracted.getProcessedFields(), hasSize(1));
     }
 
-    public void testDetect_GivenFieldsWithDotsWhenSubobjectsFalseThenIsNonMultiField(){
-        FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder()
-            .addAggregatableField("metrics", "object")
+    public void testDetect_GivenFieldsWithDotsWhenSubobjectsFalseThenIsNonMultiField() {
+        FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("metrics", "object")
             .addAggregatableField("metrics.field_1", "double")
             .addAggregatableField("metrics.field_1.max", "double")
             .addAggregatableField("metrics.field_1.min", "double")


### PR DESCRIPTION
This change fixes #88605 by preventing aggregatable fields with aggregatable parent-fields from being converted into multifields. 

I was able to reproduce the issue mentioned in #88605, and then confirmed that this change fixes the issue. 