### PR TITLE
[Fleet] Fix Fleet API docs

### DIFF
--- a/docs/reference/fleet/fleet-multi-search.asciidoc
+++ b/docs/reference/fleet/fleet-multi-search.asciidoc
@@ -2,7 +2,7 @@
 [[fleet-multi-search]]
 === Fleet multi search API
 ++++
-<titleabbrev>Fleet search</titleabbrev>
+<titleabbrev>Fleet multi search</titleabbrev>
 ++++
 
 Executes several <<fleet-search,fleet searches>> with a single API request.

--- a/docs/reference/fleet/index.asciidoc
+++ b/docs/reference/fleet/index.asciidoc
@@ -11,6 +11,7 @@ agent and action data. These APIs are experimental and for internal use by
 
 * <<get-global-checkpoints,Get global checkpoints>>
 * <<fleet-search,Fleet search>>
+* <<fleet-multi-search,Fleet multi search>>
 
 // top-level
 include::get-global-checkpoints.asciidoc[]


### PR DESCRIPTION
While working on Fleet indices, I noticed a couple of inconsistencies in the Fleet API docs:

![Screenshot 2023-07-24 at 17 07 44](https://github.com/elastic/elasticsearch/assets/23701614/d5d3d290-4bb1-4d84-bb9e-d103d2586695)