### PR TITLE
Adding ApiFilteringActionFilter

### DIFF
--- a/docs/changelog/97985.yaml
+++ b/docs/changelog/97985.yaml
@@ -1,0 +1,5 @@
+pr: 97985
+summary: Adding `ApiFilteringActionFilter`
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/module-info.java
+++ b/x-pack/plugin/core/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module org.elasticsearch.xcore {
     exports org.elasticsearch.xpack.core.aggregatemetric;
     exports org.elasticsearch.xpack.core.analytics.action;
     exports org.elasticsearch.xpack.core.analytics;
+    exports org.elasticsearch.xpack.core.api.filtering;
     exports org.elasticsearch.xpack.core.application;
     exports org.elasticsearch.xpack.core.archive;
     exports org.elasticsearch.xpack.core.async;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.api.filtering;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+
+public abstract class ApiFilteringActionFilter<Res extends ActionResponse> implements ActionFilter {
+
+    private final ThreadContext threadContext;
+
+    public ApiFilteringActionFilter(ThreadContext threadContext) {
+        this.threadContext = threadContext;
+    }
+
+    @Override
+    public int order() {
+        return 0;
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+        Task task,
+        String action,
+        Request request,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    ) {
+        final ActionListener<Response> responseFilteringListener;
+        if (isOperator() == false && getActionName().equals(action)) {
+            responseFilteringListener = listener.map(this::filter);
+        } else {
+            responseFilteringListener = listener;
+        }
+        chain.proceed(task, action, request, responseFilteringListener);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <Response extends ActionResponse> Response filter(Response response) throws Exception {
+        if (response.getClass().equals(getResponseClass())) {
+            return (Response) getFilteringFunction().apply((Res) response);
+        } else {
+            return response;
+        }
+    }
+
+    private boolean isOperator() {
+        return AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR.equals(
+            threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY)
+        );
+    }
+
+    public abstract String getActionName();
+
+    public abstract Class<Res> getResponseClass();
+
+    public abstract CheckedFunction<Res, Res, Exception> getFilteringFunction();
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilterTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.api.filtering;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ApiFilteringActionFilterTests extends ESTestCase {
+
+    public void testApply() {
+        boolean isOperator = randomBoolean();
+        final ThreadContext threadContext = getTestThreadContext(isOperator);
+        String action = "test.action";
+        ApiFilteringActionFilter<TestResponse> filter = new TestFilter(threadContext);
+        Task task = null;
+        TestRequest request = new TestRequest();
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        AtomicBoolean responseModified = new AtomicBoolean(false);
+        ActionListener<TestResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(TestResponse testResponse) {
+                listenerCalled.set(true);
+                responseModified.set(testResponse.modified);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail(Strings.format("Unexpected exception: %s", e.getMessage()));
+            }
+        };
+        ActionFilterChain<TestRequest, TestResponse> chain = (task1, action1, request1, listener1) -> {
+            listener1.onResponse(new TestResponse());
+        };
+        filter.apply(task, "wrong.action", request, listener, chain);
+        assertThat(listenerCalled.get(), equalTo(true));
+        assertThat(responseModified.get(), equalTo(false));
+        filter.apply(task, action, request, listener, chain);
+        assertThat(listenerCalled.get(), equalTo(true));
+        assertThat(responseModified.get(), equalTo(true));
+        // The response should only have been modified if we are not an operator user
+        assertThat(responseModified.get(), equalTo(isOperator == false));
+    }
+
+    public void testApplyWithException() {
+        /*
+         * This test makes sure that we have correct behavior if the filter function throws an exception. In that case we expect
+         * onFailure() to be called on the delegate listener for a non-operator user. For an operator user, we expect onResponse() to be
+         * called on the delegate listener because the filter function will never have been called.
+         */
+        boolean isOperator = randomBoolean();
+        final ThreadContext threadContext = getTestThreadContext(isOperator);
+        String action = "test.exception.action";
+        ApiFilteringActionFilter<TestResponse> filter = new ExceptionTestFilter(threadContext);
+        Task task = null;
+        TestRequest request = new TestRequest();
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        ActionListener<TestResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(TestResponse testResponse) {
+                listenerCalled.set(true);
+                assertThat(isOperator, equalTo(true));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listenerCalled.set(true);
+                assertThat(isOperator, equalTo(false));
+            }
+        };
+        ActionFilterChain<TestRequest, TestResponse> chain = (task1, action1, request1, listener1) -> {
+            listener1.onResponse(new TestResponse());
+        };
+        filter.apply(task, action, request, listener, chain);
+        assertThat(listenerCalled.get(), equalTo(true));
+    }
+
+    private static class TestFilter extends ApiFilteringActionFilter<TestResponse> {
+
+        TestFilter(ThreadContext threadContext) {
+            super(threadContext);
+        }
+
+        @Override
+        public String getActionName() {
+            return "test.action";
+        }
+
+        @Override
+        public Class<TestResponse> getResponseClass() {
+            return TestResponse.class;
+        }
+
+        @Override
+        public CheckedFunction<TestResponse, TestResponse, Exception> getFilteringFunction() {
+            return testResponse -> {
+                testResponse.modified = true;
+                return testResponse;
+            };
+        }
+    }
+
+    private static class ExceptionTestFilter extends ApiFilteringActionFilter<TestResponse> {
+
+        ExceptionTestFilter(ThreadContext threadContext) {
+            super(threadContext);
+        }
+
+        @Override
+        public String getActionName() {
+            return "test.exception.action";
+        }
+
+        @Override
+        public Class<TestResponse> getResponseClass() {
+            return TestResponse.class;
+        }
+
+        @Override
+        public CheckedFunction<TestResponse, TestResponse, Exception> getFilteringFunction() {
+            return testResponse -> { throw new RuntimeException("Throwing expected exception"); };
+        }
+    }
+
+    private ThreadContext getTestThreadContext(boolean isOperator) {
+        Settings settings;
+        if (isOperator) {
+            settings = Settings.builder().put("request.headers._security_privilege_category", "operator").build();
+        } else {
+            settings = Settings.EMPTY;
+        }
+        return new ThreadContext(settings);
+    }
+
+    private static class TestRequest extends ActionRequest {
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    private static class TestResponse extends ActionResponse {
+        boolean modified = false;
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {}
+    }
+}


### PR DESCRIPTION
This PR adds an abstract ActionFilter meant to be extended in serverless modules that need to redact part of a response. When an implementing class is registered with a plugin, filterResponse() is applied if the transport action being called is the actionName passed to the constructor and the response's class is the responseClass passed to the constructor.