### PR TITLE
Extract cold path from FrozenIndexInput

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -99,9 +99,15 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
         final long position = getAbsolutePosition();
         final int length = b.remaining();
         if (cacheFile.tryRead(b, position)) {
+            // fast-path succeeded, increment stats and return
             stats.addCachedBytesRead(length);
             return;
         }
+        readWithoutBlobCacheSlow(b, position, length);
+    }
+
+    // slow path for readWithoutBlobCache, extracted to a separate method to make the fast-path inline better
+    private void readWithoutBlobCacheSlow(ByteBuffer b, long position, int length) throws Exception {
         // Semaphore that, when all permits are acquired, ensures that async callbacks (such as those used by readCacheFile) are not
         // accessing the byte buffer anymore that was passed to readWithoutBlobCache
         // In particular, it's important to acquire all permits before adapting the ByteBuffer's offset

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -122,7 +122,9 @@ public abstract class MetadataCachingIndexInput extends BaseSearchableSnapshotIn
         final long position = getAbsolutePosition();
         final int length = b.remaining();
 
-        logger.trace("readInternal: read [{}-{}] ([{}] bytes) from [{}]", position, position + length, length, this);
+        if (logger.isTraceEnabled()) {
+            logger.trace("readInternal: read [{}-{}] ([{}] bytes) from [{}]", position, position + length, length, this);
+        }
 
         try {
             final ByteRange blobCacheByteRange = rangeToReadFromBlobCache(position, length);


### PR DESCRIPTION
Making use of some more of last-week's findings in frozen:
Just like we did in the search index input, we should have the fast-path in a small method so it inlines (hopefully) in scenarios like reading backwards in a file where this method is very hot. Also, profiling showed that allocating the boxed numbers for the trace call is a visible contributor to the cost of this method, so wrapping that call in a manual check.
