### PR TITLE
Filtering enrich stats in the transport action

### DIFF
--- a/docs/changelog/97911.yaml
+++ b/docs/changelog/97911.yaml
@@ -1,0 +1,5 @@
+pr: 97911
+summary: Filtering enrich stats in the transport action
+area: Stats
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -161,9 +161,10 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_037 = registerTransportVersion(8_500_037, "d76a4f22-8878-43e0-acfa-15e452195fa7");
     public static final TransportVersion V_8_500_038 = registerTransportVersion(8_500_038, "9ef93580-feae-409f-9989-b49e411ca7a9");
     public static final TransportVersion V_8_500_039 = registerTransportVersion(8_500_039, "c23722d7-6139-4cf2-b8a1-600fbd4ec359");
+    public static final TransportVersion V_8_500_040 = registerTransportVersion(8_500_040, "e8038bd6-e69d-4e35-8aa2-700e301a017d");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_039);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_040);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -33,16 +33,36 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
     }
 
     public static class Request extends MasterNodeRequest<Request> {
+        private final boolean rollupStats;
 
-        public Request() {}
+        public Request(boolean rollupStats) {
+            this.rollupStats = rollupStats;
+        }
 
         public Request(StreamInput in) throws IOException {
             super(in);
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_040)) {
+                rollupStats = in.readBoolean();
+            } else {
+                rollupStats = false;
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_040)) {
+                out.writeBoolean(this.rollupStats);
+            }
         }
 
         @Override
         public ActionRequestValidationException validate() {
             return null;
+        }
+
+        public boolean shouldRollupStats() {
+            return rollupStats;
         }
     }
 

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -239,7 +239,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
             }
         }
 
-        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, new EnrichStatsAction.Request())
+        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, new EnrichStatsAction.Request(false))
             .actionGet();
         assertThat(statsResponse.getCoordinatorStats().size(), equalTo(internalCluster().size()));
         String nodeId = internalCluster().getInstance(ClusterService.class, coordinatingNode).localNode().getId();

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
@@ -49,7 +49,7 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
 
     public void testEnrichCacheValuesCannotBeCorrupted() {
         // Ensure enrich cache is empty
-        var statsRequest = new EnrichStatsAction.Request();
+        var statsRequest = new EnrichStatsAction.Request(false);
         var statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
         assertThat(statsResponse.getCacheStats().size(), equalTo(1));
         assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(0L));

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestEnrichStatsAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -34,8 +35,14 @@ public class RestEnrichStatsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) throws IOException {
-        final EnrichStatsAction.Request request = new EnrichStatsAction.Request();
+        final EnrichStatsAction.Request request = new EnrichStatsAction.Request(
+            "serverless".equals(restRequest.param(RestRequest.RESPONSE_RESTRICTED))
+        );
         return channel -> client.execute(EnrichStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 
+    @Override
+    protected Set<String> responseParams() {
+        return Set.of(RestRequest.RESPONSE_RESTRICTED);
+    }
 }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/BasicEnrichTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/BasicEnrichTests.java
@@ -146,7 +146,7 @@ public class BasicEnrichTests extends ESSingleNodeTestCase {
             }
         }
 
-        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, new EnrichStatsAction.Request())
+        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, new EnrichStatsAction.Request(false))
             .actionGet();
         assertThat(statsResponse.getCoordinatorStats().size(), equalTo(1));
         String localNodeId = getInstanceFromNode(ClusterService.class).localNode().getId();
@@ -226,7 +226,7 @@ public class BasicEnrichTests extends ESSingleNodeTestCase {
         assertThat(entries.containsKey(matchField), is(true));
         assertThat(entries.get(enrichField), equalTo("94040"));
 
-        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, new EnrichStatsAction.Request())
+        EnrichStatsAction.Response statsResponse = client().execute(EnrichStatsAction.INSTANCE, new EnrichStatsAction.Request(false))
             .actionGet();
         assertThat(statsResponse.getCoordinatorStats().size(), equalTo(1));
         String localNodeId = getInstanceFromNode(ClusterService.class).localNode().getId();

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollector.java
@@ -52,7 +52,7 @@ public final class EnrichStatsCollector extends Collector {
             final long timestamp = timestamp();
             final String clusterUuid = clusterUuid(clusterState);
 
-            final EnrichStatsAction.Request request = new EnrichStatsAction.Request();
+            final EnrichStatsAction.Request request = new EnrichStatsAction.Request(false);
             final EnrichStatsAction.Response response = client.execute(EnrichStatsAction.INSTANCE, request)
                 .actionGet(getCollectionTimeout());
 


### PR DESCRIPTION
This is meant to be an alternative to #97472 and https://github.com/elastic/elasticsearch/pull/97472. It filters the results of the _enrich/_stats response to not include node information when the user is not an operator. It does this in the transport action itself. Like the other PRs, this not only means that the node_id is removed -- it also rolls up the stats for all nodes into one pseudo node so that information about the number of nodes is not leaked.