### PR TITLE
Fast path for single-region reads from SharedBlobCache

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -259,6 +259,10 @@ public class SparseFileTracker {
         }
     }
 
+    public boolean checkAvailable(long upTo) {
+        return complete >= upTo;
+    }
+
     /**
      * Called before reading a range from the file to ensure that this range is present. Unlike
      * {@link SparseFileTracker#waitForRange(ByteRange, ByteRange, ActionListener)} this method does not expect the caller to fill in any

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -767,6 +768,18 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             throw new AlreadyClosedException("File chunk is evicted");
         }
 
+        boolean tryRead(ByteBuffer buf, long offset) throws IOException {
+            int startingPos = buf.position();
+            try (SharedBytes.IO fileChannel = sharedBytes.getFileChannel(sharedBytesPos)) {
+                fileChannel.read(buf, physicalStartOffset() + getRegionRelativePosition(offset));
+            }
+            if (evicted.get() || hasReferences() == false) {
+                buf.position(startingPos);
+                return false;
+            }
+            return true;
+        }
+
         void populateAndRead(
             final ByteRange rangeToWrite,
             final ByteRange rangeToRead,
@@ -884,6 +897,20 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
 
         public KeyType getCacheKey() {
             return cacheKey;
+        }
+
+        public boolean tryRead(ByteBuffer buf, long offset) throws IOException {
+            final int startRegion = getRegion(offset);
+            final long end = offset + buf.remaining();
+            final int endRegion = getEndingRegion(end);
+            if (startRegion != endRegion) {
+                return false;
+            }
+            final CacheFileRegion fileRegion = get(cacheKey, length, startRegion);
+            if (fileRegion.tracker.checkAvailable(end) == false) {
+                return false;
+            }
+            return fileRegion.tryRead(buf, offset);
         }
 
         public int populateAndRead(

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -98,7 +98,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
     protected void readWithoutBlobCache(ByteBuffer b) throws Exception {
         final long position = getAbsolutePosition();
         final int length = b.remaining();
-        if (cacheFile.tryRead(b, getAbsolutePosition())) {
+        if (cacheFile.tryRead(b, position)) {
             stats.addCachedBytesRead(length);
             return;
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -98,6 +98,10 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
     protected void readWithoutBlobCache(ByteBuffer b) throws Exception {
         final long position = getAbsolutePosition();
         final int length = b.remaining();
+        if (cacheFile.tryRead(b, getAbsolutePosition())) {
+            stats.addCachedBytesRead(length);
+            return;
+        }
         // Semaphore that, when all permits are acquired, ensures that async callbacks (such as those used by readCacheFile) are not
         // accessing the byte buffer anymore that was passed to readWithoutBlobCache
         // In particular, it's important to acquire all permits before adapting the ByteBuffer's offset


### PR DESCRIPTION
Bypass all the object allocation and use optimistic concurrency control to check that we actually read valid bytes. -> avoids all the object allocation on every read as well as some volatile reads + writes.
