### PR TITLE
QL: Enhance index resolution to support index patterns

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/EsIndex.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/EsIndex.java
@@ -10,17 +10,24 @@ import org.elasticsearch.xpack.ql.type.EsField;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class EsIndex {
 
     private final String name;
     private final Map<String, EsField> mapping;
+    private final Set<String> concreteIndices;
 
     public EsIndex(String name, Map<String, EsField> mapping) {
+        this(name, mapping, Set.of());
+    }
+
+    public EsIndex(String name, Map<String, EsField> mapping, Set<String> concreteIndices) {
         assert name != null;
         assert mapping != null;
         this.name = name;
         this.mapping = mapping;
+        this.concreteIndices = concreteIndices;
     }
 
     public String name() {
@@ -31,6 +38,10 @@ public class EsIndex {
         return mapping;
     }
 
+    public Set<String> concreteIndices() {
+        return concreteIndices;
+    }
+
     @Override
     public String toString() {
         return name;
@@ -38,7 +49,7 @@ public class EsIndex {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, mapping);
+        return Objects.hash(name, mapping, concreteIndices);
     }
 
     @Override
@@ -52,6 +63,8 @@ public class EsIndex {
         }
 
         EsIndex other = (EsIndex) obj;
-        return Objects.equals(name, other.name) && Objects.equals(mapping, other.mapping);
+        return Objects.equals(name, other.name)
+            && Objects.equals(mapping, other.mapping)
+            && Objects.equals(concreteIndices, other.concreteIndices);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -455,8 +455,13 @@ public class IndexResolver {
             );
         }
 
-        final String indexName = fieldCapsResponse.getIndices()[0];
-        return IndexResolution.valid(indices.isEmpty() ? new EsIndex(indexName, emptyMap()) : indices.get(0));
+        String[] indexNames = fieldCapsResponse.getIndices();
+        if (indices.isEmpty()) {
+            return IndexResolution.valid(new EsIndex(indexNames[0], emptyMap(), Set.of()));
+        } else {
+            EsIndex idx = indices.get(0);
+            return IndexResolution.valid(new EsIndex(idx.name(), idx.mapping(), Set.of(indexNames)));
+        }
     }
 
     private static EsField createField(
@@ -777,7 +782,7 @@ public class IndexResolver {
         // return indices in ascending order
         List<EsIndex> foundIndices = new ArrayList<>(indices.size());
         for (Entry<String, Fields> entry : indices.entrySet()) {
-            foundIndices.add(new EsIndex(entry.getKey(), entry.getValue().hierarchicalMapping));
+            foundIndices.add(new EsIndex(entry.getKey(), entry.getValue().hierarchicalMapping, Set.of(entry.getKey())));
         }
         foundIndices.sort(Comparator.comparing(EsIndex::name));
         return foundIndices;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -20,11 +20,15 @@ import org.elasticsearch.xpack.ql.type.KeywordEsField;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeRegistry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonMap;
@@ -50,6 +54,7 @@ public class IndexResolverTests extends ESTestCase {
 
         assertTrue(resolution.isValid());
         assertEqualsMaps(oneMapping, resolution.get().mapping());
+        assertEquals(Set.of("a", "b"), resolution.get().concreteIndices());
     }
 
     public void testMergeCompatibleMapping() throws Exception {
@@ -62,6 +67,7 @@ public class IndexResolverTests extends ESTestCase {
 
         assertTrue(resolution.isValid());
         assertEquals(basicMapping.size() + numericMapping.size(), resolution.get().mapping().size());
+        assertEquals(Set.of("basic", "numeric"), resolution.get().concreteIndices());
     }
 
     public void testMergeIncompatibleTypes() throws Exception {
@@ -77,6 +83,7 @@ public class IndexResolverTests extends ESTestCase {
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
+        assertEquals(Set.of("basic", "incompatible"), esIndex.concreteIndices());
         EsField esField = esIndex.mapping().get("gender");
         assertEquals(InvalidMappedField.class, esField.getClass());
 
@@ -102,6 +109,7 @@ public class IndexResolverTests extends ESTestCase {
         EsField esField = esIndex.mapping().get("emp_no");
         assertEquals(InvalidMappedField.class, esField.getClass());
         assertEquals("mapped as aggregatable except in [incompatible]", ((InvalidMappedField) esField).errorMessage());
+        assertEquals(Set.of("basic", "incompatible"), resolution.get().concreteIndices());
     }
 
     public void testMultiLevelObjectMappings() throws Exception {
@@ -111,6 +119,7 @@ public class IndexResolverTests extends ESTestCase {
 
         assertTrue(resolution.isValid());
         assertEqualsMaps(dottedMapping, resolution.get().mapping());
+        assertEquals(Set.of("a"), resolution.get().concreteIndices());
     }
 
     public void testMultiLevelNestedMappings() throws Exception {
@@ -141,6 +150,7 @@ public class IndexResolverTests extends ESTestCase {
         assertNull(esIndex.mapping().get("_doc_count"));
         assertEquals(INTEGER, esIndex.mapping().get("_not_meta_field").getDataType());
         assertEquals(KEYWORD, esIndex.mapping().get("text").getDataType());
+        assertEquals(Set.of("index"), resolution.get().concreteIndices());
     }
 
     public void testFlattenedHiddenSubfield() throws Exception {
@@ -160,6 +170,7 @@ public class IndexResolverTests extends ESTestCase {
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
+        assertEquals(Set.of("index"), resolution.get().concreteIndices());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("some_field").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("some_field").getProperties().get("_keyed").getDataType());
         assertEquals(OBJECT, esIndex.mapping().get("nested_field").getDataType());
@@ -189,6 +200,7 @@ public class IndexResolverTests extends ESTestCase {
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
+        assertEquals(Set.of("index"), resolution.get().concreteIndices());
         assertEquals(TEXT, esIndex.mapping().get("a").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("a").getProperties().get("b").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("a").getProperties().get("b").getProperties().get("c").getDataType());
@@ -224,6 +236,7 @@ public class IndexResolverTests extends ESTestCase {
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
+        assertEquals(Set.of("index"), resolution.get().concreteIndices());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("some_field").getDataType());
         assertEquals(OBJECT, esIndex.mapping().get("nested_field").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("nested_field").getProperties().get("sub_field1").getDataType());
@@ -286,6 +299,7 @@ public class IndexResolverTests extends ESTestCase {
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
+        assertEquals(Set.of("one-index"), resolution.get().concreteIndices());
         EsField esField = null;
         Map<String, EsField> props = esIndex.mapping();
         for (String lvl : level) {
@@ -309,7 +323,9 @@ public class IndexResolverTests extends ESTestCase {
 
         assertEquals(2, indices.size());
         assertEqualsMaps(oneMapping, indices.get(0).mapping());
+        assertEquals(Set.of("a"), indices.get(0).concreteIndices());
         assertEqualsMaps(sameMapping, indices.get(1).mapping());
+        assertEquals(Set.of("b"), indices.get(1).concreteIndices());
     }
 
     public void testSeparateIncompatibleTypes() throws Exception {
@@ -322,7 +338,9 @@ public class IndexResolverTests extends ESTestCase {
 
         assertEquals(2, indices.size());
         assertEqualsMaps(basicMapping, indices.get(0).mapping());
+        assertEquals(Set.of("basic"), indices.get(0).concreteIndices());
         assertEqualsMaps(incompatible, indices.get(1).mapping());
+        assertEquals(Set.of("incompatible"), indices.get(1).concreteIndices());
     }
 
     // covers the scenario described in https://github.com/elastic/elasticsearch/issues/43876
@@ -337,12 +355,34 @@ public class IndexResolverTests extends ESTestCase {
             mapping.put(fieldName, new KeywordEsField(fieldName));
             expectedIndices[i] = new EsIndex("index" + (i + 1), mapping);
         }
+        Arrays.sort(expectedIndices, Comparator.comparing(EsIndex::name));
 
         List<EsIndex> actualIndices = separate(expectedIndices);
+        actualIndices.sort(Comparator.comparing(EsIndex::name));
         assertEquals(indicesCount, actualIndices.size());
         for (int i = 0; i < indicesCount; i++) {
             assertEqualsMaps(expectedIndices[i].mapping(), actualIndices.get(i).mapping());
+            assertEquals(Set.of(expectedIndices[i].name()), actualIndices.get(i).concreteIndices());
         }
+    }
+
+    public void testMergeConcreteIndices() {
+        int indicesCount = randomIntBetween(2, 15);
+        EsIndex[] expectedIndices = new EsIndex[indicesCount];
+        Set<String> indexNames = new HashSet<>();
+
+        for (int i = 0; i < indicesCount; i++) {
+            Map<String, EsField> mapping = Maps.newMapWithExpectedSize(1);
+            String fieldName = "field" + (i + 1);
+            mapping.put(fieldName, new KeywordEsField(fieldName));
+            String indexName = "index" + (i + 1);
+            expectedIndices[i] = new EsIndex(indexName, mapping, Set.of(indexName));
+            indexNames.add(indexName);
+        }
+
+        IndexResolution resolution = merge(expectedIndices);
+        assertEquals(indicesCount, resolution.get().mapping().size());
+        assertEquals(indexNames, resolution.get().concreteIndices());
     }
 
     public void testIndexWithNoMapping() {


### PR DESCRIPTION
Allow IndexResolver to properly manage index patterns and pass concrete index names with the index resolution