### PR TITLE
Add missing sync on indicesThatCannotBeCreated

### DIFF
--- a/docs/changelog/97869.yaml
+++ b/docs/changelog/97869.yaml
@@ -1,0 +1,5 @@
+pr: 97869
+summary: Add missing sync on `indicesThatCannotBeCreated`
+area: CRUD
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -318,8 +318,10 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                     @Override
                     public void onFailure(Exception e) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(e);
-                        if (cause instanceof IndexNotFoundException) {
-                            indicesThatCannotBeCreated.put(index, (IndexNotFoundException) cause);
+                        if (cause instanceof IndexNotFoundException indexNotFoundException) {
+                            synchronized (indicesThatCannotBeCreated) {
+                                indicesThatCannotBeCreated.put(index, indexNotFoundException);
+                            }
                         } else if ((cause instanceof ResourceAlreadyExistsException) == false) {
                             // fail all requests involving this index, if create didn't work
                             for (int i = 0; i < bulkRequest.requests.size(); i++) {


### PR DESCRIPTION
If auto-creating multiple indices then the responses may arrive
concurrently so we must properly synchronize modifications to the map of
exceptions. All the other accesses to this map are already properly
synchronized thanks to the `counter`.