### PR TITLE
Support different snyk organisations

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
@@ -35,18 +35,22 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
             version = "$version"
 
             repositories {
-                mavenCentral() 
+                mavenCentral()
             }
-            
+
             dependencies {
                 implementation 'org.apache.lucene:lucene-monitor:9.2.0'
+            }
+
+            tasks.named('generateSnykDependencyGraph').configure {
+                remoteUrl = "http://acme.org"
             }
         """
         when:
         def build = gradleRunner("generateSnykDependencyGraph").build()
         then:
         build.task(":generateSnykDependencyGraph").outcome == TaskOutcome.SUCCESS
-        JSONAssert.assertEquals(file("build/snyk/dependencies.json").text, """{
+        JSONAssert.assertEquals("""{
             "meta": {
                 "method": "custom gradle",
                 "id": "gradle",
@@ -101,7 +105,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
                         {
                             "nodeId": "org.apache.lucene:lucene-core@9.2.0",
                             "deps": [
-                                
+
                             ],
                             "pkgId": "org.apache.lucene:lucene-core@9.2.0"
                         },
@@ -155,7 +159,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
                 ]
             },
             "target": {
-                "remoteUrl": "http://github.com/elastic/elasticsearch.git",
+                "remoteUrl": "http://acme.org",
                 "branch": "unknown"
             },
             "targetReference": "$version",
@@ -164,7 +168,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
                   "$expectedLifecycle"
                 ]
             }
-        }""", true)
+        }""", file("build/snyk/dependencies.json").text, true)
 
         where:
         version        | expectedLifecycle

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/GenerateSnykDependencyGraph.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/GenerateSnykDependencyGraph.java
@@ -57,6 +57,7 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
     private final Property<String> projectPath;
     private final Property<String> targetReference;
     private final Property<String> version;
+    private final Property<String> remoteUrl;
 
     @Inject
     public GenerateSnykDependencyGraph(ObjectFactory objectFactory) {
@@ -66,6 +67,7 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
         projectName = objectFactory.property(String.class);
         projectPath = objectFactory.property(String.class);
         version = objectFactory.property(String.class);
+        remoteUrl = objectFactory.property(String.class);
         targetReference = objectFactory.property(String.class);
     }
 
@@ -115,7 +117,7 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
     }
 
     private Object buildTargetData() {
-        return Map.of("remoteUrl", "http://github.com/elastic/elasticsearch.git", "branch", BuildParams.getGitRevision());
+        return Map.of("remoteUrl", remoteUrl.get(), "branch", BuildParams.getGitRevision());
     }
 
     @InputFiles
@@ -146,6 +148,11 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
     @Input
     public Property<String> getGradleVersion() {
         return gradleVersion;
+    }
+
+    @Input
+    public Property<String> getRemoteUrl() {
+        return remoteUrl;
     }
 
     @Input

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.gradle.internal.snyk;
 
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
-import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.gradle.internal.snyk;
 
+import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
+import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -42,14 +44,16 @@ public class SnykDependencyMonitoringGradlePlugin implements Plugin<Project> {
                 generateSnykDependencyGraph.getGradleVersion().set(project.getGradle().getGradleVersion());
                 generateSnykDependencyGraph.getTargetReference()
                     .set(providerFactory.gradleProperty("snykTargetReference").orElse(projectVersion));
+                generateSnykDependencyGraph.getRemoteUrl()
+                    .convention(providerFactory.provider(() -> GitInfo.gitInfo(project.getRootDir()).urlFromOrigin()));
                 generateSnykDependencyGraph.getOutputFile().set(projectLayout.getBuildDirectory().file("snyk/dependencies.json"));
             });
 
         project.getTasks().register(UPLOAD_TASK_NAME, UploadSnykDependenciesGraph.class, t -> {
             t.getInputFile().set(generateTaskProvider.get().getOutputFile());
             t.getToken().set(providerFactory.environmentVariable("SNYK_TOKEN"));
-            // the elasticsearch snyk project id
-            t.getProjectId().set(providerFactory.gradleProperty("snykProjectId"));
+            // the snyk org to target
+            t.getSnykOrganisation().set(providerFactory.gradleProperty("snykOrganisation"));
         });
 
         project.getPlugins().withType(JavaPlugin.class, javaPlugin -> generateTaskProvider.configure(generateSnykDependencyGraph -> {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/UploadSnykDependenciesGraph.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/UploadSnykDependenciesGraph.java
@@ -42,12 +42,12 @@ public class UploadSnykDependenciesGraph extends DefaultTask {
     private final RegularFileProperty inputFile;
     private final Property<String> token;
     private final Property<String> url;
-    private final Property<String> projectId;
+    private final Property<String> snykOrganisation;
 
     @Inject
     public UploadSnykDependenciesGraph(ObjectFactory objectFactory) {
         url = objectFactory.property(String.class).convention(DEFAULT_SERVER + GRADLE_GRAPH_ENDPOINT);
-        projectId = objectFactory.property(String.class);
+        snykOrganisation = objectFactory.property(String.class);
         token = objectFactory.property(String.class);
         inputFile = objectFactory.fileProperty();
     }
@@ -76,7 +76,7 @@ public class UploadSnykDependenciesGraph extends DefaultTask {
 
     private String calculateEffectiveEndpoint() {
         String url = this.url.get();
-        return url.endsWith(GRADLE_GRAPH_ENDPOINT) ? url : projectId.map(id -> url + "?org=" + id).getOrElse(url);
+        return snykOrganisation.map(id -> url + "?org=" + id).getOrElse(url);
     }
 
     @Input
@@ -91,8 +91,8 @@ public class UploadSnykDependenciesGraph extends DefaultTask {
 
     @Input
     @Optional
-    public Property<String> getProjectId() {
-        return projectId;
+    public Property<String> getSnykOrganisation() {
+        return snykOrganisation;
     }
 
     @InputFile


### PR DESCRIPTION
Tweaks our snyk integration to support different snyk orgs which is required to have support for elasticsearch serverless. Also replaces hardcoded remote url property by a dynamic version that resolves that property from the git origin url.
