### PR TITLE
TransportResponseHandler looks up executor itself

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/get/GetFromTranslogActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/get/GetFromTranslogActionIT.java
@@ -96,7 +96,7 @@ public class GetFromTranslogActionIT extends ESIntegTestCase {
             node,
             TransportGetFromTranslogAction.NAME,
             request,
-            new ActionListenerResponseHandler<>(response, Response::new, ThreadPool.Names.GET)
+            new ActionListenerResponseHandler<>(response, Response::new, transportService.getThreadPool().executor(ThreadPool.Names.GET))
         );
         return response.get();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/get/ShardMultiGetFomTranslogActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/get/ShardMultiGetFomTranslogActionIT.java
@@ -162,7 +162,11 @@ public class ShardMultiGetFomTranslogActionIT extends ESIntegTestCase {
             node,
             TransportShardMultiGetFomTranslogAction.NAME,
             request,
-            new ActionListenerResponseHandler<>(response, TransportShardMultiGetFomTranslogAction.Response::new, ThreadPool.Names.GET)
+            new ActionListenerResponseHandler<>(
+                response,
+                TransportShardMultiGetFomTranslogAction.Response::new,
+                transportService.getThreadPool().executor(ThreadPool.Names.GET)
+            )
         );
         return response.get();
     }

--- a/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
@@ -17,6 +18,7 @@ import org.elasticsearch.transport.TransportResponseHandler;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 
 /**
  * A simple base class for action response listeners, defaulting to using the SAME executor (as its
@@ -26,16 +28,16 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
 
     protected final ActionListener<? super Response> listener;
     private final Writeable.Reader<Response> reader;
-    private final String executor;
+    private final Executor executor;
 
-    public ActionListenerResponseHandler(ActionListener<? super Response> listener, Writeable.Reader<Response> reader, String executor) {
+    public ActionListenerResponseHandler(ActionListener<? super Response> listener, Writeable.Reader<Response> reader, Executor executor) {
         this.listener = Objects.requireNonNull(listener);
         this.reader = Objects.requireNonNull(reader);
         this.executor = Objects.requireNonNull(executor);
     }
 
     public ActionListenerResponseHandler(ActionListener<? super Response> listener, Writeable.Reader<Response> reader) {
-        this(listener, reader, ThreadPool.Names.SAME);
+        this(listener, reader, EsExecutors.DIRECT_EXECUTOR_SERVICE);
     }
 
     @Override
@@ -49,7 +51,7 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
     }
 
     @Override
-    public String executor() {
+    public Executor executor(ThreadPool threadPool) {
         return executor;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
@@ -122,7 +123,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
             GetTaskAction.NAME,
             nodeRequest,
             TransportRequestOptions.timeout(request.getTimeout()),
-            new ActionListenerResponseHandler<>(listener, GetTaskResponse::new, ThreadPool.Names.SAME)
+            new ActionListenerResponseHandler<>(listener, GetTaskResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 
 public class TransportShardRefreshAction extends TransportReplicationAction<
     BasicReplicationRequest,
@@ -43,6 +44,8 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
     public static final String NAME = RefreshAction.NAME + "[s]";
     public static final ActionType<ReplicationResponse> TYPE = new ActionType<>(NAME, ReplicationResponse::new);
     public static final String SOURCE_API = "api";
+
+    private final Executor refreshExecutor;
 
     @Inject
     public TransportShardRefreshAction(
@@ -69,6 +72,7 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
         );
         // registers the unpromotable version of shard refresh action
         new TransportUnpromotableShardRefreshAction(clusterService, transportService, shardStateAction, actionFilters, indicesService);
+        this.refreshExecutor = transportService.getThreadPool().executor(ThreadPool.Names.REFRESH);
     }
 
     @Override
@@ -129,11 +133,7 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
                     transportService.getLocalNode(),
                     TransportUnpromotableShardRefreshAction.NAME,
                     unpromotableReplicaRequest,
-                    new ActionListenerResponseHandler<>(
-                        listener.safeMap(r -> null),
-                        in -> ActionResponse.Empty.INSTANCE,
-                        ThreadPool.Names.REFRESH
-                    )
+                    new ActionListenerResponseHandler<>(listener.safeMap(r -> null), in -> ActionResponse.Empty.INSTANCE, refreshExecutor)
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -218,7 +218,7 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
                             );
                         }
                     }
-                }), TransportGetFromTranslogAction.Response::new, getExecutor(request, shardId))
+                }), TransportGetFromTranslogAction.Response::new, threadPool.executor(getExecutor(request, shardId)))
             );
         } else {
             // A non-real-time get with no explicit refresh requested.

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -213,7 +213,7 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
                             );
                         }
                     }
-                }), TransportShardMultiGetFomTranslogAction.Response::new, getExecutor(request, shardId))
+                }), TransportShardMultiGetFomTranslogAction.Response::new, threadPool.executor(getExecutor(request, shardId)))
             );
         } else {
             // A non-real-time mget with no explicit refresh requested.

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
@@ -29,6 +29,8 @@ import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.concurrent.Executor;
+
 public abstract class TransportBroadcastUnpromotableAction<Request extends BroadcastUnpromotableRequest> extends HandledTransportAction<
     Request,
     ActionResponse.Empty> {
@@ -38,7 +40,7 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
     protected final ShardStateAction shardStateAction;
 
     protected final String transportUnpromotableAction;
-    protected final String executor;
+    protected final Executor executor;
 
     protected TransportBroadcastUnpromotableAction(
         String actionName,
@@ -54,7 +56,7 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
         this.shardStateAction = shardStateAction;
         this.transportService = transportService;
         this.transportUnpromotableAction = actionName + "[u]";
-        this.executor = executor;
+        this.executor = transportService.getThreadPool().executor(executor);
 
         transportService.registerRequestHandler(transportUnpromotableAction, executor, requestReader, new UnpromotableTransportHandler());
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CleanableResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CleanableResponseHandler.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportResponse;
 
+import java.util.concurrent.Executor;
+
 /**
  * Combines an ActionListenerResponseHandler with an ActionListener.runAfter action, but with an explicit type so that tests that simulate
  * reboots can release resources without invoking the listener.
@@ -21,7 +23,7 @@ import org.elasticsearch.transport.TransportResponse;
 public class CleanableResponseHandler<T extends TransportResponse> extends ActionListenerResponseHandler<T> {
     private final Runnable cleanup;
 
-    public CleanableResponseHandler(ActionListener<? super T> listener, Writeable.Reader<T> reader, String executor, Runnable cleanup) {
+    public CleanableResponseHandler(ActionListener<? super T> listener, Writeable.Reader<T> reader, Executor executor, Runnable cleanup) {
         super(ActionListener.runAfter(listener, cleanup), reader, executor);
         this.cleanup = cleanup;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -54,6 +54,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -76,6 +77,7 @@ import java.util.stream.Collectors;
 public class CoordinationDiagnosticsService implements ClusterStateListener {
     private final ClusterService clusterService;
     private final TransportService transportService;
+    private final Executor clusterCoordinationExecutor;
     private final Coordinator coordinator;
     private final MasterHistoryService masterHistoryService;
     /**
@@ -171,6 +173,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
     ) {
         this.clusterService = clusterService;
         this.transportService = transportService;
+        this.clusterCoordinationExecutor = transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION);
         this.coordinator = coordinator;
         this.masterHistoryService = masterHistoryService;
         this.nodeHasMasterLookupTimeframe = NODE_HAS_MASTER_LOOKUP_TIMEFRAME_SETTING.get(clusterService.getSettings());
@@ -1112,7 +1115,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                     new ActionListenerResponseHandler<>(
                         ActionListener.runBefore(fetchRemoteResultListener, () -> Releasables.close(releasable)),
                         transportActionType.getResponseReader(),
-                        transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION)
+                        clusterCoordinationExecutor
                     )
                 );
             }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1112,7 +1112,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                     new ActionListenerResponseHandler<>(
                         ActionListener.runBefore(fetchRemoteResultListener, () -> Releasables.close(releasable)),
                         transportActionType.getResponseReader(),
-                        ThreadPool.Names.CLUSTER_COORDINATION
+                        transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION)
                     )
                 );
             }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -72,6 +73,7 @@ public class PublicationTransportHandler {
     public static final String PUBLISH_STATE_ACTION_NAME = "internal:cluster/coordination/publish_state";
 
     private final TransportService transportService;
+    private final Executor clusterCoordinationExecutor;
     private final NamedWriteableRegistry namedWriteableRegistry;
     private final Function<PublishRequest, PublishWithJoinResponse> handlePublishRequest;
 
@@ -97,6 +99,7 @@ public class PublicationTransportHandler {
         Function<PublishRequest, PublishWithJoinResponse> handlePublishRequest
     ) {
         this.transportService = transportService;
+        this.clusterCoordinationExecutor = transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION);
         this.namedWriteableRegistry = namedWriteableRegistry;
         this.handlePublishRequest = handlePublishRequest;
 
@@ -498,7 +501,7 @@ public class PublicationTransportHandler {
                 new BytesTransportRequest(bytes, connection.getTransportVersion()),
                 task,
                 STATE_REQUEST_OPTIONS,
-                new CleanableResponseHandler<>(listener, PublishWithJoinResponse::new, ThreadPool.Names.CLUSTER_COORDINATION, bytes::decRef)
+                new CleanableResponseHandler<>(listener, PublishWithJoinResponse::new, clusterCoordinationExecutor, bytes::decRef)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StatefulPreVoteCollector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StatefulPreVoteCollector.java
@@ -18,6 +18,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -25,6 +26,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongConsumer;
 
@@ -39,6 +41,7 @@ public class StatefulPreVoteCollector extends PreVoteCollector {
     public static final String REQUEST_PRE_VOTE_ACTION_NAME = "internal:cluster/request_pre_vote";
 
     private final TransportService transportService;
+    private final Executor clusterCoordinationExecutor;
     private final Runnable startElection;
     private final LongConsumer updateMaxTermSeen;
     private final ElectionStrategy electionStrategy;
@@ -53,6 +56,7 @@ public class StatefulPreVoteCollector extends PreVoteCollector {
         LeaderHeartbeatService leaderHeartbeatService
     ) {
         this.transportService = transportService;
+        this.clusterCoordinationExecutor = transportService.getThreadPool().executor(Names.CLUSTER_COORDINATION);
         this.startElection = startElection;
         this.updateMaxTermSeen = updateMaxTermSeen;
         this.electionStrategy = electionStrategy;
@@ -155,8 +159,8 @@ public class StatefulPreVoteCollector extends PreVoteCollector {
                         }
 
                         @Override
-                        public String executor() {
-                            return Names.CLUSTER_COORDINATION;
+                        public Executor executor(ThreadPool threadPool) {
+                            return clusterCoordinationExecutor;
                         }
 
                         @Override

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.index.IndexVersion;
@@ -93,7 +94,7 @@ public class LocalAllocateDangledIndices {
             masterNode,
             ACTION_NAME,
             request,
-            new ActionListenerResponseHandler<>(listener, AllocateDangledResponse::new, ThreadPool.Names.SAME)
+            new ActionListenerResponseHandler<>(listener, AllocateDangledResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -64,6 +64,7 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -828,9 +829,9 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         }
 
         @Override
-        public String executor() {
+        public Executor executor(ThreadPool threadPool) {
             // we do some heavy work like refreshes in the response so fork off to the generic threadpool
-            return ThreadPool.Names.GENERIC;
+            return threadPool.generic();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -146,7 +146,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
             PeerRecoveryTargetService.Actions.HANDOFF_PRIMARY_CONTEXT,
             new RecoveryHandoffPrimaryContextRequest(recoveryId, shardId, primaryContext),
             standardTimeoutRequestOptions,
-            new ActionListenerResponseHandler<>(listener.map(r -> null), in -> TransportResponse.Empty.INSTANCE, ThreadPool.Names.GENERIC)
+            new ActionListenerResponseHandler<>(listener.map(r -> null), in -> TransportResponse.Empty.INSTANCE, threadPool.generic())
         );
     }
 
@@ -348,7 +348,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
                         new ActionListenerResponseHandler<>(
                             ActionListener.runBefore(listener, request::decRef),
                             reader,
-                            ThreadPool.Names.GENERIC
+                            threadPool.generic()
                         )
                     );
                 } else {

--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
@@ -90,7 +91,7 @@ public class VerifyNodeRepositoryAction {
                     node,
                     ACTION_NAME,
                     new VerifyNodeRepositoryRequest(repository, verificationToken),
-                    new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                    new EmptyTransportResponseHandler(EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                         @Override
                         public void handleResponse(TransportResponse.Empty response) {
                             if (counter.decrementAndGet() == 0) {

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
@@ -181,7 +182,7 @@ public class TaskCancellationService {
                 BAN_PARENT_ACTION_NAME,
                 banRequest,
                 TransportRequestOptions.EMPTY,
-                new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                new EmptyTransportResponseHandler(EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                     @Override
                     public void handleResponse(TransportResponse.Empty response) {
                         logger.trace("sent ban for tasks with the parent [{}] for connection [{}]", taskId, connection);
@@ -228,7 +229,7 @@ public class TaskCancellationService {
                 BAN_PARENT_ACTION_NAME,
                 request,
                 TransportRequestOptions.EMPTY,
-                new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                new EmptyTransportResponseHandler(EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                     @Override
                     public void handleException(TransportException exp) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(exp);

--- a/server/src/main/java/org/elasticsearch/transport/EmptyTransportResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/EmptyTransportResponseHandler.java
@@ -9,15 +9,20 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.Executor;
 
 public class EmptyTransportResponseHandler implements TransportResponseHandler<TransportResponse.Empty> {
 
-    public static final EmptyTransportResponseHandler INSTANCE_SAME = new EmptyTransportResponseHandler(ThreadPool.Names.SAME);
+    public static final EmptyTransportResponseHandler INSTANCE_SAME = new EmptyTransportResponseHandler(
+        EsExecutors.DIRECT_EXECUTOR_SERVICE
+    );
 
-    private final String executor;
+    private final Executor executor;
 
-    public EmptyTransportResponseHandler(String executor) {
+    public EmptyTransportResponseHandler(Executor executor) {
         this.executor = executor;
     }
 
@@ -33,7 +38,7 @@ public class EmptyTransportResponseHandler implements TransportResponseHandler<T
     public void handleException(TransportException exp) {}
 
     @Override
-    public String executor() {
+    public Executor executor(ThreadPool threadPool) {
         return executor;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/ForkingResponseHandlerRunnable.java
+++ b/server/src/main/java/org/elasticsearch/transport/ForkingResponseHandlerRunnable.java
@@ -11,6 +11,7 @@ package org.elasticsearch.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -29,8 +30,12 @@ abstract class ForkingResponseHandlerRunnable extends AbstractRunnable {
     @Nullable
     private final TransportException transportException;
 
-    ForkingResponseHandlerRunnable(TransportResponseHandler<?> handler, @Nullable TransportException transportException) {
-        assert handler.executor().equals(ThreadPool.Names.SAME) == false : "forking handler required, but got " + handler;
+    ForkingResponseHandlerRunnable(
+        TransportResponseHandler<?> handler,
+        @Nullable TransportException transportException,
+        ThreadPool threadPool
+    ) {
+        assert handler.executor(threadPool) != EsExecutors.DIRECT_EXECUTOR_SERVICE : "forking handler required, but got " + handler;
         this.handler = handler;
         this.transportException = transportException;
     }

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -470,8 +471,8 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
         }
 
         @Override
-        public String executor() {
-            return ThreadPool.Names.MANAGEMENT;
+        public Executor executor(ThreadPool threadPool) {
+            return threadPool.executor(ThreadPool.Names.MANAGEMENT);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -124,6 +124,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
     private final Predicate<DiscoveryNode> nodePredicate;
     private final SetOnce<ClusterName> remoteClusterName = new SetOnce<>();
     private final String proxyAddress;
+    private final Executor managementExecutor;
 
     SniffConnectionStrategy(
         String clusterAlias,
@@ -185,6 +186,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
         this.nodePredicate = nodePredicate;
         this.configuredSeedNodes = configuredSeedNodes;
         this.seedNodes = seedNodes;
+        this.managementExecutor = transportService.getThreadPool().executor(ThreadPool.Names.MANAGEMENT);
     }
 
     static Stream<Setting.AffixSetting<?>> enablementSettings() {
@@ -472,7 +474,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
 
         @Override
         public Executor executor(ThreadPool threadPool) {
-            return threadPool.executor(ThreadPool.Names.MANAGEMENT);
+            return managementExecutor;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportResponseHandler.java
@@ -10,7 +10,10 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.Executor;
 
 public interface TransportResponseHandler<T extends TransportResponse> extends Writeable.Reader<T> {
 
@@ -18,8 +21,8 @@ public interface TransportResponseHandler<T extends TransportResponse> extends W
 
     void handleException(TransportException exp);
 
-    default String executor() {
-        return ThreadPool.Names.SAME;
+    default Executor executor(ThreadPool threadPool) {
+        return EsExecutors.DIRECT_EXECUTOR_SERVICE;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Booleans;
@@ -56,6 +57,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -378,11 +380,11 @@ public class TransportService extends AbstractLifecycleComponent
                         holderToNotify.action(),
                         new NodeClosedException(localNode)
                     );
-                    final var executor = handler.executor();
-                    if (executor.equals(ThreadPool.Names.SAME)) {
+                    final var executor = handler.executor(threadPool);
+                    if (executor == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                         handler.handleException(exception);
                     } else {
-                        threadPool.executor(executor).execute(new ForkingResponseHandlerRunnable(handler, exception) {
+                        executor.execute(new ForkingResponseHandlerRunnable(handler, exception, threadPool) {
                             @Override
                             protected void doRun() {
                                 handler.handleException(exception);
@@ -597,7 +599,7 @@ public class TransportService extends AbstractLifecycleComponent
                 } else {
                     l.onResponse(response);
                 }
-            }), HandshakeResponse::new, ThreadPool.Names.GENERIC)
+            }), HandshakeResponse::new, threadPool.generic())
         );
     }
 
@@ -1421,8 +1423,8 @@ public class TransportService extends AbstractLifecycleComponent
         }
 
         @Override
-        public String executor() {
-            return delegate.executor();
+        public Executor executor(ThreadPool threadPool) {
+            return delegate.executor(threadPool);
         }
 
         @Override
@@ -1474,12 +1476,12 @@ public class TransportService extends AbstractLifecycleComponent
                         // handler already completed, likely by a timeout which is logged elsewhere
                         return;
                     }
-                    final String executor = handler.executor();
-                    if (ThreadPool.Names.SAME.equals(executor)) {
+                    final var executor = handler.executor(threadPool);
+                    if (executor == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                         processResponse(handler, response);
                     } else {
                         response.incRef();
-                        threadPool.executor(executor).execute(new ForkingResponseHandlerRunnable(handler, null) {
+                        executor.execute(new ForkingResponseHandlerRunnable(handler, null, threadPool) {
                             @Override
                             protected void doRun() {
                                 processResponse(handler, response);
@@ -1525,11 +1527,11 @@ public class TransportService extends AbstractLifecycleComponent
                     return;
                 }
                 final RemoteTransportException rtx = wrapInRemote(exception);
-                final String executor = handler.executor();
-                if (ThreadPool.Names.SAME.equals(executor)) {
+                final var executor = handler.executor(threadPool);
+                if (executor == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                     processException(handler, rtx);
                 } else {
-                    threadPool.executor(executor).execute(new ForkingResponseHandlerRunnable(handler, rtx) {
+                    executor.execute(new ForkingResponseHandlerRunnable(handler, rtx, threadPool) {
                         @Override
                         protected void doRun() {
                             processException(handler, rtx);
@@ -1703,8 +1705,8 @@ public class TransportService extends AbstractLifecycleComponent
         }
 
         @Override
-        public String executor() {
-            return handler.executor();
+        public Executor executor(ThreadPool threadPool) {
+            return handler.executor(threadPool);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -84,7 +85,7 @@ public class TransportCreateIndexActionTests extends ESTestCase {
         this.action = new TransportCreateIndexAction(
             mock(TransportService.class),
             mock(ClusterService.class),
-            null,
+            mock(ThreadPool.class),
             metadataCreateIndexService,
             mock(ActionFilters.class),
             indexNameExpressionResolver,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -70,7 +71,7 @@ public class TransportUpdateSettingsActionTests extends ESTestCase {
         this.action = new TransportUpdateSettingsAction(
             mock(TransportService.class),
             mock(ClusterService.class),
-            null,
+            mock(ThreadPool.class),
             metadataUpdateSettingsService,
             mock(ActionFilters.class),
             indexNameExpressionResolver,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.reservedstate.ActionWithReservedState;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
 import org.elasticsearch.reservedstate.TransformState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParseException;
@@ -675,7 +676,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var putIndexAction = new TransportPutComposableIndexTemplateAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             null,
             mock(ActionFilters.class),
             null
@@ -688,7 +689,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var delIndexAction = new TransportDeleteComposableIndexTemplateAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             null,
             mock(ActionFilters.class),
             null
@@ -702,7 +703,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var putComponentAction = new TransportPutComponentTemplateAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             null,
             mock(ActionFilters.class),
             null,
@@ -717,7 +718,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var delComponentAction = new TransportDeleteComponentTemplateAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             null,
             mock(ActionFilters.class),
             null
@@ -923,7 +924,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         var putTemplateAction = new TransportPutComposableIndexTemplateAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             null,
             mock(ActionFilters.class),
             null

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceTests.java
@@ -1363,6 +1363,7 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
         Coordinator coordinator = mock(Coordinator.class);
         when(coordinator.getFoundPeers()).thenReturn(Collections.emptyList());
         TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
         return new CoordinationDiagnosticsService(clusterService, transportService, coordinator, masterHistoryService);
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.MockTransport;
-import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ReceiveTimeoutTransportException;
@@ -38,6 +38,7 @@ import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -568,8 +569,8 @@ public class LeaderCheckerTests extends ESTestCase {
         }
 
         @Override
-        public String executor() {
-            return Names.GENERIC;
+        public Executor executor(ThreadPool threadPool) {
+            return threadPool.generic();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -86,6 +86,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         Transport.Connection connection = mock(Transport.Connection.class);
         when(connection.getTransportVersion()).thenReturn(TransportVersion.current());
         when(transportService.getConnection(any())).thenReturn(connection);
+        when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
 
         final PublicationTransportHandler handler = new PublicationTransportHandler(transportService, writableRegistry(), pu -> null);
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -301,6 +301,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
         Coordinator coordinator = mock(Coordinator.class);
         when(coordinator.getFoundPeers()).thenReturn(Collections.emptyList());
         TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
         return new StableMasterHealthIndicatorService(
             new CoordinationDiagnosticsService(clusterService, transportService, coordinator, masterHistoryService),
             clusterService

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Random;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -85,8 +86,8 @@ public class TransportServiceLifecycleTests extends ESTestCase {
                                     }
 
                                     @Override
-                                    public String executor() {
-                                        return executor;
+                                    public Executor executor(ThreadPool threadPool) {
+                                        return threadPool.executor(executor);
                                     }
                                 }
                             );

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/TransportWriteActionTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/TransportWriteActionTestHelper.java
@@ -11,11 +11,13 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.concurrent.CountDownLatch;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class TransportWriteActionTestHelper {
 
@@ -37,13 +39,17 @@ public abstract class TransportWriteActionTestHelper {
                 throw new AssertionError(ex);
             }
         };
+
+        final var threadpool = mock(ThreadPool.class);
+        final var transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadpool);
         new TransportWriteAction.AsyncAfterWriteAction(
             indexShard,
             request,
             location,
             writerResult,
             logger,
-            new PostWriteRefresh(mock(TransportService.class)),
+            new PostWriteRefresh(transportService),
             null
         ).run();
         try {

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -101,6 +101,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase {
 
@@ -1053,6 +1054,9 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         IndexShard primary,
         ResyncReplicationRequest request
     ) {
+        final var threadpool = mock(ThreadPool.class);
+        final var transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadpool);
         final TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> result =
             new TransportWriteAction.WritePrimaryResult<>(
                 TransportResyncReplicationAction.performOnPrimary(request),
@@ -1061,7 +1065,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                 primary,
                 logger,
                 // TODO: Fix
-                new PostWriteRefresh(mock(TransportService.class))
+                new PostWriteRefresh(transportService)
 
             );
         TransportWriteActionTestHelper.performPostWriteActions(primary, request, result.location, logger);

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
@@ -81,6 +82,7 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -335,8 +337,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -366,8 +368,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
-            public String executor() {
-                return ThreadPool.Names.GENERIC;
+            public Executor executor(ThreadPool threadPool) {
+                return threadPool.generic();
             }
 
             @Override
@@ -418,8 +420,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
-            public String executor() {
-                return executor;
+            public Executor executor(ThreadPool threadPool) {
+                return threadPool.executor(executor);
             }
 
             @Override
@@ -492,8 +494,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
             }
         );
@@ -670,8 +672,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     }
 
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.GENERIC;
+                    public Executor executor(ThreadPool threadPool) {
+                        return threadPool.generic();
                     }
 
                     @Override
@@ -727,8 +729,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     }
 
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.GENERIC;
+                    public Executor executor(ThreadPool threadPool) {
+                        return threadPool.generic();
                     }
 
                     @Override
@@ -783,8 +785,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -847,8 +849,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -1075,8 +1077,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -1142,8 +1144,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -1181,8 +1183,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     }
 
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.GENERIC;
+                    public Executor executor(ThreadPool threadPool) {
+                        return threadPool.generic();
                     }
 
                     @Override
@@ -1746,8 +1748,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -1803,8 +1805,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 }
 
                 @Override
-                public String executor() {
-                    return ThreadPool.Names.GENERIC;
+                public Executor executor(ThreadPool threadPool) {
+                    return threadPool.generic();
                 }
 
                 @Override
@@ -2054,7 +2056,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                         TransportRequestOptions.EMPTY,
                         new TransportResponseHandler<TestResponse>() {
 
-                            private final String executor = randomBoolean() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC;
+                            private final Executor executor = randomBoolean()
+                                ? EsExecutors.DIRECT_EXECUTOR_SERVICE
+                                : service.getThreadPool().generic();
 
                             @Override
                             public TestResponse read(StreamInput in) throws IOException {
@@ -2086,7 +2090,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                             }
 
                             @Override
-                            public String executor() {
+                            public Executor executor(ThreadPool threadPool) {
                                 return executor;
                             }
                         }
@@ -2149,8 +2153,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
-            public String executor() {
-                return executor;
+            public Executor executor(ThreadPool threadPool) {
+                return threadPool.executor(executor);
             }
         }
 
@@ -2453,8 +2457,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
-            public String executor() {
-                return executor;
+            public Executor executor(ThreadPool threadPool) {
+                return threadPool.executor(executor);
             }
         };
 
@@ -2501,8 +2505,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
 
             @Override
-            public String executor() {
-                return randomFrom(executors);
+            public Executor executor(ThreadPool threadPool) {
+                return threadPool.executor(randomFrom(executors));
             }
         };
         ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
@@ -3360,7 +3364,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final TransportResponseHandler<T> futureHandler = new ActionListenerResponseHandler<>(
             responseListener,
             handler,
-            handler.executor()
+            handler.executor(transportService.threadPool)
         );
         responseListener.addListener(ActionListener.wrap(handler::handleResponse, e -> handler.handleException((TransportException) e)));
         final PlainActionFuture<T> future = PlainActionFuture.newFuture();

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
@@ -537,7 +538,7 @@ public class DisruptableMockTransportTests extends ESTestCase {
                     new CleanableResponseHandler<>(
                         ActionListener.running(() -> assertFalse(responseHandlerCalled.getAndSet(true))),
                         TestResponse::new,
-                        ThreadPool.Names.SAME,
+                        EsExecutors.DIRECT_EXECUTOR_SERVICE,
                         () -> assertFalse(responseHandlerReleased.getAndSet(true))
                     )
                 );

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
@@ -64,7 +65,7 @@ public class AnalyticsInfoTransportActionTests extends ESTestCase {
         AnalyticsUsageTransportAction usageAction = new AnalyticsUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             client
@@ -90,7 +91,7 @@ public class AnalyticsInfoTransportActionTests extends ESTestCase {
         AnalyticsUsageTransportAction usageAction = new AnalyticsUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             client

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncSearchAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -85,7 +86,7 @@ public class TransportGetAsyncSearchAction extends HandledTransportAction<GetAsy
                 node,
                 GetAsyncSearchAction.NAME,
                 request,
-                new ActionListenerResponseHandler<>(listener, AsyncSearchResponse::new, ThreadPool.Names.SAME)
+                new ActionListenerResponseHandler<>(listener, AsyncSearchResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
             );
         }
     }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -80,7 +81,7 @@ public class TransportGetAsyncStatusAction extends HandledTransportAction<GetAsy
                 node,
                 GetAsyncStatusAction.NAME,
                 request,
-                new ActionListenerResponseHandler<>(listener, AsyncStatusResponse::new, ThreadPool.Names.SAME)
+                new ActionListenerResponseHandler<>(listener, AsyncStatusResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
             );
         }
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRInfoTransportActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRInfoTransportActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
@@ -139,7 +140,7 @@ public class CCRInfoTransportActionTests extends ESTestCase {
         var usageAction = new CCRUsageTransportAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             Settings.EMPTY,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.ccr.CcrSettings;
 import org.elasticsearch.xpack.ccr.index.engine.FollowingEngineFactory;
@@ -36,6 +37,7 @@ import static java.util.Collections.emptySet;
 import static org.elasticsearch.xpack.ccr.action.bulk.TransportBulkShardOperationsAction.rewriteOperationWithPrimaryTerm;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BulkShardOperationsTests extends IndexShardTestCase {
 
@@ -66,6 +68,9 @@ public class BulkShardOperationsTests extends IndexShardTestCase {
             }
         }
 
+        final var threadpool = mock(ThreadPool.class);
+        final var transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadpool);
         final TransportWriteAction.WritePrimaryResult<BulkShardOperationsRequest, BulkShardOperationsResponse> result =
             TransportBulkShardOperationsAction.shardOperationOnPrimary(
                 followerPrimary.shardId(),
@@ -74,7 +79,7 @@ public class BulkShardOperationsTests extends IndexShardTestCase {
                 numOps - 1,
                 followerPrimary,
                 logger,
-                new PostWriteRefresh(mock(TransportService.class))
+                new PostWriteRefresh(transportService)
             );
 
         boolean accessStats = randomBoolean();
@@ -129,6 +134,9 @@ public class BulkShardOperationsTests extends IndexShardTestCase {
         Randomness.shuffle(firstBulk);
         Randomness.shuffle(secondBulk);
         oldPrimary.advanceMaxSeqNoOfUpdatesOrDeletes(seqno);
+        final var threadpool = mock(ThreadPool.class);
+        final var transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadpool);
         final TransportWriteAction.WritePrimaryResult<BulkShardOperationsRequest, BulkShardOperationsResponse> fullResult =
             TransportBulkShardOperationsAction.shardOperationOnPrimary(
                 oldPrimary.shardId(),
@@ -137,7 +145,7 @@ public class BulkShardOperationsTests extends IndexShardTestCase {
                 seqno,
                 oldPrimary,
                 logger,
-                new PostWriteRefresh(mock(TransportService.class))
+                new PostWriteRefresh(transportService)
             );
         assertThat(
             fullResult.replicaRequest().getOperations(),
@@ -164,7 +172,7 @@ public class BulkShardOperationsTests extends IndexShardTestCase {
                 seqno,
                 newPrimary,
                 logger,
-                new PostWriteRefresh(mock(TransportService.class))
+                new PostWriteRefresh(transportService)
             );
         final long newPrimaryTerm = newPrimary.getOperationPrimaryTerm();
         final long globalCheckpoint = newPrimary.getLastKnownGlobalCheckpoint();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -68,7 +69,7 @@ public class TransportDeleteAsyncResultAction extends HandledTransportAction<Del
                 node,
                 DeleteAsyncResultAction.NAME,
                 request,
-                new ActionListenerResponseHandler<>(listener, AcknowledgedResponse::readFrom, ThreadPool.Names.SAME)
+                new ActionListenerResponseHandler<>(listener, AcknowledgedResponse::readFrom, EsExecutors.DIRECT_EXECUTOR_SERVICE)
             );
         }
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -248,7 +249,7 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
                     node,
                     EqlSearchAction.NAME,
                     request,
-                    new ActionListenerResponseHandler<>(listener, EqlSearchResponse::new, ThreadPool.Names.SAME)
+                    new ActionListenerResponseHandler<>(listener, EqlSearchResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
                 ),
                 log
             );

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlInfoTransportActionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlInfoTransportActionTests.java
@@ -96,7 +96,7 @@ public class EqlInfoTransportActionTests extends ESTestCase {
         var usageAction = new EqlUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             client

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphInfoTransportActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphInfoTransportActionTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
@@ -45,7 +46,7 @@ public class GraphInfoTransportActionTests extends ESTestCase {
         var usageAction = new GraphUsageTransportAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             Settings.EMPTY,
@@ -83,7 +84,7 @@ public class GraphInfoTransportActionTests extends ESTestCase {
         GraphUsageTransportAction usageAction = new GraphUsageTransportAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             settings.build(),

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInfoTransportActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInfoTransportActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage;
@@ -93,7 +94,13 @@ public class IndexLifecycleInfoTransportActionTests extends ESTestCase {
         ClusterState clusterState = buildClusterState(policies, indexPolicies);
         Mockito.when(clusterService.state()).thenReturn(clusterState);
 
-        var usageAction = new IndexLifecycleUsageTransportAction(mock(TransportService.class), null, null, mock(ActionFilters.class), null);
+        var usageAction = new IndexLifecycleUsageTransportAction(
+            mock(TransportService.class),
+            null,
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            null
+        );
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, clusterState, future);
         IndexLifecycleFeatureSetUsage ilmUsage = (IndexLifecycleFeatureSetUsage) future.get().getUsage();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
@@ -298,7 +298,7 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
         );
 
         TypedChainTaskExecutor<PersistentTask<?>> chainTaskExecutor = new TypedChainTaskExecutor<>(
-            client.threadPool().executor(executor),
+            executor,
             r -> true,
             // Another process could modify tasks and thus we cannot find them via the allocation_id and name
             // If the task was removed from the node, all is well
@@ -328,7 +328,7 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
 
         logger.info("Isolating datafeeds: " + datafeedsToIsolate.toString());
         TypedChainTaskExecutor<IsolateDatafeedAction.Response> isolateDatafeedsExecutor = new TypedChainTaskExecutor<>(
-            client.threadPool().executor(executor),
+            executor,
             r -> true,
             ex -> true
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/TypedChainTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/TypedChainTaskExecutor.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 
 /**
@@ -27,7 +27,7 @@ public class TypedChainTaskExecutor<T> {
         void run(ActionListener<T> listener);
     }
 
-    private final ExecutorService executorService;
+    private final Executor executorService;
     private final LinkedList<ChainTask<T>> tasks = new LinkedList<>();
     private final Predicate<Exception> failureShortCircuitPredicate;
     private final Predicate<T> continuationPredicate;
@@ -48,7 +48,7 @@ public class TypedChainTaskExecutor<T> {
      *                                     called.
      */
     public TypedChainTaskExecutor(
-        ExecutorService executorService,
+        Executor executorService,
         Predicate<T> continuationPredicate,
         Predicate<Exception> failureShortCircuitPredicate
     ) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -148,7 +148,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         return new MachineLearningUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             TestEnvironment.newEnvironment(settings),

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringInfoTransportActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringInfoTransportActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.rest.ObjectPath;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -96,7 +97,7 @@ public class MonitoringInfoTransportActionTests extends ESTestCase {
         var usageAction = new MonitoringUsageTransportAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             new MonitoringUsageServices(monitoring, exporters)

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -107,7 +108,7 @@ public abstract class AbstractTransportQlAsyncGetResultsAction<Response extends 
                 node,
                 actionName,
                 request,
-                new ActionListenerResponseHandler<>(listener, responseReader(), ThreadPool.Names.SAME)
+                new ActionListenerResponseHandler<>(listener, responseReader(), EsExecutors.DIRECT_EXECUTOR_SERVICE)
             );
         }
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetStatusAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetStatusAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -89,7 +90,7 @@ public abstract class AbstractTransportQlAsyncGetStatusAction<
                 node,
                 actionName,
                 request,
-                new ActionListenerResponseHandler<>(listener, QlStatusResponse::new, ThreadPool.Names.SAME)
+                new ActionListenerResponseHandler<>(listener, QlStatusResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
             );
         }
     }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupInfoTransportActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupInfoTransportActionTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
@@ -34,7 +35,13 @@ public class RollupInfoTransportActionTests extends ESTestCase {
     }
 
     public void testUsage() throws ExecutionException, InterruptedException, IOException {
-        var usageAction = new RollupUsageTransportAction(mock(TransportService.class), null, null, mock(ActionFilters.class), null);
+        var usageAction = new RollupUsageTransportAction(
+            mock(TransportService.class),
+            null,
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            null
+        );
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, null, future);
         XPackFeatureSet.Usage rollupUsage = future.get().getUsage();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
@@ -376,7 +377,7 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
         return new SecurityUsageTransportAction(
             mock(TransportService.class),
             null,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             settings,

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialInfoTransportActionTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialInfoTransportActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
@@ -61,7 +62,7 @@ public class SpatialInfoTransportActionTests extends ESTestCase {
         var usageAction = new SpatialUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             mockClient()
@@ -86,7 +87,7 @@ public class SpatialInfoTransportActionTests extends ESTestCase {
         SpatialUsageTransportAction usageAction = new SpatialUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             mockClient()

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -173,7 +174,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
                     node,
                     SqlQueryAction.NAME,
                     request,
-                    new ActionListenerResponseHandler<>(listener, SqlQueryResponse::new, ThreadPool.Names.SAME)
+                    new ActionListenerResponseHandler<>(listener, SqlQueryResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
                 ),
                 log
             );

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlInfoTransportActionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlInfoTransportActionTests.java
@@ -98,7 +98,7 @@ public class SqlInfoTransportActionTests extends ESTestCase {
         var usageAction = new SqlUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             licenseState,

--- a/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePlugin.java
+++ b/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePlugin.java
@@ -56,6 +56,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -222,8 +223,8 @@ public class VotingOnlyNodePlugin extends Plugin implements ClusterCoordinationP
                         }
 
                         @Override
-                        public String executor() {
-                            return handler.executor();
+                        public Executor executor(ThreadPool threadPool) {
+                            return handler.executor(threadPool);
                         }
 
                         @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
@@ -132,7 +132,7 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
         var usageAction = new WatcherUsageTransportAction(
             mock(TransportService.class),
             clusterService,
-            null,
+            mock(ThreadPool.class),
             mock(ActionFilters.class),
             null,
             Settings.EMPTY,


### PR DESCRIPTION
Today `TransportResponseHandler` returns the name of the executor, to be looked
up later in the `ThreadPool`. In fact most implementations can supply their
executor directly, avoiding the lookup, and this API change allows the handler
to choose to use an executor which does not belong to the `ThreadPool` too.