### PR TITLE
[Profiling] Support index migrations

### DIFF
--- a/docs/changelog/97773.yaml
+++ b/docs/changelog/97773.yaml
@@ -1,0 +1,5 @@
+pr: 97773
+summary: "[Profiling] Support index migrations"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
@@ -162,7 +162,7 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         final IndexRoutingTable routingTable = state.getRoutingTable().index(metadata.getIndex());
         ClusterHealthStatus indexHealth = new ClusterIndexHealth(metadata, routingTable).getStatus();
         if (indexHealth == ClusterHealthStatus.RED) {
-            logger.debug("Index [{}] health status is RED, any pending mapping upgrades will wait until this changes", metadata.getIndex());
+            logger.trace("Index [{}] health status is RED, any pending mapping upgrades will wait until this changes", metadata.getIndex());
             return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
         }
         MappingMetadata mapping = metadata.mapping();

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/AbstractProfilingPersistenceManager.java
@@ -10,8 +10,14 @@ package org.elasticsearch.xpack.profiler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.support.RefCountingRunnable;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
@@ -21,12 +27,21 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public abstract class AbstractProfilingPersistenceManager<T extends AbstractProfilingPersistenceManager.ProfilingIndexAbstraction>
     implements
@@ -35,11 +50,14 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
     protected final Logger logger = LogManager.getLogger(getClass());
 
     private final AtomicBoolean inProgress = new AtomicBoolean(false);
-
     private final ClusterService clusterService;
+    protected final ThreadPool threadPool;
+    protected final Client client;
     private volatile boolean templatesEnabled;
 
-    public AbstractProfilingPersistenceManager(ClusterService clusterService) {
+    public AbstractProfilingPersistenceManager(ThreadPool threadPool, Client client, ClusterService clusterService) {
+        this.threadPool = threadPool;
+        this.client = client;
         this.clusterService = clusterService;
     }
 
@@ -90,9 +108,9 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         try (var refs = new RefCountingRunnable(() -> inProgress.set(false))) {
             ClusterState clusterState = event.state();
             for (T index : getManagedIndices()) {
-                Status status = getStatus(clusterState, index);
-                if (status.actionable) {
-                    onStatus(clusterState, status, index, ActionListener.releasing(refs.acquire()));
+                IndexState<T> state = getIndexState(clusterState, index);
+                if (state.getStatus().actionable) {
+                    onIndexState(clusterState, state, ActionListener.releasing(refs.acquire()));
                 }
             }
         }
@@ -120,29 +138,32 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
      * Handler that takes appropriate action for a certain index status.
      *
      * @param clusterState The current cluster state. Never <code>null</code>.
-     * @param status Status of the current index.
-     * @param index The current index.
+     * @param indexState The state of the current index.
      * @param listener Listener to be called on completion / errors.
      */
-    protected abstract void onStatus(ClusterState clusterState, Status status, T index, ActionListener<? super ActionResponse> listener);
+    protected abstract void onIndexState(
+        ClusterState clusterState,
+        IndexState<T> indexState,
+        ActionListener<? super ActionResponse> listener
+    );
 
-    private Status getStatus(ClusterState state, T index) {
+    private IndexState<T> getIndexState(ClusterState state, T index) {
         IndexMetadata metadata = indexMetadata(state, index);
         if (metadata == null) {
-            return Status.NEEDS_CREATION;
+            return new IndexState<>(index, null, Status.NEEDS_CREATION);
         }
         if (metadata.getState() == IndexMetadata.State.CLOSE) {
             logger.warn(
                 "Index [{}] is closed. This is likely to prevent Universal Profiling from functioning correctly",
                 metadata.getIndex()
             );
-            return Status.CLOSED;
+            return new IndexState<>(index, metadata.getIndex(), Status.CLOSED);
         }
         final IndexRoutingTable routingTable = state.getRoutingTable().index(metadata.getIndex());
         ClusterHealthStatus indexHealth = new ClusterIndexHealth(metadata, routingTable).getStatus();
         if (indexHealth == ClusterHealthStatus.RED) {
             logger.debug("Index [{}] health status is RED, any pending mapping upgrades will wait until this changes", metadata.getIndex());
-            return Status.UNHEALTHY;
+            return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
         }
         MappingMetadata mapping = metadata.mapping();
         if (mapping != null) {
@@ -159,21 +180,106 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
                 currentIndexVersion = getVersionField(metadata.getIndex(), meta, "index-version");
                 currentTemplateVersion = getVersionField(metadata.getIndex(), meta, "index-template-version");
                 if (currentIndexVersion == -1 || currentTemplateVersion == -1) {
-                    return Status.UNHEALTHY;
+                    return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
                 }
             }
             if (index.getVersion() > currentIndexVersion) {
-                return Status.NEEDS_VERSION_BUMP;
-            } else if (ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION > currentTemplateVersion) {
-                // TODO 8.10+: Check if there are any pending migrations. If none are pending we can consider the index up to date.
-                return Status.NEEDS_MAPPINGS_UPDATE;
+                return new IndexState<>(index, metadata.getIndex(), Status.NEEDS_VERSION_BUMP);
+            } else if (getIndexTemplateVersion() > currentTemplateVersion) {
+                // if there are no migrations we can consider the index up-to-date even if the index template version does not match.
+                List<Migration> pendingMigrations = index.getMigrations(currentTemplateVersion);
+                if (pendingMigrations.isEmpty()) {
+                    logger.trace(
+                        "Index [{}] with index template version [{}] (current is [{}]) is up-to-date (no pending migrations).",
+                        metadata.getIndex(),
+                        currentTemplateVersion,
+                        getIndexTemplateVersion()
+                    );
+                    return new IndexState<>(index, metadata.getIndex(), Status.UP_TO_DATE);
+                }
+                logger.trace(
+                    "Index [{}] with index template version [{}] (current is [{}])  has [{}] pending migrations.",
+                    metadata.getIndex(),
+                    currentTemplateVersion,
+                    getIndexTemplateVersion(),
+                    pendingMigrations.size()
+                );
+                return new IndexState<>(index, metadata.getIndex(), Status.NEEDS_MAPPINGS_UPDATE, pendingMigrations);
             } else {
-                return Status.UP_TO_DATE;
+                return new IndexState<>(index, metadata.getIndex(), Status.UP_TO_DATE);
             }
         } else {
             logger.warn("No mapping found for existing index [{}]. Index cannot be migrated.", metadata.getIndex());
-            return Status.UNHEALTHY;
+            return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
         }
+    }
+
+    // overridable for testing
+    protected int getIndexTemplateVersion() {
+        return ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION;
+    }
+
+    protected final void applyMigrations(IndexState<T> indexState, ActionListener<? super ActionResponse> listener) {
+        String writeIndex = indexState.getWriteIndex().getName();
+        try (var refs = new RefCountingRunnable(() -> listener.onResponse(null))) {
+            for (Migration migration : indexState.getPendingMigrations()) {
+                logger.debug("Applying migration [{}] for [{}].", migration, writeIndex);
+                migration.apply(
+                    writeIndex,
+                    (r -> updateMapping(r, ActionListener.releasing(refs.acquire()))),
+                    (r -> updateSettings(r, ActionListener.releasing(refs.acquire())))
+                );
+            }
+        }
+    }
+
+    protected final void updateMapping(PutMappingRequest request, ActionListener<AcknowledgedResponse> listener) {
+        request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+        executeAsync("put mapping", request, listener, (req, l) -> client.admin().indices().putMapping(req, l));
+    }
+
+    protected final void updateSettings(UpdateSettingsRequest request, ActionListener<AcknowledgedResponse> listener) {
+        request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+        executeAsync("update settings", request, listener, (req, l) -> client.admin().indices().updateSettings(req, l));
+    }
+
+    protected final <Request extends ActionRequest & IndicesRequest, Response extends AcknowledgedResponse> void executeAsync(
+        final String actionName,
+        final Request request,
+        final ActionListener<Response> listener,
+        BiConsumer<Request, ActionListener<Response>> consumer
+    ) {
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            executeAsyncWithOrigin(client.threadPool().getThreadContext(), ClientHelper.PROFILING_ORIGIN, request, new ActionListener<>() {
+                @Override
+                public void onResponse(Response response) {
+                    if (response.isAcknowledged() == false) {
+                        logger.error(
+                            "Could not execute action [{}] for indices [{}] for [{}], request was not acknowledged",
+                            actionName,
+                            request.indices(),
+                            ClientHelper.PROFILING_ORIGIN
+                        );
+                    }
+                    listener.onResponse(response);
+                }
+
+                @Override
+                public void onFailure(Exception ex) {
+                    logger.error(
+                        () -> format(
+                            "Could not execute action [%s] for indices [%s] for [%s]",
+                            actionName,
+                            request.indices(),
+                            ClientHelper.PROFILING_ORIGIN
+                        ),
+                        ex
+                    );
+                    listener.onFailure(ex);
+                }
+            }, consumer);
+        });
     }
 
     private int getVersionField(Index index, Map<String, Object> meta, String fieldName) {
@@ -187,6 +293,40 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         }
         logger.warn("Metadata version field [{}] of index [{}] is [{}] (expected an integer).", fieldName, index, value);
         return -1;
+    }
+
+    protected static final class IndexState<T extends ProfilingIndexAbstraction> {
+        private final T index;
+        private final Index writeIndex;
+        private final Status status;
+        private final List<Migration> pendingMigrations;
+
+        IndexState(T index, Index writeIndex, Status status) {
+            this(index, writeIndex, status, null);
+        }
+
+        IndexState(T index, Index writeIndex, Status status, List<Migration> pendingMigrations) {
+            this.index = index;
+            this.writeIndex = writeIndex;
+            this.status = status;
+            this.pendingMigrations = pendingMigrations;
+        }
+
+        public T getIndex() {
+            return index;
+        }
+
+        public Index getWriteIndex() {
+            return writeIndex;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public List<Migration> getPendingMigrations() {
+            return pendingMigrations;
+        }
     }
 
     enum Status {
@@ -214,5 +354,7 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         String getName();
 
         int getVersion();
+
+        List<Migration> getMigrations(int currentIndexTemplateVersion);
     }
 }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/Migration.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/Migration.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiler;
+
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Encapsulates a single migration action.
+ */
+public interface Migration {
+    /**
+     * @return The index template version that the targeted index will be on after the migration has been applied.
+     */
+    int getTargetIndexTemplateVersion();
+
+    /**
+     * Applies this migration. Depending on the type of migration one or the other consumer will be called.
+     *
+     * @param index The name of the specific index to which the migration should be applied.
+     * @param mappingConsumer A consumer that applies mapping changes. Must not be null.
+     * @param settingsConsumer A consumer that applies settings changes. Must not be null.
+     */
+    void apply(String index, Consumer<PutMappingRequest> mappingConsumer, Consumer<UpdateSettingsRequest> settingsConsumer);
+
+    /**
+     * Builds migrations for an index.
+     */
+    class Builder {
+        private final List<Migration> migrations = new ArrayList<>();
+        private Integer targetVersion;
+
+        private void checkVersionSet() {
+            if (targetVersion == null) {
+                throw new IllegalStateException("Set targetVersion before defining migrations");
+            }
+        }
+
+        /**
+         * @param version The index template version that the targeted index will reach after this migration has been applied.
+         * @return <code>this</code> to allow for method chaining.
+         */
+        public Builder migrateToIndexTemplateVersion(int version) {
+            this.targetVersion = version;
+            return this;
+        }
+
+        /**
+         * Adds new property to an index mapping. This method should be used for simple cases where a new property needs to be added
+         * without any further mapping parameters. For more complex cases use {@link #putMapping(Map)} instead and provide the body of
+         * the PUT mapping API call.
+         *
+         * @param property The name of the new property. Must not be null.
+         * @param type The mapping type. Must not be null.
+         * @return <code>this</code> to allow for method chaining.
+         */
+        public Builder addProperty(String property, String type) {
+            Map<String, ?> body = Map.of("properties", Map.of(property, Map.of("type", type)));
+            return putMapping(body);
+        }
+
+        /**
+         * Adds a change to an existing index mapping. Use {@link #addProperty(String, String)} instead for simple cases.
+         *
+         * @param body The complete body for this mapping change.
+         * @return <code>this</code> to allow for method chaining.
+         */
+        public Builder putMapping(Map<String, ?> body) {
+            checkVersionSet();
+            this.migrations.add(new PutMappingMigration(targetVersion, body));
+            return this;
+        }
+
+        /**
+         * Adds or modifies dynamic index settings.
+         *
+         * @param settings A settings object representing the required dynamic index settings.
+         * @return <code>this</code> to allow for method chaining.
+         */
+        public Builder dynamicSettings(Settings settings) {
+            checkVersionSet();
+            this.migrations.add(new DynamicIndexSettingsMigration(targetVersion, settings));
+            return this;
+        }
+
+        /**
+         * Builds the specified list of migrations.
+         *
+         * @param indexVersion The current index version.
+         * @return An unmodifiable list of migrations in program order (i.e. the order in which they have been called).
+         */
+        public List<Migration> build(int indexVersion) {
+            // ensure that the index template version is up-to-date after all migrations have been applied
+            Map<String, ?> updateIndexTemplateVersion = Map.of(
+                "_meta",
+                Map.of("index-template-version", targetVersion, "index-version", indexVersion)
+            );
+            migrations.add(new PutMappingMigration(targetVersion, updateIndexTemplateVersion));
+            return Collections.unmodifiableList(migrations);
+        }
+    }
+
+    class PutMappingMigration implements Migration {
+        private final int targetVersion;
+        private final Map<String, ?> body;
+
+        public PutMappingMigration(int targetVersion, Map<String, ?> body) {
+            this.targetVersion = targetVersion;
+            this.body = body;
+        }
+
+        @Override
+        public int getTargetIndexTemplateVersion() {
+            return targetVersion;
+        }
+
+        public void apply(String index, Consumer<PutMappingRequest> mappingConsumer, Consumer<UpdateSettingsRequest> settingsConsumer) {
+            mappingConsumer.accept(new PutMappingRequest(index).source(body));
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT, "put mapping to target version [%d]", targetVersion);
+        }
+    }
+
+    class DynamicIndexSettingsMigration implements Migration {
+        private final int targetVersion;
+        private final Settings settings;
+
+        public DynamicIndexSettingsMigration(int targetVersion, Settings settings) {
+            this.targetVersion = targetVersion;
+            this.settings = settings;
+        }
+
+        @Override
+        public int getTargetIndexTemplateVersion() {
+            return targetVersion;
+        }
+
+        public void apply(String index, Consumer<PutMappingRequest> mappingConsumer, Consumer<UpdateSettingsRequest> settingsConsumer) {
+            settingsConsumer.accept(new UpdateSettingsRequest(settings, index));
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT, "update settings to target version [%d]", targetVersion);
+        }
+    }
+}

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/Migration.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/Migration.java
@@ -31,8 +31,8 @@ public interface Migration {
      * Applies this migration. Depending on the type of migration one or the other consumer will be called.
      *
      * @param index The name of the specific index to which the migration should be applied.
-     * @param mappingConsumer A consumer that applies mapping changes. Must not be null.
-     * @param settingsConsumer A consumer that applies settings changes. Must not be null.
+     * @param mappingConsumer A consumer that applies mapping changes.
+     * @param settingsConsumer A consumer that applies settings changes.
      */
     void apply(String index, Consumer<PutMappingRequest> mappingConsumer, Consumer<UpdateSettingsRequest> settingsConsumer);
 
@@ -63,8 +63,8 @@ public interface Migration {
          * without any further mapping parameters. For more complex cases use {@link #putMapping(Map)} instead and provide the body of
          * the PUT mapping API call.
          *
-         * @param property The name of the new property. Must not be null.
-         * @param type The mapping type. Must not be null.
+         * @param property The name of the new property.
+         * @param type The mapping type.
          * @return <code>this</code> to allow for method chaining.
          */
         public Builder addProperty(String property, String type) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -24,6 +24,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -67,27 +68,23 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         ProfilingIndex.kv("profiling-symbols-global", ProfilingIndexTemplateRegistry.PROFILING_SYMBOLS_VERSION)
     );
 
-    private final ThreadPool threadPool;
-    private final Client client;
-
     public ProfilingIndexManager(ThreadPool threadPool, Client client, ClusterService clusterService) {
-        super(clusterService);
-        this.threadPool = threadPool;
-        this.client = client;
+        super(threadPool, client, clusterService);
     }
 
     @Override
-    protected void onStatus(
+    protected void onIndexState(
         ClusterState clusterState,
-        Status status,
-        ProfilingIndex index,
+        IndexState<ProfilingIndex> indexState,
         ActionListener<? super ActionResponse> listener
     ) {
+        Status status = indexState.getStatus();
         switch (status) {
-            case NEEDS_CREATION -> createIndex(clusterState, index, listener);
-            case NEEDS_VERSION_BUMP -> bumpVersion(clusterState, index, listener);
+            case NEEDS_CREATION -> createIndex(clusterState, indexState.getIndex(), listener);
+            case NEEDS_VERSION_BUMP -> bumpVersion(clusterState, indexState.getIndex(), listener);
+            case NEEDS_MAPPINGS_UPDATE -> applyMigrations(indexState, listener);
             default -> {
-                logger.debug("Skipping status change [{}] for index [{}].", status, index);
+                logger.trace("Skipping status change [{}] for index [{}].", status, indexState.getIndex());
                 // ensure that listener is notified we're done
                 listener.onResponse(null);
             }
@@ -278,41 +275,10 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         });
     }
 
-    private void onDeleteIndexFailure(String[] indices, Exception ex) {
-        logger.error(() -> format("error deleting indices [%s] for [%s]", indices, ClientHelper.PROFILING_ORIGIN), ex);
-    }
-
     private void deleteIndices(final String[] indices, final ActionListener<AcknowledgedResponse> listener) {
-        final Executor executor = threadPool.generic();
-        executor.execute(() -> {
-            DeleteIndexRequest request = new DeleteIndexRequest(indices);
-            request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
-            executeAsyncWithOrigin(
-                client.threadPool().getThreadContext(),
-                ClientHelper.PROFILING_ORIGIN,
-                request,
-                new ActionListener<AcknowledgedResponse>() {
-                    @Override
-                    public void onResponse(AcknowledgedResponse response) {
-                        if (response.isAcknowledged() == false) {
-                            logger.error(
-                                "error deleting indices [{}] for [{}], request was not acknowledged",
-                                indices,
-                                ClientHelper.PROFILING_ORIGIN
-                            );
-                        }
-                        listener.onResponse(response);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        onDeleteIndexFailure(indices, e);
-                        listener.onFailure(e);
-                    }
-                },
-                (req, l) -> client.admin().indices().delete(req, l)
-            );
-        });
+        DeleteIndexRequest request = new DeleteIndexRequest(indices);
+        request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+        executeAsync("delete", request, listener, (req, l) -> client.admin().indices().delete(req, l));
     }
 
     enum OnVersionBump {
@@ -328,29 +294,41 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
         private final int version;
         private final String generation;
         private final OnVersionBump onVersionBump;
+        private final List<Migration> migrations;
 
         public static ProfilingIndex regular(String name, int version, OnVersionBump onVersionBump) {
-            return new ProfilingIndex(name, version, null, onVersionBump);
+            return regular(name, version, onVersionBump, null);
+        }
+
+        public static ProfilingIndex regular(String name, int version, OnVersionBump onVersionBump, Migration.Builder builder) {
+            List<Migration> migrations = builder != null ? builder.build(version) : null;
+            return new ProfilingIndex(name, version, null, onVersionBump, migrations);
         }
 
         public static ProfilingIndex kv(String name, int version) {
-            // K/V indices will age automatically as per the ILM policy, and we won't force-upgrade them on version bumps
-            return new ProfilingIndex(name, version, "000001", OnVersionBump.KEEP_OLD);
+            return kv(name, version, null);
         }
 
-        private ProfilingIndex(String namePrefix, int version, String generation, OnVersionBump onVersionBump) {
+        public static ProfilingIndex kv(String name, int version, Migration.Builder builder) {
+            List<Migration> migrations = builder != null ? builder.build(version) : null;
+            // K/V indices will age automatically as per the ILM policy, and we won't force-upgrade them on version bumps
+            return new ProfilingIndex(name, version, "000001", OnVersionBump.KEEP_OLD, migrations);
+        }
+
+        private ProfilingIndex(String namePrefix, int version, String generation, OnVersionBump onVersionBump, List<Migration> migrations) {
             this.namePrefix = namePrefix;
             this.version = version;
             this.generation = generation;
             this.onVersionBump = onVersionBump;
+            this.migrations = migrations;
         }
 
         public ProfilingIndex withVersion(int version) {
-            return new ProfilingIndex(namePrefix, version, generation, onVersionBump);
+            return new ProfilingIndex(namePrefix, version, generation, onVersionBump, migrations);
         }
 
         public ProfilingIndex withGeneration(String generation) {
-            return new ProfilingIndex(namePrefix, version, generation, onVersionBump);
+            return new ProfilingIndex(namePrefix, version, generation, onVersionBump, migrations);
         }
 
         public boolean isMatchWithoutVersion(String indexName) {
@@ -390,6 +368,13 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
 
         public int getVersion() {
             return version;
+        }
+
+        @Override
+        public List<Migration> getMigrations(int currentIndexTemplateVersion) {
+            return migrations != null
+                ? migrations.stream().filter(m -> m.getTargetIndexTemplateVersion() > currentIndexTemplateVersion).toList()
+                : Collections.emptyList();
         }
 
         public OnVersionBump getOnVersionBump() {


### PR DESCRIPTION
With this commit we add the required infrastructure to detect whether indices need to be migrated and define migrations to update mappings or dynamic index settings.
