### PR TITLE
[Profiling] Tighten index name check

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -361,7 +361,10 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         private boolean isVersionNumber(String name, int startIndex) {
             final int versionNumberLength = 3;
             String versionNumberCandidate = name.substring(startIndex, Math.min(startIndex + versionNumberLength, name.length()));
-            return versionNumberCandidate.length() == versionNumberLength && versionNumberCandidate.chars().allMatch(Character::isDigit);
+            return versionNumberCandidate.length() == versionNumberLength
+                // do an explicit range check here for latin digits as Character#isDigit() also considers other
+                // Unicode digit characters that we don't want to recognize here.
+                && versionNumberCandidate.chars().allMatch((c) -> '0' <= c && c <= '9');
         }
 
         public boolean isMatchWithoutGeneration(String indexName) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -354,7 +354,13 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         }
 
         public boolean isMatchWithoutVersion(String indexName) {
-            return indexName.startsWith("." + namePrefix + "-v");
+            String expectedPrefix = "." + namePrefix + "-v";
+            return indexName.startsWith(expectedPrefix) && isVersionNumber(indexName, expectedPrefix.length());
+        }
+
+        private boolean isVersionNumber(String name, int startIndex) {
+            final int versionNumberLength = 3;
+            return name.substring(startIndex, startIndex + versionNumberLength).chars().allMatch(Character::isDigit);
         }
 
         public boolean isMatchWithoutGeneration(String indexName) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -354,7 +354,7 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         }
 
         public boolean isMatchWithoutVersion(String indexName) {
-            return indexName.startsWith("." + namePrefix);
+            return indexName.startsWith("." + namePrefix + "-v");
         }
 
         public boolean isMatchWithoutGeneration(String indexName) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -360,7 +360,8 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
 
         private boolean isVersionNumber(String name, int startIndex) {
             final int versionNumberLength = 3;
-            return name.substring(startIndex, startIndex + versionNumberLength).chars().allMatch(Character::isDigit);
+            String versionNumberCandidate = name.substring(startIndex, Math.min(startIndex + versionNumberLength, name.length()));
+            return versionNumberCandidate.length() == versionNumberLength && versionNumberCandidate.chars().allMatch(Character::isDigit);
         }
 
         public boolean isMatchWithoutGeneration(String indexName) {

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
@@ -227,6 +227,12 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         indicesDeleted.set(0);
     }
 
+    public void testIndexMatchWithoutVersion() {
+        ProfilingIndexManager.ProfilingIndex idx = ProfilingIndexManager.ProfilingIndex.kv("profiling-test", 1);
+        assertTrue(idx.isMatchWithoutVersion(".profiling-test-v002"));
+        assertFalse(idx.isMatchWithoutVersion(".profiling-testing-v001"));
+    }
+
     private ActionResponse verifyIndexInstalled(
         AtomicInteger calledTimes,
         ActionType<?> action,

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
@@ -231,6 +231,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         ProfilingIndexManager.ProfilingIndex idx = ProfilingIndexManager.ProfilingIndex.kv("profiling-test", 1);
         assertTrue(idx.isMatchWithoutVersion(".profiling-test-v002"));
         assertFalse(idx.isMatchWithoutVersion(".profiling-testing-v001"));
+        assertFalse(idx.isMatchWithoutVersion(".profiling-test-verbose"));
     }
 
     private ActionResponse verifyIndexInstalled(

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexManagerTests.java
@@ -232,6 +232,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         assertTrue(idx.isMatchWithoutVersion(".profiling-test-v002"));
         assertFalse(idx.isMatchWithoutVersion(".profiling-testing-v001"));
         assertFalse(idx.isMatchWithoutVersion(".profiling-test-verbose"));
+        assertFalse(idx.isMatchWithoutVersion(".profiling-test-v"));
     }
 
     private ActionResponse verifyIndexInstalled(


### PR DESCRIPTION
All profiling-related indices contain a version identifier in their name. In some places we need to check whether an index exists regardless of its version. Previously this check was too lenient because it also considered indices with the same prefix (e.g. a check for `profiling-stackframes` would also match `profiling-stackframes-all`). With this commit we tighten the check to match the full name until the version identifier.