### PR TITLE
[DOCS] Remove 'coming in 7.17.12' from release notes

### DIFF
--- a/docs/reference/release-notes/7.17.12.asciidoc
+++ b/docs/reference/release-notes/7.17.12.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.17.12]]
 == {es} version 7.17.12
 
-coming[7.17.12]
-
 Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 
 [[bug-7.17.12]]


### PR DESCRIPTION
This PR removes an out-dated "coming" note.