### PR TITLE
Fix SharedBytesTests on Windows

### DIFF
--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.blobcache.shared;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
@@ -32,7 +33,7 @@ public class SharedBytesTests extends ESTestCase {
                 nodeEnv,
                 ignored -> {},
                 ignored -> {},
-                randomBoolean()
+                IOUtils.WINDOWS == false && randomBoolean()
             );
             final var sharedBytesPath = nodeEnv.nodeDataPaths()[0].resolve("shared_snapshot_cache");
             assertTrue(Files.exists(sharedBytesPath));


### PR DESCRIPTION
Can't use mmap on Windows, so disabling it here like was done for other tests in https://github.com/elastic/elasticsearch/pull/97639

closes #97626
