### PR TITLE
[8.9] UnmappedFieldFetcher should ignore nested fields (#97987)

### DIFF
--- a/docs/changelog/97987.yaml
+++ b/docs/changelog/97987.yaml
@@ -1,0 +1,6 @@
+pr: 97987
+summary: '`UnmappedFieldFetcher` should ignore nested fields'
+area: Search
+type: bug
+issues:
+ - 97684

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,9 +94,7 @@ public class FieldFetcher {
         // immediately below the current scope. This means that the unmapped field fetcher won't
         // retrieve any fields that live inside a nested child, instead leaving this to the
         // NestedFieldFetchers defined for each child scope in buildFieldContexts()
-        Set<String> mappedAndNestedFields = new HashSet<>(mappedFields);
-        mappedAndNestedFields.addAll(context.nestedLookup().getImmediateChildMappers(nestedScope));
-        return new UnmappedFieldFetcher(mappedAndNestedFields, unmappedFetchPatterns);
+        return new UnmappedFieldFetcher(mappedFields, context.nestedLookup().getImmediateChildMappers(nestedScope), unmappedFetchPatterns);
     }
 
     private static ValueFetcher buildValueFetcher(SearchExecutionContext context, ResolvedField fieldAndFormat) {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -1006,6 +1006,31 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         assertThat(Strings.toString(searchHit), containsString("\"ml.top_classes\":"));
     }
 
+    public void testNestedIOOB() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+              "nested_field" : {
+                "type" : "nested",
+                "properties" : {
+                  "file" : { "type" : "keyword" }
+                }
+              }
+            }}}
+            """);
+        String source = """
+            { "nested_field" : { "file" : "somefile.txt" } }
+            """;
+        var results = fetchFields(
+            mapperService,
+            source,
+            List.of(new FieldAndFormat("file", null, true), new FieldAndFormat("*", null, true))
+        );
+        assertThat(results.keySet(), hasSize(1));
+
+        results = fetchFields(mapperService, source, fieldAndFormatList("nested_field.file", null, true));
+        assertThat(results.keySet(), hasSize(1));
+    }
+
     @SuppressWarnings("unchecked")
     public void testFlattenedField() throws IOException {
         XContentBuilder mapping = mapping(b -> b.startObject("flat").field("type", "flattened").endObject());


### PR DESCRIPTION
Backports the following commits to 8.9:
 - UnmappedFieldFetcher should ignore nested fields (#97987)