### PR TITLE
Change downsample threadpool size.

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -598,7 +598,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         return boundedBy(2 * allocatedProcessors, 2, Integer.MAX_VALUE);
     }
 
-    static int oneEighthAllocatedProcessors(final int allocatedProcessors) {
+    public static int oneEighthAllocatedProcessors(final int allocatedProcessors) {
         return boundedBy(allocatedProcessors / 8, 1, Integer.MAX_VALUE);
     }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -146,7 +146,7 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
         final FixedExecutorBuilder downsample = new FixedExecutorBuilder(
             settingsToUse,
             Rollup.DOWSAMPLE_TASK_THREAD_POOL_NAME,
-            ThreadPool.searchOrGetThreadPoolSize(EsExecutors.allocatedProcessors(settingsToUse)),
+            ThreadPool.oneEighthAllocatedProcessors(EsExecutors.allocatedProcessors(settingsToUse)),
             Rollup.DOWNSAMPLE_TASK_THREAD_POOL_QUEUE_SIZE,
             "xpack.downsample.thread_pool",
             EsExecutors.TaskTrackingConfig.DO_NOT_TRACK


### PR DESCRIPTION
Changed the downsample threadpool size to one eight of the allocated processors. Downsampling is a cpu intensive operation (search + heavy aggregation that rolls up documents) and could overwhelm a node. On top of this the downsample operation also delegates to force merge api, which has a threadpool that is also bounded to one eight of the allocated processors.

Relates to #97141