### PR TITLE
Update post-analytics-collection-event.asciidoc

### DIFF
--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -56,22 +56,14 @@ POST _application/analytics/my_analytics_collection/event/search_click
   "user": {
     "id": "5f26f01a-bbee-4202-9298-81261067abbd"
   },
-  "page": {
-    "url": "https://www.elastic.co/"
-  },
   "search":{
     "query": "search term",
-    "filters": {},
-    "page": {"current": 1, "size": 10},
     "results": {
       "items": [
         {
           "document": {
             "id": "123",
             "index": "products"
-          },
-          "page": {
-            "url": "http://www.elastic.co/"
           }
         }
       ],
@@ -83,7 +75,8 @@ POST _application/analytics/my_analytics_collection/event/search_click
     "search_application": "website"
   },
   "document":{
-    "id": "123"
+    "id": "123",
+    "index": "products"
   }
 }
 ----

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -44,11 +44,11 @@ Occurs either when the event type is unknown or when event payload contains inva
 [[post-analytics-collection-event-example]]
 ==== {api-examples-title}
 
-The following example send a `page_view` event to an Analytics Collection called `my_analytics_collection`:
+The following example send a `search_click` event to an Analytics Collection called `my_analytics_collection`:
 
 [source,console]
 ----
-POST _application/analytics/my_analytics_collection/event/page_view
+POST _application/analytics/my_analytics_collection/event/search_click
 {
   "session": {
     "id": "1797ca95-91c9-4e2e-b1bd-9c38e6f386a9"
@@ -58,6 +58,32 @@ POST _application/analytics/my_analytics_collection/event/page_view
   },
   "page": {
     "url": "https://www.elastic.co/"
+  },
+  "search":{
+    "query": "search term",
+    "filters": {},
+    "page": {"current": 1, "size": 10},
+    "results": {
+      "items": [
+        {
+          "document": {
+            "id": "123",
+            "index": "products"
+          },
+          "page": {
+            "url": "http://www.elastic.co/"
+          }
+        }
+      ],
+      "total_results": 10
+    },
+    "sort": {
+      "name": "relevance"
+    },
+    "search_application": "website"
+  },
+  "document":{
+    "id": "123"
   }
 }
 ----

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -22,7 +22,12 @@ Post an event to an Analytics Collection.
 (Required, string) Analytics collection name you want to ingest event in.
 
 `<event_type>`::
-(Required, string) Analytics event type. Can be one of `page_view`, `search`, `search_click`
+(Required, string) Analytics event type. Can be one of `page_view`, `search`, `search_click`.
+
+[[post-analytics-collection-event-request-body]]
+==== {api-request-body-title}
+Full request body parameters can be found in {enterprise-search-ref}/analytics-events-reference.html[Enterprise Analytics Events^].
+
 
 [[post-analytics-collection-event-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -22,7 +22,7 @@ Post an event to an Analytics Collection.
 (Required, string) Analytics collection name you want to ingest event in.
 
 `<event_type>`::
-(Required, string) Analytics event type. Can be one of `page_view`, `search`, `click`
+(Required, string) Analytics event type. Can be one of `page_view`, `search`, `search_click`
 
 [[post-analytics-collection-event-prereqs]]
 ==== {api-prereq-title}


### PR DESCRIPTION
Update API endpoint. Instead of `click`, it should be `search_click`. 

Expanded on request body in the API example which is based on https://www.elastic.co/guide/en/enterprise-search/master/analytics-events-reference.html#analytics-events-reference-examples

**This documentation page should link to the above page for full request body details.** 
I'm not sure if we should duplicate the same info or place the full request body details in Elasticsearch doc or Enterprise search doc. But we should at least cross reference it to make users able to find them. Please feel free to make further improvements.

Btw, I noticed some inconsistencies when testing the fields on 8.9.0 version (build-hash `35f3212cc719a24ada5e1b1579f82aef298b7a82`):
1. The enterprise-search doc shows `page.url` should be `page.url.original`, but this was rejected by Elasticsearch with the following message:
> [page] url doesn't support values of type: START_OBJECT"
2. The enterprise-search doc shows `search.filters` can accept an array, but this is rejected by Elasticsearch with the following message:
> [search] filters doesn't support values of type: START_ARRAY"
Maybe some of the changes are still in progress? I remove these two parameters from the example to avoid confusion. But it would be great to get some consistency. 