### PR TITLE
Refactor Div QL arithmetic function to accept data type explicitly

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/EqlFunctionRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/EqlFunctionRegistry.java
@@ -68,7 +68,7 @@ public class EqlFunctionRegistry extends FunctionRegistry {
             // Arithmetic
             new FunctionDefinition[] {
                 def(Add.class, Add::new, "add"),
-                def(Div.class, Div::new, "divide"),
+                def(Div.class, (BinaryBuilder<Div>) Div::new, "divide"),
                 def(Mod.class, Mod::new, "modulo"),
                 def(Mul.class, Mul::new, "multiply"),
                 def(ToNumber.class, ToNumber::new, "number"),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Div.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/Div.java
@@ -17,23 +17,33 @@ import org.elasticsearch.xpack.ql.type.DataTypeConverter;
  */
 public class Div extends ArithmeticOperation implements BinaryComparisonInversible {
 
+    private DataType dataType;
+
     public Div(Source source, Expression left, Expression right) {
+        this(source, left, right, null);
+    }
+
+    public Div(Source source, Expression left, Expression right, DataType dataType) {
         super(source, left, right, DefaultBinaryArithmeticOperation.DIV);
+        this.dataType = dataType;
     }
 
     @Override
     protected NodeInfo<Div> info() {
-        return NodeInfo.create(this, Div::new, left(), right());
+        return NodeInfo.create(this, Div::new, left(), right(), dataType);
     }
 
     @Override
     protected Div replaceChildren(Expression newLeft, Expression newRight) {
-        return new Div(source(), newLeft, newRight);
+        return new Div(source(), newLeft, newRight, dataType);
     }
 
     @Override
     public DataType dataType() {
-        return DataTypeConverter.commonType(left().dataType(), right().dataType());
+        if (dataType == null) {
+            dataType = DataTypeConverter.commonType(left().dataType(), right().dataType());
+        }
+        return dataType;
     }
 
     @Override


### PR DESCRIPTION
This PR adds the ability to pass the data type to Div QL arithmetic function.
The change does not affect the existing usages (ie. EQL), but is needed for ESQL implementation