### PR TITLE
Synonyms - Change synonyms internal user for minimum privileges

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.security.user;
 
+import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzerAction;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
@@ -180,7 +181,7 @@ public class InternalUsers {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder().indices(".synonyms*").privileges("all").allowRestrictedIndices(true).build(),
                 // Need manage privilege to be able to reload index analyzers for all indices
-                RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("manage").build(), },
+                RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges(ReloadAnalyzerAction.NAME).build(), },
             null,
             null,
             null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -180,7 +180,6 @@ public class InternalUsers {
             null,
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder().indices(".synonyms*").privileges("all").allowRestrictedIndices(true).build(),
-                // Need manage privilege to be able to reload index analyzers for all indices
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges(ReloadAnalyzerAction.NAME).build(), },
             null,
             null,


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/97621. After checking with the [security team](https://elastic.slack.com/archives/CA6N3HDF1/p1689328457266199), this solution can be improved to allow just the `ReloadAnalyzerAction` on all indices instead of the `manage` privilege.