### PR TITLE
[8.9] Fix `sub_searches` serialization bug (#97587)

### DIFF
--- a/docs/changelog/97587.yaml
+++ b/docs/changelog/97587.yaml
@@ -1,0 +1,5 @@
+pr: 97587
+summary: Fix `sub_searches` serialization bug
+area: Ranking
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -94,9 +94,8 @@ setup:
 ---
 "kNN search plus query":
   - skip:
-      version: all #' - 8.3.99'
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97144"
-      # reason: 'kNN added to search endpoint in 8.4'
+      version: ' - 8.3.99'
+      reason: 'kNN added to search endpoint in 8.4'
   - do:
       search:
         index: test
@@ -122,9 +121,8 @@ setup:
 ---
 "kNN multi-field search with query":
   - skip:
-      version: all #' - 8.6.99'
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97144"
-      # reason: 'multi-field kNN search added to search endpoint in 8.7'
+      version: ' - 8.6.99'
+      reason: 'multi-field kNN search added to search endpoint in 8.7'
   - do:
       search:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/45_knn_search_byte.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/45_knn_search_byte.yml
@@ -66,9 +66,6 @@ setup:
 
 ---
 "kNN search plus query":
-  - skip:
-      version: all
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97144"
   - do:
       search:
         index: test

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -292,7 +292,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalNamedWriteable(postQueryBuilder);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_013)) {
             out.writeList(subSearchSourceBuilders);
-        } else if (out.getTransportVersion().before(TransportVersion.V_8_8_0) && subSearchSourceBuilders.size() >= 2) {
+        } else if (out.getTransportVersion().before(TransportVersion.V_8_4_0) && subSearchSourceBuilders.size() >= 2) {
             throw new IllegalArgumentException("cannot serialize [sub_searches] to version [" + out.getTransportVersion() + "]");
         } else {
             out.writeOptionalNamedWriteable(query());


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Fix `sub_searches` serialization bug (#97587)