### PR TITLE
[Profiling] Consider static settings in status

### DIFF
--- a/docs/changelog/97890.yaml
+++ b/docs/changelog/97890.yaml
@@ -1,0 +1,5 @@
+pr: 97890
+summary: "[Profiling] Consider static settings in status"
+area: Application
+type: bug
+issues: []


### PR DESCRIPTION
Previously the profiling status check only considered the dynamically set value for `xpack.profiling.templates.enabled`. If a user set a value statically in `elasticsearch.yml` the status check did not reflect that leading to puzzling responses. With this commit we check not only dynamically defined cluster settings but also the static ones before returning the setting's default value.