### PR TITLE
Mention missing internal users in docs

### DIFF
--- a/x-pack/docs/en/security/authentication/internal-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/internal-users.asciidoc
@@ -4,9 +4,9 @@
 
 NOTE: These users are designed for internal use by {es} only. Authenticating with these users is not supported.
 
-The {stack-security-features} use five _internal_ users (`_system`, `_xpack`,
-`_xpack_security`, `_async_search`, and `_security_profile`), which are responsible for the operations
-that take place inside an {es} cluster.
+The {stack-security-features} use eight _internal_ users (`_system`, `_xpack`,
+`_xpack_security`, `_async_search`, `_security_profile`, `_storage`, `_data_stream_lifecycle` and `_synonyms`),
+which are responsible for the operations that take place inside an {es} cluster.
 
 These users are only used by requests that originate from within the cluster.
 For this reason, they cannot be used to authenticate against the API and there

--- a/x-pack/docs/en/security/authentication/internal-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/internal-users.asciidoc
@@ -4,8 +4,8 @@
 
 NOTE: These users are designed for internal use by {es} only. Authenticating with these users is not supported.
 
-The {stack-security-features} use eight _internal_ users (`_system`, `_xpack`,
-`_xpack_security`, `_async_search`, `_security_profile`, `_storage`, `_data_stream_lifecycle` and `_synonyms`),
+The {stack-security-features} use six _internal_ users (`_system`, `_xpack`,
+`_xpack_security`, `_async_search`, `_security_profile` and `_storage`),
 which are responsible for the operations that take place inside an {es} cluster.
 
 These users are only used by requests that originate from within the cluster.


### PR DESCRIPTION
This PR adds missing `_storage` internal user to the `internal-users.asciidoc`. 
This user was [added in 8.9.0 version](https://github.com/elastic/elasticsearch/pull/95694).