### PR TITLE
Enhance QL math utils to support unsigned longs

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.ql.planner;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
@@ -51,6 +53,7 @@ import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.TermsQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.Check;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
@@ -66,7 +69,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.ql.type.DataTypes.IP;
+import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
+import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAsNumber;
 
 public final class ExpressionTranslators {
 
@@ -292,12 +298,18 @@ public final class ExpressionTranslators {
                 }
                 format = formatter.pattern();
                 isDateLiteralComparison = true;
+            } else if (field.dataType() == IP && value instanceof BytesRef bytesRef) {
+                value = DocValueFormat.IP.format(bytesRef);
             } else if (field.dataType() == VERSION) {
                 // VersionStringFieldMapper#indexedValueForSearch() only accepts as input String or BytesRef with the String (i.e. not
                 // encoded) representation of the version as it'll do the encoding itself.
-                if (value instanceof Version version) {
+                if (value instanceof BytesRef bytesRef) {
+                    value = new Version(bytesRef).toString();
+                } else if (value instanceof Version version) {
                     value = version.toString();
                 }
+            } else if (field.dataType() == UNSIGNED_LONG && value instanceof Long ul) {
+                value = unsignedLongAsNumber(ul);
             }
 
             ZoneId zoneId = null;
@@ -398,16 +410,19 @@ public final class ExpressionTranslators {
             return handler.wrapFunctionQuery(in, in.value(), () -> translate(in, handler));
         }
 
+        private static boolean needsTypeSpecificValueHandling(DataType fieldType) {
+            return DataTypes.isDateTime(fieldType) || fieldType == IP || fieldType == VERSION || fieldType == UNSIGNED_LONG;
+        }
+
         private static Query translate(In in, TranslatorHandler handler) {
             FieldAttribute field = checkIsFieldAttribute(in.value());
-            boolean needsTypeSpecificValueHandling = DataTypes.isDateTime(field.dataType()) || field.dataType() == VERSION;
 
             Set<Object> terms = new LinkedHashSet<>();
             List<Query> queries = new ArrayList<>();
 
             for (Expression rhs : in.list()) {
                 if (DataTypes.isNull(rhs.dataType()) == false) {
-                    if (needsTypeSpecificValueHandling) {
+                    if (needsTypeSpecificValueHandling(field.dataType())) {
                         // delegates to BinaryComparisons translator to ensure consistent handling of date and time values
                         Query query = BinaryComparisons.translate(new Equals(in.source(), in.value(), rhs, in.zoneId()), handler);
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/NumericUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/NumericUtils.java
@@ -16,6 +16,15 @@ public abstract class NumericUtils {
     // 18446744073709551615.0
     public static final double UNSIGNED_LONG_MAX_AS_DOUBLE = UNSIGNED_LONG_MAX.doubleValue();
 
+    // 0x8000000000000000
+    public static final long TWOS_COMPLEMENT_BITMASK = Long.MIN_VALUE;
+    // 9223372036854775808 == 0x8000000000000000
+    public static final BigInteger LONG_MAX_PLUS_ONE_AS_BIGINTEGER = BigInteger.ONE.shiftLeft(Long.SIZE - 1);
+    // 9223372036854775808.0
+    public static final double LONG_MAX_PLUS_ONE_AS_DOUBLE = LONG_MAX_PLUS_ONE_AS_BIGINTEGER.doubleValue();
+    public static final long ONE_AS_UNSIGNED_LONG = asLongUnsigned(BigInteger.ONE);
+    public static final long ZERO_AS_UNSIGNED_LONG = asLongUnsigned(BigInteger.ZERO);
+
     public static boolean isUnsignedLong(BigInteger bi) {
         return bi.signum() >= 0 && bi.compareTo(UNSIGNED_LONG_MAX) <= 0;
     }
@@ -33,5 +42,59 @@ public abstract class NumericUtils {
             throw new ArithmeticException("unsigned_long overflow");
         }
         return bi;
+    }
+
+    /**
+     * Converts a BigInteger holding an unsigned_long to its (signed) long representation.
+     * There's no checking on the input value, if this is negative or exceeds unsigned_long range -- call
+     * {@link #isUnsignedLong(BigInteger)} if needed.
+     * @param ul The unsigned_long value to convert.
+     * @return The long representation of the unsigned_long.
+     */
+    public static long asLongUnsigned(BigInteger ul) {
+        if (ul.bitLength() < Long.SIZE) {
+            return twosComplement(ul.longValue());
+        } else {
+            return ul.subtract(LONG_MAX_PLUS_ONE_AS_BIGINTEGER).longValue();
+        }
+    }
+
+    /**
+     * Converts a long value to an unsigned long stored as a (signed) long.
+     * @param ul Long value to convert to unsigned long
+     * @return The long representation of the converted unsigned long.
+     */
+    public static long asLongUnsigned(long ul) {
+        return twosComplement(ul);
+    }
+
+    /**
+     * Converts an unsigned long value "encoded" into a (signed) long to a Number, holding the "expanded" value. This can be either a
+     * Long (if original value fits), or a BigInteger, otherwise.
+     * <p>
+     *     An unsigned long is converted to a (signed) long by adding Long.MIN_VALUE (or subtracting "abs"(Long.MIN_VALUE), so that
+     *     [0, "abs"(MIN_VALUE) + MAX_VALUE] becomes [MIN_VALUE, MAX_VALUE]) before storing the result. When recovering the original value:
+     *     - if the result is negative, the unsigned long value has been less than Long.MAX_VALUE, so recovering it requires adding the
+     *     Long.MIN_VALUE back; this is equivalent to 2-complementing it; the function returns a Long;
+     *     - if the result remained positive, the value was greater than Long.MAX_VALUE, so we need to add that back; the function returns
+     *     a BigInteger.
+     * </p>
+     * @param l "Encoded" unsigned long.
+     * @return Number, holding the "decoded" value.
+     */
+    public static Number unsignedLongAsNumber(long l) {
+        return l < 0 ? twosComplement(l) : LONG_MAX_PLUS_ONE_AS_BIGINTEGER.add(BigInteger.valueOf(l));
+    }
+
+    public static BigInteger unsignedLongAsBigInteger(long l) {
+        return l < 0 ? BigInteger.valueOf(twosComplement(l)) : LONG_MAX_PLUS_ONE_AS_BIGINTEGER.add(BigInteger.valueOf(l));
+    }
+
+    public static double unsignedLongToDouble(long l) {
+        return l < 0 ? twosComplement(l) : LONG_MAX_PLUS_ONE_AS_DOUBLE + l;
+    }
+
+    private static long twosComplement(long l) {
+        return l ^ TWOS_COMPLEMENT_BITMASK;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalMathProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryOptionalMathProcessor.java
@@ -24,7 +24,7 @@ public class BinaryOptionalMathProcessor implements Processor {
 
     public enum BinaryOptionalMathOperation implements BiFunction<Number, Number, Number> {
 
-        ROUND((n, precision) -> Maths.round(n, precision)),
+        ROUND((n, precision) -> Maths.round(n, precision.longValue())),
         TRUNCATE((n, precision) -> Maths.truncate(n, precision));
 
         private final BiFunction<Number, Number, Number> process;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryMathProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryMathProcessorTests.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Processors;
 
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
+import static org.elasticsearch.xpack.ql.util.NumericUtils.UNSIGNED_LONG_MAX;
+import static org.elasticsearch.xpack.ql.util.NumericUtils.asLongUnsigned;
 
 public class BinaryMathProcessorTests extends AbstractWireSerializingTestCase<BinaryMathProcessor> {
     public static BinaryMathProcessor randomProcessor() {
@@ -108,6 +110,11 @@ public class BinaryMathProcessorTests extends AbstractWireSerializingTestCase<Bi
         assertEquals(1234456.234567, new Round(EMPTY, l(1234456.234567), l(20)).makePipe().asProcessor().process(null));
         assertEquals(12344561234567456.2345, new Round(EMPTY, l(12344561234567456.234567), l(4)).makePipe().asProcessor().process(null));
         assertEquals(12344561234567000., new Round(EMPTY, l(12344561234567456.234567), l(-3)).makePipe().asProcessor().process(null));
+        // UnsignedLong MAX_VALUE
+        expectThrows(
+            ArithmeticException.class,
+            () -> new Round(EMPTY, l(asLongUnsigned(UNSIGNED_LONG_MAX)), l(-1)).makePipe().asProcessor().process(null)
+        );
     }
 
     public void testRoundInputValidation() {


### PR DESCRIPTION
Enrhance QL math processor, expression translators and utils to allow supporting unsigned longs (needed for ESQL).

Including here also two one-line enhancements to ExpressionTranslators to properly support Version and IP types.