### PR TITLE
[Profiling] Use more descriptive action name

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/CancellationIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/CancellationIT.java
@@ -84,7 +84,7 @@ public class CancellationIT extends ProfilingTestCase {
                   }
                 }
             """, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8)));
-        verifyCancellation(GetProfilingAction.NAME, restRequest);
+        verifyCancellation(GetStackTracesAction.NAME, restRequest);
     }
 
     void verifyCancellation(String action, Request restRequest) throws Exception {

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -9,15 +9,15 @@ package org.elasticsearch.xpack.profiling;
 
 import java.util.List;
 
-public class GetProfilingActionIT extends ProfilingTestCase {
+public class GetStackTracesActionIT extends ProfilingTestCase {
     @Override
     protected boolean useOnlyAllEvents() {
         return randomBoolean();
     }
 
-    public void testGetProfilingDataUnfiltered() throws Exception {
-        GetProfilingRequest request = new GetProfilingRequest(1, null);
-        GetProfilingResponse response = client().execute(GetProfilingAction.INSTANCE, request).get();
+    public void testGetStackTracesUnfiltered() throws Exception {
+        GetStackTracesRequest request = new GetStackTracesRequest(1, null);
+        GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
         assertEquals(1, response.getTotalFrames());
         assertNotNull(response.getStackTraces());
         StackTrace stackTrace = response.getStackTraces().get("QjoLteG7HX3VUUXr-J4kHQ");

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesAction.java
@@ -8,11 +8,11 @@ package org.elasticsearch.xpack.profiling;
 
 import org.elasticsearch.action.ActionType;
 
-public final class GetProfilingAction extends ActionType<GetProfilingResponse> {
-    public static final GetProfilingAction INSTANCE = new GetProfilingAction();
-    public static final String NAME = "indices:data/read/profiling";
+public final class GetStackTracesAction extends ActionType<GetStackTracesResponse> {
+    public static final GetStackTracesAction INSTANCE = new GetStackTracesAction();
+    public static final String NAME = "indices:data/read/profiling/stack_traces";
 
-    private GetProfilingAction() {
-        super(NAME, GetProfilingResponse::new);
+    private GetStackTracesAction() {
+        super(NAME, GetStackTracesResponse::new);
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQu
 /**
  * A request to get profiling details
  */
-public class GetProfilingRequest extends ActionRequest implements IndicesRequest {
+public class GetStackTracesRequest extends ActionRequest implements IndicesRequest {
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField SAMPLE_SIZE_FIELD = new ParseField("sample_size");
 
@@ -41,16 +41,16 @@ public class GetProfilingRequest extends ActionRequest implements IndicesRequest
 
     private Integer sampleSize;
 
-    public GetProfilingRequest() {
+    public GetStackTracesRequest() {
         this(null, null);
     }
 
-    public GetProfilingRequest(Integer sampleSize, QueryBuilder query) {
+    public GetStackTracesRequest(Integer sampleSize, QueryBuilder query) {
         this.sampleSize = sampleSize;
         this.query = query;
     }
 
-    public GetProfilingRequest(StreamInput in) throws IOException {
+    public GetStackTracesRequest(StreamInput in) throws IOException {
         this.query = in.readOptionalNamedWriteable(QueryBuilder.class);
         this.sampleSize = in.readOptionalInt();
     }
@@ -152,7 +152,7 @@ public class GetProfilingRequest extends ActionRequest implements IndicesRequest
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        GetProfilingRequest that = (GetProfilingRequest) o;
+        GetStackTracesRequest that = (GetStackTracesRequest) o;
         return Objects.equals(query, that.query) && Objects.equals(sampleSize, that.sampleSize);
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
-public class GetProfilingResponse extends ActionResponse implements ChunkedToXContentObject {
+public class GetStackTracesResponse extends ActionResponse implements ChunkedToXContentObject {
     @Nullable
     private final Map<String, StackTrace> stackTraces;
     @Nullable
@@ -34,7 +34,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
     private final int totalFrames;
     private final double samplingRate;
 
-    public GetProfilingResponse(StreamInput in) throws IOException {
+    public GetStackTracesResponse(StreamInput in) throws IOException {
         this.stackTraces = in.readBoolean()
             ? in.readMap(
                 i -> new StackTrace(
@@ -61,7 +61,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
         this.samplingRate = in.readDouble();
     }
 
-    public GetProfilingResponse(
+    public GetStackTracesResponse(
         Map<String, StackTrace> stackTraces,
         Map<String, StackFrame> stackFrames,
         Map<String, String> executables,
@@ -167,7 +167,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        GetProfilingResponse response = (GetProfilingResponse) o;
+        GetStackTracesResponse response = (GetStackTracesResponse) o;
         return totalFrames == response.totalFrames
             && samplingRate == response.samplingRate
             && Objects.equals(stackTraces, response.stackTraces)

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/KvIndexResolver.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/KvIndexResolver.java
@@ -35,7 +35,7 @@ public class KvIndexResolver {
     private final IndexNameExpressionResolver resolver;
     /**
      * Specifies the time period for which K/V indices should be considered to overlap. See
-     * also @{@link TransportGetProfilingAction#PROFILING_KV_INDEX_OVERLAP}.
+     * also @{@link TransportGetStackTracesAction#PROFILING_KV_INDEX_OVERLAP}.
      */
     private final TimeValue kvIndexOverlapPeriod;
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -125,7 +125,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         List<RestHandler> handlers = new ArrayList<>();
         handlers.add(new RestGetStatusAction());
         if (enabled) {
-            handlers.add(new RestGetProfilingAction());
+            handlers.add(new RestGetStackTracesAction());
         }
         return Collections.unmodifiableList(handlers);
     }
@@ -134,9 +134,9 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     public List<Setting<?>> getSettings() {
         return List.of(
             PROFILING_TEMPLATES_ENABLED,
-            TransportGetProfilingAction.PROFILING_MAX_STACKTRACE_QUERY_SLICES,
-            TransportGetProfilingAction.PROFILING_MAX_DETAIL_QUERY_SLICES,
-            TransportGetProfilingAction.PROFILING_QUERY_REALTIME
+            TransportGetStackTracesAction.PROFILING_MAX_STACKTRACE_QUERY_SLICES,
+            TransportGetStackTracesAction.PROFILING_MAX_DETAIL_QUERY_SLICES,
+            TransportGetStackTracesAction.PROFILING_QUERY_REALTIME
         );
     }
 
@@ -157,7 +157,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return List.of(
-            new ActionHandler<>(GetProfilingAction.INSTANCE, TransportGetProfilingAction.class),
+            new ActionHandler<>(GetStackTracesAction.INSTANCE, TransportGetStackTracesAction.class),
             new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class)
         );
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetStackTracesAction.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-public class RestGetProfilingAction extends BaseRestHandler {
+public class RestGetStackTracesAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(new Route(POST, "/_profiling/stacktraces"));
@@ -26,13 +26,13 @@ public class RestGetProfilingAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        GetProfilingRequest getProfilingRequest = new GetProfilingRequest();
-        request.applyContentParser(getProfilingRequest::parseXContent);
+        GetStackTracesRequest getStackTracesRequest = new GetStackTracesRequest();
+        request.applyContentParser(getStackTracesRequest::parseXContent);
 
         return channel -> {
-            RestActionListener<GetProfilingResponse> listener = new RestChunkedToXContentListener<>(channel);
+            RestActionListener<GetStackTracesResponse> listener = new RestChunkedToXContentListener<>(channel);
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
-            cancelClient.execute(GetProfilingAction.INSTANCE, getProfilingRequest, listener);
+            cancelClient.execute(GetStackTracesAction.INSTANCE, getStackTracesRequest, listener);
         };
     }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -25,16 +25,16 @@ import java.io.IOException;
 
 import static java.util.Collections.emptyList;
 
-public class GetProfilingRequestTests extends ESTestCase {
+public class GetStackTracesRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
         Integer sampleSize = randomBoolean() ? randomIntBetween(0, Integer.MAX_VALUE) : null;
         QueryBuilder query = randomBoolean() ? new BoolQueryBuilder() : null;
 
-        GetProfilingRequest request = new GetProfilingRequest(sampleSize, query);
+        GetStackTracesRequest request = new GetStackTracesRequest(sampleSize, query);
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request.writeTo(out);
             try (NamedWriteableAwareStreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry())) {
-                GetProfilingRequest deserialized = new GetProfilingRequest(in);
+                GetStackTracesRequest deserialized = new GetStackTracesRequest(in);
                 assertEquals(sampleSize, deserialized.getSampleSize());
                 assertEquals(query, deserialized.getQuery());
             }
@@ -57,12 +57,12 @@ public class GetProfilingRequestTests extends ESTestCase {
         //end::noformat
         )) {
 
-            GetProfilingRequest profilingRequest = new GetProfilingRequest();
-            profilingRequest.parseXContent(content);
+            GetStackTracesRequest request = new GetStackTracesRequest();
+            request.parseXContent(content);
 
-            assertEquals(Integer.valueOf(500), profilingRequest.getSampleSize());
+            assertEquals(Integer.valueOf(500), request.getSampleSize());
             // a basic check suffices here
-            assertEquals("@timestamp", ((RangeQueryBuilder) profilingRequest.getQuery()).fieldName());
+            assertEquals("@timestamp", ((RangeQueryBuilder) request.getQuery()).fieldName());
         }
     }
 
@@ -83,8 +83,8 @@ public class GetProfilingRequestTests extends ESTestCase {
         //end::noformat
         )) {
 
-            GetProfilingRequest profilingRequest = new GetProfilingRequest();
-            ParsingException ex = expectThrows(ParsingException.class, () -> profilingRequest.parseXContent(content));
+            GetStackTracesRequest request = new GetStackTracesRequest();
+            ParsingException ex = expectThrows(ParsingException.class, () -> request.parseXContent(content));
             assertEquals("Unknown key for a VALUE_NUMBER in [sample-size].", ex.getMessage());
         }
     }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesResponseTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesResponseTests.java
@@ -14,13 +14,13 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import java.util.List;
 import java.util.Map;
 
-public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<GetProfilingResponse> {
+public class GetStackTracesResponseTests extends AbstractWireSerializingTestCase<GetStackTracesResponse> {
     private <T> T randomNullable(T v) {
         return randomBoolean() ? v : null;
     }
 
     @Override
-    protected GetProfilingResponse createTestInstance() {
+    protected GetStackTracesResponse createTestInstance() {
         int totalFrames = randomIntBetween(1, 100);
 
         Map<String, StackTrace> stackTraces = randomNullable(
@@ -44,17 +44,17 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
         Map<String, String> executables = randomNullable(Map.of("QCCDqjSg3bMK1C4YRK6Tiw", "libc.so.6"));
         Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), randomIntBetween(1, 200)));
 
-        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, 1.0);
+        return new GetStackTracesResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, 1.0);
     }
 
     @Override
-    protected GetProfilingResponse mutateInstance(GetProfilingResponse instance) {
+    protected GetStackTracesResponse mutateInstance(GetStackTracesResponse instance) {
         return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
     }
 
     @Override
-    protected Writeable.Reader<GetProfilingResponse> instanceReader() {
-        return GetProfilingResponse::new;
+    protected Writeable.Reader<GetStackTracesResponse> instanceReader() {
+        return GetStackTracesResponse::new;
     }
 
     public void testChunking() {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
@@ -28,21 +28,21 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-public class RestGetProfilingActionTests extends RestActionTestCase {
+public class RestGetStackTracesActionTests extends RestActionTestCase {
     @Before
     public void setUpAction() {
-        controller().registerHandler(new RestGetProfilingAction());
+        controller().registerHandler(new RestGetStackTracesAction());
     }
 
     public void testPrepareEmptyRequest() {
         SetOnce<Boolean> executeCalled = new SetOnce<>();
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
-            assertThat(request, instanceOf(GetProfilingRequest.class));
-            GetProfilingRequest profilingRequest = (GetProfilingRequest) request;
-            assertThat(profilingRequest.getSampleSize(), nullValue());
-            assertThat(profilingRequest.getQuery(), nullValue());
+            assertThat(request, instanceOf(GetStackTracesRequest.class));
+            GetStackTracesRequest getStackTracesRequest = (GetStackTracesRequest) request;
+            assertThat(getStackTracesRequest.getSampleSize(), nullValue());
+            assertThat(getStackTracesRequest.getQuery(), nullValue());
             executeCalled.set(true);
-            return new GetProfilingResponse(
+            return new GetStackTracesResponse(
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -62,12 +62,12 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
     public void testPrepareParameterizedRequest() {
         SetOnce<Boolean> executeCalled = new SetOnce<>();
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
-            assertThat(request, instanceOf(GetProfilingRequest.class));
-            GetProfilingRequest profilingRequest = (GetProfilingRequest) request;
-            assertThat(profilingRequest.getSampleSize(), is(10000));
-            assertThat(profilingRequest.getQuery(), notNullValue(QueryBuilder.class));
+            assertThat(request, instanceOf(GetStackTracesRequest.class));
+            GetStackTracesRequest getStackTracesRequest = (GetStackTracesRequest) request;
+            assertThat(getStackTracesRequest.getSampleSize(), is(10000));
+            assertThat(getStackTracesRequest.getQuery(), notNullValue(QueryBuilder.class));
             executeCalled.set(true);
-            return new GetProfilingResponse(
+            return new GetStackTracesResponse(
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -76,7 +76,7 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
                 0.0
             );
         });
-        RestRequest profilingRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
             .withPath("/_profiling/stacktraces")
             .withContent(new BytesArray("""
                             {
@@ -98,7 +98,7 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
                             }
                 """), XContentType.JSON)
             .build();
-        dispatchRequest(profilingRequest);
+        dispatchRequest(request);
         assertThat(executeCalled.get(), equalTo(true));
     }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesActionTests.java
@@ -12,15 +12,15 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Collections;
 import java.util.List;
 
-public class TransportGetProfilingActionTests extends ESTestCase {
+public class TransportGetStackTracesActionTests extends ESTestCase {
     public void testSliceEmptyList() {
-        assertEquals(List.of(List.of()), TransportGetProfilingAction.sliced(Collections.emptyList(), 4));
+        assertEquals(List.of(List.of()), TransportGetStackTracesAction.sliced(Collections.emptyList(), 4));
     }
 
     public void testSliceListSmallerOrEqualToSliceCount() {
         int slices = 7;
         List<String> input = randomList(0, slices, () -> randomAlphaOfLength(3));
-        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        List<List<String>> sliced = TransportGetStackTracesAction.sliced(input, slices);
         assertEquals(1, sliced.size());
         assertEquals(input, sliced.get(0));
     }
@@ -28,7 +28,7 @@ public class TransportGetProfilingActionTests extends ESTestCase {
     public void testSliceListMultipleOfSliceCount() {
         int slices = 2;
         List<String> input = List.of("a", "b", "c", "d");
-        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        List<List<String>> sliced = TransportGetStackTracesAction.sliced(input, slices);
         assertEquals(slices, sliced.size());
         assertEquals(List.of("a", "b"), sliced.get(0));
         assertEquals(List.of("c", "d"), sliced.get(1));
@@ -37,7 +37,7 @@ public class TransportGetProfilingActionTests extends ESTestCase {
     public void testSliceListGreaterThanSliceCount() {
         int slices = 3;
         List<String> input = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
-        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        List<List<String>> sliced = TransportGetStackTracesAction.sliced(input, slices);
         assertEquals(slices, sliced.size());
         assertEquals(List.of("a", "b", "c"), sliced.get(0));
         assertEquals(List.of("d", "e", "f"), sliced.get(1));
@@ -48,7 +48,7 @@ public class TransportGetProfilingActionTests extends ESTestCase {
         int slices = randomIntBetween(1, 16);
         // To ensure that we can actually slice the list
         List<String> input = randomList(slices + 1, 20000, () -> "s");
-        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        List<List<String>> sliced = TransportGetStackTracesAction.sliced(input, slices);
         assertEquals(slices, sliced.size());
     }
 }

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -487,7 +487,7 @@ public class Constants {
         "indices:data/read/mtv",
         "indices:data/read/mtv[shard]",
         "indices:data/read/open_point_in_time",
-        "indices:data/read/profiling",
+        "indices:data/read/profiling/stack_traces",
         "indices:data/read/rank_eval",
         "indices:data/read/scroll",
         "indices:data/read/scroll/clear",


### PR DESCRIPTION
With this commit we rename `GetProfilingAction` to `GetStackTracesAction` to better convey its intent.