### PR TITLE
[8.8] Mute testScheduleNowWithSystemClock (#97788)

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulerTests.java
@@ -327,6 +327,7 @@ public class TransformSchedulerTests extends ESTestCase {
         transformScheduler.stop();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/95445")
     public void testScheduleNowWithSystemClock() throws Exception {
         String transformId = "test-schedule-now-with-system-clock";
         TimeValue frequency = TimeValue.timeValueHours(1);  // Very long pause between checkpoints


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Mute testScheduleNowWithSystemClock (#97788)