### PR TITLE
Release master service task on timeout

### DIFF
--- a/docs/changelog/97711.yaml
+++ b/docs/changelog/97711.yaml
@@ -1,0 +1,5 @@
+pr: 97711
+summary: Release master service task on timeout
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -1429,7 +1429,7 @@ public class MasterService extends AbstractLifecycleComponent {
 
         private final TimeValue timeout;
         private final String source;
-        private final AtomicReference<T> taskHolder;
+        private final AtomicReference<T> taskHolder; // atomically read and set to null by at most one of {execute, timeout}
 
         private TaskTimeoutHandler(TimeValue timeout, String source, AtomicReference<T> taskHolder) {
             this.timeout = timeout;
@@ -1605,7 +1605,7 @@ public class MasterService extends AbstractLifecycleComponent {
                 for (int i = 0; i < entryCount; i++) {
                     final var entry = queue.poll();
                     assert entry != null;
-                    final var task = entry.taskHolder().getAndSet(null);
+                    final var task = entry.acquireForExecution();
                     if (task != null) {
                         taskCount += 1;
                         executing.add(


### PR DESCRIPTION
Today when a task in a master service queue times out it remains in the
queue until its batch is eventually processed. This might mean we retain
a reference to the task (and therefore any dependent listeners and other
objects) for an extended period of time after it has failed. This commit
adjusts the timeout handling to drop the reference to the task when it
completes.