### PR TITLE
[Fleet] Specify individual rules for Fleet indices

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -95,10 +95,10 @@ GET /_security/service/elastic/fleet-server
           "allow_restricted_indices": false
         },
         {
-          "names" : [
+          "names": [
             "traces-apm.sampled-*"
           ],
-          "privileges" : [
+          "privileges": [
             "read",
             "monitor",
             "maintenance"
@@ -110,13 +110,97 @@ GET /_security/service/elastic/fleet-server
             ".fleet-secrets*"
           ],
           "privileges": [
-            "read",
+            "read"
           ],
           "allow_restricted_indices": true
         },
         {
           "names": [
-            ".fleet-*"
+            ".fleet-actions*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            ".fleet-agents*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            ".fleet-artifacts*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            ".fleet-enrollment-api-keys*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            ".fleet-policies*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            ".fleet-policies-leader*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            ".fleet-servers*"
           ],
           "privileges": [
             "read",
@@ -143,11 +227,11 @@ GET /_security/service/elastic/fleet-server
       ],
       "applications": [
         {
-          "application" : "kibana-*",
-          "privileges" : [
+          "application": "kibana-*",
+          "privileges": [
             "reserved_fleet-setup"
           ],
-          "resources" : [
+          "resources": [
             "*"
           ]
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -147,11 +147,7 @@ class KibanaOwnedReservedRoleDescriptors {
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".fleet-agents*")
-                    .privileges("all")
-                    .allowRestrictedIndices(true)
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".fleet-agents*").privileges("all").allowRestrictedIndices(true).build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-artifacts*")
                     .privileges("all")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -135,16 +135,48 @@ class KibanaOwnedReservedRoleDescriptors {
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry
                 RoleDescriptor.IndicesPrivileges.builder().indices(".logs-endpoint.diagnostic.collection-*").privileges("read").build(),
-                // Fleet secrets, Kibana can only write to this index.
-                // This definition must come before .fleet* below.
+                // Fleet secrets. Kibana can only write to this index.
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-secrets*")
                     .privileges("write", "delete", "create_index")
                     .allowRestrictedIndices(true)
                     .build(),
-                // Fleet Server indices. Kibana create this indice before Fleet Server use them.
-                // Fleet Server indices. Kibana read and write to this indice to manage Elastic Agents
-                RoleDescriptor.IndicesPrivileges.builder().indices(".fleet*").allowRestrictedIndices(true).privileges("all").build(),
+                // Other Fleet indices. Kibana reads and writes to these indices to manage Elastic Agents.
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-actions*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-agents*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-artifacts*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-enrollment-api-keys*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-policies*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-policies-leader*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-servers*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
                 // Fleet telemetry queries Agent Logs indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-elastic_agent*").privileges("read").build(),
                 // Legacy "Alerts as data" used in Security Solution.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -748,7 +748,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         });
 
         Arrays.asList(
-            ".fleet",
             ".fleet-agents",
             ".fleet-actions",
             ".fleet-enrollment-api-keys",
@@ -756,6 +755,18 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".fleet-actions-results",
             ".fleet-servers"
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
+
+        final IndexAbstraction dotFleetSecretsIndex = mockIndexAbstraction(".fleet-secrets");
+        assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(dotFleetSecretsIndex), is(false));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(dotFleetSecretsIndex), is(false));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(GetIndexAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(IndexAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(GetAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(dotFleetSecretsIndex), is(false));
 
         // read-only indices for Fleet telemetry
         Arrays.asList("logs-elastic_agent-default", "logs-elastic_agent.fleet_server-default").forEach((index) -> {

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -135,7 +135,91 @@ public class ServiceAccountIT extends ESRestTestCase {
                 },
                 {
                   "names": [
-                    ".fleet-*"
+                    ".fleet-actions*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    ".fleet-agents*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    ".fleet-artifacts*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    ".fleet-enrollment-api-keys*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    ".fleet-policies*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    ".fleet-policies-leader*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    ".fleet-servers*"
                   ],
                   "privileges": [
                     "read",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -84,14 +84,45 @@ final class ElasticServiceAccounts {
                     .indices("traces-apm.sampled-*")
                     .privileges("read", "monitor", "maintenance")
                     .build(),
+                // Fleet secrets. Fleet Server can only read from this index.
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-secrets*")
                     .privileges("read")
                     .allowRestrictedIndices(true)
                     .build(),
+                // Other Fleet indices. Fleet Server needs "maintenance" privilege to be able to perform operations with "refresh".
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".fleet-*")
-                    // Fleet Server needs "maintenance" privilege to be able to perform operations with "refresh"
+                    .indices(".fleet-actions*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-agents*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-artifacts*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-enrollment-api-keys*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-policies*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-policies-leader*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-servers*")
                     .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
                     .allowRestrictedIndices(true)
                     .build(),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -238,8 +238,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         });
 
         List.of(
-            ".fleet-" + randomAlphaOfLengthBetween(1, 20),
-            ".fleet-action" + randomAlphaOfLengthBetween(1, 20),
+            ".fleet-actions" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-agents" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-enrollment-api-keys" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-policies" + randomAlphaOfLengthBetween(1, 20),
@@ -262,6 +261,20 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             assertThat(role.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(dotFleetIndex), is(false));
             assertThat(role.indices().allowedIndicesMatcher("indices:foo").test(dotFleetIndex), is(false));
         });
+
+        final IndexAbstraction dotFleetSecretsIndex = mockIndexAbstraction(".fleet-secrets" + randomAlphaOfLengthBetween(1, 20));
+        assertThat(role.indices().allowedIndicesMatcher(DeleteAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(IndexAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(BulkAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(GetAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(MultiGetAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(SearchAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(dotFleetSecretsIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(IndicesStatsAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(dotFleetSecretsIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher("indices:foo").test(dotFleetSecretsIndex), is(false));
 
         final IndexAbstraction apmSampledTracesIndex = mockIndexAbstraction("traces-apm.sampled-" + randomAlphaOfLengthBetween(1, 20));
         assertThat(role.indices().allowedIndicesMatcher(DeleteAction.NAME).test(apmSampledTracesIndex), is(true));


### PR DESCRIPTION
### Context

Fleet team is currently implementing phase 1 of storing Fleet secrets ([meta issue](https://github.com/elastic/ingest-dev/issues/1000), [phase 1 issue](https://github.com/elastic/kibana/issues/154715)), where a a new system index was created to store the secrets (cf. [this schema](https://user-images.githubusercontent.com/1813008/218431667-079a6ca8-b046-4a88-b085-4ac522c33e9e.png)).

The access expectations are as follows:
   - Kibana system should only have write and delete access, NOT read access.
   - Fleet server should have read access only.

The `.fleet-secrets` system index was added in https://github.com/elastic/elasticsearch/pull/95625; delete privilege was added in https://github.com/elastic/elasticsearch/pull/96080.

Upon testing, Mark found out that the `kibana_system` user has all privileges on `.fleet-*` indices, thus breaking the requirements; the initial proposed fixed was to rename the index to `.secrets-fleet` in https://github.com/elastic/elasticsearch/pull/96172. Following discussion on this PR, an alternative approach was decided that will allow better clarity on the different Fleet-related system indices as well as introducing fine-grained access to `.fleet-secrets`:
1. Break down access rules for each individual index (cf. [this comment](https://github.com/elastic/elasticsearch/pull/96172#issuecomment-1551180846)). This is what this PR does.
2. Make the `.fleet-secrets` index internal (cf. [this comment](https://github.com/elastic/elasticsearch/pull/96172#issuecomment-1553554429)). This change is implemented in https://github.com/elastic/elasticsearch/pull/97728.

### What this PR does

Remove the generic `.fleet-*` index privileges for Kibana and Fleet Server, break them down into the specific indices defined in x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java.

### How to test this PR

1. Build and run ES along with Kibana.
2. In Kibana's Dev Tools, run `GET /_security/service/elastic/kibana`: the Fleet individual indices should be listed in the response.
3. Same with `GET /_security/service/elastic/fleet-server`.
