### PR TITLE
Clean up EmptyTransportResponseHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -16,12 +16,10 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
 import org.elasticsearch.transport.TransportChannel;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
@@ -91,22 +89,22 @@ public class VerifyNodeRepositoryAction {
                     node,
                     ACTION_NAME,
                     new VerifyNodeRepositoryRequest(repository, verificationToken),
-                    new EmptyTransportResponseHandler(EsExecutors.DIRECT_EXECUTOR_SERVICE) {
+                    new EmptyTransportResponseHandler(new ActionListener<>() {
                         @Override
-                        public void handleResponse(TransportResponse.Empty response) {
+                        public void onResponse(Void unused) {
                             if (counter.decrementAndGet() == 0) {
                                 finishVerification(repository, listener, nodes, errors);
                             }
                         }
 
                         @Override
-                        public void handleException(TransportException exp) {
+                        public void onFailure(Exception exp) {
                             errors.add(new VerificationFailure(node.getId(), exp));
                             if (counter.decrementAndGet() == 0) {
                                 finishVerification(repository, listener, nodes, errors);
                             }
                         }
-                    }
+                    })
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
@@ -30,7 +29,6 @@ import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.NodeNotConnectedException;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
@@ -182,15 +180,15 @@ public class TaskCancellationService {
                 BAN_PARENT_ACTION_NAME,
                 banRequest,
                 TransportRequestOptions.EMPTY,
-                new EmptyTransportResponseHandler(EsExecutors.DIRECT_EXECUTOR_SERVICE) {
+                new EmptyTransportResponseHandler(new ActionListener<>() {
                     @Override
-                    public void handleResponse(TransportResponse.Empty response) {
+                    public void onResponse(Void unused) {
                         logger.trace("sent ban for tasks with the parent [{}] for connection [{}]", taskId, connection);
                         countDownListener.onResponse(null);
                     }
 
                     @Override
-                    public void handleException(TransportException exp) {
+                    public void onFailure(Exception exp) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(exp);
                         assert cause instanceof ElasticsearchSecurityException == false;
                         if (isUnimportantBanFailure(cause)) {
@@ -215,6 +213,8 @@ public class TaskCancellationService {
                         countDownListener.onFailure(exp);
                     }
                 }
+
+                )
             );
         }
     }
@@ -229,9 +229,12 @@ public class TaskCancellationService {
                 BAN_PARENT_ACTION_NAME,
                 request,
                 TransportRequestOptions.EMPTY,
-                new EmptyTransportResponseHandler(EsExecutors.DIRECT_EXECUTOR_SERVICE) {
+                new EmptyTransportResponseHandler(new ActionListener<>() {
                     @Override
-                    public void handleException(TransportException exp) {
+                    public void onResponse(Void unused) {}
+
+                    @Override
+                    public void onFailure(Exception exp) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(exp);
                         assert cause instanceof ElasticsearchSecurityException == false;
                         if (isUnimportantBanFailure(cause)) {
@@ -261,7 +264,7 @@ public class TaskCancellationService {
                             );
                         }
                     }
-                }
+                })
             );
         }
     }
@@ -392,6 +395,8 @@ public class TaskCancellationService {
         }
     }
 
+    private static final EmptyTransportResponseHandler NOOP_HANDLER = new EmptyTransportResponseHandler(ActionListener.noop());
+
     /**
      * Sends an action to cancel a child task, associated with the given request ID and parent task.
      */
@@ -406,13 +411,7 @@ public class TaskCancellationService {
                 reason
             );
             final CancelChildRequest request = CancelChildRequest.createCancelChildRequest(parentTask, childRequestId, reason);
-            transportService.sendRequest(
-                childNode,
-                CANCEL_CHILD_ACTION_NAME,
-                request,
-                TransportRequestOptions.EMPTY,
-                EmptyTransportResponseHandler.INSTANCE_SAME
-            );
+            transportService.sendRequest(childNode, CANCEL_CHILD_ACTION_NAME, request, TransportRequestOptions.EMPTY, NOOP_HANDLER);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/EmptyTransportResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/EmptyTransportResponseHandler.java
@@ -8,37 +8,29 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.threadpool.ThreadPool;
-
-import java.util.concurrent.Executor;
 
 public class EmptyTransportResponseHandler implements TransportResponseHandler<TransportResponse.Empty> {
 
-    public static final EmptyTransportResponseHandler INSTANCE_SAME = new EmptyTransportResponseHandler(
-        EsExecutors.DIRECT_EXECUTOR_SERVICE
-    );
+    private final ActionListener<Void> listener;
 
-    private final Executor executor;
-
-    public EmptyTransportResponseHandler(Executor executor) {
-        this.executor = executor;
+    public EmptyTransportResponseHandler(ActionListener<Void> listener) {
+        this.listener = listener;
     }
 
     @Override
-    public TransportResponse.Empty read(StreamInput in) {
+    public void handleResponse(TransportResponse.Empty response) {
+        listener.onResponse(null);
+    }
+
+    @Override
+    public void handleException(TransportException exp) {
+        listener.onFailure(exp);
+    }
+
+    @Override
+    public final TransportResponse.Empty read(StreamInput in) {
         return TransportResponse.Empty.INSTANCE;
-    }
-
-    @Override
-    public void handleResponse(TransportResponse.Empty response) {}
-
-    @Override
-    public void handleException(TransportException exp) {}
-
-    @Override
-    public Executor executor(ThreadPool threadPool) {
-        return executor;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/EmptyTransportResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/EmptyTransportResponseHandler.java
@@ -20,12 +20,12 @@ public class EmptyTransportResponseHandler implements TransportResponseHandler<T
     }
 
     @Override
-    public void handleResponse(TransportResponse.Empty response) {
+    public final void handleResponse(TransportResponse.Empty response) {
         listener.onResponse(null);
     }
 
     @Override
-    public void handleException(TransportException exp) {
+    public final void handleException(TransportException exp) {
         listener.onFailure(exp);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -576,7 +576,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         serviceB.addMessageListener(tracerB);
 
         try {
-            submitRequest(serviceA, nodeB, ACTION, TransportRequest.Empty.INSTANCE, EmptyTransportResponseHandler.INSTANCE_SAME).get();
+            submitRequest(serviceA, nodeB, ACTION, TransportRequest.Empty.INSTANCE, NOOP_HANDLER).get();
         } catch (ExecutionException e) {
             assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
@@ -595,7 +595,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         });
 
         try {
-            submitRequest(serviceB, nodeA, ACTION, TransportRequest.Empty.INSTANCE, EmptyTransportResponseHandler.INSTANCE_SAME).get();
+            submitRequest(serviceB, nodeA, ACTION, TransportRequest.Empty.INSTANCE, NOOP_HANDLER).get();
         } catch (ExecutionException e) {
             assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
@@ -615,7 +615,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
         // use assert busy as callbacks are called on a different thread
         try {
-            submitRequest(serviceA, nodeA, ACTION, TransportRequest.Empty.INSTANCE, EmptyTransportResponseHandler.INSTANCE_SAME).get();
+            submitRequest(serviceA, nodeA, ACTION, TransportRequest.Empty.INSTANCE, NOOP_HANDLER).get();
         } catch (ExecutionException e) {
             assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
@@ -1045,7 +1045,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 nodeA,
                 "internal:foobar",
                 new StringMessageRequest(""),
-                EmptyTransportResponseHandler.INSTANCE_SAME
+                NOOP_HANDLER
             );
             latch2.countDown();
             assertThat(expectThrows(ExecutionException.class, foobar::get).getCause(), instanceOf(TransportException.class));
@@ -3372,4 +3372,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         transportService.sendRequest(node, action, request, options, futureHandler);
         return future;
     }
+
+    private static final EmptyTransportResponseHandler NOOP_HANDLER = new EmptyTransportResponseHandler(ActionListener.noop());
 }


### PR DESCRIPTION
No-op handlers are kind of an antipattern, but `EmptyTransportResponseHandler`
makes it easy to write such a handler by accident. Also none of its
implementations fork. This commit turns it into a wrapper around an
`ActionListener<Void>` so that callers can't accidentally drop a notification,
and gets rid of the explicit executor parameter.