### PR TITLE
Limit precision when formatting percentage in DesiredBalanceReconciler

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.core.TimeValue;
@@ -461,11 +462,11 @@ public class DesiredBalanceReconciler {
             if (allAllocations > 0 && undesiredAllocations > undesiredAllocationsLogThreshold * allAllocations) {
                 undesiredAllocationLogInterval.maybeExecute(
                     () -> logger.warn(
-                        "[{}%] of assigned shards ({}/{}) are not on their desired nodes, which exceeds the warn threshold of [{}%]",
-                        100.0 * undesiredAllocations / allAllocations,
+                        "[{}] of assigned shards ({}/{}) are not on their desired nodes, which exceeds the warn threshold of [{}]",
+                        Strings.format1Decimals(100.0 * undesiredAllocations / allAllocations, "%"),
                         undesiredAllocations,
                         allAllocations,
-                        100.0 * undesiredAllocationsLogThreshold
+                        Strings.format1Decimals(100.0 * undesiredAllocationsLogThreshold, "%")
                     )
                 );
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -1159,7 +1159,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
                 "Should log first too many shards on undesired locations",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
-                "[100.0%] of assigned shards (1/1) are not on their desired nodes, which exceeds the warn threshold of [10.0%]"
+                "[100%] of assigned shards (1/1) are not on their desired nodes, which exceeds the warn threshold of [10%]"
             )
         );
         assertThatLogger(

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -364,6 +364,11 @@ public class StringsTests extends ESTestCase {
         assertEquals(validFileName, stripDisallowedChars(invalidFileName.toString()));
     }
 
+    public void testFormat1Decimals() {
+        assertThat(Strings.format1Decimals(100.0 / 2, "%"), equalTo("50%"));
+        assertThat(Strings.format1Decimals(100.0 / 3, "%"), equalTo("33.3%"));
+    }
+
     private static String lowercaseAsciiOnly(String s) {
         // explicitly lowercase just ascii characters
         StringBuilder sb = new StringBuilder(s);


### PR DESCRIPTION
This logger used to produce messages like `[19.497084548104958%] of assigned shards (535/2744) are not on their desired nodes, which exceeds the warn threshold of [10.0%]` that are harder to read. This change limits the precision using `Strings.format1Decimals`.