### PR TITLE
Move some common version methods into VersionId

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -64,7 +64,7 @@ import java.util.TreeMap;
  * different version value. If you need to know whether the cluster as a whole speaks a new enough {@link TransportVersion} to understand a
  * newly-added feature, use {@link org.elasticsearch.cluster.ClusterState#getMinTransportVersion}.
  */
-public record TransportVersion(int id) implements VersionId, Comparable<TransportVersion> {
+public record TransportVersion(int id) implements VersionId<TransportVersion> {
 
     /*
      * NOTE: IntelliJ lies!
@@ -291,34 +291,8 @@ public record TransportVersion(int id) implements VersionId, Comparable<Transpor
         return CurrentHolder.CURRENT;
     }
 
-    public boolean after(TransportVersion version) {
-        return version.id < id;
-    }
-
-    public boolean onOrAfter(TransportVersion version) {
-        return version.id <= id;
-    }
-
-    public boolean before(TransportVersion version) {
-        return version.id > id;
-    }
-
-    public boolean onOrBefore(TransportVersion version) {
-        return version.id >= id;
-    }
-
-    public boolean between(TransportVersion lowerInclusive, TransportVersion upperExclusive) {
-        if (upperExclusive.onOrBefore(lowerInclusive)) throw new IllegalArgumentException();
-        return onOrAfter(lowerInclusive) && before(upperExclusive);
-    }
-
     public static TransportVersion fromString(String str) {
         return TransportVersion.fromId(Integer.parseInt(str));
-    }
-
-    @Override
-    public int compareTo(TransportVersion other) {
-        return Integer.compare(this.id, other.id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -33,7 +33,7 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
 
-public class Version implements VersionId, Comparable<Version>, ToXContentFragment {
+public class Version implements VersionId<Version>, ToXContentFragment {
     /*
      * The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator AA
      * values below 25 are for alpha builder (since 5.0), and above 25 and below 50 are beta builds, and below 99 are RC builds, with 99
@@ -315,27 +315,6 @@ public class Version implements VersionId, Comparable<Version>, ToXContentFragme
     @Override
     public int id() {
         return id;
-    }
-
-    public boolean after(Version version) {
-        return version.id < id;
-    }
-
-    public boolean onOrAfter(Version version) {
-        return version.id <= id;
-    }
-
-    public boolean before(Version version) {
-        return version.id > id;
-    }
-
-    public boolean onOrBefore(Version version) {
-        return version.id >= id;
-    }
-
-    @Override
-    public int compareTo(Version other) {
-        return Integer.compare(this.id, other.id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/VersionId.java
+++ b/server/src/main/java/org/elasticsearch/common/VersionId.java
@@ -11,9 +11,35 @@ package org.elasticsearch.common;
 /**
  * Indicates a class that represents a version id of some kind
  */
-public interface VersionId {
+public interface VersionId<T extends VersionId<T>> extends Comparable<T> {
     /**
      * The version id this object represents
      */
     int id();
+
+    default boolean after(T version) {
+        return version.id() < id();
+    }
+
+    default boolean onOrAfter(T version) {
+        return version.id() <= id();
+    }
+
+    default boolean before(T version) {
+        return version.id() > id();
+    }
+
+    default boolean onOrBefore(T version) {
+        return version.id() >= id();
+    }
+
+    default boolean between(T lowerInclusive, T upperExclusive) {
+        if (upperExclusive.onOrBefore(lowerInclusive)) throw new IllegalArgumentException();
+        return onOrAfter(lowerInclusive) && before(upperExclusive);
+    }
+
+    @Override
+    default int compareTo(T o) {
+        return Integer.compare(id(), o.id());
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1285,7 +1285,7 @@ public class Setting<T> implements ToXContentObject {
         }
     }
 
-    public static <T extends VersionId> Setting<T> versionIdSetting(
+    public static <T extends VersionId<T>> Setting<T> versionIdSetting(
         String key,
         T defaultValue,
         IntFunction<T> parseVersion,
@@ -1294,7 +1294,7 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, Integer.toString(defaultValue.id()), s -> parseVersion.apply(Integer.parseInt(s)), properties);
     }
 
-    public static <T extends VersionId> Setting<T> versionIdSetting(
+    public static <T extends VersionId<T>> Setting<T> versionIdSetting(
         final String key,
         Setting<T> fallbackSetting,
         Validator<T> validator,

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -523,14 +523,15 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
     /**
      * Returns a parsed version.
      */
-    public <T extends VersionId> T getAsVersionId(String setting, IntFunction<T> parseVersion) throws SettingsException {
+    public <T extends VersionId<T>> T getAsVersionId(String setting, IntFunction<T> parseVersion) throws SettingsException {
         return getAsVersionId(setting, parseVersion, null);
     }
 
     /**
      * Returns a parsed version.
      */
-    public <T extends VersionId> T getAsVersionId(String setting, IntFunction<T> parseVersion, T defaultVersion) throws SettingsException {
+    public <T extends VersionId<T>> T getAsVersionId(String setting, IntFunction<T> parseVersion, T defaultVersion)
+        throws SettingsException {
         String sValue = get(setting);
         if (sValue == null) {
             return defaultVersion;
@@ -1043,7 +1044,7 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
          * @param version The version value
          * @return The builder
          */
-        public Builder put(String setting, VersionId version) {
+        public <T extends VersionId<T>> Builder put(String setting, T version) {
             put(setting, version.id());
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1044,7 +1044,7 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
          * @param version The version value
          * @return The builder
          */
-        public <T extends VersionId<T>> Builder put(String setting, T version) {
+        public Builder put(String setting, VersionId<?> version) {
             put(setting, version.id());
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -62,7 +62,7 @@ import java.util.TreeMap;
  * representing the reverted change. <em>Do not</em> let the index version go backwards, it must <em>always</em> be incremented.
  */
 @SuppressWarnings({"checkstyle:linelength", "deprecation"})
-public record IndexVersion(int id, Version luceneVersion) implements VersionId, Comparable<IndexVersion>, ToXContentFragment {
+public record IndexVersion(int id, Version luceneVersion) implements VersionId<IndexVersion>, ToXContentFragment {
 
     /*
      * NOTE: IntelliJ lies!
@@ -311,34 +311,8 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId, 
         return CurrentHolder.CURRENT;
     }
 
-    public boolean after(IndexVersion version) {
-        return version.id < id;
-    }
-
-    public boolean onOrAfter(IndexVersion version) {
-        return version.id <= id;
-    }
-
-    public boolean before(IndexVersion version) {
-        return version.id > id;
-    }
-
-    public boolean onOrBefore(IndexVersion version) {
-        return version.id >= id;
-    }
-
-    public boolean between(IndexVersion lowerInclusive, IndexVersion upperExclusive) {
-        if (upperExclusive.onOrBefore(lowerInclusive)) throw new IllegalArgumentException();
-        return onOrAfter(lowerInclusive) && before(upperExclusive);
-    }
-
     public boolean isLegacyIndexVersion() {
         return before(MINIMUM_COMPATIBLE);
-    }
-
-    @Override
-    public int compareTo(IndexVersion other) {
-        return Integer.compare(this.id, other.id);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/VersionHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/VersionHttpResource.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.VersionId;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
@@ -83,7 +84,7 @@ public class VersionHttpResource extends HttpResource {
     }
 
     /**
-     * Ensure that the {@code response} contains a {@link Version} that is {@linkplain Version#onOrAfter(Version) on or after} the
+     * Ensure that the {@code response} contains a {@link Version} that is {@linkplain VersionId#onOrAfter on or after} the
      * {@link #minimumVersion}.
      *
      * @param response The response to parse.


### PR DESCRIPTION
Move common method implementations into the shared `VersionId` interface