### PR TITLE
Use ThreadPoolExecutor#getMaximumPoolSize to limit the number of slices on concurrent search

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -203,7 +203,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     @Override
     protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
-        return computeSlices(leaves, queueSizeBasedExecutor.threadPoolExecutor.getPoolSize(), MINIMUM_DOCS_PER_SLICE);
+        return computeSlices(leaves, queueSizeBasedExecutor.threadPoolExecutor.getMaximumPoolSize(), MINIMUM_DOCS_PER_SLICE);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -252,6 +252,9 @@ public class ContextIndexSearcherTests extends ESTestCase {
         ) {
             @Override
             protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
+                if (leaves.size() == 1) {
+                    return super.slices(leaves);
+                }
                 return slices(leaves, 1, 1);
             }
         };
@@ -261,7 +264,6 @@ public class ContextIndexSearcherTests extends ESTestCase {
             () -> searcher.search(new MatchAllDocsQuery(), collectorManager)
         );
         assertThat(exception.getMessage(), equalTo("fake exception"));
-
         assertThat(visitDocs.get() + missingDocs.get(), equalTo(numDocs));
         directoryReader.close();
         directory.close();


### PR DESCRIPTION
We are currently using the method #getPoolSize which is wrong as it return how many threads has been initialized, e.g if you call it after the creation of the threadpool it return 0.