### PR TITLE
Remove redundant ref-counting in SharedBytes.IO

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -14,7 +14,6 @@ import org.elasticsearch.blobcache.common.ByteBufferReference;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -252,9 +251,7 @@ public class SharedBytes extends AbstractRefCounted {
 
     public IO getFileChannel(int sharedBytesPos) {
         assert fileChannel != null;
-        var res = ios[sharedBytesPos];
-        incRef();
-        return res;
+        return ios[sharedBytesPos];
     }
 
     long getPhysicalOffset(long chunkPosition) {
@@ -263,7 +260,7 @@ public class SharedBytes extends AbstractRefCounted {
         return physicalOffset;
     }
 
-    public final class IO implements Releasable {
+    public final class IO {
 
         private final long pageStart;
 
@@ -314,11 +311,6 @@ public class SharedBytes extends AbstractRefCounted {
                 assert false;
                 throw new IllegalArgumentException("bad access");
             }
-        }
-
-        @Override
-        public void close() {
-            decRef();
         }
     }
 

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
@@ -37,17 +37,7 @@ public class SharedBytesTests extends ESTestCase {
             );
             final var sharedBytesPath = nodeEnv.nodeDataPaths()[0].resolve("shared_snapshot_cache");
             assertTrue(Files.exists(sharedBytesPath));
-            SharedBytes.IO fileChannel = sharedBytes.getFileChannel(randomInt(regions - 1));
-            assertTrue(Files.exists(sharedBytesPath));
-            if (randomBoolean()) {
-                fileChannel.close();
-                assertTrue(Files.exists(sharedBytesPath));
-                sharedBytes.decRef();
-            } else {
-                sharedBytes.decRef();
-                assertTrue(Files.exists(sharedBytesPath));
-                fileChannel.close();
-            }
+            sharedBytes.decRef();
             assertFalse(Files.exists(sharedBytesPath));
         }
     }


### PR DESCRIPTION
No need to use ref-counting here to keep the shared bytes alive after they got closed. SharedBytes live for as long as the node lives, so if this ever becomes an issues we should fix it by fixing the shutdown order of services and not deal with the significant overhead of ref-counting on every read.
