### PR TITLE
Add Configuration to PatternLayout backport(97679)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
@@ -10,10 +10,13 @@ package org.elasticsearch.common.logging;
 
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.Node;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
@@ -63,11 +66,12 @@ public class ESJsonLayout extends AbstractStringLayout {
 
     private final PatternLayout patternLayout;
 
-    protected ESJsonLayout(String typeName, Charset charset, String[] esmessagefields) {
+    protected ESJsonLayout(String typeName, Charset charset, String[] esmessagefields, final Configuration config) {
         super(charset);
         this.patternLayout = PatternLayout.newBuilder()
             .withPattern(pattern(typeName, esmessagefields))
             .withAlwaysWriteExceptions(false)
+            .withConfiguration(config)
             .build();
     }
 
@@ -135,8 +139,8 @@ public class ESJsonLayout extends AbstractStringLayout {
     }
 
     @PluginFactory
-    public static ESJsonLayout createLayout(String type, Charset charset, String[] esmessagefields) {
-        return new ESJsonLayout(type, charset, esmessagefields);
+    public static ESJsonLayout createLayout(String type, Charset charset, String[] esmessagefields, Configuration configuration) {
+        return new ESJsonLayout(type, charset, esmessagefields, configuration);
     }
 
     PatternLayout getPatternLayout() {
@@ -156,6 +160,9 @@ public class ESJsonLayout extends AbstractStringLayout {
         @PluginAttribute("esmessagefields")
         private String esMessageFields;
 
+        @PluginConfiguration
+        private Configuration config;
+
         public Builder() {
             setCharset(StandardCharsets.UTF_8);
         }
@@ -163,7 +170,7 @@ public class ESJsonLayout extends AbstractStringLayout {
         @Override
         public ESJsonLayout build() {
             String[] split = Strings.isNullOrEmpty(esMessageFields) ? new String[] {} : esMessageFields.split(",");
-            return ESJsonLayout.createLayout(type, charset, split);
+            return ESJsonLayout.createLayout(type, charset, split, new DefaultConfiguration());
         }
 
         public Charset getCharset() {


### PR DESCRIPTION
in 2.17.2 (patch release) log4j has made a refactoring that requires a Configuration to be manually passed into the created PatternLayout
If the Configuration is not passed, the System Variable lookup will not work This results in cluster.name field not being populated in logs

This commit creates a PatternLayout with a DefaultConfiguration (the same was used previous to the refactoring)

backports #97679

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
