### PR TITLE
improve logging in circuit breakes

### DIFF
--- a/docs/changelog/97954.yaml
+++ b/docs/changelog/97954.yaml
@@ -1,0 +1,5 @@
+pr: 97954
+summary: Improve logging in circuit breakers
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -92,7 +92,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         this.topNSize = getTopDocsSize(request);
         this.performFinalReduce = request.isFinalReduce();
         this.onPartialMergeFailure = onPartialMergeFailure;
-        this.label = request.getDescription();
+        this.label = request.buildDescription();
 
         SearchSourceBuilder source = request.source();
         int size = source == null || source.size() == -1 ? SearchService.DEFAULT_SIZE : source.size();

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -69,6 +69,8 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
     private final PendingMerges pendingMerges;
     private final Consumer<Exception> onPartialMergeFailure;
 
+    private final String label;
+
     /**
      * Creates a {@link QueryPhaseResultConsumer} that incrementally reduces aggregation results
      * as shard results are consumed.
@@ -90,6 +92,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         this.topNSize = getTopDocsSize(request);
         this.performFinalReduce = request.isFinalReduce();
         this.onPartialMergeFailure = onPartialMergeFailure;
+        this.label = request.getDescription();
 
         SearchSourceBuilder source = request.source();
         int size = source == null || source.size() == -1 ? SearchService.DEFAULT_SIZE : source.size();
@@ -308,7 +311,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
 
         synchronized long addEstimateAndMaybeBreak(long estimatedSize) {
-            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, "<reduce_aggs>");
+            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, label);
             circuitBreakerBytes += estimatedSize;
             maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
             return circuitBreakerBytes;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -245,7 +245,7 @@ public class JoinHelper {
             // to this node. We try and keep the problem local to this node by checking that we can at least allocate one byte:
             final var breaker = circuitBreakerService.getBreaker(CircuitBreaker.IN_FLIGHT_REQUESTS);
             try {
-                breaker.addEstimateBytesAndMaybeBreak(1L, "pre-flight join request");
+                breaker.addEstimateBytesAndMaybeBreak(1L, joinRequest.getDescription());
             } catch (Exception e) {
                 pendingJoinInfo.message = PENDING_JOIN_FAILED;
                 pendingOutgoingJoins.remove(dedupKey);

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -395,9 +395,11 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     public void checkParentLimit(long newBytesReserved, String label) throws CircuitBreakingException {
         final MemoryUsage memoryUsed = memoryUsed(newBytesReserved);
         long parentLimit = this.parentSettings.getLimit();
+        String parentName = this.parentSettings.getName();
         if (memoryUsed.totalUsage > parentLimit && overLimitStrategy.overLimit(memoryUsed).totalUsage > parentLimit) {
             this.parentTripCount.incrementAndGet();
             final String messageString = buildParentTripMessage(
+                parentName,
                 newBytesReserved,
                 label,
                 memoryUsed,
@@ -417,6 +419,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
 
     // exposed for tests
     static String buildParentTripMessage(
+        String parentName,
         long newBytesReserved,
         String label,
         MemoryUsage memoryUsed,
@@ -425,7 +428,9 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         Map<String, CircuitBreaker> breakers
     ) {
         final var message = new StringBuilder();
-        message.append("[parent] Data too large, data for [");
+        message.append("[");
+        message.append(parentName);
+        message.append("] Data too large, data for [");
         message.append(label);
         message.append("] would be [");
         appendBytesSafe(message, memoryUsed.totalUsage);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -1279,7 +1279,10 @@ public class SearchPhaseControllerTests extends ESTestCase {
             }
             CircuitBreakingException exc = expectThrows(CircuitBreakingException.class, () -> consumer.reduce());
             assertEquals(shouldFailPartial, hasConsumedFailure.get());
-            assertThat(exc.getMessage(), containsString("<reduce_aggs>"));
+            assertThat(
+                exc.getMessage(),
+                containsString("indices[], search_type[QUERY_THEN_FETCH], source[{\"size\":0,\"aggregations\":{\"test\":{\"max\":{}}}}]")
+            );
             circuitBreaker.shouldBreak.set(false);
         } else {
             consumer.reduce();

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -899,6 +899,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
 
         assertThat(
             HierarchyCircuitBreakerService.buildParentTripMessage(
+                "parent",
                 1L,
                 "test",
                 new HierarchyCircuitBreakerService.MemoryUsage(2L, 3L, 4L, 5L),
@@ -916,6 +917,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
 
         assertThat(
             HierarchyCircuitBreakerService.buildParentTripMessage(
+                "parent",
                 1L,
                 "test",
                 new HierarchyCircuitBreakerService.MemoryUsage(2L, 3L, 4L, 5L),
@@ -933,6 +935,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             HierarchyCircuitBreakerService.permitNegativeValues = true;
             assertThat(
                 HierarchyCircuitBreakerService.buildParentTripMessage(
+                    "parent",
                     -1L,
                     "test",
                     new HierarchyCircuitBreakerService.MemoryUsage(-2L, -3L, -4L, -5L),


### PR DESCRIPTION
Improve logging in CircuitBreakers. Provide the name of the parent that breaks and more detailed information about the request that causes the break.

Closes( #62452)
