### PR TITLE
Add tags to a couple of aggs docs.

### DIFF
--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -77,6 +77,8 @@ https://static.googleusercontent.com/media/research.google.com/fr//pubs/archive/
 algorithm, which counts based on the hashes of the values with some interesting
 properties:
 
+// tag::explanation[]
+
  * configurable precision, which decides on how to trade memory for accuracy,
  * excellent accuracy on low-cardinality sets,
  * fixed memory usage: no matter if there are tens or billions of unique values,
@@ -157,8 +159,10 @@ accuracy. Also note that even with a threshold as low as 100, the error
 remains very low (1-6% as seen in the above graph) even when counting millions of items.
 
 The HyperLogLog++ algorithm depends on the leading zeros of hashed
-values, the exact distributions of hashes in a dataset can affect the 
+values, the exact distributions of hashes in a dataset can affect the
 accuracy of the cardinality.
+
+// end::explanation[]
 
 ==== Pre-computed hashes
 
@@ -249,7 +253,7 @@ There are different mechanisms by which cardinality aggregations can be executed
 
 Additionally, there are two "heuristic based" modes.  These modes will cause
 Elasticsearch to use some data about the state of the index to choose an
-appropriate execution method.  The two heuristics are: 
+appropriate execution method.  The two heuristics are:
  - `save_time_heuristic` - this is the default in Elasticsearch 8.4 and later.
  - `save_memory_heuristic` - this was the default in Elasticsearch 8.3 and
    earlier

--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -234,6 +234,7 @@ GET latency/_search
 [[search-aggregations-metrics-percentile-aggregation-approximation]]
 ==== Percentiles are (usually) approximate
 
+// tag::approximate[]
 There are many different algorithms to calculate percentiles. The naive
 implementation simply stores all the values in a sorted array. To find the 50th
 percentile, you simply find the value that is at `my_array[count(my_array) * 0.5]`.
@@ -267,6 +268,8 @@ It shows how precision is better for extreme percentiles. The reason why error d
 for large number of values is that the law of large numbers makes the distribution of
 values more and more uniform and the t-digest tree can do a better job at summarizing
 it. It would not be the case on more skewed distributions.
+
+// end::approximate[]
 
 [WARNING]
 ====


### PR DESCRIPTION
This is a very minor change that adds tags to a couple of aggs docs. These tags are currently unused, but will be referred to by ESQL docs.