### PR TITLE
[ML] Fix ML usage action when ML sub-features are disabled

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1248,7 +1248,7 @@ public class MachineLearning extends Plugin
             trainedModelAllocationClusterServiceSetOnce.get(),
             deploymentManager.get(),
             nodeAvailabilityZoneMapper,
-            machineLearningExtension.get()
+            new MachineLearningExtensionHolder(machineLearningExtension.get())
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -885,8 +885,9 @@ public class MachineLearning extends Plugin
         IndicesService indicesService
     ) {
         if (enabled == false) {
-            // special holder for @link(MachineLearningFeatureSetUsage) which needs access to job manager, empty if ML is disabled
-            return List.of(new JobManagerHolder());
+            // Holders for @link(MachineLearningFeatureSetUsage) which needs access to job manager and ML extension,
+            // both empty if ML is disabled
+            return List.of(new JobManagerHolder(), new MachineLearningExtensionHolder());
         }
 
         machineLearningExtension.get().configure(environment.settings());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1247,7 +1247,8 @@ public class MachineLearning extends Plugin
             trainedModelAssignmentService,
             trainedModelAllocationClusterServiceSetOnce.get(),
             deploymentManager.get(),
-            nodeAvailabilityZoneMapper
+            nodeAvailabilityZoneMapper,
+            machineLearningExtension.get()
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtensionHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtensionHolder.java
@@ -18,10 +18,21 @@ import java.util.Objects;
  */
 public class MachineLearningExtensionHolder {
 
-    private MachineLearningExtension machineLearningExtension;
+    private final MachineLearningExtension machineLearningExtension;
+
+    /**
+     * Used by Guice, and in cases where ML is disabled.
+     */
+    public MachineLearningExtensionHolder() {
+        this.machineLearningExtension = null;
+    }
 
     public MachineLearningExtensionHolder(MachineLearningExtension machineLearningExtension) {
         this.machineLearningExtension = Objects.requireNonNull(machineLearningExtension);
+    }
+
+    public boolean isEmpty() {
+        return machineLearningExtension == null;
     }
 
     public MachineLearningExtension getMachineLearningExtension() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtensionHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtensionHolder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.node.Node;
+
+import java.util.Objects;
+
+/**
+ * Wrapper for the {@link MachineLearningExtension} interface that allows it to be used
+ * given the way {@link Node} does Guice bindings for plugin components.
+ * TODO: remove this class entirely once Guice is removed entirely.
+ */
+public class MachineLearningExtensionHolder {
+
+    private MachineLearningExtension machineLearningExtension;
+
+    public MachineLearningExtensionHolder(MachineLearningExtension machineLearningExtension) {
+        this.machineLearningExtension = Objects.requireNonNull(machineLearningExtension);
+    }
+
+    public MachineLearningExtension getMachineLearningExtension() {
+        return machineLearningExtension;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -87,7 +87,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         Client client,
         XPackLicenseState licenseState,
         JobManagerHolder jobManagerHolder,
-        MachineLearningExtension machineLearningExtension
+        MachineLearningExtensionHolder machineLearningExtensionHolder
     ) {
         super(
             XPackUsageFeatureAction.MACHINE_LEARNING.name(),
@@ -100,7 +100,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         this.client = new OriginSettingClient(client, ML_ORIGIN);
         this.licenseState = licenseState;
         this.jobManagerHolder = jobManagerHolder;
-        this.machineLearningExtension = machineLearningExtension;
+        this.machineLearningExtension = machineLearningExtensionHolder.getMachineLearningExtension();
         this.enabled = XPackSettings.MACHINE_LEARNING_ENABLED.get(environment.settings());
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -73,6 +73,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
     private final Client client;
     private final XPackLicenseState licenseState;
     private final JobManagerHolder jobManagerHolder;
+    private final MachineLearningExtension machineLearningExtension;
     private final boolean enabled;
 
     @Inject
@@ -85,7 +86,8 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         Environment environment,
         Client client,
         XPackLicenseState licenseState,
-        JobManagerHolder jobManagerHolder
+        JobManagerHolder jobManagerHolder,
+        MachineLearningExtension machineLearningExtension
     ) {
         super(
             XPackUsageFeatureAction.MACHINE_LEARNING.name(),
@@ -98,6 +100,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         this.client = new OriginSettingClient(client, ML_ORIGIN);
         this.licenseState = licenseState;
         this.jobManagerHolder = jobManagerHolder;
+        this.machineLearningExtension = machineLearningExtension;
         this.enabled = XPackSettings.MACHINE_LEARNING_ENABLED.get(environment.settings());
     }
 
@@ -187,10 +190,18 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         dataframeAnalyticsStatsRequest.setPageParams(new PageParams(0, 10_000));
         ActionListener<GetDatafeedsStatsAction.Response> datafeedStatsListener = ActionListener.wrap(response -> {
             addDatafeedsUsage(response, datafeedsUsage);
-            client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest, dataframeAnalyticsStatsListener);
+            if (machineLearningExtension.isDataFrameAnalyticsEnabled()) {
+                client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest, dataframeAnalyticsStatsListener);
+            } else {
+                addInferenceUsage(inferenceUsageListener);
+            }
         }, e -> {
             logger.warn("Failed to get datafeed stats to include in ML usage", e);
-            client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest, dataframeAnalyticsStatsListener);
+            if (machineLearningExtension.isDataFrameAnalyticsEnabled()) {
+                client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest, dataframeAnalyticsStatsListener);
+            } else {
+                addInferenceUsage(inferenceUsageListener);
+            }
         });
 
         // Step 1. Extract usage from jobs stats and then request stats for all datafeeds
@@ -210,8 +221,14 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         );
 
         // Step 0. Kick off the chain of callbacks by requesting jobs stats
-        GetJobsStatsAction.Request jobStatsRequest = new GetJobsStatsAction.Request(Metadata.ALL);
-        client.execute(GetJobsStatsAction.INSTANCE, jobStatsRequest, jobStatsListener);
+        if (machineLearningExtension.isAnomalyDetectionEnabled()) {
+            GetJobsStatsAction.Request jobStatsRequest = new GetJobsStatsAction.Request(Metadata.ALL);
+            client.execute(GetJobsStatsAction.INSTANCE, jobStatsRequest, jobStatsListener);
+        } else if (machineLearningExtension.isDataFrameAnalyticsEnabled()) {
+            client.execute(GetDataFrameAnalyticsStatsAction.INSTANCE, dataframeAnalyticsStatsRequest, dataframeAnalyticsStatsListener);
+        } else {
+            addInferenceUsage(inferenceUsageListener);
+        }
     }
 
     private void addJobsUsage(GetJobsStatsAction.Response response, List<Job> jobs, Map<String, Object> jobsUsage) {
@@ -361,23 +378,27 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
     }
 
     private void addInferenceUsage(ActionListener<Map<String, Object>> listener) {
-        GetTrainedModelsAction.Request getModelsRequest = new GetTrainedModelsAction.Request(
-            "*",
-            Collections.emptyList(),
-            Collections.emptySet()
-        );
-        getModelsRequest.setPageParams(new PageParams(0, 10_000));
-        client.execute(GetTrainedModelsAction.INSTANCE, getModelsRequest, ActionListener.wrap(getModelsResponse -> {
-            GetTrainedModelsStatsAction.Request getStatsRequest = new GetTrainedModelsStatsAction.Request("*");
-            getStatsRequest.setPageParams(new PageParams(0, 10_000));
-            client.execute(GetTrainedModelsStatsAction.INSTANCE, getStatsRequest, ActionListener.wrap(getStatsResponse -> {
-                Map<String, Object> inferenceUsage = new LinkedHashMap<>();
-                addInferenceIngestUsage(getStatsResponse, inferenceUsage);
-                addTrainedModelStats(getModelsResponse, getStatsResponse, inferenceUsage);
-                addDeploymentStats(getStatsResponse, inferenceUsage);
-                listener.onResponse(inferenceUsage);
+        if (machineLearningExtension.isDataFrameAnalyticsEnabled() || machineLearningExtension.isNlpEnabled()) {
+            GetTrainedModelsAction.Request getModelsRequest = new GetTrainedModelsAction.Request(
+                "*",
+                Collections.emptyList(),
+                Collections.emptySet()
+            );
+            getModelsRequest.setPageParams(new PageParams(0, 10_000));
+            client.execute(GetTrainedModelsAction.INSTANCE, getModelsRequest, ActionListener.wrap(getModelsResponse -> {
+                GetTrainedModelsStatsAction.Request getStatsRequest = new GetTrainedModelsStatsAction.Request("*");
+                getStatsRequest.setPageParams(new PageParams(0, 10_000));
+                client.execute(GetTrainedModelsStatsAction.INSTANCE, getStatsRequest, ActionListener.wrap(getStatsResponse -> {
+                    Map<String, Object> inferenceUsage = new LinkedHashMap<>();
+                    addInferenceIngestUsage(getStatsResponse, inferenceUsage);
+                    addTrainedModelStats(getModelsResponse, getStatsResponse, inferenceUsage);
+                    addDeploymentStats(getStatsResponse, inferenceUsage);
+                    listener.onResponse(inferenceUsage);
+                }, listener::onFailure));
             }, listener::onFailure));
-        }, listener::onFailure));
+        } else {
+            listener.onResponse(Map.of());
+        }
     }
 
     private void addDeploymentStats(GetTrainedModelsStatsAction.Response statsResponse, Map<String, Object> inferenceUsage) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -100,7 +100,11 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         this.client = new OriginSettingClient(client, ML_ORIGIN);
         this.licenseState = licenseState;
         this.jobManagerHolder = jobManagerHolder;
-        this.machineLearningExtension = machineLearningExtensionHolder.getMachineLearningExtension();
+        if (machineLearningExtensionHolder.isEmpty()) {
+            this.machineLearningExtension = new DefaultMachineLearningExtension();
+        } else {
+            this.machineLearningExtension = machineLearningExtensionHolder.getMachineLearningExtension();
+        }
         this.enabled = XPackSettings.MACHINE_LEARNING_ENABLED.get(environment.settings());
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlControllerHolder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlControllerHolder.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  */
 public class MlControllerHolder {
 
-    private MlController mlController;
+    private final MlController mlController;
 
     public MlControllerHolder(MlController mlController) {
         this.mlController = Objects.requireNonNull(mlController);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -155,7 +155,9 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             client,
             licenseState,
             jobManagerHolder,
-            new MachineLearningTests.MlTestExtension(true, true, isAnomalyDetectionEnabled, isDataFrameAnalyticsEnabled, isNlpEnabled)
+            new MachineLearningExtensionHolder(
+                new MachineLearningTests.MlTestExtension(true, true, isAnomalyDetectionEnabled, isDataFrameAnalyticsEnabled, isNlpEnabled)
+            )
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -138,7 +139,12 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         client.threadPool().shutdown();
     }
 
-    private MachineLearningUsageTransportAction newUsageAction(Settings settings) {
+    private MachineLearningUsageTransportAction newUsageAction(
+        Settings settings,
+        boolean isAnomalyDetectionEnabled,
+        boolean isDataFrameAnalyticsEnabled,
+        boolean isNlpEnabled
+    ) {
         return new MachineLearningUsageTransportAction(
             mock(TransportService.class),
             clusterService,
@@ -148,7 +154,8 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             TestEnvironment.newEnvironment(settings),
             client,
             licenseState,
-            jobManagerHolder
+            jobManagerHolder,
+            new MachineLearningTests.MlTestExtension(true, true, isAnomalyDetectionEnabled, isDataFrameAnalyticsEnabled, isNlpEnabled)
         );
     }
 
@@ -162,7 +169,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         boolean available = randomBoolean();
         when(licenseState.isAllowed(MachineLearningField.ML_API_FEATURE)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
-        var usageAction = newUsageAction(commonSettings);
+        var usageAction = newUsageAction(commonSettings, randomBoolean(), randomBoolean(), randomBoolean());
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
         XPackFeatureSet.Usage usage = future.get().getUsage();
@@ -190,7 +197,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             licenseState
         );
         assertThat(featureSet.enabled(), is(expected));
-        var usageAction = newUsageAction(settings.build());
+        var usageAction = newUsageAction(settings.build(), randomBoolean(), randomBoolean(), randomBoolean());
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
         XPackFeatureSet.Usage usage = future.get().getUsage();
@@ -207,235 +214,11 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", true);
 
-        Job opened1 = buildJob(
-            "opened1",
-            Collections.singletonList(buildMinDetector("foo")),
-            Collections.singletonMap("created_by", randomFrom("a-cool-module", "a_cool_module", "a cool module"))
-        );
-        GetJobsStatsAction.Response.JobStats opened1JobStats = buildJobStats("opened1", JobState.OPENED, 100L, 3L);
-        Job opened2 = buildJob("opened2", Arrays.asList(buildMinDetector("foo"), buildMinDetector("bar")));
-        GetJobsStatsAction.Response.JobStats opened2JobStats = buildJobStats("opened2", JobState.OPENED, 200L, 8L);
-        Job closed1 = buildJob("closed1", Arrays.asList(buildMinDetector("foo"), buildMinDetector("bar"), buildMinDetector("foobar")));
-        GetJobsStatsAction.Response.JobStats closed1JobStats = buildJobStats("closed1", JobState.CLOSED, 300L, 0);
-        givenJobs(Arrays.asList(opened1, opened2, closed1), Arrays.asList(opened1JobStats, opened2JobStats, closed1JobStats));
-
-        givenDatafeeds(
-            Arrays.asList(
-                buildDatafeedStats(DatafeedState.STARTED),
-                buildDatafeedStats(DatafeedState.STARTED),
-                buildDatafeedStats(DatafeedState.STOPPED)
-            )
-        );
-
-        DataFrameAnalyticsConfig dfa1 = DataFrameAnalyticsConfigTests.createRandom("dfa_1");
-        DataFrameAnalyticsConfig dfa2 = DataFrameAnalyticsConfigTests.createRandom("dfa_2");
-        DataFrameAnalyticsConfig dfa3 = DataFrameAnalyticsConfigTests.createRandom("dfa_3");
-
-        List<DataFrameAnalyticsConfig> dataFrameAnalytics = Arrays.asList(dfa1, dfa2, dfa3);
-        givenDataFrameAnalytics(
-            dataFrameAnalytics,
-            Arrays.asList(
-                buildDataFrameAnalyticsStats(dfa1.getId(), DataFrameAnalyticsState.STOPPED, null),
-                buildDataFrameAnalyticsStats(dfa2.getId(), DataFrameAnalyticsState.STOPPED, 100L),
-                buildDataFrameAnalyticsStats(dfa3.getId(), DataFrameAnalyticsState.STARTED, 200L)
-            )
-        );
-
-        Map<String, Integer> expectedDfaCountByAnalysis = new HashMap<>();
-        dataFrameAnalytics.forEach(dfa -> {
-            String analysisName = dfa.getAnalysis().getWriteableName();
-            Integer analysisCount = expectedDfaCountByAnalysis.computeIfAbsent(analysisName, c -> 0);
-            expectedDfaCountByAnalysis.put(analysisName, ++analysisCount);
-        });
-
-        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance("model_1")
-            .setModelSize(100)
-            .setEstimatedOperations(200)
-            .setMetadata(Collections.singletonMap("analytics_config", "anything"))
-            .setInferenceConfig(ClassificationConfig.EMPTY_PARAMS)
-            .build();
-        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("model_2")
-            .setModelSize(200)
-            .setEstimatedOperations(400)
-            .setMetadata(Collections.singletonMap("analytics_config", "anything"))
-            .setInferenceConfig(RegressionConfig.EMPTY_PARAMS)
-            .build();
-        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance("model_3")
-            .setModelSize(300)
-            .setEstimatedOperations(600)
-            .setInferenceConfig(new NerConfig(null, null, null, null))
-            .build();
-        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("model_4")
-            .setTags(Collections.singletonList("prepackaged"))
-            .setModelSize(1000)
-            .setEstimatedOperations(2000)
-            .build();
-        givenTrainedModels(Arrays.asList(trainedModel1, trainedModel2, trainedModel3, trainedModel4));
-
         Map<String, Integer> trainedModelsCountByAnalysis = Map.of("classification", 1, "regression", 1, "ner", 1);
 
-        givenTrainedModelStats(
-            new GetTrainedModelsStatsAction.Response(
-                new QueryPage<>(
-                    List.of(
-                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
-                            trainedModel1.getModelId(),
-                            new TrainedModelSizeStats(trainedModel1.getModelSize(), 0L),
-                            new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
-                                List.of(),
-                                Map.of(
-                                    "pipeline_1",
-                                    List.of(
-                                        new IngestStats.ProcessorStat(
-                                            InferenceProcessor.TYPE,
-                                            InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(10, 1, 1000, 100)
-                                        ),
-                                        new IngestStats.ProcessorStat(
-                                            InferenceProcessor.TYPE,
-                                            InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(20, 2, 2000, 200)
-                                        ),
-                                        // Adding a non inference processor that should be ignored
-                                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(100, 100, 100, 100))
-                                    )
-                                )
-                            ),
-                            1,
-                            null,
-                            null
-                        ),
-                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
-                            trainedModel2.getModelId(),
-                            new TrainedModelSizeStats(trainedModel2.getModelSize(), 0L),
-                            new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
-                                List.of(),
-                                Map.of(
-                                    "pipeline_1",
-                                    List.of(
-                                        new IngestStats.ProcessorStat(
-                                            InferenceProcessor.TYPE,
-                                            InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(30, 3, 3000, 300)
-                                        )
-                                    )
-                                )
-                            ),
-                            2,
-                            null,
-                            null
-                        ),
-                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
-                            trainedModel3.getModelId(),
-                            new TrainedModelSizeStats(trainedModel3.getModelSize(), 0L),
-                            new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
-                                List.of(),
-                                Map.of(
-                                    "pipeline_2",
-                                    List.of(
-                                        new IngestStats.ProcessorStat(
-                                            InferenceProcessor.TYPE,
-                                            InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(40, 4, 4000, 400)
-                                        )
-                                    )
-                                )
-                            ),
-                            3,
-                            null,
-                            new AssignmentStats(
-                                "deployment_3",
-                                "model_3",
-                                null,
-                                null,
-                                null,
-                                null,
-                                Instant.now(),
-                                List.of(),
-                                Priority.NORMAL
-                            ).setState(AssignmentState.STOPPING)
-                        ),
-                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
-                            trainedModel4.getModelId(),
-                            new TrainedModelSizeStats(trainedModel4.getModelSize(), 0L),
-                            new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
-                                List.of(),
-                                Map.of(
-                                    "pipeline_3",
-                                    List.of(
-                                        new IngestStats.ProcessorStat(
-                                            InferenceProcessor.TYPE,
-                                            InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(50, 5, 5000, 500)
-                                        )
-                                    )
-                                )
-                            ),
-                            4,
-                            null,
-                            new AssignmentStats(
-                                "deployment_4",
-                                "model_4",
-                                2,
-                                2,
-                                1000,
-                                ByteSizeValue.ofBytes(1000),
-                                Instant.now(),
-                                List.of(
-                                    AssignmentStats.NodeStats.forStartedState(
-                                            DiscoveryNodeUtils.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
-                                            5,
-                                            42.0,
-                                            42.0,
-                                            0,
-                                            1,
-                                            3L,
-                                            2,
-                                            3,
-                                            Instant.now(),
-                                            Instant.now(),
-                                            randomIntBetween(1, 16),
-                                            randomIntBetween(1, 16),
-                                            1L,
-                                            2L,
-                                            33.0,
-                                            1L
-                                    ),
-                                    AssignmentStats.NodeStats.forStartedState(
-                                            DiscoveryNodeUtils.create("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
-                                            4,
-                                            50.0,
-                                            50.0,
-                                            0,
-                                            1,
-                                            1L,
-                                            2,
-                                            3,
-                                            Instant.now(),
-                                            Instant.now(),
-                                            randomIntBetween(1, 16),
-                                            randomIntBetween(1, 16),
-                                            2L,
-                                            4L,
-                                            34.0,
-                                            1L
-                                    )
-                                ),
-                                Priority.NORMAL
-                            ).setState(AssignmentState.STARTED).setAllocationStatus(new AllocationStatus(2, 2))
-                        )
-                    ),
-                    0,
-                    GetTrainedModelsStatsAction.Response.RESULTS_FIELD
-                )
-            )
-        );
+        Map<String, Integer> expectedDfaCountByAnalysis = setupComplexMocks();
 
-        var usageAction = newUsageAction(settings.build());
+        var usageAction = newUsageAction(settings.build(), true, true, true);
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
         XPackFeatureSet.Usage mlUsage = future.get().getUsage();
@@ -558,6 +341,180 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         }
     }
 
+    public void testAnomalyDetectionDisabled() throws Exception {
+        when(licenseState.isAllowed(MachineLearningField.ML_API_FEATURE)).thenReturn(true);
+        Settings.Builder settings = Settings.builder().put(commonSettings);
+        settings.put("xpack.ml.enabled", true);
+
+        Map<String, Integer> trainedModelsCountByAnalysis = Map.of("classification", 1, "regression", 1, "ner", 1);
+
+        // This test works by setting up a mocks that imply jobs and datafeeds exist, then
+        // checking that the usage stats don't mention them. This proves that the trained model
+        // APIs were bypassed. In reality of course the cluster state would not contain trained
+        // models if the features were disabled.
+        Map<String, Integer> expectedDfaCountByAnalysis = setupComplexMocks();
+
+        var usageAction = newUsageAction(settings.build(), false, true, true);
+        PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
+        usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
+        XPackFeatureSet.Usage mlUsage = future.get().getUsage();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        mlUsage.writeTo(out);
+        XPackFeatureSet.Usage serializedUsage = new MachineLearningFeatureSetUsage(out.bytes().streamInput());
+
+        for (XPackFeatureSet.Usage usage : Arrays.asList(mlUsage, serializedUsage)) {
+            assertThat(usage, is(notNullValue()));
+            assertThat(usage.name(), is(XPackField.MACHINE_LEARNING));
+            assertThat(usage.enabled(), is(true));
+            assertThat(usage.available(), is(true));
+            XContentSource source;
+            try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+                usage.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                source = new XContentSource(builder);
+            }
+
+            assertThat(source.getValue("jobs"), anEmptyMap());
+            assertThat(source.getValue("datafeeds"), anEmptyMap());
+
+            assertThat(source.getValue("data_frame_analytics_jobs._all.count"), equalTo(3));
+            assertThat(source.getValue("data_frame_analytics_jobs.started.count"), equalTo(1));
+            assertThat(source.getValue("data_frame_analytics_jobs.stopped.count"), equalTo(2));
+            assertThat(source.getValue("data_frame_analytics_jobs.analysis_counts"), equalTo(expectedDfaCountByAnalysis));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.min"), equalTo(100.0));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.max"), equalTo(200.0));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.total"), equalTo(300.0));
+            assertThat(source.getValue("data_frame_analytics_jobs.memory_usage.peak_usage_bytes.avg"), equalTo(150.0));
+
+            assertThat(source.getValue("inference.trained_models._all.count"), equalTo(4));
+            assertThat(source.getValue("inference.trained_models.model_size_bytes.min"), equalTo(100.0));
+            assertThat(source.getValue("inference.trained_models.model_size_bytes.max"), equalTo(300.0));
+            assertThat(source.getValue("inference.trained_models.model_size_bytes.total"), equalTo(600.0));
+            assertThat(source.getValue("inference.trained_models.model_size_bytes.avg"), equalTo(200.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.min"), equalTo(200.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.max"), equalTo(600.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.total"), equalTo(1200.0));
+            assertThat(source.getValue("inference.trained_models.estimated_operations.avg"), equalTo(400.0));
+            assertThat(source.getValue("inference.trained_models.count.total"), equalTo(4));
+            trainedModelsCountByAnalysis.forEach(
+                (name, count) -> assertThat(source.getValue("inference.trained_models.count." + name), equalTo(count))
+            );
+            assertThat(source.getValue("inference.trained_models.count.prepackaged"), equalTo(1));
+            assertThat(source.getValue("inference.trained_models.count.other"), equalTo(1));
+
+            assertThat(source.getValue("inference.ingest_processors._all.pipelines.count"), equalTo(10));
+            assertThat(source.getValue("inference.ingest_processors._all.num_docs_processed.sum"), equalTo(150));
+            assertThat(source.getValue("inference.ingest_processors._all.num_docs_processed.min"), equalTo(10));
+            assertThat(source.getValue("inference.ingest_processors._all.num_docs_processed.max"), equalTo(50));
+            assertThat(source.getValue("inference.ingest_processors._all.time_ms.sum"), equalTo(15));
+            assertThat(source.getValue("inference.ingest_processors._all.time_ms.min"), equalTo(1));
+            assertThat(source.getValue("inference.ingest_processors._all.time_ms.max"), equalTo(5));
+            assertThat(source.getValue("inference.ingest_processors._all.num_failures.sum"), equalTo(1500));
+            assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
+            assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
+            assertThat(source.getValue("inference.deployments.count"), equalTo(2));
+            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.5));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1300.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(300.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(650.0));
+            assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(45.55555555555556, 1e-10));
+        }
+    }
+
+    public void testUsageWithTrainedModelsDisabled() throws Exception {
+        when(licenseState.isAllowed(MachineLearningField.ML_API_FEATURE)).thenReturn(true);
+        Settings.Builder settings = Settings.builder().put(commonSettings);
+        settings.put("xpack.ml.enabled", true);
+
+        // This test works by setting up a mocks that imply trained models exist, then checking
+        // that the usage stats don't mention them. This proves that the trained model APIs
+        // were bypassed. In reality of course the cluster state would not contain trained
+        // models if the features were disabled.
+        setupComplexMocks();
+
+        var usageAction = newUsageAction(settings.build(), true, false, false);
+        PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
+        usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
+        XPackFeatureSet.Usage mlUsage = future.get().getUsage();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        mlUsage.writeTo(out);
+        XPackFeatureSet.Usage serializedUsage = new MachineLearningFeatureSetUsage(out.bytes().streamInput());
+
+        for (XPackFeatureSet.Usage usage : Arrays.asList(mlUsage, serializedUsage)) {
+            assertThat(usage, is(notNullValue()));
+            assertThat(usage.name(), is(XPackField.MACHINE_LEARNING));
+            assertThat(usage.enabled(), is(true));
+            assertThat(usage.available(), is(true));
+            XContentSource source;
+            try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+                usage.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                source = new XContentSource(builder);
+            }
+            assertThat(source.getValue("jobs._all.count"), equalTo(3));
+            assertThat(source.getValue("jobs._all.detectors.min"), equalTo(1.0));
+            assertThat(source.getValue("jobs._all.detectors.max"), equalTo(3.0));
+            assertThat(source.getValue("jobs._all.detectors.total"), equalTo(6.0));
+            assertThat(source.getValue("jobs._all.detectors.avg"), equalTo(2.0));
+            assertThat(source.getValue("jobs._all.model_size.min"), equalTo(100.0));
+            assertThat(source.getValue("jobs._all.model_size.max"), equalTo(300.0));
+            assertThat(source.getValue("jobs._all.model_size.total"), equalTo(600.0));
+            assertThat(source.getValue("jobs._all.model_size.avg"), equalTo(200.0));
+            assertThat(source.getValue("jobs._all.created_by.a_cool_module"), equalTo(1));
+            assertThat(source.getValue("jobs._all.created_by.unknown"), equalTo(2));
+
+            assertThat(source.getValue("jobs.opened.count"), equalTo(2));
+            assertThat(source.getValue("jobs.opened.detectors.min"), equalTo(1.0));
+            assertThat(source.getValue("jobs.opened.detectors.max"), equalTo(2.0));
+            assertThat(source.getValue("jobs.opened.detectors.total"), equalTo(3.0));
+            assertThat(source.getValue("jobs.opened.detectors.avg"), equalTo(1.5));
+            assertThat(source.getValue("jobs.opened.model_size.min"), equalTo(100.0));
+            assertThat(source.getValue("jobs.opened.model_size.max"), equalTo(200.0));
+            assertThat(source.getValue("jobs.opened.model_size.total"), equalTo(300.0));
+            assertThat(source.getValue("jobs.opened.model_size.avg"), equalTo(150.0));
+            assertThat(source.getValue("jobs.opened.created_by.a_cool_module"), equalTo(1));
+            assertThat(source.getValue("jobs.opened.created_by.unknown"), equalTo(1));
+
+            assertThat(source.getValue("jobs.closed.count"), equalTo(1));
+            assertThat(source.getValue("jobs.closed.detectors.min"), equalTo(3.0));
+            assertThat(source.getValue("jobs.closed.detectors.max"), equalTo(3.0));
+            assertThat(source.getValue("jobs.closed.detectors.total"), equalTo(3.0));
+            assertThat(source.getValue("jobs.closed.detectors.avg"), equalTo(3.0));
+            assertThat(source.getValue("jobs.closed.model_size.min"), equalTo(300.0));
+            assertThat(source.getValue("jobs.closed.model_size.max"), equalTo(300.0));
+            assertThat(source.getValue("jobs.closed.model_size.total"), equalTo(300.0));
+            assertThat(source.getValue("jobs.closed.model_size.avg"), equalTo(300.0));
+            assertThat(source.getValue("jobs.closed.created_by.a_cool_module"), is(nullValue()));
+            assertThat(source.getValue("jobs.closed.created_by.unknown"), equalTo(1));
+
+            assertThat(source.getValue("jobs.opening"), is(nullValue()));
+            assertThat(source.getValue("jobs.closing"), is(nullValue()));
+            assertThat(source.getValue("jobs.failed"), is(nullValue()));
+
+            assertThat(source.getValue("datafeeds._all.count"), equalTo(3));
+            assertThat(source.getValue("datafeeds.started.count"), equalTo(2));
+            assertThat(source.getValue("datafeeds.stopped.count"), equalTo(1));
+
+            assertThat(source.getValue("data_frame_analytics_jobs"), anEmptyMap());
+
+            assertThat(source.getValue("jobs._all.forecasts.total"), equalTo(11));
+            assertThat(source.getValue("jobs._all.forecasts.forecasted_jobs"), equalTo(2));
+
+            assertThat(source.getValue("jobs.closed.forecasts.total"), equalTo(0));
+            assertThat(source.getValue("jobs.closed.forecasts.forecasted_jobs"), equalTo(0));
+
+            assertThat(source.getValue("jobs.opened.forecasts.total"), equalTo(11));
+            assertThat(source.getValue("jobs.opened.forecasts.forecasted_jobs"), equalTo(2));
+
+            assertThat(source.getValue("inference"), anEmptyMap());
+        }
+    }
+
     public void testUsageWithOrphanedTask() throws Exception {
         when(licenseState.isAllowed(MachineLearningField.ML_API_FEATURE)).thenReturn(true);
         Settings.Builder settings = Settings.builder().put(commonSettings);
@@ -575,7 +532,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         GetJobsStatsAction.Response.JobStats closed1JobStats = buildJobStats("closed1", JobState.CLOSED, 300L, 0);
         givenJobs(Arrays.asList(opened1, closed1), Arrays.asList(opened1JobStats, opened2JobStats, closed1JobStats));
 
-        var usageAction = newUsageAction(settings.build());
+        var usageAction = newUsageAction(settings.build(), true, true, true);
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
         XPackFeatureSet.Usage usage = future.get().getUsage();
@@ -605,7 +562,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", false);
 
-        var usageAction = newUsageAction(settings.build());
+        var usageAction = newUsageAction(settings.build(), randomBoolean(), randomBoolean(), randomBoolean());
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
         XPackFeatureSet.Usage mlUsage = future.get().getUsage();
@@ -627,7 +584,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", true);
 
-        var usageAction = newUsageAction(settings.build());
+        var usageAction = newUsageAction(settings.build(), randomBoolean(), randomBoolean(), randomBoolean());
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, clusterState, future);
         XPackFeatureSet.Usage usage = future.get().getUsage();
@@ -653,7 +610,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         settings.put("xpack.ml.enabled", true);
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
 
-        var usageAction = newUsageAction(settings.build());
+        var usageAction = newUsageAction(settings.build(), true, true, true);
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, ClusterState.EMPTY_STATE, future);
         XPackFeatureSet.Usage usage = future.get().getUsage();
@@ -868,5 +825,234 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
 
     private static ForecastStats buildForecastStats(long numberOfForecasts) {
         return new ForecastStatsTests().createForecastStats(numberOfForecasts, numberOfForecasts);
+    }
+
+    private Map<String, Integer> setupComplexMocks() {
+        Job opened1 = buildJob(
+            "opened1",
+            Collections.singletonList(buildMinDetector("foo")),
+            Collections.singletonMap("created_by", randomFrom("a-cool-module", "a_cool_module", "a cool module"))
+        );
+        GetJobsStatsAction.Response.JobStats opened1JobStats = buildJobStats("opened1", JobState.OPENED, 100L, 3L);
+        Job opened2 = buildJob("opened2", Arrays.asList(buildMinDetector("foo"), buildMinDetector("bar")));
+        GetJobsStatsAction.Response.JobStats opened2JobStats = buildJobStats("opened2", JobState.OPENED, 200L, 8L);
+        Job closed1 = buildJob("closed1", Arrays.asList(buildMinDetector("foo"), buildMinDetector("bar"), buildMinDetector("foobar")));
+        GetJobsStatsAction.Response.JobStats closed1JobStats = buildJobStats("closed1", JobState.CLOSED, 300L, 0);
+        givenJobs(Arrays.asList(opened1, opened2, closed1), Arrays.asList(opened1JobStats, opened2JobStats, closed1JobStats));
+
+        givenDatafeeds(
+            Arrays.asList(
+                buildDatafeedStats(DatafeedState.STARTED),
+                buildDatafeedStats(DatafeedState.STARTED),
+                buildDatafeedStats(DatafeedState.STOPPED)
+            )
+        );
+
+        DataFrameAnalyticsConfig dfa1 = DataFrameAnalyticsConfigTests.createRandom("dfa_1");
+        DataFrameAnalyticsConfig dfa2 = DataFrameAnalyticsConfigTests.createRandom("dfa_2");
+        DataFrameAnalyticsConfig dfa3 = DataFrameAnalyticsConfigTests.createRandom("dfa_3");
+
+        List<DataFrameAnalyticsConfig> dataFrameAnalytics = Arrays.asList(dfa1, dfa2, dfa3);
+        givenDataFrameAnalytics(
+            dataFrameAnalytics,
+            Arrays.asList(
+                buildDataFrameAnalyticsStats(dfa1.getId(), DataFrameAnalyticsState.STOPPED, null),
+                buildDataFrameAnalyticsStats(dfa2.getId(), DataFrameAnalyticsState.STOPPED, 100L),
+                buildDataFrameAnalyticsStats(dfa3.getId(), DataFrameAnalyticsState.STARTED, 200L)
+            )
+        );
+
+        Map<String, Integer> expectedDfaCountByAnalysis = new HashMap<>();
+        dataFrameAnalytics.forEach(dfa -> {
+            String analysisName = dfa.getAnalysis().getWriteableName();
+            Integer analysisCount = expectedDfaCountByAnalysis.computeIfAbsent(analysisName, c -> 0);
+            expectedDfaCountByAnalysis.put(analysisName, ++analysisCount);
+        });
+
+        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance("model_1")
+            .setModelSize(100)
+            .setEstimatedOperations(200)
+            .setMetadata(Collections.singletonMap("analytics_config", "anything"))
+            .setInferenceConfig(ClassificationConfig.EMPTY_PARAMS)
+            .build();
+        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("model_2")
+            .setModelSize(200)
+            .setEstimatedOperations(400)
+            .setMetadata(Collections.singletonMap("analytics_config", "anything"))
+            .setInferenceConfig(RegressionConfig.EMPTY_PARAMS)
+            .build();
+        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance("model_3")
+            .setModelSize(300)
+            .setEstimatedOperations(600)
+            .setInferenceConfig(new NerConfig(null, null, null, null))
+            .build();
+        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("model_4")
+            .setTags(Collections.singletonList("prepackaged"))
+            .setModelSize(1000)
+            .setEstimatedOperations(2000)
+            .build();
+        givenTrainedModels(Arrays.asList(trainedModel1, trainedModel2, trainedModel3, trainedModel4));
+
+        givenTrainedModelStats(
+            new GetTrainedModelsStatsAction.Response(
+                new QueryPage<>(
+                    List.of(
+                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
+                            trainedModel1.getModelId(),
+                            new TrainedModelSizeStats(trainedModel1.getModelSize(), 0L),
+                            new IngestStats(
+                                new IngestStats.Stats(0, 0, 0, 0),
+                                List.of(),
+                                Map.of(
+                                    "pipeline_1",
+                                    List.of(
+                                        new IngestStats.ProcessorStat(
+                                            InferenceProcessor.TYPE,
+                                            InferenceProcessor.TYPE,
+                                            new IngestStats.Stats(10, 1, 1000, 100)
+                                        ),
+                                        new IngestStats.ProcessorStat(
+                                            InferenceProcessor.TYPE,
+                                            InferenceProcessor.TYPE,
+                                            new IngestStats.Stats(20, 2, 2000, 200)
+                                        ),
+                                        // Adding a non inference processor that should be ignored
+                                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(100, 100, 100, 100))
+                                    )
+                                )
+                            ),
+                            1,
+                            null,
+                            null
+                        ),
+                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
+                            trainedModel2.getModelId(),
+                            new TrainedModelSizeStats(trainedModel2.getModelSize(), 0L),
+                            new IngestStats(
+                                new IngestStats.Stats(0, 0, 0, 0),
+                                List.of(),
+                                Map.of(
+                                    "pipeline_1",
+                                    List.of(
+                                        new IngestStats.ProcessorStat(
+                                            InferenceProcessor.TYPE,
+                                            InferenceProcessor.TYPE,
+                                            new IngestStats.Stats(30, 3, 3000, 300)
+                                        )
+                                    )
+                                )
+                            ),
+                            2,
+                            null,
+                            null
+                        ),
+                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
+                            trainedModel3.getModelId(),
+                            new TrainedModelSizeStats(trainedModel3.getModelSize(), 0L),
+                            new IngestStats(
+                                new IngestStats.Stats(0, 0, 0, 0),
+                                List.of(),
+                                Map.of(
+                                    "pipeline_2",
+                                    List.of(
+                                        new IngestStats.ProcessorStat(
+                                            InferenceProcessor.TYPE,
+                                            InferenceProcessor.TYPE,
+                                            new IngestStats.Stats(40, 4, 4000, 400)
+                                        )
+                                    )
+                                )
+                            ),
+                            3,
+                            null,
+                            new AssignmentStats(
+                                "deployment_3",
+                                "model_3",
+                                null,
+                                null,
+                                null,
+                                null,
+                                Instant.now(),
+                                List.of(),
+                                Priority.NORMAL
+                            ).setState(AssignmentState.STOPPING)
+                        ),
+                        new GetTrainedModelsStatsAction.Response.TrainedModelStats(
+                            trainedModel4.getModelId(),
+                            new TrainedModelSizeStats(trainedModel4.getModelSize(), 0L),
+                            new IngestStats(
+                                new IngestStats.Stats(0, 0, 0, 0),
+                                List.of(),
+                                Map.of(
+                                    "pipeline_3",
+                                    List.of(
+                                        new IngestStats.ProcessorStat(
+                                            InferenceProcessor.TYPE,
+                                            InferenceProcessor.TYPE,
+                                            new IngestStats.Stats(50, 5, 5000, 500)
+                                        )
+                                    )
+                                )
+                            ),
+                            4,
+                            null,
+                            new AssignmentStats(
+                                "deployment_4",
+                                "model_4",
+                                2,
+                                2,
+                                1000,
+                                ByteSizeValue.ofBytes(1000),
+                                Instant.now(),
+                                List.of(
+                                    AssignmentStats.NodeStats.forStartedState(
+                                        DiscoveryNodeUtils.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
+                                        5,
+                                        42.0,
+                                        42.0,
+                                        0,
+                                        1,
+                                        3L,
+                                        2,
+                                        3,
+                                        Instant.now(),
+                                        Instant.now(),
+                                        randomIntBetween(1, 16),
+                                        randomIntBetween(1, 16),
+                                        1L,
+                                        2L,
+                                        33.0,
+                                        1L
+                                    ),
+                                    AssignmentStats.NodeStats.forStartedState(
+                                        DiscoveryNodeUtils.create("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
+                                        4,
+                                        50.0,
+                                        50.0,
+                                        0,
+                                        1,
+                                        1L,
+                                        2,
+                                        3,
+                                        Instant.now(),
+                                        Instant.now(),
+                                        randomIntBetween(1, 16),
+                                        randomIntBetween(1, 16),
+                                        2L,
+                                        4L,
+                                        34.0,
+                                        1L
+                                    )
+                                ),
+                                Priority.NORMAL
+                            ).setState(AssignmentState.STARTED).setAllocationStatus(new AllocationStatus(2, 2))
+                        )
+                    ),
+                    0,
+                    GetTrainedModelsStatsAction.Response.RESULTS_FIELD
+                )
+            )
+        );
+        return expectedDfaCountByAnalysis;
     }
 }


### PR DESCRIPTION
To support differentiation of serverless product types it's now possible to disable subsets of ML functionality.

The ML usage action was not updated to reflect this, so still attempted to call actions to find out about usage of disabled sub-features. Because that action is designed to never fail, it actually returned reasonable output in these cases. However, it generated a lot of log spam with warnings about calling non-existent actions.

This PR adjusts the logic of the ML usage action to take into account which sub-features might be disabled, and avoid calling actions which won't exist in this case.