### PR TITLE
Make build info pluggable internally

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -385,6 +385,7 @@ module org.elasticsearch.server {
     uses org.elasticsearch.jdk.ModuleQualifiedExportsService;
     uses org.elasticsearch.node.internal.TerminationHandlerProvider;
     uses org.elasticsearch.internal.VersionExtension;
+    uses org.elasticsearch.internal.BuildExtension;
 
     provides org.apache.lucene.codecs.PostingsFormat
         with

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.internal.BuildExtension;
 
 import java.io.IOException;
 import java.net.URL;
@@ -24,61 +25,24 @@ import java.util.jar.Manifest;
  */
 public record Build(Type type, String hash, String date, boolean isSnapshot, String version) {
 
-    private static final Build CURRENT;
+    private static class CurrentHolder {
+        private static final Build CURRENT = findCurrent();
+
+        // finds the pluggable current build, or uses the local build as a fallback
+        private static Build findCurrent() {
+            var buildExtension = BuildExtension.load();
+            if (buildExtension == null) {
+                return findLocalBuild();
+            }
+            var build = buildExtension.getCurrentBuild();
+            return build;
+        }
+    }
 
     /**
-     * The current build of Elasticsearch. Filled with information scanned at
-     * startup from the jar.
+     * Finds build info scanned from the server jar.
      */
-    public static Build current() {
-        return CURRENT;
-    }
-
-    public enum Type {
-
-        DEB("deb"),
-        DOCKER("docker"),
-        RPM("rpm"),
-        TAR("tar"),
-        ZIP("zip"),
-        UNKNOWN("unknown");
-
-        final String displayName;
-
-        public String displayName() {
-            return displayName;
-        }
-
-        Type(final String displayName) {
-            this.displayName = displayName;
-        }
-
-        public static Type fromDisplayName(final String displayName, final boolean strict) {
-            switch (displayName) {
-                case "deb":
-                    return Type.DEB;
-                case "docker":
-                    return Type.DOCKER;
-                case "rpm":
-                    return Type.RPM;
-                case "tar":
-                    return Type.TAR;
-                case "zip":
-                    return Type.ZIP;
-                case "unknown":
-                    return Type.UNKNOWN;
-                default:
-                    if (strict) {
-                        throw new IllegalStateException("unexpected distribution type [" + displayName + "]; your distribution is broken");
-                    } else {
-                        return Type.UNKNOWN;
-                    }
-            }
-        }
-
-    }
-
-    static {
+    private static Build findLocalBuild() {
         final Type type;
         final String hash;
         final String date;
@@ -139,7 +103,56 @@ public record Build(Type type, String hash, String date, boolean isSnapshot, Str
             );
         }
 
-        CURRENT = new Build(type, hash, date, isSnapshot, version);
+        return new Build(type, hash, date, isSnapshot, version);
+    }
+
+
+    public static Build current() {
+        return CurrentHolder.CURRENT;
+    }
+
+    public enum Type {
+
+        DEB("deb"),
+        DOCKER("docker"),
+        RPM("rpm"),
+        TAR("tar"),
+        ZIP("zip"),
+        UNKNOWN("unknown");
+
+        final String displayName;
+
+        public String displayName() {
+            return displayName;
+        }
+
+        Type(final String displayName) {
+            this.displayName = displayName;
+        }
+
+        public static Type fromDisplayName(final String displayName, final boolean strict) {
+            switch (displayName) {
+                case "deb":
+                    return Type.DEB;
+                case "docker":
+                    return Type.DOCKER;
+                case "rpm":
+                    return Type.RPM;
+                case "tar":
+                    return Type.TAR;
+                case "zip":
+                    return Type.ZIP;
+                case "unknown":
+                    return Type.UNKNOWN;
+                default:
+                    if (strict) {
+                        throw new IllegalStateException("unexpected distribution type [" + displayName + "]; your distribution is broken");
+                    } else {
+                        return Type.UNKNOWN;
+                    }
+            }
+        }
+
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -106,7 +106,6 @@ public record Build(Type type, String hash, String date, boolean isSnapshot, Str
         return new Build(type, hash, date, isSnapshot, version);
     }
 
-
     public static Build current() {
         return CurrentHolder.CURRENT;
     }

--- a/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.internal;
+
+import org.elasticsearch.Build;
+
+import java.util.ServiceLoader;
+
+/**
+ * Allows plugging in current build info.
+ */
+public interface BuildExtension {
+
+    /**
+     * Returns the {@link Build} that represents the running Elasticsearch code.
+     */
+    Build getCurrentBuild();
+
+    /**
+     * Loads a single BuildExtension, or returns {@code null} if none are found.
+     */
+    static BuildExtension load() {
+        var loader = ServiceLoader.load(BuildExtension.class);
+        var extensions = loader.stream().toList();
+        if (extensions.size() > 1) {
+            throw new IllegalStateException("More than one build extension found");
+        } else if (extensions.size() == 0) {
+            return null;
+        }
+        return extensions.get(0).get();
+    }
+}


### PR DESCRIPTION
This commit makes the Build.current() pluggable. This is only available for internal builds.