### PR TITLE
[8.9] Document manage_search_application privilege (#97903)

### DIFF
--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -109,6 +109,9 @@ rollup jobs.
 Enables the use of internal {es} APIs to initiate and manage SAML authentication
 on behalf of other users.
 
+`manage_search_application`::
+All CRUD operations on <<search-application-apis, search applications>>.
+
 `manage_security`::
 All security-related operations such as CRUD operations on users and roles and
 cache clearing.


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Document manage_search_application privilege (#97903)