### PR TITLE
Fix bug in NestedUtils.partitionByChildren() (#97970)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/NestedUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/NestedUtils.java
@@ -71,20 +71,18 @@ public final class NestedUtils {
         String currentInputName = pathFunction.apply(currentInput);
         assert currentInputName.startsWith(scope);
 
-        // Find all the inputs that sort before the first child, and add them to the current scope entry
-        while (currentInputName.compareTo(currentChild) < 0) {
-            output.get(scope).add(currentInput);
-            if (inputIterator.hasNext() == false) {
-                return output;
-            }
-            currentInput = inputIterator.next();
-            currentInputName = pathFunction.apply(currentInput);
-            assert currentInputName.startsWith(scope);
-        }
-
         // Iterate through all the children
         while (currentChild != null) {
-            if (currentInputName.startsWith(currentChild + ".")) {
+            if (currentInputName.compareTo(currentChild) < 0) {
+                // If we sort before the current child, then we sit in the parent scope
+                output.get(scope).add(currentInput);
+                if (inputIterator.hasNext() == false) {
+                    return output;
+                }
+                currentInput = inputIterator.next();
+                currentInputName = pathFunction.apply(currentInput);
+                assert currentInputName.startsWith(scope);
+            } else if (currentInputName.startsWith(currentChild + ".")) {
                 // If this input sits under the current child, add it to that child scope
                 // and then get the next input
                 output.get(currentChild).add(currentInput);

--- a/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/NestedUtilsTests.java
@@ -23,6 +23,7 @@ public class NestedUtilsTests extends ESTestCase {
             "child1.grandchild",
             "child1.grandchild2",
             "child11",
+            "child12",
             "child2.grandchild",
             "frog"
         );
@@ -30,7 +31,7 @@ public class NestedUtilsTests extends ESTestCase {
         assertEquals(
             org.elasticsearch.core.Map.of(
                 "",
-                org.elasticsearch.core.List.of("a", "b", "child11", "frog"),
+                org.elasticsearch.core.List.of("a", "b", "child11", "child12", "frog"),
                 "child1",
                 org.elasticsearch.core.List.of("child1.grandchild", "child1.grandchild2"),
                 "child2",


### PR DESCRIPTION
If multiple fields appeared between two child scopes, the following children 
would be incorrectly assigned to the parent scope.
