### PR TITLE
Improve error message for index exclusions when multi-target syntax is used for index exclusion

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -450,11 +450,12 @@ public class IndexNameExpressionResolver {
         } else if (indexExpressions.length == 1) {
             if (indexExpressions[0].startsWith("-")) {
                 // this can arise when multi-target syntax is used with an exclusion not in the "inclusion" list, such as
-                // GET test1,test2,-test3
-                // the caller should have put GET test*,-test3
+                // "GET test1,test2,-test3"
+                // the caller should have put "GET test*,-test3"
                 infe = new IndexNotFoundException(
                     "if you intended to exclude this index, ensure that you use wildcards that include it before explicitly excluding it",
-                    indexExpressions[0]);
+                    indexExpressions[0]
+                );
             } else {
                 infe = new IndexNotFoundException(indexExpressions[0]);
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -448,7 +448,16 @@ public class IndexNameExpressionResolver {
             infe = new IndexNotFoundException("no indices exist", Metadata.ALL);
             infe.setResources("index_or_alias", Metadata.ALL);
         } else if (indexExpressions.length == 1) {
-            infe = new IndexNotFoundException(indexExpressions[0]);
+            if (indexExpressions[0].startsWith("-")) {
+                // this can arise when multi-target syntax is used with an exclusion not in the "inclusion" list, such as
+                // GET test1,test2,-test3
+                // the caller should have put GET test*,-test3
+                infe = new IndexNotFoundException(
+                    "if you intended to exclude this index, ensure that you use wildcards that include it before explicitly excluding it",
+                    indexExpressions[0]);
+            } else {
+                infe = new IndexNotFoundException(indexExpressions[0]);
+            }
             infe.setResources("index_or_alias", indexExpressions[0]);
         } else {
             infe = new IndexNotFoundException((String) null);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -435,6 +435,19 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         );
         assertThat(infe.getResourceId().toString(), equalTo("[-*]"));
 
+        infe = expectThrows(
+            IndexNotFoundException.class,
+            // throws error because "-foobar" was not covered by a wildcard that included it
+            () -> indexNameExpressionResolver.concreteIndexNames(context2, "bar", "hidden", "-foobar")
+        );
+        assertThat(
+            infe.getMessage(),
+            containsString(
+                "if you intended to exclude this index, ensure that you use wildcards that include it " + "before explicitly excluding it"
+            )
+        );
+        assertThat(infe.getResourceId().toString(), equalTo("[-foobar]"));
+
         // open and hidden
         options = IndicesOptions.fromOptions(false, true, true, false, true);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);


### PR DESCRIPTION
An index can be excluded after using a wildcard that includes it, such as `GET test*,-test3/_search`

But if a wildcard is not used, it throws an exception. For example `GET test1,test2,-test3/_search` results in:

    "type": "index_not_found_exception",
    "reason": "no such index [-test3]"

This commit changes the error message in this case to say:

    "type": "index_not_found_exception",
    "reason": "no such index [-test3] and if you intended to exclude this index, ensure that you use wildcards that include it before explicitly excluding it"

This error message also more closely matches a similar error when trying to exclude a cluster in a 
cross-cluster search: https://github.com/elastic/elasticsearch/pull/97865