### PR TITLE
[testcluster] Fix merging of JVM args

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -673,6 +673,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 + " "
                 + featureFlagProperties
                 + systemProperties
+                + ' '
                 + jvmArgs
                 + debugArgs);
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -667,15 +667,18 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             }
 
             String heapSize = System.getProperty("tests.heap.size", "512m");
-            environment.put("ES_JAVA_OPTS", "-Xms" + heapSize + " -Xmx" + heapSize + " -ea -esa "
-            // Support passing in additional JVM arguments
-                + System.getProperty("tests.jvm.argline", "")
-                + " "
-                + featureFlagProperties
-                + systemProperties
-                + ' '
-                + jvmArgs
-                + debugArgs);
+            final String esJavaOpts = Stream.of(
+                "-Xms" + heapSize,
+                "-Xmx" + heapSize,
+                "-ea",
+                "-esa",
+                System.getProperty("tests.jvm.argline", ""),
+                featureFlagProperties,
+                systemProperties,
+                jvmArgs,
+                debugArgs
+            ).filter(s -> s.isEmpty() == false).collect(Collectors.joining(" "));
+            environment.put("ES_JAVA_OPTS", esJavaOpts);
 
             return environment;
         }


### PR DESCRIPTION
If the system properties and jvm args are both non-empty then we need a space between them.
