### PR TITLE
Always resolve the reroute listener

### DIFF
--- a/docs/changelog/97969.yaml
+++ b/docs/changelog/97969.yaml
@@ -1,0 +1,5 @@
+pr: 97969
+summary: Always resolve the reroute listener
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -514,6 +514,8 @@ public class MetadataCreateIndexService {
             );
             if (request.performReroute()) {
                 updated = allocationService.reroute(updated, "index [" + indexMetadata.getIndex().getName() + "] created", rerouteListener);
+            } else {
+                rerouteListener.onResponse(null);
             }
             return updated;
         });


### PR DESCRIPTION
If index creation request is issued with performReroute=false then the corresponding reroute listener is not resolved causing the request to stuck indefinitely.

(I am making this a draft until I have some time to retest this manually and cover it with some unit test)
