### PR TITLE
[DOCS] Make it clear that "both" is not a valid value for "script.allowed_types"

### DIFF
--- a/docs/reference/scripting/security.asciidoc
+++ b/docs/reference/scripting/security.asciidoc
@@ -36,7 +36,7 @@ configured to run both types of scripts. To limit what type of scripts are run,
 set `script.allowed_types` to `inline` or `stored`. To prevent any scripts from 
 running, set `script.allowed_types` to `none`.
 
-IMPORTANT: If you use {kib}, set `script.allowed_types` to `both` or `inline`.
+IMPORTANT: If you use {kib}, set `script.allowed_types` to both or just `inline`.
 Some {kib} features rely on inline scripts and do not function as expected
 if {es} does not allow inline scripts.
 


### PR DESCRIPTION
The fact that "both" is formatted as `both` in the [documentation for `script.allowed_types`](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-security.html#allowed-script-types-setting) makes users think that `both` is a valid value. However, configuring `both` results in this error at start up:

```
fatal exception while booting Elasticsearch
es-search-data-node-1 | java.lang.IllegalArgumentException: unknown script type [both] found in setting [script.allowed_types].
```

Users should configure `script.allowed_types: "inline, stored"` instead.

This PR removes the formatting of the word both to make it more clear that `both` is not a valid value.