### PR TITLE
Refactor nested field handling in FieldFetcher (#97683)

### DIFF
--- a/docs/changelog/97683.yaml
+++ b/docs/changelog/97683.yaml
@@ -1,0 +1,5 @@
+pr: 97683
+summary: Refactor nested field handling in `FieldFetcher`
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/NestedUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/NestedUtils.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Utility methods for dealing with nested mappers
+ */
+public final class NestedUtils {
+
+    private NestedUtils() {}
+
+    /**
+     * Partition a set of input objects by the children of a specific nested scope
+     *
+     * The returned map will contain an entry for all children, even if some of them
+     * are empty in the inputs.
+     *
+     * All children, and all input paths, must begin with the scope.  Both children
+     * and inputs should be in sorted order.
+     *
+     * @param scope         the nested scope to base partitions on
+     * @param children      the immediate children of the nested scope
+     * @param inputs        a set of inputs to partition
+     * @param pathFunction  a function to retrieve a path for each input
+     * @param <T>           the type of the inputs
+     * @return              a map of nested paths to lists of inputs
+     */
+    public static <T> Map<String, List<T>> partitionByChildren(
+        String scope,
+        List<String> children,
+        List<T> inputs,
+        Function<T, String> pathFunction
+    ) {
+        // No immediate nested children, so we can shortcut and just return all inputs
+        // under the current scope
+        if (children.isEmpty()) {
+            return Collections.singletonMap(scope, inputs);
+        }
+
+        // Set up the output map, with one entry for the current scope and one for each
+        // of its children
+        Map<String, List<T>> output = new HashMap<>();
+        output.put(scope, new ArrayList<>());
+        for (String child : children) {
+            output.put(child, new ArrayList<>());
+        }
+
+        // No inputs, so we can return the output map with all entries empty
+        if (inputs.isEmpty()) {
+            return output;
+        }
+
+        Iterator<String> childrenIterator = children.iterator();
+        String currentChild = childrenIterator.next();
+        Iterator<T> inputIterator = inputs.iterator();
+        T currentInput = inputIterator.next();
+        String currentInputName = pathFunction.apply(currentInput);
+        assert currentInputName.startsWith(scope);
+
+        // Find all the inputs that sort before the first child, and add them to the current scope entry
+        while (currentInputName.compareTo(currentChild) < 0) {
+            output.get(scope).add(currentInput);
+            if (inputIterator.hasNext() == false) {
+                return output;
+            }
+            currentInput = inputIterator.next();
+            currentInputName = pathFunction.apply(currentInput);
+            assert currentInputName.startsWith(scope);
+        }
+
+        // Iterate through all the children
+        while (currentChild != null) {
+            if (currentInputName.startsWith(currentChild + ".")) {
+                // If this input sits under the current child, add it to that child scope
+                // and then get the next input
+                output.get(currentChild).add(currentInput);
+                if (inputIterator.hasNext() == false) {
+                    // return if no more inputs
+                    return output;
+                }
+                currentInput = inputIterator.next();
+                currentInputName = pathFunction.apply(currentInput);
+                assert currentInputName.startsWith(scope);
+            } else {
+                // If there are no more children then skip to filling up the parent scope again
+                if (childrenIterator.hasNext() == false) {
+                    break;
+                }
+                // Move to the next child
+                currentChild = childrenIterator.next();
+                if (currentChild == null || currentInputName.compareTo(currentChild) < 0) {
+                    // If we still sort before the next child, then add to the parent scope
+                    // and move to the next input
+                    output.get(scope).add(currentInput);
+                    if (inputIterator.hasNext() == false) {
+                        // if no more inputs then return
+                        return output;
+                    }
+                    currentInput = inputIterator.next();
+                    currentInputName = pathFunction.apply(currentInput);
+                    assert currentInputName.startsWith(scope);
+                }
+            }
+        }
+        output.get(scope).add(currentInput);
+
+        // if there are inputs left, then they all sort after the last child but
+        // are not contained by them, so just add them all to the parent scope
+        while (inputIterator.hasNext()) {
+            currentInput = inputIterator.next();
+            currentInputName = pathFunction.apply(currentInput);
+            assert currentInputName.startsWith(scope);
+            output.get(scope).add(currentInput);
+        }
+        return output;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -9,29 +9,25 @@
 package org.elasticsearch.search.fetch.subphase;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedValueFetcher;
-import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.NestedUtils;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A helper class to {@link FetchFieldsPhase} that's initialized with a list of field patterns to fetch.
@@ -39,36 +35,31 @@ import java.util.stream.Collectors;
  */
 public class FieldFetcher {
 
-    /**
-     * Default maximum number of states in the automaton that looks up unmapped fields.
-     */
-    private static final int AUTOMATON_MAX_DETERMINIZED_STATES = 100000;
+    private static class ResolvedField {
+        String field;
+        String matchingPattern;
+        MappedFieldType ft;
+        String format;
 
-    public static FieldFetcher create(SearchExecutionContext context, Collection<FieldAndFormat> fieldAndFormats) {
-        Set<String> nestedMappingPaths = context.hasNested()
-            ? context.nestedMappings().stream().map(ObjectMapper::name).collect(Collectors.toSet())
-            : Collections.emptySet();
-        return create(context, fieldAndFormats, nestedMappingPaths, "");
+        ResolvedField(String field, String matchingPattern, MappedFieldType ft, String format) {
+            this.field = field;
+            this.matchingPattern = matchingPattern;
+            this.ft = ft;
+            this.format = format;
+        }
     }
 
-    private static FieldFetcher create(
-        SearchExecutionContext context,
-        Collection<FieldAndFormat> fieldAndFormats,
-        Set<String> nestedMappingsInScope,
-        String nestedScopePath
-    ) {
-        // here we only need the nested paths that are closes to the root, e.g. only "foo" if also "foo.bar" is present.
-        // the remaining nested field paths are handled recursively
-        Set<String> nestedParentPaths = getParentPaths(nestedMappingsInScope, context);
+    /**
+     * Build a FieldFetcher for a given search context and collection of fields and formats
+     */
+    public static FieldFetcher create(SearchExecutionContext context, Collection<FieldAndFormat> fieldAndFormats) {
 
-        // Using a LinkedHashMap so fields are returned in the order requested.
-        // We won't formally guarantee this but but its good for readability of the response
-        Map<String, FieldContext> fieldContexts = new LinkedHashMap<>();
         List<String> unmappedFetchPattern = new ArrayList<>();
+        List<ResolvedField> resolvedFields = new ArrayList<>();
 
         for (FieldAndFormat fieldAndFormat : fieldAndFormats) {
             String fieldPattern = fieldAndFormat.field;
-            boolean isWildcardPattern = Regex.isSimpleMatchPattern(fieldPattern);
+            String matchingPattern = Regex.isSimpleMatchPattern(fieldPattern) ? fieldPattern : null;
             if (fieldAndFormat.includeUnmapped != null && fieldAndFormat.includeUnmapped) {
                 unmappedFetchPattern.add(fieldAndFormat.field);
             }
@@ -76,94 +67,113 @@ public class FieldFetcher {
             for (String field : context.getMatchingFieldNames(fieldPattern)) {
                 MappedFieldType ft = context.getFieldType(field);
                 // we want to skip metadata fields if we have a wildcard pattern
-                if (context.isMetadataField(field) && isWildcardPattern) {
+                if (context.isMetadataField(field) && matchingPattern != null) {
                     continue;
                 }
-                if (field.startsWith(nestedScopePath) == false) {
-                    // this field is out of scope for this FieldFetcher (its likely nested) so ignore
-                    continue;
-                }
-                String nestedParentPath = null;
-                if (nestedParentPaths.isEmpty() == false) {
-                    // try to find the shortest nested parent path for this field
-                    for (String nestedFieldPath : nestedParentPaths) {
-                        if (field.startsWith(nestedFieldPath)
-                            && field.length() > nestedFieldPath.length()
-                            && field.charAt(nestedFieldPath.length()) == '.') {
-                            nestedParentPath = nestedFieldPath;
-                            break;
-                        }
-                    }
-                }
-                // only add concrete fields if they are not beneath a known nested field
-                if (nestedParentPath == null) {
-                    ValueFetcher valueFetcher;
-                    try {
-                        valueFetcher = ft.valueFetcher(context, fieldAndFormat.format);
-                    } catch (IllegalArgumentException e) {
-                        StringBuilder error = new StringBuilder("error fetching [").append(field).append(']');
-                        if (isWildcardPattern) {
-                            error.append(" which matched [").append(fieldAndFormat.field).append(']');
-                        }
-                        error.append(": ").append(e.getMessage());
-                        throw new IllegalArgumentException(error.toString(), e);
-                    }
-                    fieldContexts.put(field, new FieldContext(field, valueFetcher));
-                }
+                resolvedFields.add(new ResolvedField(field, matchingPattern, ft, fieldAndFormat.format));
             }
         }
 
-        // create a new nested value fetcher for patterns under nested field
-        for (String nestedFieldPath : nestedParentPaths) {
-            // We construct a field fetcher that narrows the allowed lookup scope to everything beneath its nested field path.
-            // We also need to remove this nested field path and everything beneath it from the list of available nested fields before
-            // creating this internal field fetcher to avoid infinite loops on this recursion
-            Set<String> narrowedScopeNestedMappings = nestedMappingsInScope.stream()
-                .filter(s -> nestedParentPaths.contains(s) == false)
-                .collect(Collectors.toSet());
+        // The fields need to be sorted so that the nested partition functions will work correctly.
+        resolvedFields.sort(Comparator.comparing(f -> f.field));
 
-            FieldFetcher nestedSubFieldFetcher = FieldFetcher.create(
-                context,
-                fieldAndFormats,
-                narrowedScopeNestedMappings,
-                nestedFieldPath
-            );
+        Map<String, FieldContext> fieldContexts = buildFieldContexts(context, "", resolvedFields, unmappedFetchPattern);
 
-            // add a special ValueFetcher that filters source and collects its subfields
-            fieldContexts.put(
-                nestedFieldPath,
-                new FieldContext(nestedFieldPath, new NestedValueFetcher(nestedFieldPath, nestedSubFieldFetcher))
-            );
+        UnmappedFieldFetcher unmappedFieldFetcher = buildUnmappedFieldFetcher(context, fieldContexts.keySet(), "", unmappedFetchPattern);
+
+        return new FieldFetcher(fieldContexts, unmappedFieldFetcher);
+    }
+
+    private static UnmappedFieldFetcher buildUnmappedFieldFetcher(
+        SearchExecutionContext context,
+        Set<String> mappedFields,
+        String nestedScope,
+        List<String> unmappedFetchPatterns
+    ) {
+        if (unmappedFetchPatterns.isEmpty()) {
+            return UnmappedFieldFetcher.EMPTY;
         }
+        // We pass in all mapped field names, and all the names of nested mappers that appear
+        // immediately below the current scope. This means that the unmapped field fetcher won't
+        // retrieve any fields that live inside a nested child, instead leaving this to the
+        // NestedFieldFetchers defined for each child scope in buildFieldContexts()
+        Set<String> mappedAndNestedFields = new HashSet<>(mappedFields);
+        mappedAndNestedFields.addAll(context.getImmediateChildMappers(nestedScope));
+        return new UnmappedFieldFetcher(mappedAndNestedFields, unmappedFetchPatterns);
+    }
 
-        CharacterRunAutomaton unmappedFieldsFetchAutomaton = null;
-        // We separate the "include_unmapped" field patters with wildcards from the rest in order to use less
-        // space in the lookup automaton
-        Map<Boolean, List<String>> partitions = unmappedFetchPattern.stream()
-            .collect(Collectors.partitioningBy((s -> Regex.isSimpleMatchPattern(s))));
-        List<String> unmappedWildcardPattern = partitions.get(true);
-        List<String> unmappedConcreteFields = partitions.get(false);
-        if (unmappedWildcardPattern.isEmpty() == false) {
-            unmappedFieldsFetchAutomaton = new CharacterRunAutomaton(
-                Regex.simpleMatchToAutomaton(unmappedWildcardPattern.toArray(new String[unmappedWildcardPattern.size()])),
-                AUTOMATON_MAX_DETERMINIZED_STATES
-            );
+    private static ValueFetcher buildValueFetcher(SearchExecutionContext context, ResolvedField fieldAndFormat) {
+        try {
+            return fieldAndFormat.ft.valueFetcher(context, fieldAndFormat.format);
+        } catch (IllegalArgumentException e) {
+            StringBuilder error = new StringBuilder("error fetching [").append(fieldAndFormat.field).append(']');
+            if (fieldAndFormat.matchingPattern != null) {
+                error.append(" which matched [").append(fieldAndFormat.matchingPattern).append(']');
+            }
+            error.append(": ").append(e.getMessage());
+            throw new IllegalArgumentException(error.toString(), e);
         }
-        return new FieldFetcher(fieldContexts, unmappedFieldsFetchAutomaton, unmappedConcreteFields);
+    }
+
+    // Builds field contexts for each resolved field. If there are child mappers below
+    // the nested scope, then the resolved fields are partitioned by where they fall in
+    // the nested hierarchy, and we build a nested FieldContext for each child by calling
+    // this method again for the subset of resolved fields that live within it.
+    private static Map<String, FieldContext> buildFieldContexts(
+        SearchExecutionContext context,
+        String nestedScope,
+        List<ResolvedField> fields,
+        List<String> unmappedFetchPatterns
+    ) {
+
+        final boolean includeUnmapped = unmappedFetchPatterns.isEmpty() == false;
+
+        Map<String, List<ResolvedField>> fieldsByNestedMapper = NestedUtils.partitionByChildren(
+            nestedScope,
+            context.getImmediateChildMappers(nestedScope),
+            fields,
+            f -> f.field
+        );
+
+        // Keep the outputs sorted for easier testing
+        Map<String, FieldContext> output = new LinkedHashMap<>();
+        for (String scope : fieldsByNestedMapper.keySet()) {
+            if (nestedScope.equals(scope)) {
+                // These are fields in the current scope, so add them directly to the output map
+                for (ResolvedField ff : fieldsByNestedMapper.get(nestedScope)) {
+                    output.put(ff.field, new FieldContext(ff.field, buildValueFetcher(context, ff)));
+                }
+            } else {
+                // don't create nested fetchers if no children have been requested as part of the fields
+                // request, unless we are trying to also fetch unmapped fields``
+                if (includeUnmapped || fieldsByNestedMapper.get(scope).isEmpty() == false) {
+                    // These fields are in a child scope, so build a nested mapper for them
+                    Map<String, FieldContext> scopedFields = buildFieldContexts(
+                        context,
+                        scope,
+                        fieldsByNestedMapper.get(scope),
+                        unmappedFetchPatterns
+                    );
+                    UnmappedFieldFetcher unmappedFieldFetcher = buildUnmappedFieldFetcher(
+                        context,
+                        scopedFields.keySet(),
+                        scope,
+                        unmappedFetchPatterns
+                    );
+                    NestedValueFetcher nvf = new NestedValueFetcher(scope, new FieldFetcher(scopedFields, unmappedFieldFetcher));
+                    output.put(scope, new FieldContext(scope, nvf));
+                }
+            }
+        }
+        return output;
     }
 
     private final Map<String, FieldContext> fieldContexts;
-    private final CharacterRunAutomaton unmappedFieldsFetchAutomaton;
-    private final List<String> unmappedConcreteFields;
+    private final UnmappedFieldFetcher unmappedFieldFetcher;
 
-    public FieldFetcher(
-        Map<String, FieldContext> fieldContexts,
-        @Nullable CharacterRunAutomaton unmappedFieldsFetchAutomaton,
-        @Nullable List<String> unmappedConcreteFields
-    ) {
+    public FieldFetcher(Map<String, FieldContext> fieldContexts, UnmappedFieldFetcher unmappedFieldFetcher) {
         this.fieldContexts = fieldContexts;
-        this.unmappedFieldsFetchAutomaton = unmappedFieldsFetchAutomaton;
-        this.unmappedConcreteFields = unmappedConcreteFields;
+        this.unmappedFieldFetcher = unmappedFieldFetcher;
     }
 
     public Map<String, DocumentField> fetch(SourceLookup sourceLookup) throws IOException {
@@ -178,111 +188,9 @@ public class FieldFetcher {
                 documentFields.put(field, new DocumentField(field, parsedValues, ignoredValues));
             }
         }
-        collectUnmapped(documentFields, sourceLookup, "", 0);
+
+        unmappedFieldFetcher.collectUnmapped(documentFields, sourceLookup);
         return documentFields;
-    }
-
-    private void collectUnmapped(Map<String, DocumentField> documentFields, Map<String, Object> source, String parentPath, int lastState) {
-        // lookup field patterns containing wildcards
-        if (this.unmappedFieldsFetchAutomaton != null) {
-            for (String key : source.keySet()) {
-                Object value = source.get(key);
-                String currentPath = parentPath + key;
-                if (this.fieldContexts.containsKey(currentPath)) {
-                    continue;
-                }
-                int currentState = step(this.unmappedFieldsFetchAutomaton, key, lastState);
-                if (currentState == -1) {
-                    // current path doesn't match any fields pattern
-                    continue;
-                }
-                if (value instanceof Map) {
-                    // one step deeper into source tree
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> objectMap = (Map<String, Object>) value;
-                    collectUnmapped(
-                        documentFields,
-                        objectMap,
-                        currentPath + ".",
-                        step(this.unmappedFieldsFetchAutomaton, ".", currentState)
-                    );
-                } else if (value instanceof List) {
-                    // iterate through list values
-                    collectUnmappedList(documentFields, (List<?>) value, currentPath, currentState);
-                } else {
-                    // we have a leaf value
-                    if (this.unmappedFieldsFetchAutomaton.isAccept(currentState)) {
-                        if (value != null) {
-                            DocumentField currentEntry = documentFields.get(currentPath);
-                            if (currentEntry == null) {
-                                List<Object> list = new ArrayList<>();
-                                list.add(value);
-                                documentFields.put(currentPath, new DocumentField(currentPath, list));
-                            } else {
-                                currentEntry.getValues().add(value);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // lookup concrete fields
-        if (this.unmappedConcreteFields != null) {
-            for (String path : unmappedConcreteFields) {
-                if (this.fieldContexts.containsKey(path)) {
-                    continue; // this is actually a mapped field
-                }
-                List<Object> values = XContentMapValues.extractRawValues(path, source);
-                if (values.isEmpty() == false) {
-                    documentFields.put(path, new DocumentField(path, values));
-                }
-            }
-        }
-    }
-
-    private void collectUnmappedList(Map<String, DocumentField> documentFields, Iterable<?> iterable, String parentPath, int lastState) {
-        List<Object> list = new ArrayList<>();
-        for (Object value : iterable) {
-            if (value instanceof Map) {
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> objectMap = (Map<String, Object>) value;
-                collectUnmapped(documentFields, objectMap, parentPath + ".", step(this.unmappedFieldsFetchAutomaton, ".", lastState));
-            } else if (value instanceof List) {
-                // weird case, but can happen for objects with "enabled" : "false"
-                collectUnmappedList(documentFields, (List<?>) value, parentPath, lastState);
-            } else if (this.unmappedFieldsFetchAutomaton.isAccept(lastState) && this.fieldContexts.containsKey(parentPath) == false) {
-                list.add(value);
-            }
-        }
-        if (list.isEmpty() == false) {
-            DocumentField currentEntry = documentFields.get(parentPath);
-            if (currentEntry == null) {
-                documentFields.put(parentPath, new DocumentField(parentPath, list));
-            } else {
-                currentEntry.getValues().addAll(list);
-            }
-        }
-    }
-
-    private static Set<String> getParentPaths(Set<String> nestedPathsInScope, SearchExecutionContext context) {
-        Set<String> parentPaths = new HashSet<>();
-        for (String candidate : nestedPathsInScope) {
-            String nestedParent = context.getNestedParent(candidate);
-            // if the candidate has no nested parent itself, its a minimal parent path
-            // if the candidate has a parent which is out of scope this means it minimal itself
-            if (nestedParent == null || nestedPathsInScope.contains(nestedParent) == false) {
-                parentPaths.add(candidate);
-            }
-        }
-        return parentPaths;
-    }
-
-    private static int step(CharacterRunAutomaton automaton, String key, int state) {
-        for (int i = 0; state != -1 && i < key.length(); ++i) {
-            state = automaton.step(state, key.charAt(i));
-        }
-        return state;
     }
 
     public void setNextReader(LeafReaderContext readerContext) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/UnmappedFieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/UnmappedFieldFetcher.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.fetch.subphase;
+
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.search.lookup.SourceLookup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Class to fetch all unmapped fields from a Source that match a set of patterns
+ *
+ * Takes a set of mapped fields to ignore when matching, which should include
+ * any nested mappers.
+ */
+public class UnmappedFieldFetcher {
+
+    /**
+     * Default maximum number of states in the automaton that looks up unmapped fields.
+     */
+    private static final int AUTOMATON_MAX_DETERMINIZED_STATES = 100000;
+
+    private final CharacterRunAutomaton unmappedFieldsFetchAutomaton;
+    private final List<String> unmappedConcreteFields = new ArrayList<>();
+    private final Set<String> mappedFields;
+
+    public static final UnmappedFieldFetcher EMPTY = new UnmappedFieldFetcher(Collections.emptySet(), Collections.emptyList());
+
+    /**
+     * Builds an UnmappedFieldFetcher
+     * @param mappedFields              a set of fields to ignore when iterating through the map
+     * @param unmappedFetchPatterns     a set of patterns to match unmapped fields in the source against
+     */
+    public UnmappedFieldFetcher(Set<String> mappedFields, List<String> unmappedFetchPatterns) {
+        List<String> unmappedWildcardPatterns = new ArrayList<>();
+        // We separate the "include_unmapped" field patters with wildcards from the rest in order to use less
+        // space in the lookup automaton
+        for (String pattern : unmappedFetchPatterns) {
+            if (Regex.isSimpleMatchPattern(pattern)) {
+                unmappedWildcardPatterns.add(pattern);
+            } else {
+                unmappedConcreteFields.add(pattern);
+            }
+        }
+        this.unmappedFieldsFetchAutomaton = buildAutomaton(unmappedWildcardPatterns);
+        this.mappedFields = mappedFields;
+    }
+
+    private static CharacterRunAutomaton buildAutomaton(List<String> patterns) {
+        if (patterns.isEmpty()) {
+            return null;
+        }
+        return new CharacterRunAutomaton(Regex.simpleMatchToAutomaton(patterns.toArray(new String[0])), AUTOMATON_MAX_DETERMINIZED_STATES);
+    }
+
+    /**
+     * Collect unmapped fields from a Source
+     * @param documentFields    a map to receive unmapped field values as DocumentFields
+     * @param source            the Source
+     */
+    public void collectUnmapped(Map<String, DocumentField> documentFields, SourceLookup source) {
+        if (this.unmappedFieldsFetchAutomaton == null && this.unmappedConcreteFields.isEmpty()) {
+            return;
+        }
+        collectUnmapped(documentFields, source.source(), "", 0);
+    }
+
+    private void collectUnmapped(Map<String, DocumentField> documentFields, Map<String, Object> source, String parentPath, int lastState) {
+        // lookup field patterns containing wildcards
+        if (this.unmappedFieldsFetchAutomaton != null) {
+            for (String key : source.keySet()) {
+                Object value = source.get(key);
+                String currentPath = parentPath + key;
+                if (this.mappedFields.contains(currentPath)) {
+                    continue;
+                }
+                int currentState = step(this.unmappedFieldsFetchAutomaton, key, lastState);
+                if (currentState == -1) {
+                    // current path doesn't match any fields pattern
+                    continue;
+                }
+                if (value instanceof Map) {
+                    // one step deeper into source tree
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> objectMap = (Map<String, Object>) value;
+                    collectUnmapped(
+                        documentFields,
+                        objectMap,
+                        currentPath + ".",
+                        step(this.unmappedFieldsFetchAutomaton, ".", currentState)
+                    );
+                } else if (value instanceof List) {
+                    // iterate through list values
+                    collectUnmappedList(documentFields, (List<?>) value, currentPath, currentState);
+                } else {
+                    // we have a leaf value
+                    if (this.unmappedFieldsFetchAutomaton.isAccept(currentState)) {
+                        if (value != null) {
+                            DocumentField currentEntry = documentFields.get(currentPath);
+                            if (currentEntry == null) {
+                                List<Object> list = new ArrayList<>();
+                                list.add(value);
+                                documentFields.put(currentPath, new DocumentField(currentPath, list));
+                            } else {
+                                currentEntry.getValues().add(value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // lookup concrete fields
+        if (this.unmappedConcreteFields != null) {
+            for (String path : unmappedConcreteFields) {
+                if (this.mappedFields.contains(path)) {
+                    continue; // this is actually a mapped field
+                }
+                List<Object> values = XContentMapValues.extractRawValues(path, source);
+                if (values.isEmpty() == false) {
+                    documentFields.put(path, new DocumentField(path, values));
+                }
+            }
+        }
+    }
+
+    private void collectUnmappedList(Map<String, DocumentField> documentFields, Iterable<?> iterable, String parentPath, int lastState) {
+        List<Object> list = new ArrayList<>();
+        for (Object value : iterable) {
+            if (value instanceof Map) {
+                @SuppressWarnings("unchecked")
+                final Map<String, Object> objectMap = (Map<String, Object>) value;
+                collectUnmapped(documentFields, objectMap, parentPath + ".", step(this.unmappedFieldsFetchAutomaton, ".", lastState));
+            } else if (value instanceof List) {
+                // weird case, but can happen for objects with "enabled" : "false"
+                collectUnmappedList(documentFields, (List<?>) value, parentPath, lastState);
+            } else if (this.unmappedFieldsFetchAutomaton.isAccept(lastState) && this.mappedFields.contains(parentPath) == false) {
+                list.add(value);
+            }
+        }
+        if (list.isEmpty() == false) {
+            DocumentField currentEntry = documentFields.get(parentPath);
+            if (currentEntry == null) {
+                documentFields.put(parentPath, new DocumentField(parentPath, list));
+            } else {
+                currentEntry.getValues().addAll(list);
+            }
+        }
+    }
+
+    private static int step(CharacterRunAutomaton automaton, String key, int state) {
+        for (int i = 0; state != -1 && i < key.length(); ++i) {
+            state = automaton.step(state, key.charAt(i));
+        }
+        return state;
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class NestedUtilsTests extends ESTestCase {
+
+    public void testPartitionByChild() {
+        List<String> children = org.elasticsearch.core.List.of("child1", "child2", "stepchild");
+        List<String> inputs = org.elasticsearch.core.List.of(
+            "a",
+            "b",
+            "child1.grandchild",
+            "child1.grandchild2",
+            "child11",
+            "child2.grandchild",
+            "frog"
+        );
+        Map<String, List<String>> partitioned = NestedUtils.partitionByChildren("", children, inputs, s -> s);
+        assertEquals(
+            org.elasticsearch.core.Map.of(
+                "",
+                org.elasticsearch.core.List.of("a", "b", "child11", "frog"),
+                "child1",
+                org.elasticsearch.core.List.of("child1.grandchild", "child1.grandchild2"),
+                "child2",
+                org.elasticsearch.core.List.of("child2.grandchild"),
+                "stepchild",
+                org.elasticsearch.core.List.of()
+            ),
+            partitioned
+        );
+    }
+
+    public void testScopedPartitionByChild() {
+        List<String> children = org.elasticsearch.core.List.of("a.child1", "a.child2", "a.stepchild");
+        List<String> inputs = org.elasticsearch.core.List.of(
+            "a.a",
+            "a.b",
+            "a.child1.grandchild",
+            "a.child1.grandchild2",
+            "a.child11",
+            "a.child2.grandchild",
+            "a.frog"
+        );
+        Map<String, List<String>> partitioned = NestedUtils.partitionByChildren("a", children, inputs, s -> s);
+        assertEquals(
+            org.elasticsearch.core.Map.of(
+                "a",
+                org.elasticsearch.core.List.of("a.a", "a.b", "a.child11", "a.frog"),
+                "a.child1",
+                org.elasticsearch.core.List.of("a.child1.grandchild", "a.child1.grandchild2"),
+                "a.child2",
+                org.elasticsearch.core.List.of("a.child2.grandchild"),
+                "a.stepchild",
+                org.elasticsearch.core.List.of()
+            ),
+            partitioned
+        );
+    }
+
+    public void testScopedPartitionWithMultifields() {
+        List<String> children = org.elasticsearch.core.List.of("user.address");
+        List<String> inputs = org.elasticsearch.core.List.of(
+            "user.address.city",
+            "user.address.zip",
+            "user.first",
+            "user.last",
+            "user.last.keyword"
+        );
+        Map<String, List<String>> partitioned = NestedUtils.partitionByChildren("user", children, inputs, s -> s);
+        assertEquals(
+            org.elasticsearch.core.Map.of(
+                "user",
+                org.elasticsearch.core.List.of("user.first", "user.last", "user.last.keyword"),
+                "user.address",
+                org.elasticsearch.core.List.of("user.address.city", "user.address.zip")
+            ),
+            partitioned
+        );
+    }
+
+    public void testEmptyCases() {
+        // No children, everything gets mapped under the scope
+        assertEquals(
+            org.elasticsearch.core.Map.of("scope", org.elasticsearch.core.List.of("foo")),
+            NestedUtils.partitionByChildren("scope", org.elasticsearch.core.List.of(), org.elasticsearch.core.List.of("foo"), s -> s)
+        );
+        // No inputs, we get an empty map under the scope
+        assertEquals(
+            org.elasticsearch.core.Map.of("scope", org.elasticsearch.core.List.of(), "scope.child", org.elasticsearch.core.List.of()),
+            NestedUtils.partitionByChildren(
+                "scope",
+                org.elasticsearch.core.List.of("scope.child"),
+                org.elasticsearch.core.List.<String>of(),
+                s -> s
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
The current recursive nested field handling implementation in FieldFetcher can be O(n^2) in the number of nested mappings, whether or not a nested field has been requested or not. For indexes with a very large number of nested fields, this can mean it takes multiple seconds to build a FieldFetcher, making the fetch phase of queries extremely slow, even if no nested fields are actually asked for.

This commit reworks the logic so that building nested fetchers is only O(n log n) in the number of nested mappers; additionally, we only pay this cost for nested fields that have been requested.