### PR TITLE
Allow "slow" MethodHandle invocations in tests

### DIFF
--- a/build-tools-internal/src/main/resources/forbidden/es-all-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/es-all-signatures.txt
@@ -17,11 +17,6 @@ java.util.concurrent.ThreadLocalRandom
 
 java.security.MessageDigest#clone() @ use org.elasticsearch.common.hash.MessageDigests
 
-@defaultMessage Don't use MethodHandles in slow ways, don't be lenient in tests.
-java.lang.invoke.MethodHandle#invoke(java.lang.Object[])
-java.lang.invoke.MethodHandle#invokeWithArguments(java.lang.Object[])
-java.lang.invoke.MethodHandle#invokeWithArguments(java.util.List)
-
 @defaultMessage Don't open socket connections
 java.net.URL#openStream()
 java.net.URLConnection#connect()

--- a/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
@@ -38,6 +38,11 @@ java.lang.Math#abs(long)
 @defaultMessage Please do not try to stop the world
 java.lang.System#gc()
 
+@defaultMessage Don't use MethodHandles in slow ways
+java.lang.invoke.MethodHandle#invoke(java.lang.Object[])
+java.lang.invoke.MethodHandle#invokeWithArguments(java.lang.Object[])
+java.lang.invoke.MethodHandle#invokeWithArguments(java.util.List)
+
 @defaultMessage Use Channels.* methods to write to channels. Do not write directly.
 java.nio.channels.WritableByteChannel#write(java.nio.ByteBuffer)
 java.nio.channels.FileChannel#write(java.nio.ByteBuffer, long)


### PR DESCRIPTION
MethodHandles provide an alternative to reflective method invocation. In many cases they are faster than reflective methods. But sometimes they might be just as slow. We currently forbid use of these "slow" variants, even in tests. But tests don't really care about speed, per se, and they are no worse than using reflection, which is what we would resort to in tests.

This commit adjusts the forbidden rules to disallow "slow" MethodHandle invocations only in server code, not in tests.