### PR TITLE
[8.9] Ignore `total_shards_per_node` setting on searchable snapshots in frozen (#97979)

### DIFF
--- a/docs/changelog/97979.yaml
+++ b/docs/changelog/97979.yaml
@@ -1,0 +1,5 @@
+pr: 97979
+summary: Ignore the `total_shards_per_node` setting on searchable snapshots in frozen
+area: ILM+SLM
+type: bug
+issues: []

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -17,6 +17,11 @@ the frozen phase, the action mounts a <<partially-mounted,partially mounted
 index>> prefixed with `partial-` to the frozen tier. In other phases, the action mounts a
 <<fully-mounted,fully mounted index>> prefixed with `restored-` to the corresponding data tier.
 
+In the frozen tier, the action will ignore the setting
+<<total-shards-per-node,`index.routing.allocation.total_shards_per_node`>>, if it was present in the original index,
+to account for the difference in the number of nodes between the frozen and the other tiers.
+
+
 WARNING: Don't include the `searchable_snapshot` action in both the hot and cold
 phases. This can result in indices failing to automatically migrate to the cold
 tier during the cold phase.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
+import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -134,12 +135,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             snapshotName,
             indexName,
             settingsBuilder.build(),
-            // we captured the index metadata when we took the snapshot. the index likely had the ILM execution state in the metadata.
-            // if we were to restore the lifecycle.name setting, the restored index would be captured by the ILM runner and,
-            // depending on what ILM execution state was captured at snapshot time, make it's way forward from _that_ step forward in
-            // the ILM policy.
-            // we'll re-set this setting on the restored index at a later step once we restored a deterministic execution state
-            new String[] { LifecycleSettings.LIFECYCLE_NAME },
+            ignoredIndexSettings(this.getKey().phase()),
             // we'll not wait for the snapshot to complete in this step as the async steps are executed from threads that shouldn't
             // perform expensive operations (ie. clusterStateProcessed)
             false,
@@ -182,6 +178,26 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             return Optional.of(DataTier.DATA_HOT);
         }
         return Optional.empty();
+    }
+
+    /**
+     * This method returns the settings that need to be ignored when we mount the searchable snapshot. Currently, it returns:
+     * - index.lifecycle.name: The index likely had the ILM execution state in the metadata. If we were to restore the lifecycle.name
+     * setting, the restored index would be captured by the ILM runner and, depending on what ILM execution state was captured at snapshot
+     * time, make it's way forward from _that_ step forward in the ILM policy. We'll re-set this setting on the restored index at a later
+     * step once we restored a deterministic execution state
+     * - index.routing.allocation.total_shards_per_node: It is  likely that frozen tier has fewer nodes than the hot tier.
+     * Keeping this setting runs the risk that we will not have enough nodes to allocate all the shards in the
+     * frozen tier and the user does not have any way of fixing this. For this reason, we ignore this setting when moving to frozen.
+     */
+    static String[] ignoredIndexSettings(String phase) {
+        // if we are mounting a searchable snapshot in the hot phase, then we should not change the total_shards_per_node setting
+        if (TimeseriesLifecycleType.FROZEN_PHASE.equals(phase)) {
+            return new String[] {
+                LifecycleSettings.LIFECYCLE_NAME,
+                ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey() };
+        }
+        return new String[] { LifecycleSettings.LIFECYCLE_NAME };
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
@@ -29,7 +30,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotStep> {
 
@@ -170,7 +170,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 snapshotName,
                 indexName,
                 RESTORED_INDEX_PREFIX,
-                indexName
+                indexName,
+                new String[] { LifecycleSettings.LIFECYCLE_NAME }
             )
         ) {
             MountSnapshotStep step = new MountSnapshotStep(
@@ -291,7 +292,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                     snapshotName,
                     indexName,
                     RESTORED_INDEX_PREFIX,
-                    indexNameSnippet
+                    indexNameSnippet,
+                    new String[] { LifecycleSettings.LIFECYCLE_NAME }
                 )
             ) {
                 MountSnapshotStep step = new MountSnapshotStep(
@@ -303,6 +305,47 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 );
                 PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, clusterState, null, f));
             }
+        }
+    }
+
+    public void testIgnoreTotalShardsPerNodeInFrozenPhase() throws Exception {
+        String indexName = randomAlphaOfLength(10);
+        String policyName = "test-ilm-policy";
+        Map<String, String> ilmCustom = new HashMap<>();
+        String snapshotName = indexName + "-" + policyName;
+        ilmCustom.put("snapshot_name", snapshotName);
+        String repository = "repository";
+        ilmCustom.put("snapshot_repository", repository);
+
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, ilmCustom)
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5));
+        IndexMetadata indexMetadata = indexMetadataBuilder.build();
+
+        ClusterState clusterState = ClusterState.builder(emptyClusterState())
+            .metadata(Metadata.builder().put(indexMetadata, true).build())
+            .build();
+
+        try (
+            NoOpClient client = getRestoreSnapshotRequestAssertingClient(
+                repository,
+                snapshotName,
+                indexName,
+                RESTORED_INDEX_PREFIX,
+                indexName,
+                new String[] { LifecycleSettings.LIFECYCLE_NAME, ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey() }
+            )
+        ) {
+            MountSnapshotStep step = new MountSnapshotStep(
+                new StepKey(TimeseriesLifecycleType.FROZEN_PHASE, randomAlphaOfLength(10), randomAlphaOfLength(10)),
+                randomStepKey(),
+                client,
+                RESTORED_INDEX_PREFIX,
+                randomStorageType()
+            );
+            PlainActionFuture.<Void, Exception>get(f -> step.performAction(indexMetadata, clusterState, null, f));
         }
     }
 
@@ -326,7 +369,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
         String expectedSnapshotName,
         String indexName,
         String restoredIndexPrefix,
-        String expectedSnapshotIndexName
+        String expectedSnapshotIndexName,
+        String[] expectedIgnoredIndexSettings
     ) {
         return new NoOpClient(getTestName()) {
             @Override
@@ -345,8 +389,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                     mountSearchableSnapshotRequest.waitForCompletion(),
                     is(false)
                 );
-                assertThat(mountSearchableSnapshotRequest.ignoreIndexSettings(), is(notNullValue()));
-                assertThat(mountSearchableSnapshotRequest.ignoreIndexSettings()[0], is(LifecycleSettings.LIFECYCLE_NAME));
+                assertThat(mountSearchableSnapshotRequest.ignoreIndexSettings(), is(expectedIgnoredIndexSettings));
                 assertThat(mountSearchableSnapshotRequest.mountedIndexName(), is(restoredIndexPrefix + indexName));
                 assertThat(mountSearchableSnapshotRequest.snapshotIndexName(), is(expectedSnapshotIndexName));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Ignore `total_shards_per_node` setting on searchable snapshots in frozen (#97979)](https://github.com/elastic/elasticsearch/pull/97979)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)