### PR TITLE
Set async search response as empty after failure.

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
@@ -110,7 +110,7 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
 
         @Override
         public TestAsyncResponse convertToFailure(Exception exc) {
-            return new TestAsyncResponse(test, expirationTimeMillis, exc.getMessage());
+            return new TestAsyncResponse("", expirationTimeMillis, exc.getMessage());
         }
     }
 


### PR DESCRIPTION
Async response result should always be empty if we got failure in search process.