### PR TITLE
[8.8] [DOCS] Update RRF tech preview statement (#97851)

### DIFF
--- a/docs/reference/search/rrf.asciidoc
+++ b/docs/reference/search/rrf.asciidoc
@@ -1,7 +1,7 @@
 [[rrf]]
 === Reciprocal rank fusion
 
-preview::[]
+preview::["This functionality is in technical preview and may be changed or removed in a future release. The syntax will likely change before GA. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf[Reciprocal rank fusion (RRF)]
 is a method for combining multiple result sets with different relevance

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -555,9 +555,12 @@ Period of time used to extend the life of the PIT.
 
 [[request-body-rank]]
 `rank`::
+preview:[]
+This param is in technical preview and may change in the future. The syntax will
+likely change before GA.
++
 (Optional, object) Defines a method for combining and ranking result sets from
 either:
-+
 * 1 query and 1 or more kNN searches
 * 2 or more kNN searches
 +

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -561,6 +561,7 @@ likely change before GA.
 +
 (Optional, object) Defines a method for combining and ranking result sets from
 either:
++
 * 1 query and 1 or more kNN searches
 * 2 or more kNN searches
 +


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Update RRF tech preview statement (#97851)](https://github.com/elastic/elasticsearch/pull/97851)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)