### PR TITLE
Support routing parameter in reindex api to limit target shards

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.rest.RestRequest;
@@ -66,6 +67,9 @@ public class RestReindexAction extends AbstractBaseReindexRestHandler<ReindexReq
         }
         if (request.hasParam(DocWriteRequest.REQUIRE_ALIAS)) {
             internal.setRequireAlias(request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false));
+        }
+        if (request.hasParam("source_routing")) {
+            internal.getSearchRequest().routing(Strings.splitStringByCommaToArray(request.param("source_routing")));
         }
 
         return internal;

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
@@ -78,4 +78,14 @@ public class RestReindexActionTests extends RestActionTestCase {
             assertEquals("10m", request.getScrollTime().toString());
         }
     }
+
+    public void testSetSourceRouting() throws IOException {
+
+        FakeRestRequest.Builder requestBuilder = new FakeRestRequest.Builder(xContentRegistry());
+        requestBuilder.withParams(singletonMap("source_routing", "u1,u2"));
+        requestBuilder.withContent(new BytesArray("{}"), XContentType.JSON);
+        ReindexRequest request = action.buildRequest(requestBuilder.build(), new NamedWriteableRegistry(Collections.emptyList()));
+        assertEquals("u1,u2", request.getSearchRequest().routing());
+
+    }
 }


### PR DESCRIPTION
Reindex API is used to reindex data from source index to destination using search/filter request.  Normal Search Request provide feasibility to hit the targeted shards using routing parameter to limit scope of shard search requests.
As part of this request, we want leverage routing parameter in reindex api.
