### PR TITLE
Add specific cluster error info, shard info and additional metadata for CCS when minimizing roundtrips

### DIFF
--- a/MP-README.md
+++ b/MP-README.md
@@ -1,5 +1,0 @@
-Tests to run
-grs -p server test --tests org.elasticsearch.action.search.TransportSearchActionTests -Dtests.iters=3
-grs ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT"
-grs ':server:internalClusterTest' --tests "org.elasticsearch.search.ccs.CrossClusterSearchIT"
-grs ':x-pack:plugin:async-search:internalClusterTest' --tests "org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT"

--- a/MP-README.md
+++ b/MP-README.md
@@ -1,3 +1,5 @@
 Tests to run
 gr -p server test --tests org.elasticsearch.action.search.TransportSearchActionTests -Dtests.iters=3
 gr ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT.testMatchAll"
+grs ':server:internalClusterTest' --tests "org.elasticsearch.search.ccs.CrossClusterSearchIT"
+grs ':x-pack:plugin:async-search:internalClusterTest' --tests "org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT"

--- a/MP-README.md
+++ b/MP-README.md
@@ -1,5 +1,5 @@
 Tests to run
 gr -p server test --tests org.elasticsearch.action.search.TransportSearchActionTests -Dtests.iters=3
-gr ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT.testMatchAll"
+gr ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT"
 grs ':server:internalClusterTest' --tests "org.elasticsearch.search.ccs.CrossClusterSearchIT"
 grs ':x-pack:plugin:async-search:internalClusterTest' --tests "org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT"

--- a/MP-README.md
+++ b/MP-README.md
@@ -1,0 +1,3 @@
+Tests to run
+gr -p server test --tests org.elasticsearch.action.search.TransportSearchActionTests -Dtests.iters=3
+gr ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT.testMatchAll"

--- a/MP-README.md
+++ b/MP-README.md
@@ -1,5 +1,5 @@
 Tests to run
-gr -p server test --tests org.elasticsearch.action.search.TransportSearchActionTests -Dtests.iters=3
-gr ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT"
+grs -p server test --tests org.elasticsearch.action.search.TransportSearchActionTests -Dtests.iters=3
+grs ':qa:multi-cluster-search:v8.10.0#multi-cluster' --tests "org.elasticsearch.search.CCSDuelIT"
 grs ':server:internalClusterTest' --tests "org.elasticsearch.search.ccs.CrossClusterSearchIT"
 grs ':x-pack:plugin:async-search:internalClusterTest' --tests "org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT"

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -431,22 +431,6 @@ The API returns the following response:
 --------------------------------------------------
 // TEST[skip: terminated_early is absent from final results so is hard to reproduce here]
 
-x // TESTRESPONSE[s/FklQYndoTDJ2VEFlMEVBTzFJMGhJVFEaLVlKYndBWWZSMUdicUc4WVlEaFl4ZzoxNTU=/$body.id/]
-x // TESTRESPONSE[s/"is_partial": true/"is_partial": $body.is_partial/]
-x // TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
-x // TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
-x // TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
-x // TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
-x // TESTRESPONSE[s/"num_reduce_phases": 0/"num_reduce_phases": "$body.response.num_reduce_phases"/]
-x // TESTRESPONSE[s/"took": 1020/"took": "$body.response.took"/]
-x // TESTRESPONSE[s/"total": 8/"total": $body.response._shards.total/]
-x // TESTRESPONSE[s/"successful": 0/"successful": $body.response._shards.successful/]
-x // TESTRESPONSE[s/"successful" : 0/"successful": $body.response._clusters.successful/]
-x // TESTRESPONSE[s/"value": 0/"value": "$body.response.hits.total.value"/]
-x // TESTRESPONSE[s/"max_score": null/"max_score": "$body.response.hits.max_score"/]
-x // TESTRESPONSE[s/"hits": \[\]/"hits": $body.response.hits.hits/]
-
-
 <1> The async search id.
 <2> When `ccs_minimize_roundtrips` = `true` and searches on the remote clusters
 are still running, this section indicates the number of shards in scope for the

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -130,8 +130,8 @@ The API returns the following response:
   "took": 150,
   "timed_out": false,
   "_shards": {
-    "total": 1,
-    "successful": 1,
+    "total": 3,
+    "successful": 3,
     "failed": 0,
     "skipped": 0
   },
@@ -142,12 +142,15 @@ The API returns the following response:
     "details": {
       "cluster_one": {  <1>
         "status": "successful",
-        "total_shards": 3,
-        "successful_shards": 3,
-        "skipped_shards": 0,
-        "failed_shards": 0,
-        "percent_shards_successful": "100.00",
-        "search_duration": 27
+        "indices": "my-index-000001",
+        "took": 148,
+        "timed_out": false,
+        "_shards": {
+          "total": 3,
+          "successful": 3,
+          "skipped": 0,
+          "failed": 0
+        }
       }
     }
   },
@@ -182,17 +185,16 @@ The API returns the following response:
 // TESTRESPONSE[s/"took": 150/"took": "$body.took"/]
 // TESTRESPONSE[s/"max_score": 1/"max_score": "$body.hits.max_score"/]
 // TESTRESPONSE[s/"_score": 1/"_score": "$body.hits.hits.0._score"/]
-// TESTRESPONSE[s/"total_shards": 3/"total_shards": "$body._clusters.details.cluster_one.total_shards"/]
-// TESTRESPONSE[s/"successful_shards": 3/"successful_shards": "$body._clusters.details.cluster_one.successful_shards"/]
-// TESTRESPONSE[s/"skipped_shards": 0/"skipped_shards": "$body._clusters.details.cluster_one.skipped_shards"/]
-// TESTRESPONSE[s/"failed_shards": 0/"failed_shards": "$body._clusters.details.cluster_one.failed_shards"/]
-// TESTRESPONSE[s/"percent_shards_successful": "100.00"/"percent_shards_successful": "$body._clusters.details.cluster_one.percent_shards_successful"/]
-// TESTRESPONSE[s/"search_duration": 27/"search_duration": "$body._clusters.details.cluster_one.search_duration"/]
+// TESTRESPONSE[s/"total": 3/"total": "$body._shards.total"/]
+// TESTRESPONSE[s/"successful": 3/"successful": "$body._shards.successful"/]
+// TESTRESPONSE[s/"skipped": 0/"skipped": "$body._shards.skipped"/]
+// TESTRESPONSE[s/"failed": 3/"failed": "$body._shards.failed"/]
+// TESTRESPONSE[s/"took": 148/"took": "$body._clusters.details.cluster_one.took"/]
 
-
-<1> The details section shows information about the search on each remote cluster.
+<1> The details section shows information about the search on each cluster.
 <2> The search response body includes the name of the remote cluster in the
 `_index` parameter.
+
 
 
 [discrete]
@@ -240,30 +242,39 @@ The API returns the following response:
     "details": {
       "(local)": {            <1>
         "status": "successful",
-        "total_shards": 5,
-        "successful_shards": 5,
-        "skipped_shards": 0,
-        "failed_shards": 0,
-        "percent_shards_successful": "100.00",
-        "search_duration": 21
+        "indices": "my-index-000001",
+        "took": 21,
+        "timed_out": false,
+        "_shards": {
+          "total": 5,
+          "successful": 5,
+          "skipped": 0,
+          "failed": 0
+        }
       },
       "cluster_one": {
         "status": "successful",
-        "total_shards": 4,
-        "successful_shards": 4,
-        "skipped_shards": 0,
-        "failed_shards": 0,
-        "percent_shards_successful": "100.00",
-        "search_duration": 35
+        "indices": "my-index-000001",
+        "took": 48,
+        "timed_out": false,
+        "_shards": {
+          "total": 4,
+          "successful": 4,
+          "skipped": 0,
+          "failed": 0
+        }
       },
       "cluster_two": {
         "status": "successful",
-        "total_shards": 3,
-        "successful_shards": 3,
-        "skipped_shards": 0,
-        "failed_shards": 0,
-        "percent_shards_successful": "100.00",
-        "search_duration": 37
+        "indices": "my-index-000001",
+        "took": 141,
+        "timed_out": false,
+        "_shards": {
+          "total" : 3,
+          "successful" : 3,
+          "skipped": 0,
+          "failed": 0
+        }
       }
     }
   },
@@ -335,15 +346,15 @@ The API returns the following response:
 // TESTRESPONSE[s/"_score": 2/"_score": "$body.hits.hits.1._score"/]
 // TESTRESPONSE[s/"total": 12/"total": "$body._shards.total"/]
 // TESTRESPONSE[s/"successful": 12/"successful": "$body._shards.successful"/]
-// TESTRESPONSE[s/"total_shards": 5/"total_shards": "$body._clusters.details.(local).total_shards"/]
-// TESTRESPONSE[s/"successful_shards": 5/"successful_shards": "$body._clusters.details.(local).successful_shards"/]
-// TESTRESPONSE[s/"search_duration": 21/"search_duration": "$body._clusters.details.(local).search_duration"/]
-// TESTRESPONSE[s/"total_shards": 4/"total_shards": "$body._clusters.details.cluster_one.total_shards"/]
-// TESTRESPONSE[s/"successful_shards": 4/"successful_shards": "$body._clusters.details.cluster_one.successful_shards"/]
-// TESTRESPONSE[s/"search_duration": 35/"search_duration": "$body._clusters.details.cluster_one.search_duration"/]
-// TESTRESPONSE[s/"total_shards": 3/"total_shards": "$body._clusters.details.cluster_two.total_shards"/]
-// TESTRESPONSE[s/"successful_shards": 3/"successful_shards": "$body._clusters.details.cluster_two.successful_shards"/]
-// TESTRESPONSE[s/"search_duration": 37/"search_duration": "$body._clusters.details.cluster_two.search_duration"/]
+// TESTRESPONSE[s/"total": 5/"total": "$body._clusters.details.(local)._shards.total"/]
+// TESTRESPONSE[s/"successful": 5/"successful": "$body._clusters.details.(local)._shards.successful"/]
+// TESTRESPONSE[s/"took": 21/"took": "$body._clusters.details.(local).took"/]
+// TESTRESPONSE[s/"total": 4/"total": "$body._clusters.details.cluster_one._shards.total"/]
+// TESTRESPONSE[s/"successful": 4/"successful": "$body._clusters.details.cluster_one._shards.successful"/]
+// TESTRESPONSE[s/"took": 48/"took": "$body._clusters.details.cluster_one.took"/]
+// TESTRESPONSE[s/"total" : 3/"total": "$body._clusters.details.cluster_two._shards.total"/]
+// TESTRESPONSE[s/"successful" : 3/"successful": "$body._clusters.details.cluster_two._shards.successful"/]
+// TESTRESPONSE[s/"took": 141/"took": "$body._clusters.details.cluster_two.took"/]
 
 <1> The local (querying) cluster is identified as "(local)".
 <2> This document's `_index` parameter doesn't include a cluster name. This
@@ -351,7 +362,7 @@ means the document came from the local cluster.
 <3> This document came from `cluster_one`.
 <4> This document came from `cluster_two`.
 
-BELOW THIS LINE, TESTS WILL FAIL - NOT UPDATED YET
+
 
 [discrete]
 [[ccs-async-search-minimize-roundtrips-true]]
@@ -380,7 +391,7 @@ POST /my-index-000001,cluster_one:my-index-000001,cluster_two:my-index-000001/_a
 }
 --------------------------------------------------
 // TEST[continued]
-// TEST[s/ccs_minimize_roundtrips=true/ccs_minimize_roundtrips=true&wait_for_completion_timeout=1s&keep_on_completion=true/]
+// TEST[s/ccs_minimize_roundtrips=true/ccs_minimize_roundtrips=true&wait_for_completion_timeout=100ms&keep_on_completion=true/]
 
 
 The API returns the following response:
@@ -419,20 +430,22 @@ The API returns the following response:
   }
 }
 --------------------------------------------------
-// TESTRESPONSE[s/FklQYndoTDJ2VEFlMEVBTzFJMGhJVFEaLVlKYndBWWZSMUdicUc4WVlEaFl4ZzoxNTU=/$body.id/]
-// TESTRESPONSE[s/"is_partial": true/"is_partial": $body.is_partial/]
-// TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
-// TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
-// TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
-// TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
-// TESTRESPONSE[s/"num_reduce_phases": 0/"num_reduce_phases": "$body.response.num_reduce_phases"/]
-// TESTRESPONSE[s/"took": 1020/"took": "$body.response.took"/]
-// TESTRESPONSE[s/"total": 8/"total": $body.response._shards.total/]
-// TESTRESPONSE[s/"successful": 0/"successful": $body.response._shards.successful/]
-// TESTRESPONSE[s/"successful" : 0/"successful": $body.response._clusters.successful/]
-// TESTRESPONSE[s/"value": 0/"value": "$body.response.hits.total.value"/]
-// TESTRESPONSE[s/"max_score": null/"max_score": "$body.response.hits.max_score"/]
-// TESTRESPONSE[s/"hits": \[\]/"hits": $body.response.hits.hits/]
+// TEST[skip: terminated_early is absent from final results so is hard to reproduce here]
+
+x // TESTRESPONSE[s/FklQYndoTDJ2VEFlMEVBTzFJMGhJVFEaLVlKYndBWWZSMUdicUc4WVlEaFl4ZzoxNTU=/$body.id/]
+x // TESTRESPONSE[s/"is_partial": true/"is_partial": $body.is_partial/]
+x // TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
+x // TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
+x // TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
+x // TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
+x // TESTRESPONSE[s/"num_reduce_phases": 0/"num_reduce_phases": "$body.response.num_reduce_phases"/]
+x // TESTRESPONSE[s/"took": 1020/"took": "$body.response.took"/]
+x // TESTRESPONSE[s/"total": 8/"total": $body.response._shards.total/]
+x // TESTRESPONSE[s/"successful": 0/"successful": $body.response._shards.successful/]
+x // TESTRESPONSE[s/"successful" : 0/"successful": $body.response._clusters.successful/]
+x // TESTRESPONSE[s/"value": 0/"value": "$body.response.hits.total.value"/]
+x // TESTRESPONSE[s/"max_score": null/"max_score": "$body.response.hits.max_score"/]
+x // TESTRESPONSE[s/"hits": \[\]/"hits": $body.response.hits.hits/]
 
 
 <1> The async search id.
@@ -445,6 +458,9 @@ and all are currently running (since `successful` and `skipped` both equal 0).
 
 
 
+
+
+
 If you query the <<get-async-search,get async search>> endpoint while the query is
 still running, you will see an update in the `_clusters` and `_shards` section of
 the response when the local search has finished.
@@ -453,7 +469,7 @@ the response when the local search has finished.
 --------------------------------------------------
 GET /_async_search/FklQYndoTDJ2VEFlMEVBTzFJMGhJVFEaLVlKYndBWWZSMUdicUc4WVlEaFl4ZzoxNTU=
 --------------------------------------------------
-// TEST[skip: terminated_early is absent from final results so is hard to reproduce here]
+// TEST[continued s/FklQYndoTDJ2VEFlMEVBTzFJMGhJVFEaLVlKYndBWWZSMUdicUc4WVlEaFl4ZzoxNTU=/\${body.id}/]
 
 Response:
 
@@ -539,7 +555,45 @@ Response:
     "_clusters": {
       "total": 3,
       "successful": 3,   <3>
-      "skipped": 0
+      "skipped": 0,
+      "details": {
+        "(local)": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 14382,
+          "timed_out": false,
+          "_shards": {
+            "total": 10,
+            "successful": 10,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_one": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 22193,
+          "timed_out": false,
+          "_shards": {
+            "total": 12,
+            "successful": 12,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_two": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 27550,
+          "timed_out": false,
+          "_shards": {
+            "total": 6,
+            "successful": 6,
+            "skipped": 0,
+            "failed": 0
+          }
+        }
+      }
     },
     "hits": {
       "total": {
@@ -559,6 +613,9 @@ Response:
 // TESTRESPONSE[s/1685996911108/$body.expiration_time_in_millis/]
 // TESTRESPONSE[s/1685564938727/$body.completion_time_in_millis/]
 // TESTRESPONSE[s/"took": 27619/"took": "$body.response.took"/]
+// TESTRESPONSE[s/"took": 14382/"took": "$body.$_path"/]
+// TESTRESPONSE[s/"took": 22193/"took": "$body.$_path"/]
+// TESTRESPONSE[s/"took": 27550/"took": "$body.$_path"/]
 // TESTRESPONSE[s/"total": 28/"total": $body.response._shards.total/]
 // TESTRESPONSE[s/"successful": 28/"successful": $body.response._shards.successful/]
 // TESTRESPONSE[s/"successful": 3/"successful": $body.response._clusters.successful/]
@@ -566,12 +623,15 @@ Response:
 // TESTRESPONSE[s/"relation": "eq"/"relation": "$body.response.hits.total.relation"/]
 // TESTRESPONSE[s/"max_score": 1.8293576/"max_score": "$body.response.hits.max_score"/]
 // TESTRESPONSE[s/"hits": \[...list of hits here...\]/"hits": $body.response.hits.hits/]
+// TESTRESPONSE[s/"total": \d+/"total": $body.$_path/]
+// TESTRESPONSE[s/"successful": \d+/"successful": $body.$_path/]
 
 
 <1> Once the search has finished, the completion_time is present.
 <2> The `_shards` section is now updated to show that 28 total shards
 were searched across all clusters and that all were successful.
 <3> The `_clusters` section shows that searches on all 3 clusters were successful.
+
 
 
 
@@ -599,7 +659,7 @@ Example using the same set up as in the previous section (`ccs_minimize_roundtri
 
 [source,console]
 --------------------------------------------------
-GET /my-index-000001,cluster_one:my-index-000001,cluster_two:my-index-000001/_async_search?ccs_minimize_roundtrips=false
+POST /my-index-000001,cluster_one:my-index-000001,cluster_two:my-index-000001/_async_search?ccs_minimize_roundtrips=false
 {
   "query": {
     "match": {
@@ -610,7 +670,7 @@ GET /my-index-000001,cluster_one:my-index-000001,cluster_two:my-index-000001/_as
 }
 --------------------------------------------------
 // TEST[continued]
-// TEST[s/ccs_minimize_roundtrips=false/ccs_minimize_roundtrips=false&wait_for_completion_timeout=1s&keep_on_completion=true/]
+// TEST[s/ccs_minimize_roundtrips=false/ccs_minimize_roundtrips=false&wait_for_completion_timeout=2s&keep_on_completion=true/]
 
 
 The API returns the following response if the query takes longer than
@@ -627,7 +687,6 @@ the `wait_for_completion_timeout` duration (see <<async-search>>).
   "response": {
     "took": 1020,
     "timed_out": false,
-    "num_reduce_phases": 0,
     "_shards": {
       "total": 28,     <1>
       "successful": 0,
@@ -656,19 +715,18 @@ the `wait_for_completion_timeout` duration (see <<async-search>>).
 // TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
 // TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
-// TESTRESPONSE[s/"num_reduce_phases": 0/"num_reduce_phases": "$body.response.num_reduce_phases"/]
-// TESTRESPONSE[s/"took": 1020/"took": "$body.response.took"/]
-// TESTRESPONSE[s/"total": 28/"total": $body.response._shards.total/]
-// TESTRESPONSE[s/"successful": 0/"successful": $body.response._shards.successful/]
-// TESTRESPONSE[s/"successful": 3/"successful": $body.response._clusters.successful/]
-// TESTRESPONSE[s/"value": 0/"value": "$body.response.hits.total.value"/]
 // TESTRESPONSE[s/"max_score": null/"max_score": "$body.response.hits.max_score"/]
+// TESTRESPONSE[s/\d+/$body.$_path/]
 // TESTRESPONSE[s/"hits": \[\]/"hits": $body.response.hits.hits/]
 
 <1> All shards from all clusters in scope for the search are listed here. Watch this
 section for updates to monitor search progress.
 <2> The `_clusters` section shows that shard information was successfully
 gathered from all 3 clusters and that all will be searched (none are being skipped).
+
+
+
+MP 123
 
 
 
@@ -879,3 +937,5 @@ duration of an upgrade is not supported.
 
 For more information about upgrades, see
 {stack-ref}/upgrading-elasticsearch.html[Upgrading {es}].
+
+

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -363,7 +363,6 @@ means the document came from the local cluster.
 <4> This document came from `cluster_two`.
 
 
-
 [discrete]
 [[ccs-async-search-minimize-roundtrips-true]]
 === Using async search for {ccs} with ccs_minimize_roundtrips=true
@@ -457,10 +456,6 @@ across all clusters only when the search is completed.
 and all are currently running (since `successful` and `skipped` both equal 0).
 
 
-
-
-
-
 If you query the <<get-async-search,get async search>> endpoint while the query is
 still running, you will see an update in the `_clusters` and `_shards` section of
 the response when the local search has finished.
@@ -516,8 +511,6 @@ is set to 1. The `_clusters` response section will not be updated for the remote
 until all remote searches have finished (either successfully or been skipped).
 <3> Number of hits from the local cluster search. Final hits are not
 shown until searches on all clusters have been completed and merged.
-
-
 
 
 After searches on all the clusters have completed, when you query the
@@ -633,8 +626,6 @@ were searched across all clusters and that all were successful.
 <3> The `_clusters` section shows that searches on all 3 clusters were successful.
 
 
-
-
 [discrete]
 [[ccs-async-search-minimize-roundtrips-false]]
 === Using async search for {ccs} with ccs_minimize_roundtrips=false
@@ -723,12 +714,6 @@ the `wait_for_completion_timeout` duration (see <<async-search>>).
 section for updates to monitor search progress.
 <2> The `_clusters` section shows that shard information was successfully
 gathered from all 3 clusters and that all will be searched (none are being skipped).
-
-
-
-MP 123
-
-
 
 
 [discrete]
@@ -937,5 +922,3 @@ duration of an upgrade is not supported.
 
 For more information about upgrades, see
 {stack-ref}/upgrading-elasticsearch.html[Upgrading {es}].
-
-

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -138,7 +138,18 @@ The API returns the following response:
   "_clusters": {
     "total": 1,
     "successful": 1,
-    "skipped": 0
+    "skipped": 0,
+    "details": {
+      "cluster_one": {  <1>
+        "status": "success",
+        "total_shards": 3,
+        "successful_shards": 3,
+        "skipped_shards": 0,
+        "failed_shards": 0,
+        "percent_shards_successful": "100.00",
+        "search_duration": 27
+      }
+    }
   },
   "hits": {
     "total" : {
@@ -148,7 +159,7 @@ The API returns the following response:
     "max_score": 1,
     "hits": [
       {
-        "_index": "cluster_one:my-index-000001", <1>
+        "_index": "cluster_one:my-index-000001", <2>
         "_id": "0",
         "_score": 1,
         "_source": {
@@ -171,9 +182,18 @@ The API returns the following response:
 // TESTRESPONSE[s/"took": 150/"took": "$body.took"/]
 // TESTRESPONSE[s/"max_score": 1/"max_score": "$body.hits.max_score"/]
 // TESTRESPONSE[s/"_score": 1/"_score": "$body.hits.hits.0._score"/]
+// TESTRESPONSE[s/"total_shards": 3/"total_shards": "$body._clusters.details.cluster_one.total_shards"/]
+// TESTRESPONSE[s/"successful_shards": 3/"successful_shards": "$body._clusters.details.cluster_one.successful_shards"/]
+// TESTRESPONSE[s/"skipped_shards": 0/"skipped_shards": "$body._clusters.details.cluster_one.skipped_shards"/]
+// TESTRESPONSE[s/"failed_shards": 0/"failed_shards": "$body._clusters.details.cluster_one.failed_shards"/]
+// TESTRESPONSE[s/"percent_shards_successful": "100.00"/"percent_shards_successful": "$body._clusters.details.cluster_one.percent_shards_successful"/]
+// TESTRESPONSE[s/"search_duration": 27/"search_duration": "$body._clusters.details.cluster_one.search_duration"/]
 
-<1> The search response body includes the name of the remote cluster in the
+
+<1> The details section shows information about the search on each remote cluster.
+<2> The search response body includes the name of the remote cluster in the
 `_index` parameter.
+
 
 [discrete]
 [[ccs-search-multi-remote-cluster]]
@@ -208,15 +228,44 @@ The API returns the following response:
   "timed_out": false,
   "num_reduce_phases": 4,
   "_shards": {
-    "total": 3,
-    "successful": 3,
+    "total": 12,
+    "successful": 12,
     "failed": 0,
     "skipped": 0
   },
   "_clusters": {
     "total": 3,
     "successful": 3,
-    "skipped": 0
+    "skipped": 0,
+    "details": {
+      "(local)": {            <1>
+        "status": "success",
+        "total_shards": 5,
+        "successful_shards": 5,
+        "skipped_shards": 0,
+        "failed_shards": 0,
+        "percent_shards_successful": "100.00",
+        "search_duration": 21
+      },
+      "cluster_one": {
+        "status": "success",
+        "total_shards": 4,
+        "successful_shards": 4,
+        "skipped_shards": 0,
+        "failed_shards": 0,
+        "percent_shards_successful": "100.00",
+        "search_duration": 35
+      },
+      "cluster_two": {
+        "status": "success",
+        "total_shards": 3,
+        "successful_shards": 3,
+        "skipped_shards": 0,
+        "failed_shards": 0,
+        "percent_shards_successful": "100.00",
+        "search_duration": 37
+      }
+    }
   },
   "hits": {
     "total" : {
@@ -226,7 +275,7 @@ The API returns the following response:
     "max_score": 1,
     "hits": [
       {
-        "_index": "my-index-000001", <1>
+        "_index": "my-index-000001", <2>
         "_id": "0",
         "_score": 2,
         "_source": {
@@ -243,7 +292,7 @@ The API returns the following response:
         }
       },
       {
-        "_index": "cluster_one:my-index-000001", <2>
+        "_index": "cluster_one:my-index-000001", <3>
         "_id": "0",
         "_score": 1,
         "_source": {
@@ -260,7 +309,7 @@ The API returns the following response:
         }
       },
       {
-        "_index": "cluster_two:my-index-000001", <3>
+        "_index": "cluster_two:my-index-000001", <4>
         "_id": "0",
         "_score": 1,
         "_source": {
@@ -284,15 +333,25 @@ The API returns the following response:
 // TESTRESPONSE[s/"max_score": 1/"max_score": "$body.hits.max_score"/]
 // TESTRESPONSE[s/"_score": 1/"_score": "$body.hits.hits.0._score"/]
 // TESTRESPONSE[s/"_score": 2/"_score": "$body.hits.hits.1._score"/]
+// TESTRESPONSE[s/"total": 12/"total": "$body._shards.total"/]
+// TESTRESPONSE[s/"successful": 12/"successful": "$body._shards.successful"/]
+// TESTRESPONSE[s/"total_shards": 5/"total_shards": "$body._clusters.details.(local).total_shards"/]
+// TESTRESPONSE[s/"successful_shards": 5/"successful_shards": "$body._clusters.details.(local).successful_shards"/]
+// TESTRESPONSE[s/"search_duration": 21/"search_duration": "$body._clusters.details.(local).search_duration"/]
+// TESTRESPONSE[s/"total_shards": 4/"total_shards": "$body._clusters.details.cluster_one.total_shards"/]
+// TESTRESPONSE[s/"successful_shards": 4/"successful_shards": "$body._clusters.details.cluster_one.successful_shards"/]
+// TESTRESPONSE[s/"search_duration": 35/"search_duration": "$body._clusters.details.cluster_one.search_duration"/]
+// TESTRESPONSE[s/"total_shards": 3/"total_shards": "$body._clusters.details.cluster_two.total_shards"/]
+// TESTRESPONSE[s/"successful_shards": 3/"successful_shards": "$body._clusters.details.cluster_two.successful_shards"/]
+// TESTRESPONSE[s/"search_duration": 37/"search_duration": "$body._clusters.details.cluster_two.search_duration"/]
 
-<1> This document's `_index` parameter doesn't include a cluster name. This
+<1> The local (querying) cluster is identified as "(local)".
+<2> This document's `_index` parameter doesn't include a cluster name. This
 means the document came from the local cluster.
-<2> This document came from `cluster_one`.
-<3> This document came from `cluster_two`.
+<3> This document came from `cluster_one`.
+<4> This document came from `cluster_two`.
 
-
-
-
+BELOW THIS LINE, TESTS WILL FAIL - NOT UPDATED YET
 
 [discrete]
 [[ccs-async-search-minimize-roundtrips-true]]

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -141,7 +141,7 @@ The API returns the following response:
     "skipped": 0,
     "details": {
       "cluster_one": {  <1>
-        "status": "success",
+        "status": "successful",
         "total_shards": 3,
         "successful_shards": 3,
         "skipped_shards": 0,
@@ -239,7 +239,7 @@ The API returns the following response:
     "skipped": 0,
     "details": {
       "(local)": {            <1>
-        "status": "success",
+        "status": "successful",
         "total_shards": 5,
         "successful_shards": 5,
         "skipped_shards": 0,
@@ -248,7 +248,7 @@ The API returns the following response:
         "search_duration": 21
       },
       "cluster_one": {
-        "status": "success",
+        "status": "successful",
         "total_shards": 4,
         "successful_shards": 4,
         "skipped_shards": 0,
@@ -257,7 +257,7 @@ The API returns the following response:
         "search_duration": 35
       },
       "cluster_two": {
-        "status": "success",
+        "status": "successful",
         "total_shards": 3,
         "successful_shards": 3,
         "skipped_shards": 0,

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -175,9 +175,10 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_050 = registerTransportVersion(8_500_050, "69722fa2-7c0a-4227-86fb-6d6a9a0a0321");
     public static final TransportVersion V_8_500_051 = registerTransportVersion(8_500_051, "a28b43bc-bb5f-4406-afcf-26900aa98a71");
     public static final TransportVersion V_8_500_052 = registerTransportVersion(8_500_052, "2d382b3d-9838-4cce-84c8-4142113e5c2b");
+    public static final TransportVersion V_8_500_053 = registerTransportVersion(8_500_053, "aa603bae-01e2-380a-8950-6604468e8c6d");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_052);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_053);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -603,7 +603,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 builder.field(TOTAL_FIELD.getPreferredName(), total);
                 builder.field(SUCCESSFUL_FIELD.getPreferredName(), getSuccessful());
                 builder.field(SKIPPED_FIELD.getPreferredName(), getSkipped());
-                // builder.field(FAILED_FIELD.getPreferredName(), getFailed());
+                // TODO: add FAILED_FIELD
                 if (clusterInfo.size() > 0) {
                     builder.startObject("details");
                     for (Cluster cluster : clusterInfo.values()) {
@@ -807,7 +807,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             {
                 builder.field("status", getStatus().toString());
                 builder.field("indices", indexExpression);
-                if (took.get() > 0) {
+                if (took.get() >= 0) {
                     builder.field("took", took.doubleValue());
                 }
                 builder.field("timed_out", timedOut.get());

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -598,6 +598,13 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 builder.field(TOTAL_FIELD.getPreferredName(), total);
                 builder.field(SUCCESSFUL_FIELD.getPreferredName(), getSuccessful());
                 builder.field(SKIPPED_FIELD.getPreferredName(), getSkipped());
+                if (clusterInfo.size() > 0) {
+                    builder.startObject("details");
+                    for (Cluster cluster : clusterInfo.values()) {
+                        cluster.toXContent(builder, params);
+                    }
+                    builder.endObject();
+                }
                 builder.endObject();
             }
             return builder;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -783,7 +783,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                     builder.endObject();
                 }
                 if (failures != null && failures.isEmpty() == false) {
-                    builder.startArray("errors");
+                    builder.startArray("failures");
                     for (ShardSearchFailure failure : failures) {
                         failure.toXContent(builder, params);
                     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -803,9 +803,10 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             if (clusterAlias.equals("")) {
                 name = "(local)";
             }
-            builder.startObject(name + ":" + indexExpression);
+            builder.startObject(name);
             {
                 builder.field("status", getStatus().toString());
+                builder.field("indices", indexExpression);
                 if (took.get() > 0) {
                     builder.field("took", took.doubleValue());
                 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -823,7 +823,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.searchLatencyMillis = searchLatencyMillis;
         }
 
-        public int getTotalShards() {
+        public Integer getTotalShards() {
             return totalShards;
         }
 
@@ -831,7 +831,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.totalShards = totalShards;
         }
 
-        public int getSuccessfulShards() {
+        public Integer getSuccessfulShards() {
             return successfulShards;
         }
 
@@ -839,7 +839,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.successfulShards = successfulShards;
         }
 
-        public int getSkippedShards() {
+        public Integer getSkippedShards() {
             return skippedShards;
         }
 
@@ -847,7 +847,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.skippedShards = skippedShards;
         }
 
-        public int getFailedShards() {
+        public Integer getFailedShards() {
             return failedShards;
         }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -49,6 +49,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -681,7 +684,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         @Override
         public int hashCode() {
             /// MP TODO: not sure what to do about successful and skipped here, since they are calculated differently
-            /// MP TODO: between CCS MRT=true and other search types
+            /// MP TODO: between CCS MRT=true and other search types and are not immutable for CCS
             return Objects.hash(total, successful, skipped);
         }
 
@@ -718,13 +721,14 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     public static class Cluster implements ToXContentFragment, Writeable {
         private final String clusterAlias;
         private final String indexExpression; // original index expression from the user for this cluster
-        private Status status;
+        private volatile Status status;  // can be updated in different threads
         private final List<ShardSearchFailure> failures;
-        private Integer totalShards;  /// MP TODO: use these to update the _shards fields (otherwise skipped clusters aren't counted)
-        private Integer successfulShards;
-        private Integer skippedShards;
-        private Integer failedShards;
-        private Long took;  // search latency in millis for this cluster sub-search
+        private final AtomicInteger totalShards;
+        private final AtomicInteger successfulShards;
+        private final AtomicInteger skippedShards;
+        private final AtomicInteger failedShards;
+        private final AtomicLong took;  // search latency in millis for this cluster sub-search
+        private final AtomicBoolean timedOut;
 
         /**
          * Marks the status of a Cluster search involved in a Cross-Cluster search.
@@ -756,20 +760,27 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         public Cluster(String clusterAlias, String indexExpression) {
             this.clusterAlias = clusterAlias;
             this.indexExpression = indexExpression;
-            this.failures = new ArrayList<>();
+            this.failures = Collections.synchronizedList(new ArrayList<>());
             this.status = Status.RUNNING;
+            this.timedOut = new AtomicBoolean(false);
+            this.totalShards = new AtomicInteger(-1);
+            this.successfulShards = new AtomicInteger(-1);
+            this.skippedShards = new AtomicInteger(-1);
+            this.failedShards = new AtomicInteger(-1);
+            this.took = new AtomicLong(-1);
         }
 
         public Cluster(StreamInput in) throws IOException {
             this.clusterAlias = in.readString();
             this.indexExpression = in.readString();
             this.status = Status.valueOf(in.readString().toUpperCase(Locale.ROOT));
-            this.totalShards = in.readOptionalVInt();
-            this.successfulShards = in.readOptionalVInt();
-            this.skippedShards = in.readOptionalVInt();
-            this.failedShards = in.readOptionalVInt();
-            this.took = in.readOptionalVLong();
-            this.failures = in.readList(ShardSearchFailure::readShardSearchFailure);
+            this.totalShards = new AtomicInteger((int) in.readZLong());
+            this.successfulShards = new AtomicInteger((int) in.readZLong());
+            this.skippedShards = new AtomicInteger((int) in.readZLong());
+            this.failedShards = new AtomicInteger((int) in.readZLong());
+            this.took = new AtomicLong(in.readZLong());
+            this.timedOut = new AtomicBoolean(in.readBoolean());
+            this.failures = Collections.synchronizedList(in.readList(ShardSearchFailure::readShardSearchFailure));
         }
 
         @Override
@@ -777,11 +788,12 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             out.writeString(clusterAlias);
             out.writeString(indexExpression);
             out.writeString(status.toString());
-            out.writeOptionalVInt(totalShards);
-            out.writeOptionalVInt(successfulShards);
-            out.writeOptionalVInt(skippedShards);
-            out.writeOptionalVInt(failedShards);
-            out.writeOptionalVLong(took);
+            out.writeZLong(totalShards.get());
+            out.writeZLong(successfulShards.get());
+            out.writeZLong(skippedShards.get());
+            out.writeZLong(failedShards.get());
+            out.writeZLong(took.get());
+            out.writeBoolean(timedOut.get());
             out.writeList(failures);
         }
 
@@ -793,21 +805,25 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             }
             builder.startObject(name + ":" + indexExpression);
             {
-                builder.field("status", status.toString());
-                if (took != null) {
+                builder.field("status", getStatus().toString());
+                if (took.get() > 0) {
                     builder.field("took", took.doubleValue());
                 }
-                if (totalShards != null) {
+                builder.field("timed_out", timedOut.get());
+                if (totalShards.get() > 0) {
                     builder.startObject("_shards");
-                    builder.field("total", totalShards);
-                    if (successfulShards != null) {
-                        builder.field("successful", successfulShards);
+                    builder.field("total", getTotalShards());
+                    int successful = successfulShards.get();
+                    if (successful >= 0) {
+                        builder.field("successful", successful);
                     }
-                    if (skippedShards != null) {
-                        builder.field("skipped", skippedShards);
+                    int skipped = skippedShards.get();
+                    if (skipped >= 0) {
+                        builder.field("skipped", skipped);
                     }
-                    if (failedShards != null) {
-                        builder.field("failed", failedShards);
+                    int failed = failedShards.get();
+                    if (failed >= 0) {
+                        builder.field("failed", failed);
                     }
                     builder.endObject();
                 }
@@ -839,6 +855,14 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.status = status;
         }
 
+        public boolean isTimedOut() {
+            return timedOut.get();
+        }
+
+        public void markAsTimedOut() {
+            this.timedOut.set(true);
+        }
+
         public List<ShardSearchFailure> getFailures() {
             return failures;
         }
@@ -848,43 +872,43 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         }
 
         public Long getTook() {
-            return took;
+            return took.get();
         }
 
         public void setTook(Long took) {
-            this.took = took;
+            this.took.set(took);
         }
 
         public Integer getTotalShards() {
-            return totalShards;
+            return totalShards.get();
         }
 
         public void setTotalShards(int totalShards) {
-            this.totalShards = totalShards;
+            this.totalShards.set(totalShards);
         }
 
         public Integer getSuccessfulShards() {
-            return successfulShards;
+            return successfulShards.get();
         }
 
         public void setSuccessfulShards(int successfulShards) {
-            this.successfulShards = successfulShards;
+            this.successfulShards.set(successfulShards);
         }
 
         public Integer getSkippedShards() {
-            return skippedShards;
+            return skippedShards.get();
         }
 
         public void setSkippedShards(int skippedShards) {
-            this.skippedShards = skippedShards;
+            this.skippedShards.set(skippedShards);
         }
 
         public Integer getFailedShards() {
-            return failedShards;
+            return failedShards.get();
         }
 
         public void setFailedShards(int failedShards) {
-            this.failedShards = failedShards;
+            this.failedShards.set(failedShards);
         }
 
         @Override
@@ -898,13 +922,13 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 + ", failures="
                 + failures
                 + ", totalShards="
-                + totalShards
+                + totalShards.get()
                 + ", successfulShards="
-                + successfulShards
+                + successfulShards.get()
                 + ", skippedShards="
-                + skippedShards
+                + skippedShards.get()
                 + ", failedShards="
-                + failedShards
+                + failedShards.get()
                 + ", searchLatencyMillis="
                 + took
                 + '}';

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -614,7 +614,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             } else {
                 return (int) clusterInfo.values()
                     .stream()
-                    .filter(c -> c.getStatus() == Cluster.Status.SUCCESS || c.getStatus() == Cluster.Status.PARTIAL)
+                    .filter(c -> c.getStatus() == Cluster.Status.SUCCESSFUL || c.getStatus() == Cluster.Status.PARTIAL)
                     .count();
             }
         }
@@ -704,11 +704,10 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         private final String clusterAlias;
         private Status status;
         private final List<ShardSearchFailure> failures;
-        private Integer totalShards;  // TODO: use these to update the _shards fields (otherwise skipped clusters aren't counted)
+        private Integer totalShards;  /// MP TODO: use these to update the _shards fields (otherwise skipped clusters aren't counted)
         private Integer successfulShards;
         private Integer skippedShards;
         private Integer failedShards;
-        private List<String> indexes; // TODO: need this? do we need to track shards per index? Can we even do that?
         private Long searchLatencyMillis;
 
         /**
@@ -716,7 +715,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
          */
         public enum Status {
             RUNNING,  // still running
-            SUCCESS,  // all shards completed search
+            SUCCESSFUL,  // all shards completed search
             PARTIAL,  // only some shards completed the search, partial results from cluster
             SKIPPED,  // entire cluster was skipped
             FAILED;   // search was failed due to errors on this cluster

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1371,11 +1371,13 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             if (skipUnavailable) {
                 if (cluster != null) {
                     cluster.setStatus(SearchResponse.Cluster.Status.SKIPPED);
+                    cluster.addFailure(new ShardSearchFailure(e));
                 }
                 skippedClusters.incrementAndGet();
             } else {
                 if (cluster != null) {
                     cluster.setStatus(SearchResponse.Cluster.Status.FAILED);
+                    cluster.addFailure(new ShardSearchFailure(e));
                 }
                 Exception exception = e;
                 if (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(clusterAlias) == false) {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -331,15 +331,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         && rewritten.source().aggregations() != null
                             ? searchService.aggReduceContextBuilder(task::isCancelled, rewritten.source().aggregations())
                             : null;
-                    Set<String> clusterAliases = new HashSet<>(remoteClusterIndices.keySet());
-                    SearchResponse.Clusters initClusters;
+                    SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteClusterIndices, true);
                     if (localIndices == null) {
-                        initClusters = new SearchResponse.Clusters(clusterAliases, true);
                         // Notify the progress listener that a CCS with minimize_roundtrips is happening remote-only (no local shards)
                         task.getProgressListener().notifyListShards(Collections.emptyList(), Collections.emptyList(), initClusters, false);
-                    } else {
-                        clusterAliases.add("");
-                        initClusters = new SearchResponse.Clusters(clusterAliases, true);
                     }
                     ccsRemoteReduce(
                         parentTaskId,

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -540,7 +540,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     cluster.setSuccessfulShards(searchResponse.getSuccessfulShards());
                     cluster.setSkippedShards(searchResponse.getSkippedShards());
                     cluster.setFailedShards(searchResponse.getFailedShards());
-                    cluster.setSearchLatencyMillis(timeProvider.buildTookInMillis());
+                    cluster.setTook(timeProvider.buildTookInMillis());
 
                     listener.onResponse(
                         new SearchResponse(
@@ -565,7 +565,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     logCCSError(f, clusterAlias, skipUnavailable);
                     if (skipUnavailable) {
                         cluster.setStatus(SearchResponse.Cluster.Status.SKIPPED);
-                        cluster.setSearchLatencyMillis(timeProvider.buildTookInMillis());
+                        cluster.setTook(timeProvider.buildTookInMillis());
                         listener.onResponse(SearchResponse.empty(timeProvider::buildTookInMillis, clusters));
                     } else {
                         cluster.setStatus(SearchResponse.Cluster.Status.FAILED);
@@ -781,7 +781,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
                 Instant now = Instant.now();
                 Instant start = Instant.ofEpochMilli(startTime);
-                cluster.setSearchLatencyMillis(Duration.between(start, now).toMillis());
+                cluster.setTook(Duration.between(start, now).toMillis());
 
                 if (total > success) {
                     if (success == 0) {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1343,7 +1343,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             String clusterAlias,
             boolean skipUnavailable,
             CountDown countDown,
-            AtomicInteger skippedClusters,  /// MP TODO: remove?
+            AtomicInteger skippedClusters,
             AtomicReference<Exception> exceptions,
             SearchResponse.Cluster cluster,
             ActionListener<FinalResponse> originalListener

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -135,18 +135,7 @@ public class SearchResponseTests extends ESTestCase {
         int totalClusters = randomIntBetween(0, 10);
         int successfulClusters = randomIntBetween(0, totalClusters);
         int skippedClusters = totalClusters - successfulClusters;
-        if (randomBoolean()) {
-            return new SearchResponse.Clusters(totalClusters, successfulClusters, skippedClusters);
-        } else {
-            int remoteClusters = totalClusters;
-            if (totalClusters > 0 && randomBoolean()) {
-                // remoteClusters can be same as total cluster count or one less (when doing local search)
-                remoteClusters--;
-            }
-            // Clusters has an assert that if ccsMinimizeRoundtrips = true, then remoteClusters must be > 0
-            boolean ccsMinimizeRoundtrips = (remoteClusters > 0 ? randomBoolean() : false);
-            return new SearchResponse.Clusters(totalClusters, successfulClusters, skippedClusters, remoteClusters, ccsMinimizeRoundtrips);
-        }
+        return new SearchResponse.Clusters(totalClusters, successfulClusters, skippedClusters);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -523,11 +523,18 @@ public class TransportSearchActionTests extends ESTestCase {
                 ActionListener.wrap(r -> fail("no response expected"), failure::set),
                 latch
             );
+            Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
+            if (localIndices != null) {
+                clusterAliases.add("");
+            }
+            SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+
             TransportSearchAction.ccsRemoteReduce(
                 new TaskId("n", 1),
                 searchRequest,
                 localIndices,
                 remoteIndicesByCluster,
+                initClusters,
                 timeProvider,
                 emptyReduceContextBuilder(),
                 remoteClusterService,
@@ -588,11 +595,18 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
+                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
+                if (localIndices != null) {
+                    clusterAliases.add("");
+                }
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
+                    initClusters,
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -626,11 +640,17 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionListener.wrap(r -> fail("no response expected"), failure::set),
                     latch
                 );
+                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
+                if (localIndices != null) {
+                    clusterAliases.add("");
+                }
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
+                    initClusters,
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -685,11 +705,18 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionListener.wrap(r -> fail("no response expected"), failure::set),
                     latch
                 );
+                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
+                if (localIndices != null) {
+                    clusterAliases.add("");
+                }
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
+                    initClusters,
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -726,11 +753,18 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
+                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
+                if (localIndices != null) {
+                    clusterAliases.add("");
+                }
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
+                    initClusters,
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -779,11 +813,18 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
+                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
+                if (localIndices != null) {
+                    clusterAliases.add("");
+                }
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
+                    initClusters,
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -523,11 +523,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 ActionListener.wrap(r -> fail("no response expected"), failure::set),
                 latch
             );
-            Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
-            if (localIndices != null) {
-                clusterAliases.add("");
-            }
-            SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+            SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
 
             TransportSearchAction.ccsRemoteReduce(
                 new TaskId("n", 1),
@@ -595,11 +591,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
-                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
-                if (localIndices != null) {
-                    clusterAliases.add("");
-                }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
 
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
@@ -640,11 +632,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionListener.wrap(r -> fail("no response expected"), failure::set),
                     latch
                 );
-                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
-                if (localIndices != null) {
-                    clusterAliases.add("");
-                }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
@@ -705,11 +693,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionListener.wrap(r -> fail("no response expected"), failure::set),
                     latch
                 );
-                Set<String> clusterAliases = new HashSet<>(remoteClusterService.getRegisteredRemoteClusterNames());
-                if (localIndices != null) {
-                    clusterAliases.add("");
-                }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
 
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
@@ -757,7 +741,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 if (localIndices != null) {
                     clusterAliases.add("");
                 }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
 
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
@@ -817,7 +801,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 if (localIndices != null) {
                     clusterAliases.add("");
                 }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(clusterAliases, true);
+                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
 
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
@@ -12,13 +12,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.remote.RemoteInfoAction;
 import org.elasticsearch.action.admin.cluster.remote.RemoteInfoRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.RemoteConnectionInfo;
 import org.elasticsearch.transport.TransportService;
 import org.junit.After;
@@ -46,6 +49,7 @@ import static org.hamcrest.Matchers.not;
 
 public abstract class AbstractMultiClustersTestCase extends ESTestCase {
     public static final String LOCAL_CLUSTER = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+    public static final boolean DEFAULT_SKIP_UNAVAILABLE = RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE.getDefault(Settings.EMPTY);
 
     private static final Logger LOGGER = LogManager.getLogger(AbstractMultiClustersTestCase.class);
 
@@ -53,6 +57,10 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
 
     protected Collection<String> remoteClusterAlias() {
         return randomSubsetOf(List.of("cluster-a", "cluster-b"));
+    }
+
+    protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
+        return Map.of("cluster-a", DEFAULT_SKIP_UNAVAILABLE, "cluster-b", DEFAULT_SKIP_UNAVAILABLE);
     }
 
     protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
@@ -171,26 +179,34 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
     protected void configureRemoteCluster(String clusterAlias, Collection<String> seedNodes) throws Exception {
         final String remoteClusterSettingPrefix = "cluster.remote." + clusterAlias + ".";
         Settings.Builder settings = Settings.builder();
-        final List<String> seedAdresses = seedNodes.stream().map(node -> {
+        final List<String> seedAddresses = seedNodes.stream().map(node -> {
             final TransportService transportService = cluster(clusterAlias).getInstance(TransportService.class, node);
             return transportService.boundAddress().publishAddress().toString();
         }).toList();
+        boolean skipUnavailable = skipUnavailableForRemoteClusters().containsKey(clusterAlias)
+            ? skipUnavailableForRemoteClusters().get(clusterAlias)
+            : DEFAULT_SKIP_UNAVAILABLE;
         if (randomBoolean()) {
             LOGGER.info("--> use sniff mode with seed [{}], remote nodes [{}]", Collectors.joining(","), seedNodes);
             settings.putNull(remoteClusterSettingPrefix + "proxy_address")
                 .put(remoteClusterSettingPrefix + "mode", "sniff")
-                .put(remoteClusterSettingPrefix + "seeds", String.join(",", seedAdresses))
+                .put(remoteClusterSettingPrefix + "seeds", String.join(",", seedAddresses))
+                .put(remoteClusterSettingPrefix + "skip_unavailable", String.valueOf(skipUnavailable))
                 .build();
         } else {
-            final String proxyNode = randomFrom(seedAdresses);
+            final String proxyNode = randomFrom(seedAddresses);
             LOGGER.info("--> use proxy node [{}], remote nodes [{}]", proxyNode, seedNodes);
             settings.putNull(remoteClusterSettingPrefix + "seeds")
                 .put(remoteClusterSettingPrefix + "mode", "proxy")
                 .put(remoteClusterSettingPrefix + "proxy_address", proxyNode)
+                .put(remoteClusterSettingPrefix + "skip_unavailable", String.valueOf(skipUnavailable))
                 .build();
         }
 
-        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+        ClusterUpdateSettingsResponse resp = client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+        String key = Strings.format("cluster.remote.%s.skip_unavailable", clusterAlias);
+        assertEquals(String.valueOf(skipUnavailable), resp.getPersistentSettings().get(key));
+
         assertBusy(() -> {
             List<RemoteConnectionInfo> remoteConnectionInfos = client().execute(RemoteInfoAction.INSTANCE, new RemoteInfoRequest())
                 .actionGet()

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -157,11 +157,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getTotal(), equalTo(2));
             assertTrue("search cluster results should be marked as partial", clusters.hasPartialResults());
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
         }
@@ -184,7 +184,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(2));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
@@ -192,9 +192,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -202,7 +202,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
         }
 
         // check that the async_search/status response includes the same cluster details
@@ -215,7 +215,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(2));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
@@ -223,9 +223,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -233,7 +233,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
         }
     }
 
@@ -262,11 +262,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getTotal(), equalTo(2));
             assertTrue("search cluster results should be marked as partial", clusters.hasPartialResults());
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
         }
@@ -288,31 +288,31 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(0));
             assertThat(clusters.getSkipped(), equalTo(2));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
-            assertThat(localClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(localClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(localClusterSearchInfo.getTotalShards());
+            assertNull(localClusterSearchInfo.getSuccessfulShards());
+            assertNull(localClusterSearchInfo.getSkippedShards());
+            assertNull(localClusterSearchInfo.getFailedShards());
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(localClusterSearchInfo.getTook(), equalTo(-1L));
+            assertNull(localClusterSearchInfo.getTook());
             assertFalse(localClusterSearchInfo.isTimedOut());
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             SearchResponse.Cluster.Status expectedStatus = skipUnavailable
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
@@ -325,31 +325,31 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(0));
             assertThat(clusters.getSkipped(), equalTo(2));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
-            assertThat(localClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(localClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(localClusterSearchInfo.getTotalShards());
+            assertNull(localClusterSearchInfo.getSuccessfulShards());
+            assertNull(localClusterSearchInfo.getSkippedShards());
+            assertNull(localClusterSearchInfo.getFailedShards());
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(localClusterSearchInfo.getTook(), equalTo(-1L));
+            assertNull(localClusterSearchInfo.getTook());
             assertFalse(localClusterSearchInfo.isTimedOut());
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             SearchResponse.Cluster.Status expectedStatus = skipUnavailable
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
@@ -382,11 +382,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getTotal(), equalTo(2));
             assertTrue("search cluster results should be marked as partial", clusters.hasPartialResults());
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
         }
@@ -408,7 +408,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(2));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
             assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
@@ -416,11 +416,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -428,7 +428,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -440,7 +440,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(2));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
             assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
@@ -448,11 +448,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -460,7 +460,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -495,11 +495,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getTotal(), equalTo(2));
             assertTrue("search cluster results should be marked as partial", clusters.hasPartialResults());
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
         }
@@ -521,7 +521,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(1));
             assertThat(clusters.getSkipped(), equalTo(1));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
@@ -529,20 +529,20 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             SearchResponse.Cluster.Status expectedStatus = skipUnavailable
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
@@ -555,7 +555,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(1));
             assertThat(clusters.getSkipped(), equalTo(1));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
@@ -563,20 +563,20 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             SearchResponse.Cluster.Status expectedStatus = skipUnavailable
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
@@ -617,10 +617,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(1));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-            assertNull(localClusterSearchInfo);
+            assertNull(clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -628,7 +627,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
         }
 
         // check that the async_search/status response includes the same cluster details
@@ -641,10 +640,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(1));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-            assertNull(localClusterSearchInfo);
+            assertNull(clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -652,7 +650,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
         }
     }
 
@@ -691,10 +689,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(1));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-            assertNull(localClusterSearchInfo);
+            assertNull(clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -702,7 +699,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -714,10 +711,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(1));
             assertThat(clusters.getSkipped(), equalTo(0));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-            assertNull(localClusterSearchInfo);
+            assertNull(clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
             assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
@@ -725,7 +721,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -766,25 +762,20 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(0));
             assertThat(clusters.getSkipped(), equalTo(1));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-            assertNull(localClusterSearchInfo);
+            assertNull(clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             SearchResponse.Cluster.Status expectedStatus = skipUnavailable
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            if (skipUnavailable) {
-                assertThat(remoteClusterSearchInfo.getTook().longValue(), greaterThan(0L));
-            } else {
-                assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
-            }
+            assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
@@ -797,25 +788,20 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(clusters.getSuccessful(), equalTo(0));
             assertThat(clusters.getSkipped(), equalTo(1));
 
-            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-            assertNull(localClusterSearchInfo);
+            assertNull(clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY));
 
-            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
             SearchResponse.Cluster.Status expectedStatus = skipUnavailable
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
-            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            if (skipUnavailable) {
-                assertThat(remoteClusterSearchInfo.getTook().longValue(), greaterThan(0L));
-            } else {
-                assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
-            }
+            assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -192,7 +192,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
             assertNotNull(remoteClusterSearchInfo);
@@ -202,7 +202,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
         }
 
         // check that the async_search/status response includes the same cluster details
@@ -223,7 +223,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
             assertNotNull(remoteClusterSearchInfo);
@@ -233,7 +233,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
         }
     }
 
@@ -296,7 +296,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(localClusterSearchInfo.getSkippedShards());
             assertNull(localClusterSearchInfo.getFailedShards());
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(localClusterSearchInfo.getSearchLatencyMillis());
+            assertNull(localClusterSearchInfo.getTook());
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
@@ -311,7 +311,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getSkippedShards());
             assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getSearchLatencyMillis());
+            assertNull(remoteClusterSearchInfo.getTook());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -331,7 +331,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(localClusterSearchInfo.getSkippedShards());
             assertNull(localClusterSearchInfo.getFailedShards());
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(localClusterSearchInfo.getSearchLatencyMillis());
+            assertNull(localClusterSearchInfo.getTook());
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
@@ -346,7 +346,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getSkippedShards());
             assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getSearchLatencyMillis());
+            assertNull(remoteClusterSearchInfo.getTook());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -412,7 +412,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(localClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
@@ -424,7 +424,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -444,7 +444,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(localClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
@@ -456,7 +456,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -525,7 +525,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
             assertNotNull(remoteClusterSearchInfo);
@@ -538,7 +538,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getSkippedShards());
             assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getSearchLatencyMillis());
+            assertNull(remoteClusterSearchInfo.getTook());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -558,7 +558,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(localClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(localClusterSearchInfo.getTook(), greaterThan(0L));
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
             assertNotNull(remoteClusterSearchInfo);
@@ -571,7 +571,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getSkippedShards());
             assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getSearchLatencyMillis());
+            assertNull(remoteClusterSearchInfo.getTook());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -620,7 +620,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
         }
 
         // check that the async_search/status response includes the same cluster details
@@ -644,7 +644,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(0));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
         }
     }
 
@@ -690,7 +690,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -713,7 +713,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
             assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertThat(remoteClusterSearchInfo.getSearchLatencyMillis(), greaterThan(0L));
+            assertThat(remoteClusterSearchInfo.getTook(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -766,9 +766,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             if (skipUnavailable) {
-                assertThat(remoteClusterSearchInfo.getSearchLatencyMillis().longValue(), greaterThan(0L));
+                assertThat(remoteClusterSearchInfo.getTook().longValue(), greaterThan(0L));
             } else {
-                assertNull(remoteClusterSearchInfo.getSearchLatencyMillis());
+                assertNull(remoteClusterSearchInfo.getTook());
             }
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
@@ -796,9 +796,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getFailedShards());
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             if (skipUnavailable) {
-                assertThat(remoteClusterSearchInfo.getSearchLatencyMillis().longValue(), greaterThan(0L));
+                assertThat(remoteClusterSearchInfo.getTook().longValue(), greaterThan(0L));
             } else {
-                assertNull(remoteClusterSearchInfo.getSearchLatencyMillis());
+                assertNull(remoteClusterSearchInfo.getTook());
             }
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -291,12 +291,13 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
-            assertNull(localClusterSearchInfo.getTotalShards());
-            assertNull(localClusterSearchInfo.getSuccessfulShards());
-            assertNull(localClusterSearchInfo.getSkippedShards());
-            assertNull(localClusterSearchInfo.getFailedShards());
+            assertThat(localClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(localClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(localClusterSearchInfo.getTook());
+            assertThat(localClusterSearchInfo.getTook(), equalTo(-1L));
+            assertFalse(localClusterSearchInfo.isTimedOut());
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
@@ -306,12 +307,13 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertNull(remoteClusterSearchInfo.getTotalShards());
-            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-            assertNull(remoteClusterSearchInfo.getSkippedShards());
-            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getTook());
+            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -326,12 +328,13 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
-            assertNull(localClusterSearchInfo.getTotalShards());
-            assertNull(localClusterSearchInfo.getSuccessfulShards());
-            assertNull(localClusterSearchInfo.getSkippedShards());
-            assertNull(localClusterSearchInfo.getFailedShards());
+            assertThat(localClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(localClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(localClusterSearchInfo.getTook());
+            assertThat(localClusterSearchInfo.getTook(), equalTo(-1L));
+            assertFalse(localClusterSearchInfo.isTimedOut());
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
 
@@ -341,12 +344,13 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertNull(remoteClusterSearchInfo.getTotalShards());
-            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-            assertNull(remoteClusterSearchInfo.getSkippedShards());
-            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getTook());
+            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -533,12 +537,13 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertNull(remoteClusterSearchInfo.getTotalShards());
-            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-            assertNull(remoteClusterSearchInfo.getSkippedShards());
-            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getTook());
+            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -566,12 +571,13 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertNull(remoteClusterSearchInfo.getTotalShards());
-            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-            assertNull(remoteClusterSearchInfo.getSkippedShards());
-            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            assertNull(remoteClusterSearchInfo.getTook());
+            assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -760,16 +766,17 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertNull(remoteClusterSearchInfo.getTotalShards());
-            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-            assertNull(remoteClusterSearchInfo.getSkippedShards());
-            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             if (skipUnavailable) {
                 assertThat(remoteClusterSearchInfo.getTook().longValue(), greaterThan(0L));
             } else {
-                assertNull(remoteClusterSearchInfo.getTook());
+                assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
             }
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }
@@ -790,16 +797,17 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            assertNull(remoteClusterSearchInfo.getTotalShards());
-            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-            assertNull(remoteClusterSearchInfo.getSkippedShards());
-            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(-1));
+            assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(-1));
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             if (skipUnavailable) {
                 assertThat(remoteClusterSearchInfo.getTook().longValue(), greaterThan(0L));
             } else {
-                assertNull(remoteClusterSearchInfo.getTook());
+                assertThat(remoteClusterSearchInfo.getTook(), equalTo(-1L));
             }
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
         }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -433,7 +433,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
                  */
                 reducedAggs = () -> InternalAggregations.topLevelReduce(singletonList(aggregations), aggReduceContextSupplier.get());
             }
-            searchResponse.get().updatePartialResponse(shards.size(), totalHits, reducedAggs, reducePhase, false);
+            searchResponse.get().updatePartialResponse(shards.size(), totalHits, reducedAggs, reducePhase);
         }
 
         /**
@@ -444,7 +444,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         public void onFinalReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggregations, int reducePhase) {
             // best effort to cancel expired tasks
             checkCancellation();
-            searchResponse.get().updatePartialResponse(shards.size(), totalHits, () -> aggregations, reducePhase, true);
+            searchResponse.get().updatePartialResponse(shards.size(), totalHits, () -> aggregations, reducePhase);
         }
 
         @Override

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -43,7 +43,7 @@ class MutableSearchResponse {
     private static final TotalHits EMPTY_TOTAL_HITS = new TotalHits(0L, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
     private final int totalShards;
     private final int skippedShards;
-    private Clusters clusters;
+    private final Clusters clusters;
     private final AtomicArray<ShardSearchFailure> queryFailures;
     private final ThreadContext threadContext;
 
@@ -112,20 +112,6 @@ class MutableSearchResponse {
         this.totalHits = totalHits;
         this.reducedAggsSource = reducedAggs;
         this.reducePhase = reducePhase;
-        if (isFinalLocalReduce && clusters.isCcsMinimizeRoundtrips()) {
-            // currently only ccsMinimizeRoundTrip=true creates Clusters in their initial state (where successful=0)
-            // ccsMinimizeRoundtrips=false creates Clusters in its final state even at the beginning (successful+skipped=total)
-            // so update the clusters object 'successful' count if local cluster search is done AND ccsMinimizeRoundtrips=true
-            Clusters newClusters = new Clusters(
-                clusters.getTotal(),
-                clusters.getSuccessful() + 1,
-                clusters.getSkipped(),
-                clusters.getRemoteClusters(),
-                clusters.isCcsMinimizeRoundtrips()
-            );
-            this.clusters = newClusters;
-            logger.debug("Updating Clusters info to indicate that the local cluster search has completed: {}", newClusters);
-        }
     }
 
     /**

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.search;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -38,8 +36,6 @@ import static org.elasticsearch.xpack.core.async.AsyncTaskIndexService.restoreRe
  * run concurrently to 1 and ensures that we pause the search progress when an {@link AsyncSearchResponse} is built.
  */
 class MutableSearchResponse {
-    private static final Logger logger = LogManager.getLogger(MutableSearchResponse.class);
-
     private static final TotalHits EMPTY_TOTAL_HITS = new TotalHits(0L, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
     private final int totalShards;
     private final int skippedShards;
@@ -116,8 +112,6 @@ class MutableSearchResponse {
      * search is complete.
      */
     synchronized void updateFinalResponse(SearchResponse response, boolean ccsMinimizeRoundtrips) {
-        /// MP TODO: is this method ever called in CCS MRT=true
-        logger.warn("XXX MSR updateFinalResponse for MRT={}", ccsMinimizeRoundtrips);
         failIfFrozen();
 
         assert shardsInResponseMatchExpected(response, ccsMinimizeRoundtrips)
@@ -141,7 +135,6 @@ class MutableSearchResponse {
      * received from previous updates
      */
     synchronized void updateWithFailure(ElasticsearchException exc) {
-        logger.warn("XXX MSR updateWithFailure f: {}", exc.getMessage());
         failIfFrozen();
         // copy the response headers from the current context
         this.responseHeaders = threadContext.getResponseHeaders();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -99,7 +99,7 @@ class MutableSearchResponse {
         TotalHits totalHits,
         Supplier<InternalAggregations> reducedAggs,
         int reducePhase,
-        boolean isFinalLocalReduce
+        boolean isFinalLocalReduce // TODO: can be removed?
     ) {
         failIfFrozen();
         if (reducePhase < this.reducePhase) {

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.search;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -39,7 +37,6 @@ import static org.elasticsearch.xpack.core.async.AsyncTaskIndexService.restoreRe
  */
 class MutableSearchResponse {
 
-    private static final Logger logger = LogManager.getLogger(MutableSearchResponse.class);
     private static final TotalHits EMPTY_TOTAL_HITS = new TotalHits(0L, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
     private final int totalShards;
     private final int skippedShards;
@@ -90,16 +87,13 @@ class MutableSearchResponse {
     /**
      * Updates the response with the result of a partial reduction.
      * @param reducedAggs is a strategy for producing the reduced aggs
-     * @param isFinalLocalReduce true if the local cluster search has finished (during CCS with minimize_roundtrips, this can be true
-     *                           even while the overall search is still running on remote clusters)
      */
     @SuppressWarnings("HiddenField")
     synchronized void updatePartialResponse(
         int successfulShards,
         TotalHits totalHits,
         Supplier<InternalAggregations> reducedAggs,
-        int reducePhase,
-        boolean isFinalLocalReduce // TODO: can be removed?
+        int reducePhase
     ) {
         failIfFrozen();
         if (reducePhase < this.reducePhase) {

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -48,7 +48,7 @@ import static org.elasticsearch.xpack.core.async.GetAsyncResultRequestTests.rand
 import static org.hamcrest.Matchers.equalTo;
 
 public class AsyncSearchResponseTests extends ESTestCase {
-    private SearchResponse searchResponse = randomSearchResponse();
+    private SearchResponse searchResponse = randomSearchResponse(randomBoolean());
     private NamedWriteableRegistry namedWriteableRegistry;
 
     @Before
@@ -123,12 +123,18 @@ public class AsyncSearchResponseTests extends ESTestCase {
         };
     }
 
-    static SearchResponse randomSearchResponse() {
+    static SearchResponse randomSearchResponse(boolean ccs) {
         long tookInMillis = randomNonNegativeLong();
         int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
         int successfulShards = randomIntBetween(0, totalShards);
         int skippedShards = randomIntBetween(0, successfulShards);
         InternalSearchResponse internalSearchResponse = InternalSearchResponse.EMPTY_WITH_TOTAL_HITS;
+        SearchResponse.Clusters clusters;
+        if (ccs) {
+            clusters = createCCSClusterObject(20, 19, true, 10, 1, 2);
+        } else {
+            clusters = SearchResponse.Clusters.EMPTY;
+        }
         return new SearchResponse(
             internalSearchResponse,
             null,
@@ -137,10 +143,9 @@ public class AsyncSearchResponseTests extends ESTestCase {
             skippedShards,
             tookInMillis,
             ShardSearchFailure.EMPTY_ARRAY,
-            SearchResponse.Clusters.EMPTY
+            clusters
         );
     }
-
     static void assertEqualResponses(AsyncSearchResponse expected, AsyncSearchResponse actual) {
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.status(), actual.status());

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -146,6 +146,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
             clusters
         );
     }
+
     static void assertEqualResponses(AsyncSearchResponse expected, AsyncSearchResponse actual) {
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.status(), actual.status());

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -7,20 +7,26 @@
 
 package org.elasticsearch.xpack.search;
 
+import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -32,10 +38,14 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.core.async.GetAsyncResultRequestTests.randomSearchId;
+import static org.hamcrest.Matchers.equalTo;
 
 public class AsyncSearchResponseTests extends ESTestCase {
     private SearchResponse searchResponse = randomSearchResponse();
@@ -290,6 +300,315 @@ public class AsyncSearchResponseTests extends ESTestCase {
         }
     }
 
+    public void testToXContentWithCCSSearchResponseWhileRunning() throws IOException {
+        boolean isRunning = true;
+        long startTimeMillis = 1689352924517L;
+        long expirationTimeMillis = 1689784924517L;
+        long took = 22968L;
+
+        SearchHits hits = SearchHits.EMPTY_WITHOUT_TOTAL_HITS;
+        SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 2);
+
+        SearchResponse.Clusters clusters = createCCSClusterObject(3, 3, true);
+
+        SearchResponse searchResponse = new SearchResponse(sections, null, 10, 9, 1, took, new ShardSearchFailure[0], clusters);
+
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(
+            "id",
+            searchResponse,
+            null,
+            true,
+            isRunning,
+            startTimeMillis,
+            expirationTimeMillis
+        );
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.prettyPrint();
+            asyncSearchResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals(Strings.format("""
+                {
+                  "id" : "id",
+                  "is_partial" : true,
+                  "is_running" : true,
+                  "start_time_in_millis" : %s,
+                  "expiration_time_in_millis" : %s,
+                  "response" : {
+                    "took" : %s,
+                    "timed_out" : false,
+                    "num_reduce_phases" : 2,
+                    "_shards" : {
+                      "total" : 10,
+                      "successful" : 9,
+                      "skipped" : 1,
+                      "failed" : 0
+                    },
+                    "_clusters" : {
+                      "total" : 3,
+                      "successful" : 0,
+                      "skipped" : 0,
+                      "details" : {
+                        "cluster_1" : {
+                          "status" : "running",
+                          "indices" : "foo,bar*",
+                          "timed_out" : false
+                        },
+                        "cluster_2" : {
+                          "status" : "running",
+                          "indices" : "foo,bar*",
+                          "timed_out" : false
+                        },
+                        "cluster_0" : {
+                          "status" : "running",
+                          "indices" : "foo,bar*",
+                          "timed_out" : false
+                        }
+                      }
+                    },
+                    "hits" : {
+                      "max_score" : 0.0,
+                      "hits" : [ ]
+                    }
+                  }
+                }""", startTimeMillis, expirationTimeMillis, took), Strings.toString(builder));
+        }
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.prettyPrint();
+            builder.humanReadable(true);
+            asyncSearchResponse.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap("human", "true")));
+            assertEquals(
+                Strings.format(
+                    """
+                        {
+                          "id" : "id",
+                          "is_partial" : true,
+                          "is_running" : true,
+                          "start_time" : "%s",
+                          "start_time_in_millis" : %s,
+                          "expiration_time" : "%s",
+                          "expiration_time_in_millis" : %s,
+                          "response" : {
+                            "took" : %s,
+                            "timed_out" : false,
+                            "num_reduce_phases" : 2,
+                            "_shards" : {
+                              "total" : 10,
+                              "successful" : 9,
+                              "skipped" : 1,
+                              "failed" : 0
+                            },
+                            "_clusters" : {
+                              "total" : 3,
+                              "successful" : 0,
+                              "skipped" : 0,
+                              "details" : {
+                                "cluster_1" : {
+                                  "status" : "running",
+                                  "indices" : "foo,bar*",
+                                  "timed_out" : false
+                                },
+                                "cluster_2" : {
+                                  "status" : "running",
+                                  "indices" : "foo,bar*",
+                                  "timed_out" : false
+                                },
+                                "cluster_0" : {
+                                  "status" : "running",
+                                  "indices" : "foo,bar*",
+                                  "timed_out" : false
+                                }
+                              }
+                            },
+                            "hits" : {
+                              "max_score" : 0.0,
+                              "hits" : [ ]
+                            }
+                          }
+                        }""",
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(startTimeMillis)),
+                    startTimeMillis,
+                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(expirationTimeMillis)),
+                    expirationTimeMillis,
+                    took
+                ),
+                Strings.toString(builder)
+            );
+        }
+    }
+
+    // completion_time should be present since search has completed
+    public void testToXContentWithCCSSearchResponseAfterCompletion() throws IOException {
+        boolean isRunning = false;
+        long startTimeMillis = 1689352924517L;
+        long expirationTimeMillis = 1689784924517L;
+        long took = 22968L;
+        long expectedCompletionTime = startTimeMillis + took;
+
+        SearchHits hits = SearchHits.EMPTY_WITHOUT_TOTAL_HITS;
+        SearchResponseSections sections = new SearchResponseSections(hits, null, null, true, null, null, 2);
+        SearchResponse.Clusters clusters = createCCSClusterObject(4, 3, true, 2, 1, 1);
+
+        SearchResponse.Cluster localCluster = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+        assertThat(localCluster.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
+        localCluster.setTotalShards(10);
+        localCluster.setSuccessfulShards(10);
+        localCluster.setSkippedShards(3);
+        localCluster.setFailedShards(0);
+        localCluster.setTook(11111L);
+
+        SearchResponse.Cluster cluster0 = clusters.getCluster("cluster_0");
+        assertThat(cluster0.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
+        cluster0.setTotalShards(8);
+        cluster0.setSuccessfulShards(8);
+        cluster0.setSkippedShards(1);
+        cluster0.setFailedShards(0);
+        cluster0.setTook(7777L);
+
+        SearchResponse.Cluster cluster1 = clusters.getCluster("cluster_1");
+        assertThat(cluster1.getStatus(), equalTo(SearchResponse.Cluster.Status.SKIPPED));
+        cluster1.setTotalShards(2);
+        cluster1.setSuccessfulShards(0);
+        cluster1.setSkippedShards(0);
+        cluster1.setFailedShards(2);
+        cluster1.addFailure(
+            new ShardSearchFailure(
+                new NullPointerException("NPE details"),
+                new SearchShardTarget("nodeId0", new ShardId("foo", UUID.randomUUID().toString(), 0), "cluster_1")
+            )
+        );
+        cluster1.addFailure(
+            new ShardSearchFailure(
+                new CorruptIndexException("abc", "123"),
+                new SearchShardTarget("nodeId0", new ShardId("bar1", UUID.randomUUID().toString(), 0), "cluster_1")
+            )
+        );
+
+        SearchResponse.Cluster cluster2 = clusters.getCluster("cluster_2");
+        assertThat(cluster2.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
+        cluster2.setTotalShards(8);
+        cluster2.setSuccessfulShards(8);
+        cluster2.setSkippedShards(0);
+        cluster2.setFailedShards(0);
+        cluster2.markAsTimedOut();
+        cluster2.setTook(17322L);
+
+        SearchResponse searchResponse = new SearchResponse(sections, null, 10, 9, 1, took, new ShardSearchFailure[0], clusters);
+
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(
+            "id",
+            searchResponse,
+            null,
+            false,
+            isRunning,
+            startTimeMillis,
+            expirationTimeMillis
+        );
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.prettyPrint();
+            asyncSearchResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertEquals(Strings.format("""
+                {
+                  "id" : "id",
+                  "is_partial" : false,
+                  "is_running" : false,
+                  "start_time_in_millis" : %s,
+                  "expiration_time_in_millis" : %s,
+                  "completion_time_in_millis" : %s,
+                  "response" : {
+                    "took" : %s,
+                    "timed_out" : true,
+                    "num_reduce_phases" : 2,
+                    "_shards" : {
+                      "total" : 10,
+                      "successful" : 9,
+                      "skipped" : 1,
+                      "failed" : 0
+                    },
+                    "_clusters" : {
+                      "total" : 4,
+                      "successful" : 3,
+                      "skipped" : 1,
+                      "details" : {
+                        "(local)" : {
+                          "status" : "successful",
+                          "indices" : "foo,bar*",
+                          "took" : 11111.0,
+                          "timed_out" : false,
+                          "_shards" : {
+                            "total" : 10,
+                            "successful" : 10,
+                            "skipped" : 3,
+                            "failed" : 0
+                          }
+                        },
+                        "cluster_1" : {
+                          "status" : "skipped",
+                          "indices" : "foo,bar*",
+                          "timed_out" : false,
+                          "_shards" : {
+                            "total" : 2,
+                            "successful" : 0,
+                            "skipped" : 0,
+                            "failed" : 2
+                          },
+                          "failures" : [
+                            {
+                              "shard" : 0,
+                              "index" : "cluster_1:foo",
+                              "node" : "nodeId0",
+                              "reason" : {
+                                "type" : "null_pointer_exception",
+                                "reason" : "NPE details"
+                              }
+                            },
+                            {
+                              "shard" : 0,
+                              "index" : "cluster_1:bar1",
+                              "node" : "nodeId0",
+                              "reason" : {
+                                "type" : "corrupt_index_exception",
+                                "reason" : "abc (resource=123)"
+                              }
+                            }
+                          ]
+                        },
+                        "cluster_2" : {
+                          "status" : "partial",
+                          "indices" : "foo,bar*",
+                          "took" : 17322.0,
+                          "timed_out" : true,
+                          "_shards" : {
+                            "total" : 8,
+                            "successful" : 8,
+                            "skipped" : 0,
+                            "failed" : 0
+                          }
+                        },
+                        "cluster_0" : {
+                          "status" : "successful",
+                          "indices" : "foo,bar*",
+                          "took" : 7777.0,
+                          "timed_out" : false,
+                          "_shards" : {
+                            "total" : 8,
+                            "successful" : 8,
+                            "skipped" : 1,
+                            "failed" : 0
+                          }
+                        }
+                      }
+                    },
+                    "hits" : {
+                      "max_score" : 0.0,
+                      "hits" : [ ]
+                    }
+                  }
+                }""", startTimeMillis, expirationTimeMillis, expectedCompletionTime, took), Strings.toString(builder));
+        }
+    }
+
     // completion_time should NOT be present since search is still running
     public void testToXContentWithSearchResponseWhileRunning() throws IOException {
         boolean isRunning = true;
@@ -388,5 +707,71 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 Strings.toString(builder)
             );
         }
+    }
+
+    static SearchResponse.Clusters createCCSClusterObject(int totalClusters, int remoteClusters, boolean ccsMinimizeRoundtrips) {
+        OriginalIndices localIndices = null;
+        if (totalClusters > remoteClusters) {
+            localIndices = new OriginalIndices(new String[] { "foo", "bar*" }, IndicesOptions.lenientExpand());
+        }
+        assert remoteClusters > 0 : "CCS Cluster must have at least one remote cluster";
+        Map<String, OriginalIndices> remoteClusterIndices = new HashMap<>();
+        for (int i = 0; i < remoteClusters; i++) {
+            remoteClusterIndices.put("cluster_" + i, new OriginalIndices(new String[] { "foo", "bar*" }, IndicesOptions.lenientExpand()));
+        }
+
+        return new SearchResponse.Clusters(localIndices, remoteClusterIndices, ccsMinimizeRoundtrips);
+    }
+
+    static SearchResponse.Clusters createCCSClusterObject(
+        int totalClusters,
+        int remoteClusters,
+        boolean ccsMinimizeRoundtrips,
+        int successfulClusters,
+        int skippedClusters,
+        int partialClusters
+    ) {
+        assert successfulClusters + skippedClusters <= totalClusters : "successful + skipped > totalClusters";
+        assert totalClusters == remoteClusters || totalClusters - remoteClusters == 1
+            : "totalClusters and remoteClusters must be same or total = remote + 1";
+        SearchResponse.Clusters clusters = createCCSClusterObject(totalClusters, remoteClusters, ccsMinimizeRoundtrips);
+
+        int successful = successfulClusters;
+        int skipped = skippedClusters;
+        int partial = partialClusters;
+        if (totalClusters > remoteClusters) {
+            if (successful > 0) {
+                SearchResponse.Cluster local = clusters.getCluster("");
+                local.setStatus(SearchResponse.Cluster.Status.SUCCESSFUL);
+                successful--;
+            } else if (skipped > 0) {
+                SearchResponse.Cluster local = clusters.getCluster("");
+                local.setStatus(SearchResponse.Cluster.Status.SKIPPED);
+                skipped--;
+            } else if (partial > 0) {
+                SearchResponse.Cluster local = clusters.getCluster("");
+                local.setStatus(SearchResponse.Cluster.Status.PARTIAL);
+                partial--;
+            }
+        }
+
+        int numClusters = successful + skipped + partial;
+
+        for (int i = 0; i < numClusters; i++) {
+            SearchResponse.Cluster cluster = clusters.getCluster("cluster_" + i);
+            if (successful > 0) {
+                cluster.setStatus(SearchResponse.Cluster.Status.SUCCESSFUL);
+                successful--;
+            } else if (skipped > 0) {
+                cluster.setStatus(SearchResponse.Cluster.Status.SKIPPED);
+                skipped--;
+            } else if (partial > 0) {
+                cluster.setStatus(SearchResponse.Cluster.Status.PARTIAL);
+                partial--;
+            } else {
+                throw new IllegalStateException("Test setup coding error - should not get here");
+            }
+        }
+        return clusters;
     }
 }

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -187,10 +187,11 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
     }
 
     public void testGetStatusFromStoredSearchRandomizedInputs() {
+        boolean ccs = randomBoolean();  /// MP: TODO: add later
         String searchId = randomSearchId();
         AsyncSearchResponse asyncSearchResponse = AsyncSearchResponseTests.randomAsyncSearchResponse(
             searchId,
-            AsyncSearchResponseTests.randomSearchResponse()
+            AsyncSearchResponseTests.randomSearchResponse(false)
         );
 
         if (asyncSearchResponse.getSearchResponse() == null

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -47,7 +47,7 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         SearchResponse.Clusters clusters = switch (randomIntBetween(0, 3)) {
             case 1 -> SearchResponse.Clusters.EMPTY;
             case 2 -> new SearchResponse.Clusters(1, 1, 0);
-            case 3 -> AsyncSearchResponseTests.createCCSClusterObject(4, 3, true);
+            case 3 -> AsyncSearchResponseTests.createCCSClusterObjects(4, 3, true);
             default -> null;  // case 0
         };
         return new AsyncStatusResponse(
@@ -80,7 +80,7 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         SearchResponse.Clusters clusters = switch (randomIntBetween(0, 3)) {
             case 1 -> SearchResponse.Clusters.EMPTY;
             case 2 -> new SearchResponse.Clusters(1, 1, 0);
-            case 3 -> AsyncSearchResponseTests.createCCSClusterObject(4, 3, true); // new SearchResponse.Clusters(4, 1, 0, 3, true);
+            case 3 -> AsyncSearchResponseTests.createCCSClusterObjects(4, 3, true); // new SearchResponse.Clusters(4, 1, 0, 3, true);
             default -> null;  // case 0
         };
         return new AsyncStatusResponse(
@@ -377,7 +377,7 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             int partial = randomInt(20);
             successfulClusters = successful + partial;
             skippedClusters = totalClusters - successfulClusters;
-            clusters = AsyncSearchResponseTests.createCCSClusterObject(80, 80, true, successful, skippedClusters, partial);
+            clusters = AsyncSearchResponseTests.createCCSClusterObjects(80, 80, true, successful, skippedClusters, partial);
         }
         SearchResponse searchResponse = new SearchResponse(
             internalSearchResponse,
@@ -411,7 +411,7 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         int successful = randomInt(10);
         int partial = randomInt(10);
         int skipped = randomInt(10);
-        SearchResponse.Clusters clusters = AsyncSearchResponseTests.createCCSClusterObject(100, 99, true, successful, skipped, partial);
+        SearchResponse.Clusters clusters = AsyncSearchResponseTests.createCCSClusterObjects(100, 99, true, successful, skipped, partial);
 
         SearchResponse searchResponse = new SearchResponse(
             internalSearchResponse,

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -187,11 +187,11 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
     }
 
     public void testGetStatusFromStoredSearchRandomizedInputs() {
-        boolean ccs = randomBoolean();  /// MP: TODO: add later
+        boolean ccs = randomBoolean();
         String searchId = randomSearchId();
         AsyncSearchResponse asyncSearchResponse = AsyncSearchResponseTests.randomAsyncSearchResponse(
             searchId,
-            AsyncSearchResponseTests.randomSearchResponse(false)
+            AsyncSearchResponseTests.randomSearchResponse(ccs)
         );
 
         if (asyncSearchResponse.getSearchResponse() == null

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
@@ -189,7 +189,7 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
         }
         RestActions.buildBroadcastShardsHeader(builder, params, totalShards, successfulShards, skippedShards, failedShards, null);
         if (clusters != null) {
-            builder = clusters.toXContent(builder, null);
+            builder = clusters.toXContent(builder, params);
         }
         if (isRunning == false) { // completion status information is only available for a completed search
             builder.field("completion_status", completionStatus.getStatus());


### PR DESCRIPTION
For CCS searches with ccs_minimize_roundtrips=true, when an error is returned, it is unclear which cluster
caused the problem. This commit adds additional accounting and error information to the search response
for each cluster involved in a cross-cluster search.

The `_clusters` section of the SearchResponse has a new `details` section added with an entry for each cluster 
(remote and local). It includes status info, shard accounting counters and error information that are added 
incrementally as the search happens.

The search on each cluster can be in one of 5 states:
`RUNNING`
`SUCCESSFUL` - all shards were successfully searched (successful or skipped)
`PARTIAL` - some shard searches failed, but at least one succeeded and partial data has been returned
`SKIPPED` - no shards were successfully searched (all failed or cluster unavailable) when skip_unavailable=true
`FAILED` - no shards were successfully searched (all failed or cluster unavailable) when skip_unavailable=false

A new `SearchReponse.Cluster` object has been added. Each `TransportSearchAction.CCSActionListener`
(one for each cluster) has a reference to a separate Cluster instance and updates once it gets back information 
from its cluster.

The `SearchResponse.Clusters` object only uses the new `Cluster` object for CCS minimize_roundtrips=true. 
For local-only searches and CCS minimize_roundtrips=false, it uses the current (immutable) Clusters object as before.