### PR TITLE
Move aggregation execute phase into Collector manager's reduce phase

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -8,14 +8,15 @@
 package org.elasticsearch.search.aggregations;
 
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.search.aggregations.support.TimeSeriesIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.query.QueryPhase;
-import org.elasticsearch.search.query.SingleThreadCollectorManager;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,10 +30,11 @@ public class AggregationPhase {
         if (context.aggregations() == null) {
             return;
         }
-        BucketCollector bucketCollector;
+        final BucketCollector bucketCollector;
+        final Aggregator[] aggregators;
         try {
-            context.aggregations().aggregators(context.aggregations().factories().createTopLevelAggregators());
-            bucketCollector = MultiBucketCollector.wrap(true, List.of(context.aggregations().aggregators()));
+            aggregators = context.aggregations().factories().createTopLevelAggregators();
+            bucketCollector = MultiBucketCollector.wrap(true, List.of(aggregators));
             bucketCollector.preCollection();
         } catch (IOException e) {
             throw new AggregationInitializationException("Could not initialize aggregators", e);
@@ -52,7 +54,39 @@ public class AggregationPhase {
         } else {
             collector = bucketCollector.asCollector();
         }
-        context.aggregations().registerAggsCollectorManager(new SingleThreadCollectorManager(collector));
+        final CollectorManager<Collector, Void> manager = new CollectorManager<>() {
+
+            private boolean newCollectorCalled;
+
+            @Override
+            public Collector newCollector() {
+                assert newCollectorCalled == false;
+                newCollectorCalled = true;
+                return collector;
+            }
+
+            @Override
+            public Void reduce(Collection<Collector> collectors) {
+                assert collectors.size() == 1;
+                assert collector == collectors.iterator().next();
+                final List<InternalAggregation> aggregations = new ArrayList<>(aggregators.length);
+                for (Aggregator aggregator : aggregators) {
+                    try {
+                        aggregator.postCollection();
+                        aggregations.add(aggregator.buildTopLevel());
+                    } catch (IOException e) {
+                        throw new AggregationExecutionException("Failed to build aggregation [" + aggregator.name() + "]", e);
+                    }
+                    // release the aggregator to claim the used bytes as we don't need it anymore
+                    aggregator.releaseAggregations();
+                }
+                context.queryResult().aggregations(InternalAggregations.from(aggregations));
+                // disable aggregations so that they don't run on next pages in case of scrolling
+                context.aggregations(null);
+                return null;
+            }
+        };
+        context.aggregations().registerAggsCollectorManager(manager);
     }
 
     private static List<Runnable> getCancellationChecks(SearchContext context) {
@@ -73,35 +107,5 @@ public class AggregationPhase {
         }
 
         return cancellationChecks;
-    }
-
-    public static void execute(SearchContext context) {
-        if (context.aggregations() == null) {
-            context.queryResult().aggregations(null);
-            return;
-        }
-
-        if (context.queryResult().hasAggs()) {
-            // no need to compute the aggs twice, they should be computed on a per context basis
-            return;
-        }
-
-        Aggregator[] aggregators = context.aggregations().aggregators();
-
-        List<InternalAggregation> aggregations = new ArrayList<>(aggregators.length);
-        for (Aggregator aggregator : context.aggregations().aggregators()) {
-            try {
-                aggregator.postCollection();
-                aggregations.add(aggregator.buildTopLevel());
-            } catch (IOException e) {
-                throw new AggregationExecutionException("Failed to build aggregation [" + aggregator.name() + "]", e);
-            }
-            // release the aggregator to claim the used bytes as we don't need it anymore
-            aggregator.releaseAggregations();
-        }
-        context.queryResult().aggregations(InternalAggregations.from(aggregations));
-
-        // disable aggregations so that they don't run on next pages in case of scrolling
-        context.aggregations(null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/SearchContextAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/SearchContextAggregations.java
@@ -16,7 +16,6 @@ import org.apache.lucene.search.CollectorManager;
 public class SearchContextAggregations {
 
     private final AggregatorFactories factories;
-    private Aggregator[] aggregators;
     private CollectorManager<Collector, Void> aggCollectorManager;
 
     /**
@@ -28,19 +27,6 @@ public class SearchContextAggregations {
 
     public AggregatorFactories factories() {
         return factories;
-    }
-
-    public Aggregator[] aggregators() {
-        return aggregators;
-    }
-
-    /**
-     * Registers all the created aggregators (top level aggregators) for the search execution context.
-     *
-     * @param aggregators The top level aggregators of the search execution.
-     */
-    public void aggregators(Aggregator[] aggregators) {
-        this.aggregators = aggregators;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -140,7 +140,6 @@ public class QueryPhase {
 
         RescorePhase.execute(searchContext);
         SuggestPhase.execute(searchContext);
-        AggregationPhase.execute(searchContext);
 
         if (searchContext.getProfilers() != null) {
             searchContext.queryResult().profileResults(searchContext.getProfilers().buildQueryPhaseResults());


### PR DESCRIPTION
In preparation for concurrent aggregation execution, this PR moves the phase that transforms Aggregators into its internal representation to the collector manager's reduce method. Note that we still expect single thread execution. 

This commit changes the order on how we execute things. Before this change, this phase was run after the rescore and suggest phase, now it is run before. I think that's ok but I might be missing something else.