### PR TITLE
[DOCS] Removing coming 8.9.0 phrase

### DIFF
--- a/docs/reference/migration/migrate_8_9.asciidoc
+++ b/docs/reference/migration/migrate_8_9.asciidoc
@@ -9,9 +9,6 @@ your application to {es} 8.9.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.9.0]
-
-
 [discrete]
 [[breaking-changes-8.9]]
 === Breaking changes


### PR DESCRIPTION
This PR removes out-dated "coming" notes.