### PR TITLE
[8.9] Mute some PkiAuthDelegationIntegTests (#97774)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
@@ -151,6 +151,7 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         new ClearRealmCacheRequestBuilder(client()).get();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testDelegateThenAuthenticate() throws Exception {
         final X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         final X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");
@@ -193,6 +194,7 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testTokenInvalidate() throws Exception {
         final X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         final X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");
@@ -296,6 +298,7 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testDelegatePkiWithRoleMapping() throws Exception {
         X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Mute some PkiAuthDelegationIntegTests (#97774)