### PR TITLE
[DOCS] Clarify TSDS/synthetic source/runtime field restrictions

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -53,6 +53,9 @@ shard segments by `_tsid` and `@timestamp`.
 documents, the document `_id` is a hash of the document's dimensions and
 `@timestamp`. A TSDS doesn't support custom document `_id` values.
 
+* A TSDS uses <<synthetic-source,synthetic `_source`>>, and as a result is
+subject to a number of <<synthetic-source-restrictions,restrictions>>.
+
 [discrete]
 [[time-series]]
 === What is a time series?

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -28,12 +28,21 @@ PUT idx
 
 While this on the fly reconstruction is *generally* slower than saving the source
 documents verbatim and loading them at query time, it saves a lot of storage
-space. There are a couple of restrictions to be aware of:
+space. 
+
+[[synthetic-source-restrictions]]
+===== Synthetic `_source` restrictions
+
+There are a couple of restrictions to be aware of:
 
 * When you retrieve synthetic `_source` content it undergoes minor
 <<synthetic-source-modifications,modifications>> compared to the original JSON.
 * The `params._source` is unavailable in scripts. Instead use the
-{painless}/painless-field-context.html[`doc`] API or the <<script-fields-api, `field`>>.
+{painless}/painless-field-context.html[`doc`] API or the <<script-fields-api,`field` API>>.
+* Runtime fields <<runtime-fields-scriptless,without a script>>, and runtime 
+fields that access `_source` are currently not supported for indices that use 
+synthetic `_source`. Use a scripted runtime field that accesses fields <<modules-scripting-doc-vals,using doc values>> or the 
+<<script-fields-api,`field` API>> instead.
 * Synthetic `_source` can be used with indices that contain only these field
 types:
 
@@ -58,8 +67,6 @@ types:
 ** <<text-synthetic-source,`text`>>
 ** <<version-synthetic-source,`version`>>
 ** <<wildcard-synthetic-source,`wildcard`>>
-
-Runtime fields cannot, at this stage, use synthetic `_source`.
 
 [[synthetic-source-modifications]]
 ===== Synthetic `_source` modifications


### PR DESCRIPTION
This PR:

- breaks the synthetic `_source` restrictions out into its own section, with a header so it stands out more, and an ID so it can be linked to;
- clarifies the restrictions of a runtime field on synthetic `_source`;
- documents that a TSDS uses synthetic `_source` and is subject to the synthetic `_source` restrictions.