### PR TITLE
Add negate() to QL Query class hierarchy

### DIFF
--- a/x-pack/plugin/eql/src/test/resources/querytranslator_tests.txt
+++ b/x-pack/plugin/eql/src/test/resources/querytranslator_tests.txt
@@ -876,7 +876,7 @@ process where null == (exit_code > -1)
 isNull
 process where pid != null
 ;
-{"bool":{"must_not":[{"bool":{"must_not":[{"exists":{"field":"pid"
+"must":[{"term":{"event.category":{"value":"process"}}},{"exists":{"field":"pid","boost":1.0}}]
 ;
 
 disjunctionOfFunctionAndNegatedFunction

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -206,7 +206,7 @@ public final class ExpressionTranslators {
             Query wrappedQuery = handler.asQuery(not.field());
             Query q = wrappedQuery instanceof ScriptQuery
                 ? new ScriptQuery(not.source(), not.asScript())
-                : new NotQuery(not.source(), wrappedQuery);
+                : wrappedQuery.negate(not.source());
 
             return wrapIfNested(q, e);
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/BoolQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/BoolQuery.java
@@ -116,4 +116,13 @@ public class BoolQuery extends Query {
         }
         return sb.toString();
     }
+
+    @Override
+    public Query negate(Source source) {
+        List<Query> negated = queries.stream().map(q -> q.negate(q.source())).toList();
+        if (negated.stream().allMatch(q -> q instanceof NotQuery)) {
+            return new NotQuery(source, this);
+        }
+        return new BoolQuery(source, isAnd == false, negated);
+    }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/NotQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/NotQuery.java
@@ -14,6 +14,9 @@ import java.util.Objects;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
+/**
+ * Query that inverts the set of matched documents.
+ */
 public class NotQuery extends Query {
     private final Query child;
 
@@ -70,5 +73,10 @@ public class NotQuery extends Query {
     @Override
     protected String innerToString() {
         return child.toString();
+    }
+
+    @Override
+    public Query negate(Source source) {
+        return child;
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/Query.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/Query.java
@@ -14,11 +14,24 @@ import org.elasticsearch.xpack.ql.tree.Source;
  * Intermediate representation of queries that is rewritten to fetch
  * otherwise unreferenced nested fields and then used to build
  * Elasticsearch {@link QueryBuilder}s.
+ * <p>
+ *     Our expression language spits out one of three values for any
+ *     comparison, {@code true}, {@code false}, and {@code null}.
+ *     Lucene's queries either match or don't match. They don't have
+ *     a concept of {@code null}, at least not in the sense we need.
+ *     The Lucene queries produced by {@link #asBuilder()} produce
+ *     queries that do not match documents who's comparison would
+ *     return {@code null}. This is what we want in {@code WHERE}
+ *     style operations. But when you need to negate the matches you
+ *     need to make only {@code false} return values into matches -
+ *     {@code null} returns should continue to not match. You can
+ *     do that with the {@link #negate} method.
+ * </p>
  */
 public abstract class Query {
     private final Source source;
 
-    Query(Source source) {
+    protected Query(Source source) {
         if (source == null) {
             throw new IllegalArgumentException("location must be specified");
         }
@@ -81,5 +94,17 @@ public abstract class Query {
     @Override
     public String toString() {
         return getClass().getSimpleName() + source + "[" + innerToString() + "]";
+    }
+
+    /**
+     * Negate this query, returning a query that includes documents that would
+     * return {@code false} when running the represented operation. The default
+     * implementation just returns a {@link NotQuery} wrapping {@code this} because
+     * most queries don't model underlying operations that can return {@code null}.
+     * Queries that model expressions that can return {@code null} must make sure
+     * all documents that would return {@code null} are still excluded from the match.
+     */
+    public Query negate(Source source) {
+        return new NotQuery(source, this);
     }
 }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/querydsl/query/BoolQueryTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/querydsl/query/BoolQueryTests.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -124,6 +125,31 @@ public class BoolQueryTests extends ESTestCase {
                 new ExistsQuery(new Source(1, 1, StringUtils.EMPTY), "f1"),
                 new ExistsQuery(new Source(1, 7, StringUtils.EMPTY), "f2")
             ).toString()
+        );
+    }
+
+    public void testNotAllNegated() {
+        var q = new BoolQuery(Source.EMPTY, true, new ExistsQuery(Source.EMPTY, "f1"), new ExistsQuery(Source.EMPTY, "f2"));
+        assertThat(q.negate(Source.EMPTY), equalTo(new NotQuery(Source.EMPTY, q)));
+    }
+
+    public void testNotSomeNegated() {
+        var q = new BoolQuery(
+            Source.EMPTY,
+            true,
+            new ExistsQuery(Source.EMPTY, "f1"),
+            new NotQuery(Source.EMPTY, new ExistsQuery(Source.EMPTY, "f2"))
+        );
+        assertThat(
+            q.negate(Source.EMPTY),
+            equalTo(
+                new BoolQuery(
+                    Source.EMPTY,
+                    false,
+                    new NotQuery(Source.EMPTY, new ExistsQuery(Source.EMPTY, "f1")),
+                    new ExistsQuery(Source.EMPTY, "f2")
+                )
+            )
         );
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/querydsl/query/LeafQueryTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/querydsl/query/LeafQueryTests.java
@@ -9,11 +9,13 @@ package org.elasticsearch.xpack.ql.querydsl.query;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.tree.Location;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.tree.SourceTests;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.equalTo;
 
 public class LeafQueryTests extends ESTestCase {
     private static class DummyLeafQuery extends LeafQuery {
@@ -63,6 +65,16 @@ public class LeafQueryTests extends ESTestCase {
         NestedSortBuilder sort = new NestedSortBuilder(randomAlphaOfLength(5));
         query.enrichNestedSort(sort);
         assertNull(sort.getFilter());
+    }
+
+    public void testNot() {
+        var q = new LeafQueryTests.DummyLeafQuery(new Source(Location.EMPTY, "test"));
+        assertThat(q.negate(new Source(Location.EMPTY, "not")), equalTo(new NotQuery(new Source(Location.EMPTY, "not"), q)));
+    }
+
+    public void testNotNot() {
+        var q = new LeafQueryTests.DummyLeafQuery(new Source(Location.EMPTY, "test"));
+        assertThat(q.negate(Source.EMPTY).negate(Source.EMPTY), equalTo(q));
     }
 
     public void testToString() {


### PR DESCRIPTION
Little refactoring for more consistent handling of negations in QL queries.
Needed for further usage in ESQL.