### PR TITLE
More conservative ClusterState#minTransportVersion()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -222,10 +222,9 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
         this.routingNodes = routingNodes;
         assert assertConsistentRoutingNodes(routingTable, nodes, routingNodes);
 
-        this.minTransportVersion = transportVersions.values()
-            .stream()
-            .min(Comparator.naturalOrder())
-            .orElse(TransportVersion.MINIMUM_COMPATIBLE);
+        this.minTransportVersion = blocks.hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK)
+            ? TransportVersion.MINIMUM_COMPATIBLE
+            : transportVersions.values().stream().min(Comparator.naturalOrder()).orElse(TransportVersion.MINIMUM_COMPATIBLE);
     }
 
     private static boolean assertConsistentRoutingNodes(
@@ -286,7 +285,7 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
     }
 
     public TransportVersion getMinTransportVersion() {
-        return blocks.hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) ? TransportVersion.MINIMUM_COMPATIBLE : this.minTransportVersion;
+        return this.minTransportVersion;
     }
 
     public Metadata metadata() {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -222,7 +222,10 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
         this.routingNodes = routingNodes;
         assert assertConsistentRoutingNodes(routingTable, nodes, routingNodes);
 
-        this.minTransportVersion = transportVersions.values().stream().min(Comparator.naturalOrder()).orElse(TransportVersion.current());
+        this.minTransportVersion = transportVersions.values()
+            .stream()
+            .min(Comparator.naturalOrder())
+            .orElse(TransportVersion.MINIMUM_COMPATIBLE);
     }
 
     private static boolean assertConsistentRoutingNodes(
@@ -283,7 +286,7 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
     }
 
     public TransportVersion getMinTransportVersion() {
-        return this.minTransportVersion;
+        return blocks.hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) ? TransportVersion.MINIMUM_COMPATIBLE : this.minTransportVersion;
     }
 
     public Metadata metadata() {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -224,7 +224,11 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
 
         this.minTransportVersion = blocks.hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK)
             ? TransportVersion.MINIMUM_COMPATIBLE
-            : transportVersions.values().stream().min(Comparator.naturalOrder()).orElse(TransportVersion.MINIMUM_COMPATIBLE);
+            : transportVersions.values()
+                .stream()
+                .min(Comparator.naturalOrder())
+                // In practice transportVersions is always nonempty (except in tests) but use a conservative default anyway:
+                .orElse(TransportVersion.MINIMUM_COMPATIBLE);
     }
 
     private static boolean assertConsistentRoutingNodes(
@@ -765,8 +769,8 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
             return nodes;
         }
 
-        public Builder putTransportVersion(String node, TransportVersion version) {
-            transportVersions.put(node, Objects.requireNonNull(version, node));
+        public Builder putTransportVersion(String nodeId, TransportVersion version) {
+            transportVersions.put(nodeId, Objects.requireNonNull(version, nodeId));
             return this;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -1031,7 +1031,7 @@ public class ClusterStateTests extends ESTestCase {
             .blocks(
                 ClusterBlocks.builder()
                     .addGlobalBlock(
-                        new ClusterBlock(1, "description", true, true, true, RestStatus.ACCEPTED, EnumSet.allOf((ClusterBlockLevel.class)))
+                        new ClusterBlock(3, "description", true, true, true, RestStatus.ACCEPTED, EnumSet.allOf((ClusterBlockLevel.class)))
                     )
                     .addBlocks(indexMetadata)
                     .addIndexBlock(
@@ -1125,6 +1125,8 @@ public class ClusterStateTests extends ESTestCase {
     }
 
     public void testGetMinTransportVersion() throws IOException {
+        assertEquals(TransportVersion.MINIMUM_COMPATIBLE, ClusterState.EMPTY_STATE.getMinTransportVersion());
+
         var builder = ClusterState.builder(buildClusterState());
         int numNodes = randomIntBetween(2, 20);
         TransportVersion minVersion = TransportVersion.current();
@@ -1137,5 +1139,13 @@ public class ClusterStateTests extends ESTestCase {
 
         var newState = builder.build();
         assertThat(newState.getMinTransportVersion(), equalTo(minVersion));
+
+        assertEquals(
+            TransportVersion.MINIMUM_COMPATIBLE,
+            ClusterState.builder(newState)
+                .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK))
+                .build()
+                .getMinTransportVersion()
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -151,7 +151,7 @@ public class ClusterStateTests extends ESTestCase {
                           "master_node": "nodeId1",
                           "blocks": {
                             "global": {
-                              "1": {
+                              "3": {
                                 "description": "description",
                                 "retryable": true,
                                 "disable_state_persistence": true,
@@ -406,7 +406,7 @@ public class ClusterStateTests extends ESTestCase {
                       "master_node" : "nodeId1",
                       "blocks" : {
                         "global" : {
-                          "1" : {
+                          "3" : {
                             "description" : "description",
                             "retryable" : true,
                             "disable_state_persistence" : true,
@@ -657,7 +657,7 @@ public class ClusterStateTests extends ESTestCase {
                       "master_node" : "nodeId1",
                       "blocks" : {
                         "global" : {
-                          "1" : {
+                          "3" : {
                             "description" : "description",
                             "retryable" : true,
                             "disable_state_persistence" : true,

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -110,6 +111,7 @@ public class MlAutoUpdateServiceIT extends MlSingleNodeTestCase {
                         .masterNodeId("node_id")
                         .build()
                 )
+                .putTransportVersion("node_id", TransportVersion.current())
                 .build(),
             ClusterState.builder(new ClusterName("test")).build()
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ml.inference.assignment;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
@@ -121,6 +122,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
                     .add(buildNode(startedNode, true, ByteSizeValue.ofGb(4).getBytes(), 8))
                     .build()
             )
+            .putTransportVersion(nodeId, TransportVersion.current())
             .metadata(
                 Metadata.builder()
                     .putCustom(
@@ -234,6 +236,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
 
         ClusterState clusterStateWithAssignment = ClusterState.builder(new ClusterName("testRemoveAssignment"))
             .nodes(DiscoveryNodes.builder().add(buildNode("test-node", true, ByteSizeValue.ofGb(4).getBytes(), 8)).build())
+            .putTransportVersion("test-node", TransportVersion.current())
             .metadata(
                 Metadata.builder()
                     .putCustom(
@@ -265,6 +268,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
 
         ClusterState clusterStateWithAssignments = ClusterState.builder(new ClusterName("testRemoveAllAssignments"))
             .nodes(DiscoveryNodes.builder().add(buildNode("test-node", true, ByteSizeValue.ofGb(4).getBytes(), 8)).build())
+            .putTransportVersion("test-node", TransportVersion.current())
             .metadata(
                 Metadata.builder()
                     .putCustom(TrainedModelAssignmentMetadata.NAME, TrainedModelAssignmentMetadataTests.randomInstance())
@@ -361,6 +365,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
 
         ClusterState currentState = ClusterState.builder(new ClusterName("testCreateAssignment"))
             .nodes(discoveryNodes)
+            .putTransportVersion("ml-node-with-room", TransportVersion.current())
             .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().isResetMode(true).build()))
             .build();
         when(clusterService.state()).thenReturn(currentState);
@@ -1359,6 +1364,8 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         DiscoveryNode node3 = buildNode(nodeId3, true, ByteSizeValue.ofGb(4).getBytes(), 8);
         ClusterState currentState = ClusterState.builder(new ClusterName("testAreAssignedNodesRemoved"))
             .nodes(DiscoveryNodes.builder().add(node1).add(node3).build())
+            .putTransportVersion(nodeId1, TransportVersion.current())
+            .putTransportVersion(nodeId3, TransportVersion.current())
             .metadata(metadata)
             .build();
 
@@ -1411,6 +1418,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
 
         ClusterState clusterStateWithAllocation = ClusterState.builder(new ClusterName("testSetAllocationToStopping"))
             .nodes(DiscoveryNodes.builder().add(buildNode("test-node", true, ByteSizeValue.ofGb(4).getBytes(), 8)).build())
+            .putTransportVersion("test-node", TransportVersion.current())
             .metadata(
                 Metadata.builder()
                     .putCustom(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.inference.assignment;
 
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
@@ -375,6 +376,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
             "testClusterChanged",
             ClusterState.builder(new ClusterName("testClusterChanged"))
                 .nodes(nodes)
+                .putTransportVersion(NODE_ID, TransportVersion.current())
                 .metadata(
                     Metadata.builder()
                         .putCustom(
@@ -432,6 +434,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
             "testClusterChanged",
             ClusterState.builder(new ClusterName("testClusterChanged"))
                 .nodes(nodes)
+                .putTransportVersion(NODE_ID, TransportVersion.current())
                 .metadata(
                     Metadata.builder()
                         .putCustom(
@@ -484,6 +487,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
             "testClusterChanged",
             ClusterState.builder(new ClusterName("testClusterChanged"))
                 .nodes(nodes)
+                .putTransportVersion(NODE_ID, TransportVersion.current())
                 .metadata(
                     Metadata.builder()
                         .putCustom(
@@ -524,6 +528,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
             "shouldUpdateAllocations",
             ClusterState.builder(new ClusterName("shouldUpdateAllocations"))
                 .nodes(nodes)
+                .putTransportVersion(NODE_ID, TransportVersion.current())
                 .metadata(
                     Metadata.builder()
                         .putCustom(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TransportVersionUtilsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TransportVersionUtilsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.utils;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.utils.TransportVersionUtils;
 
@@ -37,7 +38,7 @@ public class TransportVersionUtilsTests extends ESTestCase {
         null,
         null,
         transportVersions,
-        null,
+        ClusterBlocks.EMPTY_CLUSTER_BLOCK,
         null,
         false,
         null
@@ -60,7 +61,7 @@ public class TransportVersionUtilsTests extends ESTestCase {
             null,
             null,
             transportVersions1,
-            null,
+            ClusterBlocks.EMPTY_CLUSTER_BLOCK,
             null,
             false,
             null


### PR DESCRIPTION
In order to guarantee that minTransportVersion() never decreases, we
should return `MINIMUM_COMPATIBLE` when the cluster is not fully formed.