### PR TITLE
Allow arbitrary content in query rule match criteria

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -57,13 +56,8 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
     public static final String NAME = "rule_query";
 
     private static final ParseField RULESET_ID_FIELD = new ParseField("ruleset_id");
-    private static final ParseField MATCH_CRITERIA_FIELD = new ParseField("match_criteria");
+    protected static final ParseField MATCH_CRITERIA_FIELD = new ParseField("match_criteria");
     private static final ParseField ORGANIC_QUERY_FIELD = new ParseField("organic");
-
-    /**
-     * Defines the set of allowed match criteria, so that we can validate that rule query requests are sending in allowed/supported data.
-     */
-    static final Set<String> ALLOWED_MATCH_CRITERIA = Set.of("query_string");
 
     private final String rulesetId;
     private final Map<String, Object> matchCriteria;
@@ -111,11 +105,6 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
         }
         if (matchCriteria == null || matchCriteria.isEmpty()) {
             throw new IllegalArgumentException("matchCriteria must not be null or empty");
-        }
-        for (String matchCriteriaKey : matchCriteria.keySet()) {
-            if (ALLOWED_MATCH_CRITERIA.contains(matchCriteriaKey) == false) {
-                throw new IllegalArgumentException("matchCriteria key [" + matchCriteriaKey + "] is not allowed");
-            }
         }
         if (Strings.isNullOrEmpty(rulesetId)) {
             throw new IllegalArgumentException("rulesetId must not be null or empty");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -56,7 +56,7 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
     public static final String NAME = "rule_query";
 
     private static final ParseField RULESET_ID_FIELD = new ParseField("ruleset_id");
-    protected static final ParseField MATCH_CRITERIA_FIELD = new ParseField("match_criteria");
+    static final ParseField MATCH_CRITERIA_FIELD = new ParseField("match_criteria");
     private static final ParseField ORGANIC_QUERY_FIELD = new ParseField("organic");
 
     private final String rulesetId;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,10 +70,6 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
         expectThrows(IllegalArgumentException.class, () -> new RuleQueryBuilder(new MatchAllQueryBuilder(), MATCH_CRITERIA, ""));
         expectThrows(IllegalArgumentException.class, () -> new RuleQueryBuilder(null, MATCH_CRITERIA, "rulesetId"));
         expectThrows(IllegalArgumentException.class, () -> new RuleQueryBuilder(null, Collections.emptyMap(), "rulesetId"));
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> new RuleQueryBuilder(new MatchAllQueryBuilder(), Map.of("invalid_key", "invalid_value"), "rulesetId")
-        );
     }
 
     public void testFromJson() throws IOException {
@@ -174,5 +171,21 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
         }
 
         return super.simulateMethod(method, args);
+    }
+
+    /**
+     * Returns a map where the keys are object names that won't trigger a standard exception (an exception that contains the string
+     * "unknown field [newField]") through {@link #testUnknownObjectException()}. The value is a string that is contained in the thrown
+     * exception or null in the case that no exception is thrown (including their children).
+     * Default is an empty Map. Can be overridden by subclasses that test queries which contain objects that get parsed on the data nodes
+     * (e.g. score functions) or objects that can contain arbitrary content (e.g. documents for percolate or more like this query, params
+     * for scripts) and/or expect some content(e.g documents with geojson geometries).
+     */
+    @Override
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
+        // document contains arbitrary content, no error expected when an object is added to it
+        final Map<String, String> objects = new HashMap<>();
+        objects.put(RuleQueryBuilder.MATCH_CRITERIA_FIELD.getPreferredName(), null);
+        return objects;
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -172,7 +172,7 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
 
         return super.simulateMethod(method, args);
     }
-    
+
     @Override
     protected Map<String, String> getObjectsHoldingArbitraryContent() {
         // document contains arbitrary content, no error expected when an object is added to it

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -172,15 +172,7 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
 
         return super.simulateMethod(method, args);
     }
-
-    /**
-     * Returns a map where the keys are object names that won't trigger a standard exception (an exception that contains the string
-     * "unknown field [newField]") through {@link #testUnknownObjectException()}. The value is a string that is contained in the thrown
-     * exception or null in the case that no exception is thrown (including their children).
-     * Default is an empty Map. Can be overridden by subclasses that test queries which contain objects that get parsed on the data nodes
-     * (e.g. score functions) or objects that can contain arbitrary content (e.g. documents for percolate or more like this query, params
-     * for scripts) and/or expect some content(e.g documents with geojson geometries).
-     */
+    
     @Override
     protected Map<String, String> getObjectsHoldingArbitraryContent() {
         // document contains arbitrary content, no error expected when an object is added to it


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/97250

We initially gated the `RuleQueryBuilder` match criteria on `query_string` matches only. However, this was not the original intention or design of match criteria, which we wanted to be a map. This change was added because existing query builder tests were failing.

This PR removes that limitation, and updates the tests so they allow arbitrary data in this case. 

The documentation PR https://github.com/elastic/elasticsearch/pull/97667 will be updated accordingly. 