### PR TITLE
CCS should fail fast when a cluster that cannot be skipped is unavailable

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1318,7 +1318,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     }
 
     private static RemoteTransportException wrapRemoteClusterFailure(String clusterAlias, Exception e, boolean skipUnavailable) {
-        return new RemoteTransportException("error while communicating with remote cluster [" + clusterAlias + "]", e, skipUnavailable);
+        return new RemoteTransportException(
+            "error while communicating with remote cluster [" + clusterAlias + "]",
+            e,
+            clusterAlias,
+            skipUnavailable
+        );
     }
 
     static Map<String, OriginalIndices> getIndicesFromSearchContexts(SearchContextId searchContext, IndicesOptions indicesOptions) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
@@ -17,29 +17,54 @@ import java.net.InetSocketAddress;
 
 /**
  * A remote exception for an action. A wrapper exception around the actual remote cause and does not fill the
- * stack trace.
+ * stack trace. The skip_unavailable cluster setting of the remote cluster can optionally be set on the exception.
  */
 public class RemoteTransportException extends ActionTransportException implements ElasticsearchWrapperException {
 
+    // not Writeable, since it is only needed on a coordinator node for an active CCS search
+    private final Boolean skipUnavailable;
+
     public RemoteTransportException(String msg, Throwable cause) {
         super(msg, null, null, cause);
+        this.skipUnavailable = null;
+    }
+
+    /**
+     * @param msg error message
+     * @param cause underlying cause
+     * @param skipUnavailable whether the remote cluster is marked with skip_unavailable in the cluster settings
+     */
+    public RemoteTransportException(String msg, Throwable cause, boolean skipUnavailable) {
+        super(msg, null, null, cause);
+        this.skipUnavailable = skipUnavailable;
     }
 
     public RemoteTransportException(String name, TransportAddress address, String action, Throwable cause) {
         super(name, address, action, cause);
+        this.skipUnavailable = null;
     }
 
     public RemoteTransportException(String name, InetSocketAddress address, String action, Throwable cause) {
         super(name, address, action, null, cause);
+        this.skipUnavailable = null;
     }
 
     public RemoteTransportException(StreamInput in) throws IOException {
         super(in);
+        this.skipUnavailable = null;
     }
 
     @Override
     public Throwable fillInStackTrace() {
         // no need for stack trace here, we always have cause
         return this;
+    }
+
+    /**
+     * @return If skipUnavailable flag was set on the Exception, returns that value.
+     * Otherwise returns null (unknown/not-set)
+     */
+    public Boolean getSkipUnavailable() {
+        return skipUnavailable;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
@@ -22,35 +22,43 @@ import java.net.InetSocketAddress;
 public class RemoteTransportException extends ActionTransportException implements ElasticsearchWrapperException {
 
     // not Writeable, since it is only needed on a coordinator node for an active CCS search
+    private final String clusterAlias;
+    // not Writeable, since it is only needed on a coordinator node for an active CCS search
     private final Boolean skipUnavailable;
 
     public RemoteTransportException(String msg, Throwable cause) {
         super(msg, null, null, cause);
+        this.clusterAlias = null;
         this.skipUnavailable = null;
     }
 
     /**
      * @param msg error message
      * @param cause underlying cause
+     * @param clusterAlias cluster alias (from local cluster settings) for cluster with this Exception
      * @param skipUnavailable whether the remote cluster is marked with skip_unavailable in the cluster settings
      */
-    public RemoteTransportException(String msg, Throwable cause, boolean skipUnavailable) {
+    public RemoteTransportException(String msg, Throwable cause, String clusterAlias, boolean skipUnavailable) {
         super(msg, null, null, cause);
+        this.clusterAlias = clusterAlias;
         this.skipUnavailable = skipUnavailable;
     }
 
     public RemoteTransportException(String name, TransportAddress address, String action, Throwable cause) {
         super(name, address, action, cause);
+        this.clusterAlias = null;
         this.skipUnavailable = null;
     }
 
     public RemoteTransportException(String name, InetSocketAddress address, String action, Throwable cause) {
         super(name, address, action, null, cause);
+        this.clusterAlias = null;
         this.skipUnavailable = null;
     }
 
     public RemoteTransportException(StreamInput in) throws IOException {
         super(in);
+        this.clusterAlias = null;
         this.skipUnavailable = null;
     }
 
@@ -61,8 +69,16 @@ public class RemoteTransportException extends ActionTransportException implement
     }
 
     /**
+     * @return cluster alias of cluster with remote transport exception, if set.
+     * If not set, returns null.
+     */
+    public String getClusterAlias() {
+        return clusterAlias;
+    }
+
+    /**
      * @return If skipUnavailable flag was set on the Exception, returns that value.
-     * Otherwise returns null (unknown/not-set)
+     * Otherwise, returns null (unknown/not-set)
      */
     public Boolean getSkipUnavailable() {
         return skipUnavailable;

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -232,7 +232,6 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         assertTrue(statusResponseAfterCompletion.isPartial());
         assertFalse(statusResponseAfterCompletion.isRunning());
         assertThat(statusResponseAfterCompletion.getClusters().getTotal(), equalTo(2));
-        assertThat(statusResponseAfterCompletion.getFailedShards(), greaterThan(0));
         assertThat(statusResponseAfterCompletion.getCompletionStatus(), equalTo(RestStatus.BAD_REQUEST));
 
         AsyncSearchResponse searchResponseAfterCompletion = getAsyncSearch(response.getId());
@@ -246,7 +245,8 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         ShardSearchFailure[] shardFailures = searchResponseAfterCompletion.getSearchResponse().getShardFailures();
         assertThat(shardFailures.length, greaterThan(0));
         String json = Strings.toString(searchResponseAfterCompletion.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
-        assertThat(json, containsString("task cancelled [by user request]"));
+        assertThat(json, containsString("cancelled [by user request]"));
+        assertThat(json, containsString("task_cancelled_exception"));
     }
 
     public void testCancelViaAsyncSearchDelete() throws Exception {


### PR DESCRIPTION
For CCS with minimize_roundtrips=true, when one of the remote clusters in scope for the search
is down (or goes down during the query) and that cluster is not marked with skip_unavailable: true,
the search will fail (as expected) but it will not fail fast. Instead, it has to wait for all the other
remote cluster searches to finish before it fails the search.

This commit changes that behavior for MRT=true. Once a fatal error is detected, the remaining
searches will be cancelled and the search will end as quickly as possible.

A "fatal error" here means that a cluster that cannot be skipped either has lost connection
(e.g, node_disconnected) or searches on all shards of that cluster fail.
