### PR TITLE
[Query Rules] Extend match types

### DIFF
--- a/docs/reference/query-rules/apis/delete-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/delete-query-ruleset.asciidoc
@@ -54,7 +54,7 @@ PUT _query_rules/my-ruleset
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "marvel"
+                    "values": ["marvel"]
                 }
             ],
             "actions": {

--- a/docs/reference/query-rules/apis/get-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/get-query-ruleset.asciidoc
@@ -54,7 +54,7 @@ PUT _query_rules/my-ruleset
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "marvel"
+                    "values": ["marvel"]
                 }
             ],
             "actions": {
@@ -71,7 +71,7 @@ PUT _query_rules/my-ruleset
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "dc"
+                    "values": ["dc"]
                 }
             ],
             "actions": {
@@ -119,7 +119,7 @@ A sample response:
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "marvel"
+                    "values": ["marvel"]
                 }
             ],
             "actions": {
@@ -136,7 +136,7 @@ A sample response:
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "dc"
+                    "values": ["dc"]
                 }
             ],
             "actions": {

--- a/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
@@ -92,7 +92,7 @@ PUT _query_rules/my-ruleset
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "marvel"
+                    "values": ["marvel"]
                 }
             ],
             "actions": {
@@ -109,7 +109,7 @@ PUT _query_rules/my-ruleset
                 {
                     "type": "exact",
                     "metadata": "query_string",
-                    "value": "dc"
+                    "values": ["dc"]
                 }
             ],
             "actions": {

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -168,9 +168,10 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_043 = registerTransportVersion(8_500_043, "50baabd14-7f5c-4f8c-9351-94e0d397aabc");
     public static final TransportVersion V_8_500_044 = registerTransportVersion(8_500_044, "96b83320-2317-4e9d-b735-356f18c1d76a");
     public static final TransportVersion V_8_500_045 = registerTransportVersion(8_500_045, "24a596dd-c843-4c0a-90b3-759697d74026");
+    public static final TransportVersion V_8_500_046 = registerTransportVersion(8_500_046, "61666d4c-a4f0-40db-8a3d-4806718247c5");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_045);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_046);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/200_query_ruleset_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/200_query_ruleset_put.yml
@@ -16,7 +16,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: elastic
+                  values: [elastic]
               actions:
                 ids:
                   - 'id1'
@@ -26,7 +26,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: kibana
+                  values: [kibana]
               actions:
                 docs:
                   - '_index': 'test-index1'
@@ -47,7 +47,7 @@ setup:
           criteria:
             - type: exact
               metadata: query_string
-              value: elastic
+              values: [elastic]
           actions:
             ids:
               - 'id1'
@@ -57,7 +57,7 @@ setup:
           criteria:
             - type: exact
               metadata: query_string
-              value: kibana
+              values: [kibana]
           actions:
             docs:
               - '_index': 'test-index1'
@@ -77,7 +77,7 @@ setup:
             criteria:
               type: 'exact'
               metadata: 'query_string'
-              value: 'elastic'
+              values: ['elastic']
             actions:
               ids:
                 - 'id1'
@@ -94,7 +94,7 @@ setup:
             criteria:
               type: 'exact'
               metadata: 'query_string'
-              value: 'elastic'
+              values: ['elastic']
             actions:
               ids:
                 - 'id2'
@@ -118,7 +118,7 @@ setup:
             criteria:
               type: 'exact'
               metadata: 'query_string'
-              value: 'elastic'
+              values: ['elastic']
             actions:
               ids:
                 - 'id1'

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/225_query_ruleset_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/225_query_ruleset_list.yml
@@ -12,7 +12,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: elastic
+                  values: [elastic]
               actions:
                 ids:
                   - 'id1'
@@ -22,7 +22,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: kibana
+                  values: [kibana]
               actions:
                 ids:
                   - 'id3'
@@ -38,7 +38,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: elastic
+                  values: [elastic]
               actions:
                 ids:
                   - 'id1'
@@ -48,7 +48,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: kibana
+                  values: [kibana]
               actions:
                 ids:
                   - 'id3'
@@ -58,7 +58,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: logstash
+                  values: [logstash]
               actions:
                 ids:
                   - 'id5'
@@ -74,7 +74,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: elastic
+                  values: [elastic]
               actions:
                 ids:
                   - 'id1'
@@ -84,7 +84,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: kibana
+                  values: [kibana]
               actions:
                 ids:
                   - 'id3'
@@ -94,7 +94,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: logstash
+                  values: [logstash]
               actions:
                 ids:
                   - 'id5'
@@ -104,7 +104,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: beats
+                  values: [beats]
               actions:
                 ids:
                   - 'id7'

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/250_query_ruleset_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/250_query_ruleset_delete.yml
@@ -12,7 +12,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: elastic
+                  values: [elastic]
               actions:
                 ids:
                   - 'id1'

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
@@ -29,6 +29,9 @@ setup:
           - index:
               _id: doc4
           - { "text": "you know, for search" }
+          - index:
+              _id: doc5
+          - { "text": "beats" }
 
   - do:
       query_ruleset.put:
@@ -54,6 +57,17 @@ setup:
                 docs:
                   - '_index': 'test-index1'
                     '_id': 'doc2'
+            - rule_id: rule3
+              type: pinned
+              criteria:
+                - type: contains
+                  metadata: query_string
+                  values: [ kibana, logstash ]
+              actions:
+                ids:
+                  - 'doc2'
+                  - 'doc3'
+
 
 ---
 "Perform a rule query with an ID match":
@@ -131,10 +145,53 @@ setup:
               organic:
                 query_string:
                   default_field: text
+                  query: beats
+              match_criteria:
+                query_string: beats
+              ruleset_id: test-ruleset
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: 'doc5' }
+
+---
+"Perform a rule query with multiple matching rules":
+
+  - do:
+      search:
+        body:
+          query:
+            rule_query:
+              organic:
+                query_string:
+                  default_field: text
                   query: logstash
               match_criteria:
                 query_string: logstash
               ruleset_id: test-ruleset
 
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: 'doc3' }
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: 'doc2' }
+  - match: { hits.hits.1._id: 'doc3'}
+
+
+---
+"Perform a rule query that matches complex rules":
+
+  - do:
+      search:
+        body:
+          query:
+            rule_query:
+              organic:
+                query_string:
+                  default_field: text
+                  query: elastic and kibana are good for search
+              match_criteria:
+                query_string: elastic and kibana are good for search
+              ruleset_id: test-ruleset
+
+  - match: { hits.total.value: 4 }
+  - match: { hits.hits.0._id: 'doc2' }
+  - match: { hits.hits.1._id: 'doc3' }
+
+

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
@@ -40,7 +40,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: search
+                  values: [search]
               actions:
                 ids:
                   - 'doc1'
@@ -49,7 +49,7 @@ setup:
               criteria:
                 - type: exact
                   metadata: query_string
-                  value: ui
+                  values: [ui]
               actions:
                 docs:
                   - '_index': 'test-index1'

--- a/x-pack/plugin/ent-search/src/main/java/module-info.java
+++ b/x-pack/plugin/ent-search/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module org.elasticsearch.application {
     requires org.elasticsearch.xcontent;
     requires org.elasticsearch.xcore;
     requires org.elasticsearch.searchbusinessrules;
+    requires org.apache.lucene.suggest;
 
     exports org.elasticsearch.xpack.application;
     exports org.elasticsearch.xpack.application.analytics;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -298,7 +298,7 @@ public class QueryRule implements Writeable, ToXContentObject {
 
                 if (criteriaType == QueryRuleCriteria.CriteriaType.GLOBAL || (criteriaMetadata != null && criteriaMetadata.equals(match))) {
                     boolean singleCriterionMatches = criterion.isMatch(matchValue, criteriaType);
-                    isRuleMatch = (isRuleMatch == null) ? singleCriterionMatches : isRuleMatch & singleCriterionMatches;
+                    isRuleMatch = (isRuleMatch == null) ? singleCriterionMatches : isRuleMatch && singleCriterionMatches;
                 }
             }
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -288,7 +288,8 @@ public class QueryRule implements Writeable, ToXContentObject {
             for (String match : matchCriteria.keySet()) {
                 final Object matchValue = matchCriteria.get(match);
                 final QueryRuleCriteria.CriteriaType criteriaType = criterion.criteriaType();
-                if (criterion.criteriaMetadata().equals(match) && criterion.isMatch(matchValue, criteriaType)) {
+                final String criteriaMetadata = criterion.criteriaMetadata();
+                if (criteriaType == QueryRuleCriteria.CriteriaType.GLOBAL || (criteriaMetadata != null && criteriaMetadata.equals(match) && criterion.isMatch(matchValue, criteriaType))) {
                     if (actions.containsKey(IDS_FIELD.getPreferredName())) {
                         matchingPinnedIds.addAll((List<String>) actions.get(IDS_FIELD.getPreferredName()));
                     } else if (actions.containsKey(DOCS_FIELD.getPreferredName())) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -287,7 +287,8 @@ public class QueryRule implements Writeable, ToXContentObject {
         for (QueryRuleCriteria criterion : criteria) {
             for (String match : matchCriteria.keySet()) {
                 final String matchValue = matchCriteria.get(match).toString();
-                if (criterion.criteriaMetadata().equals(match) && criterion.isMatch(matchValue)) {
+                final QueryRuleCriteria.CriteriaType criteriaType = criterion.criteriaType();
+                if (criterion.criteriaMetadata().equals(match) && criterion.isMatch(matchValue, criteriaType)) {
                     if (actions.containsKey(IDS_FIELD.getPreferredName())) {
                         matchingPinnedIds.addAll((List<String>) actions.get(IDS_FIELD.getPreferredName()));
                     } else if (actions.containsKey(DOCS_FIELD.getPreferredName())) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -286,7 +286,7 @@ public class QueryRule implements Writeable, ToXContentObject {
 
         for (QueryRuleCriteria criterion : criteria) {
             for (String match : matchCriteria.keySet()) {
-                final String matchValue = matchCriteria.get(match).toString();
+                final Object matchValue = matchCriteria.get(match);
                 final QueryRuleCriteria.CriteriaType criteriaType = criterion.criteriaType();
                 if (criterion.criteriaMetadata().equals(match) && criterion.isMatch(matchValue, criteriaType)) {
                     if (actions.containsKey(IDS_FIELD.getPreferredName())) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.DOCS_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.IDS_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item.INDEX_FIELD;
@@ -293,10 +294,10 @@ public class QueryRule implements Writeable, ToXContentObject {
         for (QueryRuleCriteria criterion : criteria) {
             for (String match : matchCriteria.keySet()) {
                 final Object matchValue = matchCriteria.get(match);
-                final QueryRuleCriteria.CriteriaType criteriaType = criterion.criteriaType();
+                final QueryRuleCriteriaType criteriaType = criterion.criteriaType();
                 final String criteriaMetadata = criterion.criteriaMetadata();
 
-                if (criteriaType == QueryRuleCriteria.CriteriaType.GLOBAL || (criteriaMetadata != null && criteriaMetadata.equals(match))) {
+                if (criteriaType == GLOBAL || (criteriaMetadata != null && criteriaMetadata.equals(match))) {
                     boolean singleCriterionMatches = criterion.isMatch(matchValue, criteriaType);
                     isRuleMatch = (isRuleMatch == null) ? singleCriterionMatches : isRuleMatch && singleCriterionMatches;
                 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.DOCS_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.IDS_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item.INDEX_FIELD;
@@ -297,7 +297,7 @@ public class QueryRule implements Writeable, ToXContentObject {
                 final QueryRuleCriteriaType criteriaType = criterion.criteriaType();
                 final String criteriaMetadata = criterion.criteriaMetadata();
 
-                if (criteriaType == GLOBAL || (criteriaMetadata != null && criteriaMetadata.equals(match))) {
+                if (criteriaType == ALWAYS || (criteriaMetadata != null && criteriaMetadata.equals(match))) {
                     boolean singleCriterionMatches = criterion.isMatch(matchValue, criteriaType);
                     isRuleMatch = (isRuleMatch == null) ? singleCriterionMatches : isRuleMatch && singleCriterionMatches;
                 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -289,7 +289,9 @@ public class QueryRule implements Writeable, ToXContentObject {
                 final Object matchValue = matchCriteria.get(match);
                 final QueryRuleCriteria.CriteriaType criteriaType = criterion.criteriaType();
                 final String criteriaMetadata = criterion.criteriaMetadata();
-                if (criteriaType == QueryRuleCriteria.CriteriaType.GLOBAL || (criteriaMetadata != null && criteriaMetadata.equals(match) && criterion.isMatch(matchValue, criteriaType))) {
+//                if (criterion.criteriaMatches(criterion.criteriaType(), criteriaMetadata, match)) {
+                if (criteriaType == QueryRuleCriteria.CriteriaType.GLOBAL
+                    || (criteriaMetadata != null && criteriaMetadata.equals(match) && criterion.isMatch(matchValue, criteriaType))) {
                     if (actions.containsKey(IDS_FIELD.getPreferredName())) {
                         matchingPinnedIds.addAll((List<String>) actions.get(IDS_FIELD.getPreferredName()));
                     } else if (actions.containsKey(DOCS_FIELD.getPreferredName())) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.AL
 
 public class QueryRuleCriteria implements Writeable, ToXContentObject {
 
-    public static final TransportVersion CRITERIA_METADATA_VALUES_TRANSPORT_VERSION = TransportVersion.V_8_500_045;
+    public static final TransportVersion CRITERIA_METADATA_VALUES_TRANSPORT_VERSION = TransportVersion.V_8_500_046;
     private final QueryRuleCriteriaType criteriaType;
     private final String criteriaMetadata;
     private final List<Object> criteriaValues;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -34,7 +34,10 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     private final Object criteriaValue;
 
     public enum CriteriaType {
-        EXACT;
+        EXACT,
+        PREFIX,
+        SUFFIX,
+        CONTAINS;
 
         public static CriteriaType criteriaType(String criteriaType) {
             for (CriteriaType type : values()) {
@@ -62,10 +65,6 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         Objects.requireNonNull(criteriaType);
         Objects.requireNonNull(criteriaMetadata);
         Objects.requireNonNull(criteriaValue);
-
-        if ((criteriaType == CriteriaType.EXACT) == false) {
-            throw new IllegalArgumentException("Invalid criteriaType " + criteriaType);
-        }
 
         if (Strings.isNullOrEmpty(criteriaMetadata)) {
             throw new IllegalArgumentException("criteriaMetadata cannot be blank");
@@ -180,7 +179,27 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         return Strings.toString(this);
     }
 
-    public boolean isMatch(String matchString) {
-        return criteriaType == CriteriaType.EXACT && criteriaValue.equals(matchString);
+    public boolean isMatch(String matchString, CriteriaType matchType) {
+        if (criteriaValue instanceof String criteriaValueString) {
+            switch (matchType) {
+                case EXACT -> {
+                    return criteriaValueString.equals(matchString);
+                }
+                case PREFIX -> {
+                    return matchString.startsWith(criteriaValueString);
+                }
+                case SUFFIX -> {
+                    return matchString.endsWith(criteriaValueString);
+                }
+                case CONTAINS -> {
+                    return matchString.contains(criteriaValueString);
+                }
+                default -> {
+                    return false;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.application.rules;
 
-import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -28,146 +27,28 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
 
 public class QueryRuleCriteria implements Writeable, ToXContentObject {
-    private final CriteriaType criteriaType;
+    private final QueryRuleCriteriaType criteriaType;
     private final String criteriaMetadata;
     private final List<Object> criteriaValues;
 
     private static final Logger logger = LogManager.getLogger(QueryRuleCriteria.class);
 
-    public enum CriteriaType {
-        GLOBAL {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return true;
-            }
-        },
-        EXACT {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                if (input instanceof String && criteriaValue instanceof String) {
-                    return input.equals(criteriaValue);
-                } else {
-                    return parseDouble(input) == parseDouble(criteriaValue);
-                }
-            }
-        },
-        EXACT_FUZZY {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                final LevenshteinDistance ld = new LevenshteinDistance();
-                if (input instanceof String && criteriaValue instanceof String) {
-                    return ld.getDistance((String) input, (String) criteriaValue) > 0.5f;
-                }
-                return false;
-            }
-        },
-        PREFIX {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return ((String) input).startsWith((String) criteriaValue);
-            }
-        },
-        SUFFIX {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return ((String) input).endsWith((String) criteriaValue);
-            }
-        },
-        CONTAINS {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return ((String) input).contains((String) criteriaValue);
-            }
-        },
-        LT {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return parseDouble(input) < parseDouble(criteriaValue);
-            }
-        },
-        LTE {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return parseDouble(input) <= parseDouble(criteriaValue);
-            }
-        },
-        GT {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                return parseDouble(input) > parseDouble(criteriaValue);
-            }
-        },
-        GTE {
-            @Override
-            public boolean inputMatchesCriteria(Object input, Object criteriaValue) {
-                validateInput(input);
-                return parseDouble(input) >= parseDouble(criteriaValue);
-            }
-        };
-
-        public void validateInput(Object input) {
-            boolean isValid = isValidForInput(input);
-            if (isValid == false) {
-                throw new IllegalArgumentException("Input [" + input + "] is not valid for CriteriaType [" + this + "]");
-            }
-        }
-
-        public abstract boolean inputMatchesCriteria(Object input, Object criteriaValue);
-
-        public static CriteriaType criteriaType(String criteriaType) {
-            for (CriteriaType type : values()) {
-                if (type.name().equalsIgnoreCase(criteriaType)) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException("Unknown CriteriaType: " + criteriaType);
-        }
-
-        @Override
-        public String toString() {
-            return name().toLowerCase(Locale.ROOT);
-        }
-
-        private boolean isValidForInput(Object input) {
-            if (this == EXACT) {
-                return input instanceof String || input instanceof Number;
-            } else if (List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS).contains(this)) {
-                return input instanceof String;
-            } else if (List.of(LT, LTE, GT, GTE).contains(this)) {
-                try {
-                    if (input instanceof Number == false) {
-                        parseDouble(input.toString());
-                    }
-                    return true;
-                } catch (NumberFormatException e) {
-                    return false;
-                }
-            }
-            return false;
-        }
-
-        private static double parseDouble(Object input) {
-            return (input instanceof Number) ? ((Number) input).doubleValue() : Double.parseDouble(input.toString());
-        }
-    }
-
     /**
      *
-     * @param criteriaType The {@link CriteriaType}, indicating how the criteria is matched
+     * @param criteriaType The {@link QueryRuleCriteriaType}, indicating how the criteria is matched
      * @param criteriaMetadata The metadata for this identifier, indicating the criteria key of what is matched against.
      *                         Required unless the CriteriaType is GLOBAL.
      * @param criteriaValues The values to match against when evaluating {@link QueryRuleCriteria} against a {@link QueryRule}
      *                      Required unless the CriteriaType is GLOBAL.
      */
-    public QueryRuleCriteria(CriteriaType criteriaType, @Nullable String criteriaMetadata, @Nullable List<Object> criteriaValues) {
+    public QueryRuleCriteria(QueryRuleCriteriaType criteriaType, @Nullable String criteriaMetadata, @Nullable List<Object> criteriaValues) {
 
         Objects.requireNonNull(criteriaType);
 
@@ -187,7 +68,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     }
 
     public QueryRuleCriteria(StreamInput in) throws IOException {
-        this.criteriaType = in.readEnum(CriteriaType.class);
+        this.criteriaType = in.readEnum(QueryRuleCriteriaType.class);
         this.criteriaMetadata = in.readOptionalString();
         this.criteriaValues = in.readOptionalList(StreamInput::readGenericValue);
     }
@@ -203,7 +84,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         "query_rule_criteria",
         false,
         (params, resourceName) -> {
-            final CriteriaType type = CriteriaType.criteriaType((String) params[0]);
+            final QueryRuleCriteriaType type = QueryRuleCriteriaType.type((String) params[0]);
             final String metadata = params.length >= 3 ? (String) params[1] : null;
             @SuppressWarnings("unchecked")
             final List<Object> values = params.length >= 3 ? (List<Object>) params[2] : null;
@@ -263,7 +144,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         return builder;
     }
 
-    public CriteriaType criteriaType() {
+    public QueryRuleCriteriaType criteriaType() {
         return criteriaType;
     }
 
@@ -295,14 +176,14 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         return Strings.toString(this);
     }
 
-    public boolean isMatch(Object matchValue, CriteriaType matchType) {
+    public boolean isMatch(Object matchValue, QueryRuleCriteriaType matchType) {
         if (matchType == GLOBAL) {
             return true;
         }
         final String matchString = matchValue.toString();
         for (Object criteriaValue : criteriaValues) {
             matchType.validateInput(matchValue);
-            boolean matchFound = matchType.inputMatchesCriteria(matchString, criteriaValue);
+            boolean matchFound = matchType.isMatch(matchString, criteriaValue);
             if (matchFound) {
                 return true;
             }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -204,20 +204,14 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     public boolean isMatch(Object matchValue, CriteriaType matchType) {
 
         if (criteriaType == GLOBAL) {
-            logger.info("Global criteria type, returning true");
             return true;
         }
 
         LevenshteinDistance ld = new LevenshteinDistance();
-
         String matchString = matchValue.toString();
         String criteriaValueString = criteriaValue != null ? criteriaValue.toString() : null;
         if (criteriaValueString != null && matchValue instanceof String) {
-
-            float editDistance = ld.getDistance(matchString, criteriaValueString);
-            logger.info("Edit distance between {} and {} is {}", matchString, criteriaValueString, editDistance);
-
-            boolean strMatch = switch (matchType) {
+            return switch (matchType) {
                 case EXACT -> matchString.equals(criteriaValueString);
                 case EXACT_FUZZY -> ld.getDistance(matchString, criteriaValueString) > 0.75f; // TODO make configurable
                 case PREFIX -> matchString.startsWith(criteriaValueString);
@@ -225,12 +219,10 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
                 case CONTAINS -> matchString.contains(criteriaValueString);
                 default -> false;
             };
-            logger.info("strMatch: " + strMatch);
-            return strMatch;
         } else if (criteriaValueString != null && matchValue instanceof Number) {
             try {
                 Number matchNumber = (Number) matchValue;
-                boolean numMatch = switch (matchType) {
+                return switch (matchType) {
                     case EXACT -> matchNumber.doubleValue() == Double.parseDouble(criteriaValueString);
                     case LT -> matchNumber.doubleValue() < Double.parseDouble(criteriaValueString);
                     case LTE -> matchNumber.doubleValue() <= Double.parseDouble(criteriaValueString);
@@ -238,8 +230,6 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
                     case GTE -> matchNumber.doubleValue() >= Double.parseDouble(criteriaValueString);
                     default -> false;
                 };
-                logger.info("matchType " + matchType + " matchNumber " + matchNumber + " criteriaValueString " + criteriaValueString + "; numMatch: " + numMatch);
-                return numMatch;
             } catch (NumberFormatException e) {
                 logger.warn("Query rule criteria [" + criteriaValue + "] type mismatch against [" + matchString + "]", e);
                 return false;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -35,6 +35,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 
 public class QueryRuleCriteria implements Writeable, ToXContentObject {
+
+    public static final TransportVersion CRITERIA_METADATA_VALUES_TRANSPORT_VERSION = TransportVersion.V_8_500_044;
     private final QueryRuleCriteriaType criteriaType;
     private final String criteriaMetadata;
     private final List<Object> criteriaValues;
@@ -70,7 +72,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
 
     public QueryRuleCriteria(StreamInput in) throws IOException {
         this.criteriaType = in.readEnum(QueryRuleCriteriaType.class);
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_044)) {
+        if (in.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
             this.criteriaMetadata = in.readOptionalString();
             this.criteriaValues = in.readOptionalList(StreamInput::readGenericValue);
         } else {
@@ -82,7 +84,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(criteriaType);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_044)) {
+        if (out.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
             out.writeOptionalString(criteriaMetadata);
             out.writeOptionalCollection(criteriaValues, StreamOutput::writeGenericValue);
         } else {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 
 public class QueryRuleCriteria implements Writeable, ToXContentObject {
     private final QueryRuleCriteriaType criteriaType;
@@ -44,15 +44,15 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
      *
      * @param criteriaType The {@link QueryRuleCriteriaType}, indicating how the criteria is matched
      * @param criteriaMetadata The metadata for this identifier, indicating the criteria key of what is matched against.
-     *                         Required unless the CriteriaType is GLOBAL.
+     *                         Required unless the CriteriaType is ALWAYS.
      * @param criteriaValues The values to match against when evaluating {@link QueryRuleCriteria} against a {@link QueryRule}
-     *                      Required unless the CriteriaType is GLOBAL.
+     *                      Required unless the CriteriaType is ALWAYS.
      */
     public QueryRuleCriteria(QueryRuleCriteriaType criteriaType, @Nullable String criteriaMetadata, @Nullable List<Object> criteriaValues) {
 
         Objects.requireNonNull(criteriaType);
 
-        if (criteriaType != GLOBAL) {
+        if (criteriaType != ALWAYS) {
             if (Strings.isNullOrEmpty(criteriaMetadata)) {
                 throw new IllegalArgumentException("criteriaMetadata cannot be blank");
             }
@@ -177,7 +177,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     }
 
     public boolean isMatch(Object matchValue, QueryRuleCriteriaType matchType) {
-        if (matchType == GLOBAL) {
+        if (matchType == ALWAYS) {
             return true;
         }
         final String matchString = matchValue.toString();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -70,7 +70,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
 
     public QueryRuleCriteria(StreamInput in) throws IOException {
         this.criteriaType = in.readEnum(QueryRuleCriteriaType.class);
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_041)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_044)) {
             this.criteriaMetadata = in.readOptionalString();
             this.criteriaValues = in.readOptionalList(StreamInput::readGenericValue);
         } else {
@@ -82,7 +82,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(criteriaType);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_041)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_044)) {
             out.writeOptionalString(criteriaMetadata);
             out.writeOptionalCollection(criteriaValues, StreamOutput::writeGenericValue);
         } else {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.AL
 
 public class QueryRuleCriteria implements Writeable, ToXContentObject {
 
-    public static final TransportVersion CRITERIA_METADATA_VALUES_TRANSPORT_VERSION = TransportVersion.V_8_500_044;
+    public static final TransportVersion CRITERIA_METADATA_VALUES_TRANSPORT_VERSION = TransportVersion.V_8_500_045;
     private final QueryRuleCriteriaType criteriaType;
     private final String criteriaMetadata;
     private final List<Object> criteriaValues;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.rules;
+
+import org.apache.lucene.search.spell.LevenshteinDistance;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Defines the different types of query rule criteria and their rules for matching input against the criteria.
+ */
+public enum QueryRuleCriteriaType {
+    GLOBAL {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return true;
+        }
+    },
+    EXACT {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            if (input instanceof String && criteriaValue instanceof String) {
+                return input.equals(criteriaValue);
+            } else {
+                return parseDouble(input) == parseDouble(criteriaValue);
+            }
+        }
+    },
+    EXACT_FUZZY {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            final LevenshteinDistance ld = new LevenshteinDistance();
+            if (input instanceof String && criteriaValue instanceof String) {
+                return ld.getDistance((String) input, (String) criteriaValue) > 0.5f;
+            }
+            return false;
+        }
+    },
+    PREFIX {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return ((String) input).startsWith((String) criteriaValue);
+        }
+    },
+    SUFFIX {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return ((String) input).endsWith((String) criteriaValue);
+        }
+    },
+    CONTAINS {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return ((String) input).contains((String) criteriaValue);
+        }
+    },
+    LT {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return parseDouble(input) < parseDouble(criteriaValue);
+        }
+    },
+    LTE {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return parseDouble(input) <= parseDouble(criteriaValue);
+        }
+    },
+    GT {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            return parseDouble(input) > parseDouble(criteriaValue);
+        }
+    },
+    GTE {
+        @Override
+        public boolean isMatch(Object input, Object criteriaValue) {
+            validateInput(input);
+            return parseDouble(input) >= parseDouble(criteriaValue);
+        }
+    };
+
+    public void validateInput(Object input) {
+        boolean isValid = isValidForInput(input);
+        if (isValid == false) {
+            throw new IllegalArgumentException("Input [" + input + "] is not valid for CriteriaType [" + this + "]");
+        }
+    }
+
+    public abstract boolean isMatch(Object input, Object criteriaValue);
+
+    public static QueryRuleCriteriaType type(String criteriaType) {
+        for (QueryRuleCriteriaType type : values()) {
+            if (type.name().equalsIgnoreCase(criteriaType)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown QueryRuleCriteriaType: " + criteriaType);
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isValidForInput(Object input) {
+        if (this == EXACT) {
+            return input instanceof String || input instanceof Number;
+        } else if (List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS).contains(this)) {
+            return input instanceof String;
+        } else if (List.of(LT, LTE, GT, GTE).contains(this)) {
+            try {
+                if (input instanceof Number == false) {
+                    parseDouble(input.toString());
+                }
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static double parseDouble(Object input) {
+        return (input instanceof Number) ? ((Number) input).doubleValue() : Double.parseDouble(input.toString());
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
@@ -16,7 +16,7 @@ import java.util.Locale;
  * Defines the different types of query rule criteria and their rules for matching input against the criteria.
  */
 public enum QueryRuleCriteriaType {
-    GLOBAL {
+    ALWAYS {
         @Override
         public boolean isMatch(Object input, Object criteriaValue) {
             return true;
@@ -32,7 +32,7 @@ public enum QueryRuleCriteriaType {
             }
         }
     },
-    EXACT_FUZZY {
+    FUZZY {
         @Override
         public boolean isMatch(Object input, Object criteriaValue) {
             final LevenshteinDistance ld = new LevenshteinDistance();
@@ -112,7 +112,7 @@ public enum QueryRuleCriteriaType {
     private boolean isValidForInput(Object input) {
         if (this == EXACT) {
             return input instanceof String || input instanceof Number;
-        } else if (List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS).contains(this)) {
+        } else if (List.of(FUZZY, PREFIX, SUFFIX, CONTAINS).contains(this)) {
             return input instanceof String;
         } else if (List.of(LT, LTE, GT, GTE).contains(this)) {
             try {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -201,7 +201,7 @@ public class QueryRulesIndexService {
         for (Map<String, Object> entry : rawCriteria) {
             criteria.add(
                 new QueryRuleCriteria(
-                    QueryRuleCriteria.CriteriaType.criteriaType((String) entry.get(QueryRuleCriteria.TYPE_FIELD.getPreferredName())),
+                    QueryRuleCriteriaType.type((String) entry.get(QueryRuleCriteria.TYPE_FIELD.getPreferredName())),
                     (String) entry.get(QueryRuleCriteria.METADATA_FIELD.getPreferredName()),
                     (List<Object>) entry.get(QueryRuleCriteria.VALUES_FIELD.getPreferredName())
                 )

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -180,13 +180,13 @@ public class QueryRulesIndexService {
             }
             final Map<String, Object> source = getResponse.getSource();
             @SuppressWarnings("unchecked")
-            final List<QueryRule> rules = ((List<Map<String, Object>>) source.get("rules")).stream()
+            final List<QueryRule> rules = ((List<Map<String, Object>>) source.get(QueryRuleset.RULES_FIELD.getPreferredName())).stream()
                 .map(
                     rule -> new QueryRule(
-                        (String) rule.get("rule_id"),
-                        QueryRuleType.queryRuleType((String) rule.get("type")),
-                        parseCriteria((List<Map<String, Object>>) rule.get("criteria")),
-                        (Map<String, Object>) rule.get("actions")
+                        (String) rule.get(QueryRule.ID_FIELD.getPreferredName()),
+                        QueryRuleType.queryRuleType((String) rule.get(QueryRule.TYPE_FIELD.getPreferredName())),
+                        parseCriteria((List<Map<String, Object>>) rule.get(QueryRule.CRITERIA_FIELD.getPreferredName())),
+                        (Map<String, Object>) rule.get(QueryRule.ACTIONS_FIELD.getPreferredName())
                     )
                 )
                 .collect(Collectors.toList());
@@ -201,9 +201,9 @@ public class QueryRulesIndexService {
         for (Map<String, Object> entry : rawCriteria) {
             criteria.add(
                 new QueryRuleCriteria(
-                    QueryRuleCriteria.CriteriaType.criteriaType((String) entry.get("type")),
-                    (String) entry.get("metadata"),
-                    (List<Object>) entry.get("values")
+                    QueryRuleCriteria.CriteriaType.criteriaType((String) entry.get(QueryRuleCriteria.TYPE_FIELD.getPreferredName())),
+                    (String) entry.get(QueryRuleCriteria.METADATA_FIELD.getPreferredName()),
+                    (List<Object>) entry.get(QueryRuleCriteria.VALUES_FIELD.getPreferredName())
                 )
             );
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -137,7 +137,7 @@ public class QueryRulesIndexService {
                             builder.field("type", "keyword");
                             builder.endObject();
 
-                            builder.startObject(QueryRuleCriteria.VALUE_FIELD.getPreferredName());
+                            builder.startObject(QueryRuleCriteria.VALUES_FIELD.getPreferredName());
                             builder.field("type", "object");
                             builder.field("enabled", false);
                             builder.endObject();
@@ -195,6 +195,7 @@ public class QueryRulesIndexService {
         }));
     }
 
+    @SuppressWarnings("unchecked")
     private List<QueryRuleCriteria> parseCriteria(List<Map<String, Object>> rawCriteria) {
         List<QueryRuleCriteria> criteria = new ArrayList<>(rawCriteria.size());
         for (Map<String, Object> entry : rawCriteria) {
@@ -202,7 +203,7 @@ public class QueryRulesIndexService {
                 new QueryRuleCriteria(
                     QueryRuleCriteria.CriteriaType.criteriaType((String) entry.get("type")),
                     (String) entry.get("metadata"),
-                    entry.get("value")
+                    (List<Object>) entry.get("values")
                 )
             );
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
@@ -118,6 +118,11 @@ public class PutQueryRulesetAction extends ActionType<PutQueryRulesetAction.Resp
             return new PutQueryRulesetAction.Request(QueryRuleset.fromXContent(id, parser));
         }
 
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
+
     }
 
     public static class Response extends ActionResponse implements StatusToXContentObject {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -47,12 +47,36 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         }
     }
 
+    public final void testGlobalSerialization() throws IOException {
+        for (int runs = 0; runs < 10; runs++) {
+            QueryRuleCriteria testInstance = SearchApplicationTestUtils.randomGlobalQueryRuleCriteria();
+            assertTransportSerialization(testInstance);
+            assertXContent(testInstance, randomBoolean());
+        }
+    }
+
     public void testToXContent() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {
               "type": "exact",
-              "metadata": "query_string",
-              "value": "foo"
+              "metadata": "my-key",
+              "values": ["foo","bar"]
+            }""");
+
+        QueryRuleCriteria queryRuleCriteria = QueryRuleCriteria.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(queryRuleCriteria, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        QueryRuleCriteria parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = QueryRuleCriteria.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testGlobalToXContent() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+              "type": "global"
             }""");
 
         QueryRuleCriteria queryRuleCriteria = QueryRuleCriteria.fromXContentBytes(new BytesArray(content), XContentType.JSON);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -26,15 +26,16 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.CONTAINS;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.EXACT_FUZZY;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GLOBAL;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GT;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GTE;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.LT;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.LTE;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.PREFIX;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.SUFFIX;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.CONTAINS;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT_FUZZY;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GT;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GTE;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.LT;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.LTE;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.PREFIX;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.SUFFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRuleCriteriaTests extends ESTestCase {
@@ -99,7 +100,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testExactMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.EXACT;
+        QueryRuleCriteriaType type = EXACT;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertFalse(queryRuleCriteria.isMatch("elasticc", type));
@@ -111,7 +112,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testFuzzyExactMatch() {
-        QueryRuleCriteria.CriteriaType type = EXACT_FUZZY;
+        QueryRuleCriteriaType type = EXACT_FUZZY;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("elasticc", type));
@@ -119,7 +120,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testPrefixMatch() {
-        QueryRuleCriteria.CriteriaType type = PREFIX;
+        QueryRuleCriteriaType type = PREFIX;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic", "kibana"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("kibana", type));
@@ -129,7 +130,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testSuffixMatch() {
-        QueryRuleCriteria.CriteriaType type = SUFFIX;
+        QueryRuleCriteriaType type = SUFFIX;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("search", "lucene"));
         assertTrue(queryRuleCriteria.isMatch("search", type));
         assertTrue(queryRuleCriteria.isMatch("lucene", type));
@@ -140,7 +141,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testContainsMatch() {
-        QueryRuleCriteria.CriteriaType type = CONTAINS;
+        QueryRuleCriteriaType type = CONTAINS;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("I use elastic for search", type));
@@ -148,7 +149,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testLtMatch() {
-        QueryRuleCriteria.CriteriaType type = LT;
+        QueryRuleCriteriaType type = LT;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(5, type));
         assertFalse(queryRuleCriteria.isMatch(10, type));
@@ -156,7 +157,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testLteMatch() {
-        QueryRuleCriteria.CriteriaType type = LTE;
+        QueryRuleCriteriaType type = LTE;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(5, type));
         assertTrue(queryRuleCriteria.isMatch(10, type));
@@ -164,7 +165,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testGtMatch() {
-        QueryRuleCriteria.CriteriaType type = GT;
+        QueryRuleCriteriaType type = GT;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(20, type));
         assertFalse(queryRuleCriteria.isMatch(10, type));
@@ -172,7 +173,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testGteMatch() {
-        QueryRuleCriteria.CriteriaType type = GTE;
+        QueryRuleCriteriaType type = GTE;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(20, type));
         assertTrue(queryRuleCriteria.isMatch(10, type));
@@ -180,19 +181,19 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testGlobalMatch() {
-        QueryRuleCriteria.CriteriaType type = GLOBAL;
+        QueryRuleCriteriaType type = GLOBAL;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, null, null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch(42, type));
     }
 
     public void testInvalidCriteriaInput() {
-        for (QueryRuleCriteria.CriteriaType type : List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS)) {
+        for (QueryRuleCriteriaType type : List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS)) {
             QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of("bar"));
             expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch(42, type));
         }
 
-        for (QueryRuleCriteria.CriteriaType type : List.of(LT, LTE, GT, GTE)) {
+        for (QueryRuleCriteriaType type : List.of(LT, LTE, GT, GTE)) {
             QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of(42));
             expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch("puggles", type));
         }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -26,10 +26,10 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.CONTAINS;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT_FUZZY;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.FUZZY;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GT;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GTE;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.LT;
@@ -57,9 +57,9 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         }
     }
 
-    public final void testGlobalSerialization() throws IOException {
+    public final void testAlwaysSerialization() throws IOException {
         for (int runs = 0; runs < 10; runs++) {
-            QueryRuleCriteria testInstance = SearchApplicationTestUtils.randomGlobalQueryRuleCriteria();
+            QueryRuleCriteria testInstance = new QueryRuleCriteria(ALWAYS, null, null);
             assertTransportSerialization(testInstance);
             assertXContent(testInstance, randomBoolean());
         }
@@ -83,10 +83,10 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
     }
 
-    public void testGlobalToXContent() throws IOException {
+    public void testAlwaysToXContent() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {
-              "type": "global"
+              "type": "always"
             }""");
 
         QueryRuleCriteria queryRuleCriteria = QueryRuleCriteria.fromXContentBytes(new BytesArray(content), XContentType.JSON);
@@ -112,7 +112,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testFuzzyExactMatch() {
-        QueryRuleCriteriaType type = EXACT_FUZZY;
+        QueryRuleCriteriaType type = FUZZY;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("elasticc", type));
@@ -180,15 +180,15 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         assertFalse(queryRuleCriteria.isMatch(5, type));
     }
 
-    public void testGlobalMatch() {
-        QueryRuleCriteriaType type = GLOBAL;
+    public void testAlwaysMatch() {
+        QueryRuleCriteriaType type = ALWAYS;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, null, null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch(42, type));
     }
 
     public void testInvalidCriteriaInput() {
-        for (QueryRuleCriteriaType type : List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS)) {
+        for (QueryRuleCriteriaType type : List.of(FUZZY, PREFIX, SUFFIX, CONTAINS)) {
             QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of("bar"));
             expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch(42, type));
         }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -89,6 +89,89 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
     }
 
+    public void testExactMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.EXACT;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
+        assertTrue(queryRuleCriteria.isMatch("elastic", type));
+        assertFalse(queryRuleCriteria.isMatch("elasticc", type));
+    }
+
+    public void testFuzzyExactMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.EXACT_FUZZY;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
+        assertTrue(queryRuleCriteria.isMatch("elastic", type));
+        assertTrue(queryRuleCriteria.isMatch("elasticc", type));
+        assertFalse(queryRuleCriteria.isMatch("elastic elastic elastic elastic", type));
+    }
+
+    public void testPrefixMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.PREFIX;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic", "kibana"));
+        assertTrue(queryRuleCriteria.isMatch("elastic", type));
+        assertTrue(queryRuleCriteria.isMatch("kibana", type));
+        assertTrue(queryRuleCriteria.isMatch("elastic is a great search engine", type));
+        assertTrue(queryRuleCriteria.isMatch("kibana is a great visualization tool", type));
+        assertFalse(queryRuleCriteria.isMatch("you know, for search - elastic, kibana", type));
+    }
+
+    public void testSuffixMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.SUFFIX;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("search", "lucene"));
+        assertTrue(queryRuleCriteria.isMatch("search", type));
+        assertTrue(queryRuleCriteria.isMatch("lucene", type));
+        assertTrue(queryRuleCriteria.isMatch("you know, for search", type));
+        assertTrue(queryRuleCriteria.isMatch("elasticsearch is built on top of lucene", type));
+        assertFalse(queryRuleCriteria.isMatch("search is a good use case for elastic", type));
+        assertFalse(queryRuleCriteria.isMatch("lucene and elastic are open source", type));
+    }
+
+    public void testContainsMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.CONTAINS;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
+        assertTrue(queryRuleCriteria.isMatch("elastic", type));
+        assertTrue(queryRuleCriteria.isMatch("I use elastic for search", type));
+        assertFalse(queryRuleCriteria.isMatch("you know, for search", type));
+    }
+
+    public void testLtMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.LT;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        assertTrue(queryRuleCriteria.isMatch(5, type));
+        assertFalse(queryRuleCriteria.isMatch(10, type));
+        assertFalse(queryRuleCriteria.isMatch(20, type));
+    }
+
+    public void testLteMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.LTE;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        assertTrue(queryRuleCriteria.isMatch(5, type));
+        assertTrue(queryRuleCriteria.isMatch(10, type));
+        assertFalse(queryRuleCriteria.isMatch(20, type));
+    }
+
+    public void testGtMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.GT;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        assertTrue(queryRuleCriteria.isMatch(20, type));
+        assertFalse(queryRuleCriteria.isMatch(10, type));
+        assertFalse(queryRuleCriteria.isMatch(5, type));
+    }
+
+    public void testGteMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.GTE;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        assertTrue(queryRuleCriteria.isMatch(20, type));
+        assertTrue(queryRuleCriteria.isMatch(10, type));
+        assertFalse(queryRuleCriteria.isMatch(5, type));
+    }
+
+    public void testGlobalMatch() {
+        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.GLOBAL;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, null, null);
+        assertTrue(queryRuleCriteria.isMatch("elastic", type));
+        assertTrue(queryRuleCriteria.isMatch(42, type));
+    }
+
     private void assertXContent(QueryRuleCriteria queryRule, boolean humanReadable) throws IOException {
         BytesReference originalBytes = toShuffledXContent(queryRule, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
         QueryRuleCriteria parsed;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -26,6 +26,15 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.CONTAINS;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.EXACT_FUZZY;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GT;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.GTE;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.LT;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.LTE;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.PREFIX;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType.SUFFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRuleCriteriaTests extends ESTestCase {
@@ -97,7 +106,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testFuzzyExactMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.EXACT_FUZZY;
+        QueryRuleCriteria.CriteriaType type = EXACT_FUZZY;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("elasticc", type));
@@ -105,7 +114,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testPrefixMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.PREFIX;
+        QueryRuleCriteria.CriteriaType type = PREFIX;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic", "kibana"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("kibana", type));
@@ -115,7 +124,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testSuffixMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.SUFFIX;
+        QueryRuleCriteria.CriteriaType type = SUFFIX;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("search", "lucene"));
         assertTrue(queryRuleCriteria.isMatch("search", type));
         assertTrue(queryRuleCriteria.isMatch("lucene", type));
@@ -126,7 +135,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testContainsMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.CONTAINS;
+        QueryRuleCriteria.CriteriaType type = CONTAINS;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("I use elastic for search", type));
@@ -134,7 +143,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testLtMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.LT;
+        QueryRuleCriteria.CriteriaType type = LT;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(5, type));
         assertFalse(queryRuleCriteria.isMatch(10, type));
@@ -142,7 +151,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testLteMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.LTE;
+        QueryRuleCriteria.CriteriaType type = LTE;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(5, type));
         assertTrue(queryRuleCriteria.isMatch(10, type));
@@ -150,7 +159,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testGtMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.GT;
+        QueryRuleCriteria.CriteriaType type = GT;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(20, type));
         assertFalse(queryRuleCriteria.isMatch(10, type));
@@ -158,7 +167,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testGteMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.GTE;
+        QueryRuleCriteria.CriteriaType type = GTE;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
         assertTrue(queryRuleCriteria.isMatch(20, type));
         assertTrue(queryRuleCriteria.isMatch(10, type));
@@ -166,10 +175,22 @@ public class QueryRuleCriteriaTests extends ESTestCase {
     }
 
     public void testGlobalMatch() {
-        QueryRuleCriteria.CriteriaType type = QueryRuleCriteria.CriteriaType.GLOBAL;
+        QueryRuleCriteria.CriteriaType type = GLOBAL;
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, null, null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch(42, type));
+    }
+
+    public void testInvalidCriteriaInput() {
+        for (QueryRuleCriteria.CriteriaType type : List.of(EXACT_FUZZY, PREFIX, SUFFIX, CONTAINS)) {
+            QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of("bar"));
+            expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch(42, type));
+        }
+
+        for (QueryRuleCriteria.CriteriaType type : List.of(LT, LTE, GT, GTE)) {
+            QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of(42));
+            expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch("puggles", type));
+        }
     }
 
     private void assertXContent(QueryRuleCriteria queryRule, boolean humanReadable) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -103,6 +103,11 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertFalse(queryRuleCriteria.isMatch("elasticc", type));
+
+        queryRuleCriteria = new QueryRuleCriteria(type, "zip_code", List.of("12345"));
+        assertTrue(queryRuleCriteria.isMatch(12345, type));
+        assertTrue(queryRuleCriteria.isMatch("12345", type));
+        assertFalse(queryRuleCriteria.isMatch("123456", type));
     }
 
     public void testFuzzyExactMatch() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
@@ -53,7 +53,7 @@ public class QueryRuleTests extends ESTestCase {
               "rule_id": "my_query_rule",
               "type": "pinned",
               "criteria": [
-                { "type": "exact", "metadata": "query_string", "value": "foo" }
+                { "type": "exact", "metadata": "query_string", "values": ["foo", "bar"] }
               ],
               "actions": {
                 "ids": ["id1", "id2"]
@@ -75,7 +75,7 @@ public class QueryRuleTests extends ESTestCase {
             {
               "type": "pinned",
               "criteria": [
-                { "type": "exact", "metadata": "query_string", "value": "foo" }
+                { "type": "exact", "metadata": "query_string", "values": ["foo", "bar"] }
               ],
               "actions": {
                   "ids": ["id1", "id2"]
@@ -101,7 +101,7 @@ public class QueryRuleTests extends ESTestCase {
               "rule_id": "my_query_rule",
               "type": "pinned",
               "criteria": [
-                { "type": "exact", "metadata": "query_string", "value": "foo" }
+                { "type": "exact", "metadata": "query_string", "values": ["foo", "bar"] }
               ],
               "actions": {
                 "ids": ["id1", "id2"]
@@ -116,7 +116,7 @@ public class QueryRuleTests extends ESTestCase {
               "rule_id": "my_query_rule",
               "type": "pinned",
               "criteria": [
-                { "type": "exact", "metadata": "query_string", "value": "foo" }
+                { "type": "exact", "metadata": "query_string", "values": ["foo", "bar"] }
               ],
               "actions": {
                 "docs": [
@@ -151,7 +151,7 @@ public class QueryRuleTests extends ESTestCase {
               "rule_id": "my_query_rule",
               "type": "pinned",
               "criteria": [
-                { "type": "exact", "metadata": "query_string", "value": "foo" }
+                { "type": "exact", "metadata": "query_string", "values": ["foo", "bar"] }
               ],
               "actions": {
                   "foo": "bar"

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
@@ -28,6 +28,9 @@ import java.util.Map;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.PREFIX;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.SUFFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRuleTests extends ESTestCase {
@@ -166,7 +169,7 @@ public class QueryRuleTests extends ESTestCase {
         QueryRule rule = new QueryRule(
             randomAlphaOfLength(10),
             QueryRule.QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.EXACT, "query", List.of("elastic"))),
+            List.of(new QueryRuleCriteria(EXACT, "query", List.of("elastic"))),
             Map.of("ids", List.of("id1", "id2"))
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
@@ -182,10 +185,7 @@ public class QueryRuleTests extends ESTestCase {
         QueryRule rule = new QueryRule(
             randomAlphaOfLength(10),
             QueryRule.QueryRuleType.PINNED,
-            List.of(
-                new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.PREFIX, "query", List.of("elastic")),
-                new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.SUFFIX, "query", List.of("search"))
-            ),
+            List.of(new QueryRuleCriteria(PREFIX, "query", List.of("elastic")), new QueryRuleCriteria(SUFFIX, "query", List.of("search"))),
             Map.of("ids", List.of("id1", "id2"))
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.application.rules.QueryRule.QueryRuleType;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CriteriaType;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
 import static org.elasticsearch.xpack.application.rules.QueryRulesIndexService.QUERY_RULES_CONCRETE_INDEX_NAME;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -69,7 +69,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
             final QueryRule myQueryRule1 = new QueryRule(
                 "my_rule1",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo"))),
+                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"))),
                 Map.of("ids", List.of("id1", "id2"))
             );
             final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", Collections.singletonList(myQueryRule1));
@@ -84,13 +84,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
         final QueryRule myQueryRule1 = new QueryRule(
             "my_rule1",
             QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo"))),
+            List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"))),
             Map.of("docs", List.of(Map.of("_index", "my_index1", "_id", "id1"), Map.of("_index", "my_index2", "_id", "id2")))
         );
         final QueryRule myQueryRule2 = new QueryRule(
             "my_rule2",
             QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("bar"))),
+            List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar"))),
             Map.of("docs", List.of(Map.of("_index", "my_index1", "_id", "id3"), Map.of("_index", "my_index2", "_id", "id4")))
         );
         final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", List.of(myQueryRule1, myQueryRule2));
@@ -108,13 +108,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 new QueryRule(
                     "my_rule_" + i,
                     QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo" + i))),
+                    List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo" + i))),
                     Map.of("ids", List.of("id1", "id2"))
                 ),
                 new QueryRule(
                     "my_rule_" + i + "_" + (i + 1),
                     QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("bar" + i))),
+                    List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar" + i))),
                     Map.of("ids", List.of("id3", "id4"))
                 )
             );
@@ -158,13 +158,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
             final QueryRule myQueryRule1 = new QueryRule(
                 "my_rule1",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo"))),
+                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"))),
                 Map.of("ids", List.of("id1", "id2"))
             );
             final QueryRule myQueryRule2 = new QueryRule(
                 "my_rule2",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("bar"))),
+                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar"))),
                 Map.of("ids", List.of("id3", "id4"))
             );
             final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", List.of(myQueryRule1, myQueryRule2));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
@@ -69,7 +69,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
             final QueryRule myQueryRule1 = new QueryRule(
                 "my_rule1",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "foo")),
+                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo"))),
                 Map.of("ids", List.of("id1", "id2"))
             );
             final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", Collections.singletonList(myQueryRule1));
@@ -84,13 +84,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
         final QueryRule myQueryRule1 = new QueryRule(
             "my_rule1",
             QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "foo")),
+            List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo"))),
             Map.of("docs", List.of(Map.of("_index", "my_index1", "_id", "id1"), Map.of("_index", "my_index2", "_id", "id2")))
         );
         final QueryRule myQueryRule2 = new QueryRule(
             "my_rule2",
             QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "bar")),
+            List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("bar"))),
             Map.of("docs", List.of(Map.of("_index", "my_index1", "_id", "id3"), Map.of("_index", "my_index2", "_id", "id4")))
         );
         final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", List.of(myQueryRule1, myQueryRule2));
@@ -108,13 +108,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 new QueryRule(
                     "my_rule_" + i,
                     QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "foo" + i)),
+                    List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo" + i))),
                     Map.of("ids", List.of("id1", "id2"))
                 ),
                 new QueryRule(
                     "my_rule_" + i + "_" + (i + 1),
                     QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "bar" + i)),
+                    List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("bar" + i))),
                     Map.of("ids", List.of("id3", "id4"))
                 )
             );
@@ -158,13 +158,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
             final QueryRule myQueryRule1 = new QueryRule(
                 "my_rule1",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "foo")),
+                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("foo"))),
                 Map.of("ids", List.of("id1", "id2"))
             );
             final QueryRule myQueryRule2 = new QueryRule(
                 "my_rule2",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", "bar")),
+                List.of(new QueryRuleCriteria(CriteriaType.EXACT, "query_string", List.of("bar"))),
                 Map.of("ids", List.of("id3", "id4"))
             );
             final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", List.of(myQueryRule1, myQueryRule2));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesetTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesetTests.java
@@ -55,7 +55,7 @@ public class QueryRulesetTests extends ESTestCase {
                 {
                   "rule_id": "my_query_rule1",
                   "type": "pinned",
-                  "criteria": [ {"type": "exact", "metadata": "query_string", "value": "foo"} ],
+                  "criteria": [ {"type": "exact", "metadata": "query_string", "values": ["foo", "bar"]} ],
                   "actions": {
                     "ids": ["id1", "id2"]
                   }
@@ -63,7 +63,7 @@ public class QueryRulesetTests extends ESTestCase {
                 {
                   "rule_id": "my_query_rule2",
                   "type": "pinned",
-                  "criteria": [ {"type": "exact", "metadata": "query_string", "value": "bar"} ],
+                  "criteria": [ {"type": "exact", "metadata": "query_string", "values": ["baz"]} ],
                   "actions": {
                     "ids": ["id3", "id4"]
                   }
@@ -89,7 +89,7 @@ public class QueryRulesetTests extends ESTestCase {
                 {
                   "rule_id": "my_query_rule1",
                   "type": "pinned",
-                  "criteria": [ {"type": "exact", "metadata": "query_string", "value": "foo"} ],
+                  "criteria": [ {"type": "exact", "metadata": "query_string", "values": ["foo", "bar"]} ],
                   "actions": {
                     "ids": ["id1", "id2"]
                   }
@@ -97,7 +97,7 @@ public class QueryRulesetTests extends ESTestCase {
                 {
                   "rule_id": "my_query_rule2",
                   "type": "pinned",
-                  "criteria": [ {"type": "exact", "metadata": "query_string", "value": "bar"} ],
+                  "criteria": [ {"type": "exact", "metadata": "query_string", "values": ["baz"]} ],
                   "actions": {
                     "ids": ["id3", "id4"]
                   }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -140,7 +140,7 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
                 new QueryRule(
                     "my_rule1",
                     QueryRule.QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.EXACT, "query_string", "elastic")),
+                    List.of(new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.EXACT, "query_string", List.of("elastic"))),
                     Map.of("ids", List.of("id1", "id2"))
                 )
             );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilder> {
@@ -140,7 +141,7 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
                 new QueryRule(
                     "my_rule1",
                     QueryRule.QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.EXACT, "query_string", List.of("elastic"))),
+                    List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("elastic"))),
                     Map.of("ids", List.of("id1", "id2"))
                 )
             );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
@@ -47,7 +47,7 @@ public class GetQueryRulesetActionResponseBWCSerializingTests extends AbstractBW
 
     @Override
     protected GetQueryRulesetAction.Response mutateInstanceForVersion(GetQueryRulesetAction.Response instance, TransportVersion version) {
-        if (version.before(TransportVersion.V_8_500_041)) {
+        if (version.before(TransportVersion.V_8_500_044)) {
             List<QueryRule> rules = new ArrayList<>();
             for (QueryRule rule : instance.queryRuleset().rules()) {
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CRITERIA_METADATA_VALUES_TRANSPORT_VERSION;
 import static org.elasticsearch.xpack.application.search.SearchApplicationTestUtils.randomQueryRuleset;
 
 public class GetQueryRulesetActionResponseBWCSerializingTests extends AbstractBWCSerializationTestCase<GetQueryRulesetAction.Response> {
@@ -47,7 +48,7 @@ public class GetQueryRulesetActionResponseBWCSerializingTests extends AbstractBW
 
     @Override
     protected GetQueryRulesetAction.Response mutateInstanceForVersion(GetQueryRulesetAction.Response instance, TransportVersion version) {
-        if (version.before(TransportVersion.V_8_500_044)) {
+        if (version.before(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
             List<QueryRule> rules = new ArrayList<>();
             for (QueryRule rule : instance.queryRuleset().rules()) {
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
@@ -10,10 +10,14 @@ package org.elasticsearch.xpack.application.rules.action;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.application.rules.QueryRule;
+import org.elasticsearch.xpack.application.rules.QueryRuleCriteria;
 import org.elasticsearch.xpack.application.rules.QueryRuleset;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.elasticsearch.xpack.application.search.SearchApplicationTestUtils.randomQueryRuleset;
 
@@ -43,6 +47,20 @@ public class GetQueryRulesetActionResponseBWCSerializingTests extends AbstractBW
 
     @Override
     protected GetQueryRulesetAction.Response mutateInstanceForVersion(GetQueryRulesetAction.Response instance, TransportVersion version) {
-        return new GetQueryRulesetAction.Response(instance.queryRuleset());
+        if (version.before(TransportVersion.V_8_500_041)) {
+            List<QueryRule> rules = new ArrayList<>();
+            for (QueryRule rule : instance.queryRuleset().rules()) {
+                List<QueryRuleCriteria> newCriteria = new ArrayList<>();
+                for (QueryRuleCriteria criteria : rule.criteria()) {
+                    newCriteria.add(
+                        new QueryRuleCriteria(criteria.criteriaType(), criteria.criteriaMetadata(), criteria.criteriaValues().subList(0, 1))
+                    );
+                }
+                rules.add(new QueryRule(rule.id(), rule.type(), newCriteria, rule.actions()));
+            }
+            return new GetQueryRulesetAction.Response(new QueryRuleset(instance.queryRuleset().id(), rules));
+        }
+
+        return instance;
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteria.CRITERIA_METADATA_VALUES_TRANSPORT_VERSION;
+
 public class PutQueryRulesetActionRequestBWCSerializingTests extends AbstractBWCSerializationTestCase<PutQueryRulesetAction.Request> {
 
     private QueryRuleset queryRulesSet;
@@ -48,7 +50,7 @@ public class PutQueryRulesetActionRequestBWCSerializingTests extends AbstractBWC
     @Override
     protected PutQueryRulesetAction.Request mutateInstanceForVersion(PutQueryRulesetAction.Request instance, TransportVersion version) {
 
-        if (version.before(TransportVersion.V_8_500_044)) {
+        if (version.before(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
             List<QueryRule> rules = new ArrayList<>();
             for (QueryRule rule : instance.queryRuleset().rules()) {
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
@@ -48,7 +48,7 @@ public class PutQueryRulesetActionRequestBWCSerializingTests extends AbstractBWC
     @Override
     protected PutQueryRulesetAction.Request mutateInstanceForVersion(PutQueryRulesetAction.Request instance, TransportVersion version) {
 
-        if (version.before(TransportVersion.V_8_500_041)) {
+        if (version.before(TransportVersion.V_8_500_044)) {
             List<QueryRule> rules = new ArrayList<>();
             for (QueryRule rule : instance.queryRuleset().rules()) {
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomList;
 import static org.elasticsearch.test.ESTestCase.randomLongBetween;
 import static org.elasticsearch.test.ESTestCase.randomMap;
-import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 
 // TODO - move this one package up and rename to EnterpriseSearchModuleTestUtils
 public final class SearchApplicationTestUtils {
@@ -83,13 +83,9 @@ public final class SearchApplicationTestUtils {
     }
 
     public static QueryRuleCriteria randomQueryRuleCriteria() {
-        // We intentionally don't allow global criteria in this method, since we want to test parsing metadata and values
-        QueryRuleCriteriaType type = randomFrom(Arrays.stream(QueryRuleCriteriaType.values()).filter(t -> t != GLOBAL).toList());
+        // We intentionally don't allow ALWAYS criteria in this method, since we want to test parsing metadata and values
+        QueryRuleCriteriaType type = randomFrom(Arrays.stream(QueryRuleCriteriaType.values()).filter(t -> t != ALWAYS).toList());
         return new QueryRuleCriteria(type, randomAlphaOfLengthBetween(1, 10), randomList(1, 5, () -> randomAlphaOfLengthBetween(1, 10)));
-    }
-
-    public static QueryRuleCriteria randomGlobalQueryRuleCriteria() {
-        return new QueryRuleCriteria(GLOBAL, null, null);
     }
 
     public static QueryRule randomQueryRule() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.application.rules.QueryRuleset;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -28,6 +29,7 @@ import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.test.ESTestCase.randomList;
 import static org.elasticsearch.test.ESTestCase.randomLongBetween;
 import static org.elasticsearch.test.ESTestCase.randomMap;
 
@@ -79,11 +81,15 @@ public final class SearchApplicationTestUtils {
     }
 
     public static QueryRuleCriteria randomQueryRuleCriteria() {
-        return new QueryRuleCriteria(
-            randomFrom(QueryRuleCriteria.CriteriaType.values()),
-            randomAlphaOfLengthBetween(1, 10),
-            randomAlphaOfLengthBetween(1, 10)
+        // We intentionally don't allow global criteria in this method, since we want to test parsing metadata and values
+        QueryRuleCriteria.CriteriaType type = randomFrom(
+            Arrays.stream(QueryRuleCriteria.CriteriaType.values()).filter(t -> t != QueryRuleCriteria.CriteriaType.GLOBAL).toList()
         );
+        return new QueryRuleCriteria(type, randomAlphaOfLengthBetween(1, 10), randomList(1, 5, () -> randomAlphaOfLengthBetween(1, 10)));
+    }
+
+    public static QueryRuleCriteria randomGlobalQueryRuleCriteria() {
+        return new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.GLOBAL, null, null);
     }
 
     public static QueryRule randomQueryRule() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
@@ -13,6 +13,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.application.rules.QueryRule;
 import org.elasticsearch.xpack.application.rules.QueryRuleCriteria;
+import org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType;
 import org.elasticsearch.xpack.application.rules.QueryRuleset;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
@@ -32,6 +33,7 @@ import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomList;
 import static org.elasticsearch.test.ESTestCase.randomLongBetween;
 import static org.elasticsearch.test.ESTestCase.randomMap;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GLOBAL;
 
 // TODO - move this one package up and rename to EnterpriseSearchModuleTestUtils
 public final class SearchApplicationTestUtils {
@@ -82,14 +84,12 @@ public final class SearchApplicationTestUtils {
 
     public static QueryRuleCriteria randomQueryRuleCriteria() {
         // We intentionally don't allow global criteria in this method, since we want to test parsing metadata and values
-        QueryRuleCriteria.CriteriaType type = randomFrom(
-            Arrays.stream(QueryRuleCriteria.CriteriaType.values()).filter(t -> t != QueryRuleCriteria.CriteriaType.GLOBAL).toList()
-        );
+        QueryRuleCriteriaType type = randomFrom(Arrays.stream(QueryRuleCriteriaType.values()).filter(t -> t != GLOBAL).toList());
         return new QueryRuleCriteria(type, randomAlphaOfLengthBetween(1, 10), randomList(1, 5, () -> randomAlphaOfLengthBetween(1, 10)));
     }
 
     public static QueryRuleCriteria randomGlobalQueryRuleCriteria() {
-        return new QueryRuleCriteria(QueryRuleCriteria.CriteriaType.GLOBAL, null, null);
+        return new QueryRuleCriteria(GLOBAL, null, null);
     }
 
     public static QueryRule randomQueryRule() {


### PR DESCRIPTION
Adds additional functionality to query rules and `RuleQueryBuilder`:

- Updates the API to allow multiple matching criteria values. For example, `user.country` may match on either `us` or `ca`.
- Allows more extensive criteria match types including `fuzzy`, `prefix`, `suffix`, `contains`, `lt`, `lte`, `gt`, `gte` and `always` 

Documentation to be merged in a followup PR. 