### PR TITLE
Muting pki tests until expired test certs are regenerated

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.authc.pki;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.SecureString;
@@ -46,6 +47,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97756")
 public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
 
     private static final ParseField AUTHENTICATION_FIELD = new ParseField("authentication");


### PR DESCRIPTION
see https://github.com/elastic/elasticsearch/issues/97756