### PR TITLE
Document manage_search_application privilege

### DIFF
--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -109,6 +109,9 @@ rollup jobs.
 Enables the use of internal {es} APIs to initiate and manage SAML authentication
 on behalf of other users.
 
+`manage_search_application`::
+All CRUD operations on <<search-application-apis, search applications>>.
+
 `manage_security`::
 All security-related operations such as CRUD operations on users and roles and
 cache clearing.


### PR DESCRIPTION
The API docs mention `manage_search_application`, but we do not explicitly list it as a cluster privilege in the security privileges docs.

<img width="858" alt="Screenshot 2023-07-24 at 16 08 16" src="https://github.com/elastic/elasticsearch/assets/16032709/efd310d2-4f78-4ffc-916f-cb811cf95a3c">
