### PR TITLE
[DOCS] Work around broken links

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1931,3 +1931,17 @@ coming::[8.10.0]
 === Create or update synonym sets API
 
 coming::[8.10.0]
+
+ifeval::["{release-state}"=="released"]
+
+[role="exclude",id="security-api-create-cross-cluster-api-key"]
+=== Create Cross-Cluster API key API
+
+{es-feature-flag}
+
+[role="exclude",id="security-api-update-cross-cluster-api-key"]
+=== Update Cross-Cluster API key API
+
+{es-feature-flag}
+
+endif::[]


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2722, https://github.com/elastic/elasticsearch/pull/96415

This PR provides a work-around for the following broken links:

```
13:40:21 INFO:build_docs:Bad cross-document links:
13:40:21 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.9/api-reference.html contains broken links to:
13:40:21 INFO:build_docs:   - en/elasticsearch/reference/8.9/security-api-create-cross-cluster-api-key.html
13:40:21 INFO:build_docs:   - en/elasticsearch/reference/8.9/security-api-update-cross-cluster-api-key.html
13:40:21 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/current/api-reference.html contains broken links to:
13:40:21 INFO:build_docs:   - en/elasticsearch/reference/8.9/security-api-create-cross-cluster-api-key.html
13:40:21 INFO:build_docs:   - en/elasticsearch/reference/8.9/security-api-update-cross-cluster-api-key.html
```