### PR TITLE
Fix jwt and oidc doc

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1675,18 +1675,19 @@ Provider. The value for this setting should be provided by your OpenID Connect P
 // tag::oidc-op-jwkset-path-tag[]
 `op.jwkset_path` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-The path or URL to a JSON Web Key Set with the key material that the OpenID Connect
-Provider uses for signing tokens and claims responses.
-If a path is provided, then it is resolved relative to the {es} config
-directory.
-If a URL is provided, then it must be either a `file` URL or a `https` URL.
+
+The file name or URL to a JSON Web Key Set (JWKS) with the public key material that
+the OpenID Connect Provider uses for signing tokens and claims responses. A value is considered a file name
+if it does not begin with `https://` or `http://`. The file name
+is resolved relative to the {es} configuration directory.  Changes to the file are polled
+at a frequency determined by the global {es} `resource.reload.interval.high`
+setting, which defaults to 5 seconds.
++
+If a URL is provided, then it must begin with `https://`  or `http://`.
 {es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
-requests but will attempt to refresh the JWK upon signature verification
+requests, but will attempt to refresh the JWK upon signature verification
 failure, as this might indicate that the OpenID Connect Provider has
 rotated the signing keys.
-+
-File-based resources are polled at a frequency determined by the global {es}
-`resource.reload.interval.high` setting, which defaults to 5 seconds.
 // end::oidc-op-jwkset-path-tag[]
 
 `authorization_realms`::
@@ -2320,19 +2321,18 @@ for every request, set to `0` to disable the JWT cache. Defaults to `20m`.
 // tag::jwt-pkc-jwkset-path-tag[]
 `pkc_jwkset_path` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-The file path or URL to a JSON Web Key Set (JWKS) with the public key material that
-the JWT Realm uses for verifying token signatures. If a path is provided,
-then it is resolved relative to the {es} configuration directory. In {ecloud},
-use an absolute path starting with `/app/config/`.
+The file name or URL to a JSON Web Key Set (JWKS) with the public key material that
+the JWT Realm uses for verifying token signatures. A value is considered a file name
+if it does not begin with `https://`. The file name
+is resolved relative to the {es} configuration directory.  Failures to verify a signature
+will result in an attempt to reload the file as this might indicate that the JWT provider
+has rotated the signing keys.
 +
-If a URL is provided, then it must be either a `file` URL or an `https` URL.
+If a URL is provided, then it must begin with `https://` (http:// is not supported).
 {es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
 requests, but will attempt to refresh the JWK upon signature verification
 failure, as this might indicate that the JWT Provider has
 rotated the signing keys.
-+
-File-based resources are polled at a frequency determined by the global {es}
-`resource.reload.interval.high` setting, which defaults to `5s`.
 // end::jwt-pkc-jwkset-path-tag[]
 
 // tag::jwt-hmac-jwkset-tag[]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1676,16 +1676,15 @@ Provider. The value for this setting should be provided by your OpenID Connect P
 `op.jwkset_path` {ess-icon}::
 (<<static-cluster-setting,Static>>)
 
-The file name or URL to a JSON Web Key Set (JWKS) with the public key material that
-the OpenID Connect Provider uses for signing tokens and claims responses. A value is considered a file name
-if it does not begin with `https://` or `http://`. The file name
+The file name or URL to a JSON Web Key Set (JWKS) with the public key material used to verify
+tokens and claims responses signed by the OpenID Connect Provider. A value is considered a file name
+if it does not begin with `https` or `http`. The file name
 is resolved relative to the {es} configuration directory.  Changes to the file are polled
 at a frequency determined by the global {es} `resource.reload.interval.high`
 setting, which defaults to 5 seconds.
 +
-If a URL is provided, then it must begin with `https://`  or `http://`.
-{es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
-requests but will attempt to refresh the JWK upon signature verification
+If a URL is provided, then it must begin with `https://` or `http://`.
+{es} automatically caches the retrieved JWK and will attempt to refresh the JWK upon signature verification
 failure, as this might indicate that the OpenID Connect Provider has
 rotated the signing keys.
 // end::oidc-op-jwkset-path-tag[]
@@ -2323,15 +2322,11 @@ for every request, set to `0` to disable the JWT cache. Defaults to `20m`.
 (<<static-cluster-setting,Static>>)
 The file name or URL to a JSON Web Key Set (JWKS) with the public key material that
 the JWT Realm uses for verifying token signatures. A value is considered a file name
-if it does not begin with `https://`. The file name
-is resolved relative to the {es} configuration directory.  Failures to verify a signature
-will result in an attempt to reload the file as this might indicate that the JWT provider
-has rotated the signing keys.
-+
-If a URL is provided, then it must begin with `https://` (http:// is not supported).
-{es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
-requests, but will attempt to refresh the JWK upon signature verification
-failure, as this might indicate that the JWT Provider has
+if it does not begin with `https`. The file name
+is resolved relative to the {es} configuration directory. If a URL is provided, then
+it must begin with `https://` (`http://` is not supported).
+{es} automatically caches the JWK set and will attempt to refresh the
+JWK set upon signature verification failure, as this might indicate that the JWT Provider has
 rotated the signing keys.
 // end::jwt-pkc-jwkset-path-tag[]
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1685,7 +1685,7 @@ setting, which defaults to 5 seconds.
 +
 If a URL is provided, then it must begin with `https://`  or `http://`.
 {es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
-requests, but will attempt to refresh the JWK upon signature verification
+requests but will attempt to refresh the JWK upon signature verification
 failure, as this might indicate that the OpenID Connect Provider has
 rotated the signing keys.
 // end::oidc-op-jwkset-path-tag[]

--- a/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
@@ -141,15 +141,11 @@ verify the signature of the JWT from the JWT issuer.
 `pkc_jwkset_path`::
 The file name or URL to a JSON Web Key Set (JWKS) with the public key material that
 the JWT Realm uses for verifying token signatures. A value is considered a file name
-if it does not begin with `https://`. The file name
-is resolved relative to the {es} configuration directory.  Failures to verify a signature
-will result in an attempt to reload the file as this might indicate that the JWT provider
-has rotated the signing keys.
-+
-If a URL is provided, then it must begin with `https://` (http:// is not supported).
-{es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
-requests, but will attempt to refresh the JWK upon signature verification
-failure, as this might indicate that the JWT Provider has
+if it does not begin with `https`. The file name
+is resolved relative to the {es} configuration directory. If a URL is provided, then
+it must begin with `https://` (`http://` is not supported).
+{es} automatically caches the JWK set and will attempt to refresh the
+JWK set upon signature verification failure, as this might indicate that the JWT Provider has
 rotated the signing keys.
 
 `claims.principal`::

--- a/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
@@ -139,10 +139,18 @@ Indicates that {es} should use the `RS256` or `HS256` signature algorithms to
 verify the signature of the JWT from the JWT issuer.
 
 `pkc_jwkset_path`::
-The file path to a JSON Web Key Set (JWKS) containing the public key material
-that the JWT realm uses to verify JWT signatures. If a path is provided,
-then it is resolved relative to the {es} configuration directory. In {ecloud},
-use an absolute path starting with `/app/config/`.
+The file name or URL to a JSON Web Key Set (JWKS) with the public key material that
+the JWT Realm uses for verifying token signatures. A value is considered a file name
+if it does not begin with `https://`. The file name
+is resolved relative to the {es} configuration directory.  Failures to verify a signature
+will result in an attempt to reload the file as this might indicate that the JWT provider
+has rotated the signing keys.
++
+If a URL is provided, then it must begin with `https://` (http:// is not supported).
+{es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
+requests, but will attempt to refresh the JWK upon signature verification
+failure, as this might indicate that the JWT Provider has
+rotated the signing keys.
 
 `claims.principal`::
 The name of the JWT claim that contains the user's principal (username).


### PR DESCRIPTION
This commit corrects the following issues with JWT and OIDC `jwkset_path` documentation:
* only https is supported for the JWT realm (OIDC support both https and http)
* JWT realm does not use a file watcher to reload the file every 5 seconds
* simplify "path" to  "file name" ..technically it is resolved path, but 99% of the time it will be just a file name in the config directory and "path" is ambiguous
* remove special mention of using the absolute path in cloud. .. this is an unnecessary implementation detail and the only setting (of many) that calls out the cloud config directly by absolute path
* ensure the 2 different JWT documentations are the same
* make mention of when the JWT file will be reloaded (it is not backed by the file watcher, only OIDC is)

