### PR TITLE
Move test CSV and Spec Reader support up to QL

### DIFF
--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class CsvSpecReader {
+
+    private CsvSpecReader() {}
+
+    public static SpecReader.Parser specParser() {
+        return new CsvSpecParser();
+    }
+
+    public static class CsvSpecParser implements SpecReader.Parser {
+        private static final String SCHEMA_PREFIX = "schema::";
+
+        private final StringBuilder earlySchema = new StringBuilder();
+        private final StringBuilder query = new StringBuilder();
+        private final StringBuilder data = new StringBuilder();
+        private CsvTestCase testCase;
+
+        private CsvSpecParser() {}
+
+        @Override
+        public Object parse(String line) {
+            // read the query
+            if (testCase == null) {
+                if (line.startsWith(SCHEMA_PREFIX)) {
+                    assertThat("Early schema already declared " + earlySchema, earlySchema.length(), is(0));
+                    earlySchema.append(line.substring(SCHEMA_PREFIX.length()).trim());
+                } else {
+                    if (line.endsWith(";")) {
+                        // pick up the query
+                        testCase = new CsvTestCase();
+                        query.append(line.substring(0, line.length() - 1).trim());
+                        testCase.query = query.toString();
+                        testCase.earlySchema = earlySchema.toString();
+                        earlySchema.setLength(0);
+                        query.setLength(0);
+                    }
+                    // keep reading the query
+                    else {
+                        query.append(line);
+                        query.append("\r\n");
+                    }
+                }
+            }
+            // read the results
+            else {
+                // read data
+                if (line.toLowerCase(Locale.ROOT).startsWith("warning:")) {
+                    testCase.expectedWarnings.add(line.substring("warning:".length()).trim());
+                } else if (line.startsWith(";")) {
+                    testCase.expectedResults = data.toString();
+                    // clean-up and emit
+                    CsvTestCase result = testCase;
+                    testCase = null;
+                    data.setLength(0);
+                    return result;
+                } else {
+                    data.append(line);
+                    data.append("\r\n");
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public static class CsvTestCase {
+        public String query;
+        public String earlySchema;
+        public String expectedResults;
+        public List<String> expectedWarnings = new ArrayList<>();
+    }
+
+}

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/SpecReader.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/SpecReader.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql;
+
+import org.elasticsearch.common.Strings;
+
+import java.io.BufferedReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.xpack.ql.TestUtils.pathAndName;
+import static org.junit.Assert.assertNull;
+
+public final class SpecReader {
+
+    private SpecReader() {}
+
+    public static List<Object[]> readScriptSpec(URL source, String url, Parser parser) throws Exception {
+        Objects.requireNonNull(source, "Cannot find resource " + url);
+        return readURLSpec(source, parser);
+    }
+
+    public static List<Object[]> readScriptSpec(List<URL> urls, Parser parser) throws Exception {
+        List<Object[]> results = emptyList();
+        for (URL url : urls) {
+            List<Object[]> specs = readURLSpec(url, parser);
+            if (results.isEmpty()) {
+                results = specs;
+            } else {
+                results.addAll(specs);
+            }
+        }
+
+        return results;
+    }
+
+    public static List<Object[]> readURLSpec(URL source, Parser parser) throws Exception {
+        String fileName = pathAndName(source.getFile()).v2();
+        String groupName = fileName.substring(0, fileName.lastIndexOf("."));
+
+        Map<String, Integer> testNames = new LinkedHashMap<>();
+        List<Object[]> testCases = new ArrayList<>();
+
+        String testName = null;
+        try (BufferedReader reader = TestUtils.reader(source)) {
+            String line;
+            int lineNumber = 1;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                // ignore comments
+                if (shouldSkipLine(line) == false) {
+                    // parse test name
+                    if (testName == null) {
+                        if (testNames.keySet().contains(line)) {
+                            throw new IllegalStateException(
+                                "Duplicate test name '"
+                                    + line
+                                    + "' at line "
+                                    + lineNumber
+                                    + " (previously seen at line "
+                                    + testNames.get(line)
+                                    + ")"
+                            );
+                        } else {
+                            testName = Strings.capitalize(line);
+                            testNames.put(testName, Integer.valueOf(lineNumber));
+                        }
+                    } else {
+                        Object result = parser.parse(line);
+                        // only if the parser is ready, add the object - otherwise keep on serving it lines
+                        if (result != null) {
+                            testCases.add(new Object[] { fileName, groupName, testName, Integer.valueOf(lineNumber), result });
+                            testName = null;
+                        }
+                    }
+                }
+                lineNumber++;
+            }
+            if (testName != null) {
+                throw new IllegalStateException("Read a test without a body at the end of [" + fileName + "].");
+            }
+        }
+        assertNull("Cannot find spec for test " + testName, testName);
+
+        return testCases;
+    }
+
+    public interface Parser {
+        Object parse(String line);
+    }
+
+    public static boolean shouldSkipLine(String line) {
+        return line.isEmpty() || line.startsWith("//") || line.startsWith("#");
+    }
+}

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -16,12 +16,12 @@ dependencies {
   api project(path: xpackModule('sql:sql-cli'))
 
   // H2GIS testing dependencies
-  api( "org.orbisgis:h2gis:${h2gisVersion}") {
+  api("org.orbisgis:h2gis:${h2gisVersion}") {
     exclude group: "org.locationtech.jts"
   }
 
   // select just the parts of JLine that are needed
-  api( "org.jline:jline-terminal-jna:${jlineVersion}") {
+  api("org.jline:jline-terminal-jna:${jlineVersion}") {
     exclude group: "net.java.dev.jna"
   }
   api "org.jline:jline-terminal:${jlineVersion}"
@@ -67,7 +67,7 @@ subprojects {
       transitive = false
     }
     javaRestTestImplementation project(":test:framework")
-    javaRestTestRuntimeOnly project(xpackModule('ql:test-fixtures'))
+    javaRestTestImplementation project(xpackModule('ql:test-fixtures'))
 
     // JDBC testing dependencies
     javaRestTestRuntimeOnly "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"

--- a/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/JdbcCsvSpecIT.java
@@ -8,8 +8,8 @@ package org.elasticsearch.xpack.sql.qa.multi_cluster_with_security;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.xpack.ql.SpecReader;
 import org.elasticsearch.xpack.sql.qa.jdbc.CsvSpecTestCase;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -19,8 +19,9 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 import static org.elasticsearch.transport.RemoteClusterAware.buildRemoteIndexName;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
 import static org.elasticsearch.xpack.ql.TestUtils.classpathResources;
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
 
 public class JdbcCsvSpecIT extends CsvSpecTestCase {
 
@@ -34,7 +35,7 @@ public class JdbcCsvSpecIT extends CsvSpecTestCase {
     public static List<Object[]> readScriptSpec() throws Exception {
         List<Object[]> list = new ArrayList<>();
         list.addAll(CsvSpecTestCase.readScriptSpec());
-        list.addAll(readScriptSpec(classpathResources("/multi-cluster-with-security/*.csv-spec"), specParser()));
+        list.addAll(SpecReader.readScriptSpec(classpathResources("/multi-cluster-with-security/*.csv-spec"), specParser()));
         return list;
     }
 

--- a/x-pack/plugin/sql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_node/GeoJdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_node/GeoJdbcCsvSpecIT.java
@@ -8,7 +8,8 @@
 package org.elasticsearch.xpack.sql.qa.multi_node;
 
 import org.elasticsearch.xpack.sql.qa.geo.GeoCsvSpecTestCase;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
+
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
 
 public class GeoJdbcCsvSpecIT extends GeoCsvSpecTestCase {
     public GeoJdbcCsvSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase) {

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   testImplementation(project(':x-pack:plugin:sql:qa:server')) {
     transitive = false
   }
+  api project(xpackModule('ql:test-fixtures'))
 }
 
 Project mainProject = project

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/JdbcCsvSpecIT.java
@@ -8,9 +8,10 @@ package org.elasticsearch.xpack.sql.qa.security;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.sql.qa.jdbc.CsvSpecTestCase;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
 import java.util.Properties;
+
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
 
 public class JdbcCsvSpecIT extends CsvSpecTestCase {
     public JdbcCsvSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase) {

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/GeoJdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/GeoJdbcCsvSpecIT.java
@@ -10,12 +10,12 @@ package org.elasticsearch.xpack.sql.qa.single_node;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.xpack.sql.qa.geo.GeoCsvSpecTestCase;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
 
 public class GeoJdbcCsvSpecIT extends GeoCsvSpecTestCase {
 

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcCsvSpecIT.java
@@ -9,12 +9,12 @@ package org.elasticsearch.xpack.sql.qa.single_node;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.xpack.sql.qa.jdbc.CsvSpecTestCase;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
 
 public class JdbcCsvSpecIT extends CsvSpecTestCase {
 

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcDocCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcDocCsvSpecIT.java
@@ -10,7 +10,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 import org.elasticsearch.xpack.sql.qa.jdbc.DataLoader;
 import org.elasticsearch.xpack.sql.qa.jdbc.JdbcAssert;
 import org.elasticsearch.xpack.sql.qa.jdbc.SpecBaseIntegrationTestCase;
@@ -21,9 +20,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
+import static org.elasticsearch.xpack.ql.SpecReader.Parser;
 import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.csvConnection;
 import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.executeCsvQuery;
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
 
 /**
  * CSV test specification for DOC examples.

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcFrozenCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcFrozenCsvSpecIT.java
@@ -9,13 +9,13 @@ package org.elasticsearch.xpack.sql.qa.single_node;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.xpack.sql.qa.jdbc.CsvSpecTestCase;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
 
 public class JdbcFrozenCsvSpecIT extends CsvSpecTestCase {
 

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoCsvSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoCsvSpecTestCase.java
@@ -11,7 +11,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.xpack.sql.jdbc.JdbcConfiguration;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 import org.elasticsearch.xpack.sql.qa.jdbc.SpecBaseIntegrationTestCase;
 import org.junit.Before;
 
@@ -21,9 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
+import static org.elasticsearch.xpack.ql.SpecReader.Parser;
 import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.csvConnection;
 import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.executeCsvQuery;
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
 
 /**
  * Tests comparing sql queries executed against our jdbc client

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoSqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoSqlSpecTestCase.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.sql.qa.geo;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.client.Request;
+import org.elasticsearch.xpack.ql.SpecReader.Parser;
 import org.elasticsearch.xpack.sql.qa.jdbc.LocalH2;
 import org.elasticsearch.xpack.sql.qa.jdbc.SpecBaseIntegrationTestCase;
 import org.h2gis.functions.factory.H2GISFunctions;

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvSpecTestCase.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.sql.qa.jdbc;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.xpack.ql.SpecReader;
 import org.elasticsearch.xpack.ql.TestUtils;
-import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
 import java.net.URL;
 import java.sql.Connection;
@@ -18,9 +18,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+import static org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import static org.elasticsearch.xpack.ql.CsvSpecReader.specParser;
 import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.csvConnection;
 import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.executeCsvQuery;
-import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
 
 /**
  * Tests comparing sql queries executed against our jdbc client
@@ -33,7 +34,7 @@ public abstract class CsvSpecTestCase extends SpecBaseIntegrationTestCase {
     public static List<Object[]> readScriptSpec() throws Exception {
         List<URL> urls = TestUtils.classpathResources("/*.csv-spec");
         assertTrue("Not enough specs found (" + urls.size() + ") " + urls.toString(), urls.size() >= 23);
-        return readScriptSpec(urls, specParser());
+        return SpecReader.readScriptSpec(urls, specParser());
     }
 
     public CsvSpecTestCase(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase) {

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DebugSqlSpec.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DebugSqlSpec.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.sql.qa.jdbc;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.xpack.ql.SpecReader.Parser;
+
 import java.util.List;
 
 public abstract class DebugSqlSpec extends SqlSpecTestCase {

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SpecBaseIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SpecBaseIntegrationTestCase.java
@@ -10,29 +10,23 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.xpack.ql.TestUtils;
+import org.elasticsearch.xpack.ql.SpecReader;
 import org.junit.AfterClass;
 import org.junit.Before;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.TimeZone;
 
-import static java.util.Collections.emptyList;
-import static org.elasticsearch.xpack.ql.TestUtils.pathAndName;
+import static org.elasticsearch.xpack.ql.SpecReader.Parser;
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.JDBC_TIMEZONE;
 
 /**
@@ -158,75 +152,6 @@ public abstract class SpecBaseIntegrationTestCase extends JdbcIntegrationTestCas
         URL source = SpecBaseIntegrationTestCase.class.getResource(url);
         Objects.requireNonNull(source, "Cannot find resource " + url);
 
-        return readURLSpec(source, parser);
-    }
-
-    protected static List<Object[]> readScriptSpec(List<URL> urls, Parser parser) throws Exception {
-        List<Object[]> results = emptyList();
-        for (URL url : urls) {
-            List<Object[]> specs = readURLSpec(url, parser);
-            if (results.isEmpty()) {
-                results = specs;
-            } else {
-                results.addAll(specs);
-            }
-        }
-
-        return results;
-    }
-
-    private static List<Object[]> readURLSpec(URL source, Parser parser) throws Exception {
-        String fileName = pathAndName(source.getFile()).v2();
-        String groupName = fileName.substring(0, fileName.lastIndexOf("."));
-
-        Map<String, Integer> testNames = new LinkedHashMap<>();
-        List<Object[]> testCases = new ArrayList<>();
-
-        String testName = null;
-        try (BufferedReader reader = TestUtils.reader(source)) {
-            String line;
-            int lineNumber = 1;
-            while ((line = reader.readLine()) != null) {
-                line = line.trim();
-                // ignore comments
-                if (line.isEmpty() == false && line.startsWith("//") == false) {
-                    // parse test name
-                    if (testName == null) {
-                        if (testNames.keySet().contains(line)) {
-                            throw new IllegalStateException(
-                                "Duplicate test name '"
-                                    + line
-                                    + "' at line "
-                                    + lineNumber
-                                    + " (previously seen at line "
-                                    + testNames.get(line)
-                                    + ")"
-                            );
-                        } else {
-                            testName = Strings.capitalize(line);
-                            testNames.put(testName, Integer.valueOf(lineNumber));
-                        }
-                    } else {
-                        Object result = parser.parse(line);
-                        // only if the parser is ready, add the object - otherwise keep on serving it lines
-                        if (result != null) {
-                            testCases.add(new Object[] { fileName, groupName, testName, Integer.valueOf(lineNumber), result });
-                            testName = null;
-                        }
-                    }
-                }
-                lineNumber++;
-            }
-            if (testName != null) {
-                throw new IllegalStateException("Read a test without a body at the end of [" + fileName + "].");
-            }
-        }
-        assertNull("Cannot find spec for test " + testName, testName);
-
-        return testCases;
-    }
-
-    public interface Parser {
-        Object parse(String line);
+        return SpecReader.readURLSpec(source, parser);
     }
 }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.qa.jdbc;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.xpack.ql.SpecReader;
 import org.junit.Assume;
 import org.junit.ClassRule;
 
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import static org.elasticsearch.xpack.ql.SpecReader.Parser;
 import static org.elasticsearch.xpack.ql.TestUtils.classpathResources;
 
 /**
@@ -41,7 +43,7 @@ public abstract class SqlSpecTestCase extends SpecBaseIntegrationTestCase {
     public static List<Object[]> readScriptSpec() throws Exception {
         List<URL> urls = classpathResources("/*.sql-spec");
         assertTrue("Not enough specs found " + urls.toString(), urls.size() > 10);
-        return readScriptSpec(urls, specParser());
+        return SpecReader.readScriptSpec(urls, specParser());
     }
 
     private static class SqlSpecParser implements Parser {


### PR DESCRIPTION
This commit refactors the CSV and Spec Reader test utilities used by SQL tests, by moving them up to an ancestor plugin where they can be used by other query language tests, namely ESQL.