### PR TITLE
Fix bug in NestedUtils.partitionByChildren()

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/NestedUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/NestedUtils.java
@@ -81,8 +81,7 @@ public final class NestedUtils {
                 currentInput = inputIterator.next();
                 currentInputName = pathFunction.apply(currentInput);
                 assert currentInputName.startsWith(scope);
-            }
-            else if (currentInputName.startsWith(currentChild + ".")) {
+            } else if (currentInputName.startsWith(currentChild + ".")) {
                 // If this input sits under the current child, add it to that child scope
                 // and then get the next input
                 output.get(currentChild).add(currentInput);

--- a/server/src/main/java/org/elasticsearch/search/NestedUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/NestedUtils.java
@@ -70,20 +70,19 @@ public final class NestedUtils {
         String currentInputName = pathFunction.apply(currentInput);
         assert currentInputName.startsWith(scope);
 
-        // Find all the inputs that sort before the first child, and add them to the current scope entry
-        while (currentInputName.compareTo(currentChild) < 0) {
-            output.get(scope).add(currentInput);
-            if (inputIterator.hasNext() == false) {
-                return output;
-            }
-            currentInput = inputIterator.next();
-            currentInputName = pathFunction.apply(currentInput);
-            assert currentInputName.startsWith(scope);
-        }
-
         // Iterate through all the children
         while (currentChild != null) {
-            if (currentInputName.startsWith(currentChild + ".")) {
+            if (currentInputName.compareTo(currentChild) < 0) {
+                // If we sort before the current child, then we sit in the parent scope
+                output.get(scope).add(currentInput);
+                if (inputIterator.hasNext() == false) {
+                    return output;
+                }
+                currentInput = inputIterator.next();
+                currentInputName = pathFunction.apply(currentInput);
+                assert currentInputName.startsWith(scope);
+            }
+            else if (currentInputName.startsWith(currentChild + ".")) {
                 // If this input sits under the current child, add it to that child scope
                 // and then get the next input
                 output.get(currentChild).add(currentInput);

--- a/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
@@ -17,12 +17,12 @@ public class NestedUtilsTests extends ESTestCase {
 
     public void testPartitionByChild() {
         List<String> children = List.of("child1", "child2", "stepchild");
-        List<String> inputs = List.of("a", "b", "child1.grandchild", "child1.grandchild2", "child11", "child2.grandchild", "frog");
+        List<String> inputs = List.of("a", "b", "child1.grandchild", "child1.grandchild2", "child11", "child12", "child2.grandchild", "frog");
         Map<String, List<String>> partitioned = NestedUtils.partitionByChildren("", children, inputs, s -> s);
         assertEquals(
             Map.of(
                 "",
-                List.of("a", "b", "child11", "frog"),
+                List.of("a", "b", "child11", "child12", "frog"),
                 "child1",
                 List.of("child1.grandchild", "child1.grandchild2"),
                 "child2",

--- a/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
@@ -17,7 +17,16 @@ public class NestedUtilsTests extends ESTestCase {
 
     public void testPartitionByChild() {
         List<String> children = List.of("child1", "child2", "stepchild");
-        List<String> inputs = List.of("a", "b", "child1.grandchild", "child1.grandchild2", "child11", "child12", "child2.grandchild", "frog");
+        List<String> inputs = List.of(
+            "a",
+            "b",
+            "child1.grandchild",
+            "child1.grandchild2",
+            "child11",
+            "child12",
+            "child2.grandchild",
+            "frog"
+        );
         Map<String, List<String>> partitioned = NestedUtils.partitionByChildren("", children, inputs, s -> s);
         assertEquals(
             Map.of(

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceFilter;
@@ -53,6 +54,7 @@ import java.util.function.BiFunction;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.xcontent.ObjectPath.eval;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -876,6 +878,182 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         assertNotNull(results.get("user"));
         assertNull(eval("first", results.get("user").getValues().get(0)));
         assertEquals("Toronto", eval(new String[] { "address.city", "0" }, results.get("user").getValues().get(0)));
+    }
+
+    public void testNestedGrouping() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties": {
+                                 "age": {
+                                   "type": "integer"
+                                 },
+                                 "balance": {
+                                   "type": "text",
+                                   "fields": {
+                                     "keyword": {
+                                       "type": "keyword",
+                                       "ignore_above": 256
+                                     }
+                                   }
+                                 },
+                                 "campaign": {
+                                   "type": "integer"
+                                 },
+                                 "cons_conf_idx": {
+                                   "type": "float"
+                                 },
+                                 "contact": {
+                                   "type": "keyword"
+                                 },
+                                 "day": {
+                                   "type": "text",
+                                   "fields": {
+                                     "keyword": {
+                                       "type": "keyword",
+                                       "ignore_above": 256
+                                     }
+                                   }
+                                 },
+                                 "day_of_week": {
+                                   "type": "keyword"
+                                 },
+                                 "default": {
+                                   "type": "keyword"
+                                 },
+                                 "duration": {
+                                   "type": "integer"
+                                 },
+                                 "education": {
+                                   "type": "keyword"
+                                 },
+                                 "emp_var_rate": {
+                                   "type": "float"
+                                 },
+                                 "euribor3m": {
+                                   "type": "float"
+                                 },
+                                 "housing": {
+                                   "type": "keyword"
+                                 },
+                                 "job": {
+                                   "type": "keyword"
+                                 },
+                                 "loan": {
+                                   "type": "keyword"
+                                 },
+                                 "marital": {
+                                   "type": "keyword"
+                                 },
+                                 "ml": {
+                                   "properties": {
+                                     "feature_importance": {
+                                       "type": "nested",
+                                       "dynamic": "false",
+                                       "properties": {
+                                         "classes": {
+                                           "type": "nested",
+                                           "dynamic": "false",
+                                           "properties": {
+                                             "class_name": {
+                                               "type": "keyword"
+                                             },
+                                             "importance": {
+                                               "type": "double"
+                                             }
+                                           }
+                                         },
+                                         "feature_name": {
+                                           "type": "keyword"
+                                         }
+                                       }
+                                     },
+                                     "is_training": {
+                                       "type": "boolean"
+                                     },
+                                     "prediction_probability": {
+                                       "type": "double"
+                                     },
+                                     "prediction_score": {
+                                       "type": "double"
+                                     },
+                                     "top_classes": {
+                                       "type": "nested",
+                                       "properties": {
+                                         "class_name": {
+                                           "type": "keyword"
+                                         },
+                                         "class_probability": {
+                                           "type": "double"
+                                         },
+                                         "class_score": {
+                                           "type": "double"
+                                         }
+                                       }
+                                     },
+                                     "y_prediction": {
+                                       "type": "keyword"
+                                     }
+                                   }
+                                 }
+            }}}
+            """);
+
+        String source = """
+            {
+                       "loan": "no",
+                       "ml__incremental_id": 26513,
+                       "ml": {
+                         "y_prediction": "no",
+                         "top_classes": [
+                           {
+                             "class_name": "no",
+                             "class_probability": 0.978734716971892,
+                             "class_score": 0.17187636491006547
+                           },
+                           {
+                             "class_name": "yes",
+                             "class_probability": 0.02126528302810799,
+                             "class_score": 0.02126528302810799
+                           }
+                         ],
+                         "prediction_probability": 0.978734716971892,
+                         "prediction_score": 0.17187636491006547,
+                         "feature_importance": [
+                           {
+                             "feature_name": "duration",
+                             "classes": [
+                               {
+                                 "class_name": "no",
+                                 "importance": 0.4360196873080361
+                               },
+                               {
+                                 "class_name": "yes",
+                                 "importance": -0.4360196873080361
+                               }
+                             ]
+                           },
+                           {
+                             "feature_name": "housing",
+                             "classes": [
+                               {
+                                 "class_name": "no",
+                                 "importance": 0.2993353230710585
+                               },
+                               {
+                                 "class_name": "yes",
+                                 "importance": -0.2993353230710585
+                               }
+                             ]
+                           }
+                         ],
+                         "is_training": false
+                       }
+                     }
+            """;
+
+        var results = fetchFields(mapperService, source, fieldAndFormatList("*", null, false));
+        SearchHit searchHit = new SearchHit(0);
+        searchHit.addDocumentFields(results, Map.of());
+        assertThat(Strings.toString(searchHit), containsString("\"ml.top_classes\":"));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -886,57 +886,6 @@ public class FieldFetcherTests extends MapperServiceTestCase {
                                  "age": {
                                    "type": "integer"
                                  },
-                                 "balance": {
-                                   "type": "text",
-                                   "fields": {
-                                     "keyword": {
-                                       "type": "keyword",
-                                       "ignore_above": 256
-                                     }
-                                   }
-                                 },
-                                 "campaign": {
-                                   "type": "integer"
-                                 },
-                                 "cons_conf_idx": {
-                                   "type": "float"
-                                 },
-                                 "contact": {
-                                   "type": "keyword"
-                                 },
-                                 "day": {
-                                   "type": "text",
-                                   "fields": {
-                                     "keyword": {
-                                       "type": "keyword",
-                                       "ignore_above": 256
-                                     }
-                                   }
-                                 },
-                                 "day_of_week": {
-                                   "type": "keyword"
-                                 },
-                                 "default": {
-                                   "type": "keyword"
-                                 },
-                                 "duration": {
-                                   "type": "integer"
-                                 },
-                                 "education": {
-                                   "type": "keyword"
-                                 },
-                                 "emp_var_rate": {
-                                   "type": "float"
-                                 },
-                                 "euribor3m": {
-                                   "type": "float"
-                                 },
-                                 "housing": {
-                                   "type": "keyword"
-                                 },
-                                 "job": {
-                                   "type": "keyword"
-                                 },
                                  "loan": {
                                    "type": "keyword"
                                  },


### PR DESCRIPTION
If multiple fields appeared between two child scopes, the following children
would be incorrectly assigned to the parent scope.