### PR TITLE
[8.8] Mute testTimeThrottle (#97786)

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.oneOf;
 
 public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTestCase {
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97518")
     public void testTimeThrottle() throws Exception {
         String id = randomAlphaOfLength(20);
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client()).setId(id)


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Mute testTimeThrottle (#97786)