### PR TITLE
Fix main response to return build flavor

### DIFF
--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
@@ -131,7 +131,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("cluster_uuid", clusterUuid);
         builder.startObject("version")
             .field("number", build.qualifiedVersion())
-            .field("build_flavor", "default")
+            .field("build_flavor", build.flavor())
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
             .field("build_date", build.date())


### PR DESCRIPTION
Build flavor was added back in #97770, but the main endpoint response is still hardcoded to "default". This commit updates the response to return the flavor from the build info.