### PR TITLE
[CI] Adding continuous testing for ECS dynamic templates

### DIFF
--- a/.buildkite/pipelines/ecs-dynamic-template-tests.yml
+++ b/.buildkite/pipelines/ecs-dynamic-template-tests.yml
@@ -7,3 +7,8 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       diskSizeGb: 350
       machineType: custom-32-98304
+notify:
+  - slack: "#es-delivery"
+    if: build.state == "failed"
+  - email: "logs-plus@elastic.co"
+    if: build.state == "failed"

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs-dynamic-mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs-dynamic-mappings.json
@@ -92,31 +92,17 @@
               "type": "keyword"
             },
             "path_match": [
-              "*file.path",
-              "*file.target_path",
-              "*os.full",
-              "user_agent.original"
-            ]
-          }
-        },
-        {
-          "ecs_match_keyword_and_match_only_text": {
-            "mapping": {
-              "fields": {
-                "text": {
-                  "type": "match_only_text"
-                }
-              },
-              "type": "keyword"
-            },
-            "path_match": [
               "*.title",
               "*.executable",
               "*.name",
               "*.working_directory",
               "*.full_name",
+              "*file.path",
+              "*file.target_path",
+              "*os.full",
               "email.subject",
-              "vulnerability.description"
+              "vulnerability.description",
+              "user_agent.original"
             ]
           }
         },

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs-dynamic-mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs-dynamic-mappings.json
@@ -114,7 +114,9 @@
               "*.executable",
               "*.name",
               "*.working_directory",
-              "*.full_name"
+              "*.full_name",
+              "email.subject",
+              "vulnerability.description"
             ]
           }
         },

--- a/x-pack/plugin/stack/build.gradle
+++ b/x-pack/plugin/stack/build.gradle
@@ -15,7 +15,6 @@ base {
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
-  implementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(path: ':x-pack:plugin:stack')
   clusterModules project(':modules:mapper-extras')

--- a/x-pack/plugin/stack/build.gradle
+++ b/x-pack/plugin/stack/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   name 'x-pack-stack'
@@ -16,13 +16,10 @@ base {
 dependencies {
   compileOnly project(path: xpackModule('core'))
   implementation(testArtifact(project(xpackModule('core'))))
-  implementation "org.yaml:snakeyaml:${versions.snakeyaml}"
-  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
-  implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-  implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-  implementation project(':modules:mapper-extras')
-  implementation project(xpackModule('wildcard'))
+  javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation project(path: ':x-pack:plugin:stack')
+  clusterModules project(':modules:mapper-extras')
+  clusterModules project(xpackModule('wildcard'))
 }
 
 addQaCheckDependencies(project)

--- a/x-pack/plugin/stack/build.gradle
+++ b/x-pack/plugin/stack/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.internal-cluster-test'
 
 esplugin {
   name 'x-pack-stack'
@@ -14,7 +15,14 @@ base {
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
-  testImplementation(testArtifact(project(xpackModule('core'))))
+  implementation(testArtifact(project(xpackModule('core'))))
+  implementation "org.yaml:snakeyaml:${versions.snakeyaml}"
+  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
+  implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+  implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+  implementation project(':modules:mapper-extras')
+  implementation project(xpackModule('wildcard'))
 }
 
 addQaCheckDependencies(project)

--- a/x-pack/plugin/stack/build.gradle
+++ b/x-pack/plugin/stack/build.gradle
@@ -9,6 +9,7 @@ esplugin {
   hasNativeController false
   requiresKeystore true
 }
+
 base {
   archivesName = 'x-pack-stack'
 }
@@ -19,6 +20,14 @@ dependencies {
   javaRestTestImplementation project(path: ':x-pack:plugin:stack')
   clusterModules project(':modules:mapper-extras')
   clusterModules project(xpackModule('wildcard'))
+}
+
+// These tests are only invoked direclty as part of a dedicated build job
+tasks.named('javaRestTest').configure {
+    onlyIf("E2E test task must be invoked directly") {
+      gradle.startParameter.getTaskNames().contains(this.path) ||
+        (gradle.startParameter.getTaskNames().contains(this.name) && gradle.startParameter.currentDir == project.projectDir)
+    }
 }
 
 addQaCheckDependencies(project)

--- a/x-pack/plugin/stack/src/internalClusterTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/internalClusterTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stack;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.template.TemplateUtils;
+import org.elasticsearch.xpack.wildcard.Wildcard;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.stack.StackTemplateRegistry.TEMPLATE_VERSION_VARIABLE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+@SuppressWarnings("unchecked")
+@ESTestCase.WithoutSecurityManager
+@ESIntegTestCase.SuiteScopeTestCase
+public class EcsDynamicTemplatesIT extends ESIntegTestCase {
+
+    // The dynamic templates we test against
+    public static final String ECS_DYNAMIC_TEMPLATES_FILE = "/ecs-dynamic-mappings.json";
+
+    // The current ECS state (branch main) as a containing all fields in flattened form
+    private static final String ECS_FLAT_FILE_URL = "https://raw.githubusercontent.com/elastic/ecs/main/generated/ecs/ecs_flat.yml";
+
+    private static final Set<String> OMIT_FIELD_TYPES = Set.of("object", "flattened", "nested");
+
+    private static final Set<String> OMIT_FIELDS = Set.of("data_stream.dataset", "data_stream.namespace", "data_stream.type");
+
+    private static Map<String, Object> ecsDynamicTemplates;
+    private static Map<String, Map<String, Object>> ecsFlatFieldDefinitions;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(MapperExtrasPlugin.class, Wildcard.class);
+    }
+
+    @Override
+    protected void setupSuiteScopeCluster() throws Exception {
+        prepareEcsDynamicTemplates();
+        prepareEcsDefinitions();
+    }
+
+    private static void prepareEcsDynamicTemplates() throws JsonProcessingException {
+        String rawEcsComponentTemplate = TemplateUtils.loadTemplate(
+            ECS_DYNAMIC_TEMPLATES_FILE,
+            Integer.toString(1),
+            TEMPLATE_VERSION_VARIABLE,
+            Collections.emptyMap()
+        );
+        ObjectMapper jsonObjectMapper = new ObjectMapper();
+        Map<?, ?> ecsDynamicTemplatesRaw = jsonObjectMapper.readValue(rawEcsComponentTemplate, Map.class);
+        String errorMessage = String.format(
+            Locale.ENGLISH,
+            "ECS mappings component template '%s' structure has changed, this test needs to be adjusted",
+            ECS_DYNAMIC_TEMPLATES_FILE
+        );
+        assertFalse(errorMessage, rawEcsComponentTemplate.isEmpty());
+        Object mappings = ecsDynamicTemplatesRaw.get("template");
+        assertNotNull(errorMessage, mappings);
+        assertThat(errorMessage, mappings, instanceOf(Map.class));
+        Object dynamicTemplates = ((Map<?, ?>) mappings).get("mappings");
+        assertNotNull(errorMessage, dynamicTemplates);
+        assertThat(errorMessage, dynamicTemplates, instanceOf(Map.class));
+        assertTrue(errorMessage, ((Map<?, ?>) dynamicTemplates).containsKey("dynamic_templates"));
+        ecsDynamicTemplates = (Map<String, Object>) dynamicTemplates;
+    }
+
+    private static void prepareEcsDefinitions() throws IOException {
+        ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
+        Map<?, ?> ecsFlatFieldsRawMap = yamlObjectMapper.readValue(new URL(ECS_FLAT_FILE_URL), Map.class);
+        String errorMessage = String.format(
+            Locale.ENGLISH,
+            "ECS flat mapping file at %s has changed, this test needs to be adjusted",
+            ECS_FLAT_FILE_URL
+        );
+        assertFalse(errorMessage, ecsFlatFieldsRawMap.isEmpty());
+        Map.Entry<?, ?> fieldEntry = ecsFlatFieldsRawMap.entrySet().iterator().next();
+        assertThat(errorMessage, fieldEntry.getKey(), instanceOf(String.class));
+        assertThat(errorMessage, fieldEntry.getValue(), instanceOf(Map.class));
+        Map<?, ?> fieldProperties = (Map<?, ?>) fieldEntry.getValue();
+        assertFalse(errorMessage, fieldProperties.isEmpty());
+        Map.Entry<?, ?> fieldProperty = fieldProperties.entrySet().iterator().next();
+        assertThat(errorMessage, fieldProperty.getKey(), instanceOf(String.class));
+
+        OMIT_FIELDS.forEach(ecsFlatFieldsRawMap::remove);
+
+        // noinspection CastCanBeRemovedNarrowingVariableType
+        ecsFlatFieldDefinitions = (Map<String, Map<String, Object>>) ecsFlatFieldsRawMap;
+        Iterator<Map.Entry<String, Map<String, Object>>> iterator = ecsFlatFieldDefinitions.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Map<String, Object>> entry = iterator.next();
+            Map<String, Object> definitions = entry.getValue();
+            String type = (String) definitions.get("type");
+            if (OMIT_FIELD_TYPES.contains(type)) {
+                iterator.remove();
+            } else if ("bool".equals(type)) {
+                // for some reason, 'container.security_context.privileged' has a type "bool" in ECS definitions so we are standardizing
+                definitions.put("type", "boolean");
+            }
+        }
+    }
+
+    public void testFlattenedFields() {
+        ESIntegTestCase.indicesAdmin()
+            .prepareCreate("test-flattened-fields")
+            .setSettings(Settings.builder().put("index.mapping.total_fields.limit", 10000))
+            .setMapping(ecsDynamicTemplates)
+            .get();
+        ensureGreen();
+
+        Map<String, Object> flattenedFieldsMap = new HashMap<>();
+        for (Map.Entry<String, Map<String, Object>> fieldEntry : ecsFlatFieldDefinitions.entrySet()) {
+            String fieldName = fieldEntry.getKey();
+            Map<String, Object> fieldDefinitions = fieldEntry.getValue();
+            String type = (String) fieldDefinitions.get("type");
+            assertNotNull(
+                String.format(Locale.ENGLISH, "Can't find type for field '%s' in %s file", fieldName, ECS_DYNAMIC_TEMPLATES_FILE),
+                type
+            );
+            Object testValue = generateTestValue(type);
+            flattenedFieldsMap.put(fieldName, testValue);
+        }
+        IndexResponse indexResponse = index("test-flattened-fields", "1", flattenedFieldsMap);
+        assertEquals(indexResponse.getResult(), DocWriteResponse.Result.CREATED);
+
+        GetMappingsResponse mappingsResponse = indicesAdmin().prepareGetMappings("test-flattened-fields").get();
+        assertThat(mappingsResponse.mappings().size(), equalTo(1));
+        Map<String, Object> mappings = mappingsResponse.mappings().entrySet().iterator().next().getValue().getSourceAsMap();
+        assertTrue(mappings.containsKey("properties"));
+        Map<String, String> flattenedMappings = processMappings((Map<String, Object>) mappings.get("properties"));
+        verifyEcsMappings(flattenedMappings);
+    }
+
+    private Object generateTestValue(String type) {
+        switch (type) {
+            case "geo_point" -> {
+                return new double[] { randomDouble(), randomDouble() };
+            }
+            case "long" -> {
+                return randomLong();
+            }
+            case "int" -> {
+                return randomInt();
+            }
+            case "float", "scaled_float" -> {
+                return randomFloat();
+            }
+            case "keyword", "wildcard", "text", "match_only_text" -> {
+                return randomAlphaOfLength(20);
+            }
+            case "constant_keyword" -> {
+                return "test";
+            }
+            case "date" -> {
+                return DateFormatter.forPattern("strict_date_optional_time").formatMillis(System.currentTimeMillis());
+            }
+            case "ip" -> {
+                return randomIp(true).getHostAddress();
+            }
+            case "boolean", "bool" -> {
+                return randomBoolean();
+            }
+        }
+        throw new IllegalArgumentException("Unknown field type: " + type);
+    }
+
+    private Map<String, String> processMappings(final Map<String, Object> rawMappings) {
+        Map<String, String> processedMappings = new HashMap<>();
+        processRawMappingsSubtree(rawMappings, processedMappings, "");
+        return processedMappings;
+    }
+
+    private void processRawMappingsSubtree(
+        final Map<String, Object> fieldSubtrees,
+        final Map<String, String> processedMappings,
+        final String subtreePrefix
+    ) {
+        fieldSubtrees.forEach((fieldName, fieldMappings) -> {
+            String fieldFullPath = subtreePrefix + fieldName;
+            Map<String, Object> fieldMappingsMap = ((Map<String, Object>) fieldMappings);
+            String type = (String) fieldMappingsMap.get("type");
+            if (type != null) {
+                processedMappings.put(fieldFullPath, type);
+            }
+            Map<String, Object> subfields = (Map<String, Object>) fieldMappingsMap.get("properties");
+            if (subfields != null) {
+                processRawMappingsSubtree(subfields, processedMappings, fieldFullPath + ".");
+            }
+        });
+    }
+
+    private void verifyEcsMappings(Map<String, String> flattenedActualMappings) {
+        HashMap<String, Map<String, Object>> shallowCopy = new HashMap<>(ecsFlatFieldDefinitions);
+        flattenedActualMappings.forEach((fieldName, fieldType) -> {
+            Map<String, Object> actualMappings = shallowCopy.remove(fieldName);
+            if (actualMappings == null) {
+                // todo - replace with counting
+                System.out.println("Field " + fieldName + " doesn't have mappings");
+            } else {
+                String actualType = (String) actualMappings.get("type");
+                if (fieldType.equals(actualType) == false) {
+                    // todo - replace with counting
+                    System.out.printf("Field %s should have type %s but has type %s\n", fieldName, fieldType, actualType);
+                }
+            }
+        });
+        if (shallowCopy.isEmpty() == false) {
+            shallowCopy.keySet().forEach(field -> System.out.println("field " + field + " doesn't have ECS definitions"));
+        }
+        // todo - count all misses and prepare a single report, only then assert for all misses
+        // todo - look for the "multi_fields" entry in ecsFlatFieldDefinitions and verify that as well
+    }
+}

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -44,10 +44,7 @@ import static org.hamcrest.Matchers.instanceOf;
 public class EcsDynamicTemplatesIT extends ESRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .module("mapper-extras")
-        .module("wildcard")
-        .build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("mapper-extras").module("wildcard").build();
 
     // The dynamic templates we test against
     public static final String ECS_DYNAMIC_TEMPLATES_FILE = "/ecs-dynamic-mappings.json";
@@ -105,8 +102,10 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         Map<String, ?> ecsFlatFieldsRawMap;
         URL ecsDefinitionsFlatFileUrl = new URL(ECS_FLAT_FILE_URL);
         try (InputStream ecsDynamicTemplatesIS = ecsDefinitionsFlatFileUrl.openStream()) {
-            try (XContentParser parser = XContentFactory.xContent(XContentType.YAML)
-                    .createParser(XContentParserConfiguration.EMPTY, ecsDynamicTemplatesIS)) {
+            try (
+                XContentParser parser = XContentFactory.xContent(XContentType.YAML)
+                    .createParser(XContentParserConfiguration.EMPTY, ecsDynamicTemplatesIS)
+            ) {
                 ecsFlatFieldsRawMap = parser.map();
             }
         }

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -141,9 +141,6 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             String type = (String) definitions.get("type");
             if (OMIT_FIELD_TYPES.contains(type)) {
                 iterator.remove();
-            } else if ("bool".equals(type)) {
-                // for some reason, 'container.security_context.privileged' has a type "bool" in ECS definitions so we are standardizing
-                definitions.put("type", "boolean");
             }
 
             List<Map<String, String>> multiFields = (List<Map<String, String>>) definitions.get("multi_fields");
@@ -278,7 +275,7 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             case "ip" -> {
                 return NetworkAddress.format(randomIp(true));
             }
-            case "boolean", "bool" -> {
+            case "boolean" -> {
                 return randomBoolean();
             }
             case "flattened" -> {

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -49,21 +49,14 @@ import static org.hamcrest.Matchers.instanceOf;
 @SuppressWarnings("unchecked")
 public class EcsDynamicTemplatesIT extends ESRestTestCase {
 
-    /**
-     * Indicates the ECS version used for the dynamic templates verification.
-     */
-    public static final String TESTED_ECS_VERSION = "8.9";
-
-    // The current ECS state (branch main) as a containing all fields in flattened form
-    private static final String ECS_FLAT_FILE_URL = "https://raw.githubusercontent.com/elastic/ecs/"
-        + TESTED_ECS_VERSION
-        + "/generated/ecs/ecs_flat.yml";
-
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("mapper-extras").module("wildcard").build();
 
     // The dynamic templates we test against
     public static final String ECS_DYNAMIC_TEMPLATES_FILE = "ecs-dynamic-mappings.json";
+
+    // The current ECS state (branch main) containing all fields in flattened form
+    private static final String ECS_FLAT_FILE_URL = "https://raw.githubusercontent.com/elastic/ecs/main/generated/ecs/ecs_flat.yml";
 
     private static final Set<String> OMIT_FIELD_TYPES = Set.of("object", "nested");
 

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -106,10 +106,8 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         Map<String, ?> ecsFlatFieldsRawMap;
         URL ecsDefinitionsFlatFileUrl = new URL(ECS_FLAT_FILE_URL);
         try (InputStream ecsDynamicTemplatesIS = ecsDefinitionsFlatFileUrl.openStream()) {
-            try (
-                XContentParser parser = XContentFactory.xContent(XContentType.YAML)
-                    .createParser(XContentParserConfiguration.EMPTY, ecsDynamicTemplatesIS)
-            ) {
+            try (XContentParser parser = XContentFactory.xContent(XContentType.YAML)
+                    .createParser(XContentParserConfiguration.EMPTY, ecsDynamicTemplatesIS)) {
                 ecsFlatFieldsRawMap = parser.map();
             }
         }

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -43,8 +43,12 @@ import static org.hamcrest.Matchers.instanceOf;
 
 @SuppressWarnings("unchecked")
 public class EcsDynamicTemplatesIT extends ESRestTestCase {
+
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("mapper-extras").module("wildcard").build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("mapper-extras")
+        .module("wildcard")
+        .build();
 
     // The dynamic templates we test against
     public static final String ECS_DYNAMIC_TEMPLATES_FILE = "/ecs-dynamic-mappings.json";

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -49,14 +49,21 @@ import static org.hamcrest.Matchers.instanceOf;
 @SuppressWarnings("unchecked")
 public class EcsDynamicTemplatesIT extends ESRestTestCase {
 
+    /**
+     * Indicates the ECS version used for the dynamic templates verification.
+     */
+    public static final String TESTED_ECS_VERSION = "8.9";
+
+    // The current ECS state (branch main) as a containing all fields in flattened form
+    private static final String ECS_FLAT_FILE_URL = "https://raw.githubusercontent.com/elastic/ecs/"
+        + TESTED_ECS_VERSION
+        + "/generated/ecs/ecs_flat.yml";
+
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("mapper-extras").module("wildcard").build();
 
     // The dynamic templates we test against
     public static final String ECS_DYNAMIC_TEMPLATES_FILE = "ecs-dynamic-mappings.json";
-
-    // The current ECS state (branch main) as a containing all fields in flattened form
-    private static final String ECS_FLAT_FILE_URL = "https://raw.githubusercontent.com/elastic/ecs/main/generated/ecs/ecs_flat.yml";
 
     private static final Set<String> OMIT_FIELD_TYPES = Set.of("object", "nested");
 

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.template.TemplateUtils;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
@@ -89,15 +88,15 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             "ECS mappings component template '%s' structure has changed, this test needs to be adjusted",
             ECS_DYNAMIC_TEMPLATES_FILE
         );
-        Assert.assertFalse(errorMessage, rawEcsComponentTemplate.isEmpty());
+        assertFalse(errorMessage, rawEcsComponentTemplate.isEmpty());
         Object mappings = ecsDynamicTemplatesRaw.get("template");
-        Assert.assertNotNull(errorMessage, mappings);
-        Assert.assertThat(errorMessage, mappings, instanceOf(Map.class));
+        assertNotNull(errorMessage, mappings);
+        assertThat(errorMessage, mappings, instanceOf(Map.class));
         Object dynamicTemplates = ((Map<?, ?>) mappings).get("mappings");
-        Assert.assertNotNull(errorMessage, dynamicTemplates);
-        Assert.assertThat(errorMessage, dynamicTemplates, instanceOf(Map.class));
-        Assert.assertEquals(errorMessage, 1, ((Map<?, ?>) dynamicTemplates).size());
-        Assert.assertTrue(errorMessage, ((Map<?, ?>) dynamicTemplates).containsKey("dynamic_templates"));
+        assertNotNull(errorMessage, dynamicTemplates);
+        assertThat(errorMessage, dynamicTemplates, instanceOf(Map.class));
+        assertEquals(errorMessage, 1, ((Map<?, ?>) dynamicTemplates).size());
+        assertTrue(errorMessage, ((Map<?, ?>) dynamicTemplates).containsKey("dynamic_templates"));
         ecsDynamicTemplates = (Map<String, Object>) dynamicTemplates;
     }
 
@@ -116,13 +115,13 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             "ECS flat mapping file at %s has changed, this test needs to be adjusted",
             ECS_FLAT_FILE_URL
         );
-        Assert.assertFalse(errorMessage, ecsFlatFieldsRawMap.isEmpty());
+        assertFalse(errorMessage, ecsFlatFieldsRawMap.isEmpty());
         Map.Entry<String, ?> fieldEntry = ecsFlatFieldsRawMap.entrySet().iterator().next();
-        Assert.assertThat(errorMessage, fieldEntry.getValue(), instanceOf(Map.class));
+        assertThat(errorMessage, fieldEntry.getValue(), instanceOf(Map.class));
         Map<?, ?> fieldProperties = (Map<?, ?>) fieldEntry.getValue();
-        Assert.assertFalse(errorMessage, fieldProperties.isEmpty());
+        assertFalse(errorMessage, fieldProperties.isEmpty());
         Map.Entry<?, ?> fieldProperty = fieldProperties.entrySet().iterator().next();
-        Assert.assertThat(errorMessage, fieldProperty.getKey(), instanceOf(String.class));
+        assertThat(errorMessage, fieldProperty.getKey(), instanceOf(String.class));
 
         OMIT_FIELDS.forEach(ecsFlatFieldsRawMap::remove);
 
@@ -156,16 +155,15 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             createIndexRequest.setJsonEntity(Strings.toString(bodyBuilder));
             // noinspection resource
             Response response = ESRestTestCase.client().performRequest(createIndexRequest);
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
         }
-        // ensureGreen(indexName);
 
         Map<String, Object> flattenedFieldsMap = new HashMap<>();
         for (Map.Entry<String, Map<String, Object>> fieldEntry : ecsFlatFieldDefinitions.entrySet()) {
             String fieldName = fieldEntry.getKey();
             Map<String, Object> fieldDefinitions = fieldEntry.getValue();
             String type = (String) fieldDefinitions.get("type");
-            Assert.assertNotNull(
+            assertNotNull(
                 String.format(Locale.ENGLISH, "Can't find type for field '%s' in %s file", fieldName, ECS_DYNAMIC_TEMPLATES_FILE),
                 type
             );
@@ -178,13 +176,13 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             indexRequest.setJsonEntity(Strings.toString(bodyBuilder.map(flattenedFieldsMap)));
             // noinspection resource
             Response response = ESRestTestCase.client().performRequest(indexRequest);
-            Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusLine().getStatusCode());
+            assertEquals(HttpStatus.SC_CREATED, response.getStatusLine().getStatusCode());
         }
 
         Request getMappingRequest = new Request("GET", "/" + indexName + "/_mapping");
         // noinspection resource
         Response response = ESRestTestCase.client().performRequest(getMappingRequest);
-        Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK);
         Map<String, Object> mappingResponse;
         try (
             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
@@ -192,7 +190,7 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         ) {
             mappingResponse = parser.map();
         }
-        Assert.assertThat(mappingResponse.size(), equalTo(1));
+        assertThat(mappingResponse.size(), equalTo(1));
         Map<String, Object> indexMap = (Map<String, Object>) mappingResponse.get(indexName);
         assertNotNull(indexMap);
         Map<String, Object> mappings = (Map<String, Object>) indexMap.get("mappings");

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.instanceOf;
 
 @SuppressWarnings("unchecked")
 public class EcsDynamicTemplatesIT extends ESRestTestCase {
-
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("mapper-extras").module("wildcard").build();
 

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.stack;
 
 import org.apache.http.HttpStatus;
-import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
@@ -292,10 +291,7 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         Response response = ESRestTestCase.client().performRequest(getMappingRequest);
         assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK);
         Map<String, Object> mappingResponse;
-        try (
-            XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                .createParser(XContentParserConfiguration.EMPTY, EntityUtils.toByteArray(response.getEntity()))
-        ) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, response.getEntity().getContent())) {
             mappingResponse = parser.map();
         }
         assertThat(mappingResponse.size(), equalTo(1));

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -58,7 +58,7 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
     // The current ECS state (branch main) as a containing all fields in flattened form
     private static final String ECS_FLAT_FILE_URL = "https://raw.githubusercontent.com/elastic/ecs/main/generated/ecs/ecs_flat.yml";
 
-    private static final Set<String> OMIT_FIELD_TYPES = Set.of("object", "flattened", "nested");
+    private static final Set<String> OMIT_FIELD_TYPES = Set.of("object", "nested");
 
     private static final Set<String> OMIT_FIELDS = Set.of("data_stream.dataset", "data_stream.namespace", "data_stream.type");
 
@@ -280,6 +280,10 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
             }
             case "boolean", "bool" -> {
                 return randomBoolean();
+            }
+            case "flattened" -> {
+                // creating multiple subfields
+                return Map.of("subfield1", randomAlphaOfLength(20), "subfield2", randomAlphaOfLength(20));
             }
         }
         throw new IllegalArgumentException("Unknown field type: " + type);


### PR DESCRIPTION
Closes #96713 

All three tests cases are covered:
- [x] a test document containing all ECS fields with random values in flattened form
- [x] a test document containing all ECS fields with random values in flattened form and index is set with `subobjects: false`
- [x] a test document containing all ECS fields with random values in nested/object form

In addition, I added verification that all ECS multi-field definitions are covered by the ECS dynamic templates (revealing two that actually were not).

@felixbarny @ruflin see if you agree with [my comment](https://github.com/elastic/elasticsearch/pull/97901/files#diff-5de719b6a576263ffb32a9a7a1754078f91b12abf0d4fe7141faeb7a91e6b66dR365-R367) about not failing if we create multi-field mapping even for fields of which ECS definition does not enforce such. 
For example, we define a multi-field mapping for the [`*.name`](https://github.com/elastic/elasticsearch/blob/1a254c2f08a54ca4ef4dac6760934f78ebff3b62/x-pack/plugin/core/template-resources/src/main/resources/ecs-dynamic-mappings.json#L115) pattern. If you look into the [ECS definitions](https://github.com/elastic/ecs/blob/main/generated/ecs/ecs_flat.yml), you will find that many `*.name` have multi-field mappings, while many others don't. Trying to be very accurate will result with many more dynamic templates.

@P1llus I assigned you as a reviewer because I think you were waiting for this in order to start migrating some ECS mappings to rely on the builtin dynamic templates.