### PR TITLE
Add Debug Log for Successful Remote Cluster Connections

### DIFF
--- a/docs/changelog/97743.yaml
+++ b/docs/changelog/97743.yaml
@@ -1,0 +1,5 @@
+prLink: "https://github.com/elastic/elasticsearch/pull/97743"
+user: "LoggingResearch"
+type: enhancement
+description: >
+  Adds a debug log statement in the `initializeRemoteClusters` method of the `RemoteClusterService` class to output a message when a connection is successfully established to all configured remote clusters.

--- a/docs/changelog/97743.yaml
+++ b/docs/changelog/97743.yaml
@@ -1,5 +1,0 @@
-prLink: "https://github.com/elastic/elasticsearch/pull/97743"
-user: "LoggingResearch"
-type: enhancement
-description: >
-  Adds a debug log statement in the `initializeRemoteClusters` method of the `RemoteClusterService` class to output a message when a connection is successfully established to all configured remote clusters.

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -412,6 +412,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
 
         try {
             future.get(timeValue.millis(), TimeUnit.MILLISECONDS);
+            logger.debug("connected to all configured remote clusters");
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (TimeoutException ex) {


### PR DESCRIPTION
This PR introduces a new debug log statement in the method. The added log statement will output a message when a connection is successfully established to all configured remote clusters.

This enhancement will provide valuable debugging information, making it easier to track and understand the connection status of remote clusters, especially in scenarios where network or cluster connectivity may be an issue.

