### PR TITLE
Remove explicit refresh_interval from identity-provider internal index

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/idp/saml-service-provider-template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/idp/saml-service-provider-template.json
@@ -11,7 +11,6 @@
     "number_of_replicas": 0,
     "auto_expand_replicas": "0-1",
     "index.priority": 10,
-    "index.refresh_interval": "1s",
     "index.format": 1
   },
   "mappings": {


### PR DESCRIPTION
The preference is now to rely on the implicit `refresh_interval` value
when creating internal indices.

Related https://github.com/elastic/elasticsearch/pull/97815