### PR TITLE
Move over most remaining uses of indexSettings(Version) to IndexVersion

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
@@ -24,12 +24,14 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.AssociatedIndexDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.Assert;
@@ -66,6 +68,9 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
     static final int INDEX_DOC_COUNT = 100; // arbitrarily chosen
     static final int INTERNAL_MANAGED_FLAG_VALUE = 1;
     public static final Version NEEDS_UPGRADE_VERSION = TransportGetFeatureUpgradeStatusAction.NO_UPGRADE_REQUIRED_VERSION.previousMajor();
+    public static final IndexVersion NEEDS_UPGRADE_INDEX_VERSION = IndexVersionUtils.getPreviousMajorVersion(
+        TransportGetFeatureUpgradeStatusAction.NO_UPGRADE_REQUIRED_INDEX_VERSION
+    );
 
     static final SystemIndexDescriptor EXTERNAL_UNMANAGED = SystemIndexDescriptor.builder()
         .setIndexPattern(".ext-unman-*")
@@ -89,7 +94,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         .setAliasName(".internal-managed-alias")
         .setPrimaryIndex(INTERNAL_MANAGED_INDEX_NAME)
         .setType(SystemIndexDescriptor.Type.INTERNAL_MANAGED)
-        .setSettings(createSettings(NEEDS_UPGRADE_VERSION, INTERNAL_MANAGED_FLAG_VALUE))
+        .setSettings(createSettings(NEEDS_UPGRADE_INDEX_VERSION, INTERNAL_MANAGED_FLAG_VALUE))
         .setMappings(createMapping(true, true))
         .setOrigin(ORIGIN)
         .setVersionMetaKey(VERSION_META_KEY)
@@ -104,7 +109,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         .setAliasName(".external-managed-alias")
         .setPrimaryIndex(".ext-man-old")
         .setType(SystemIndexDescriptor.Type.EXTERNAL_MANAGED)
-        .setSettings(createSettings(NEEDS_UPGRADE_VERSION, EXTERNAL_MANAGED_FLAG_VALUE))
+        .setSettings(createSettings(NEEDS_UPGRADE_INDEX_VERSION, EXTERNAL_MANAGED_FLAG_VALUE))
         .setMappings(createMapping(true, false))
         .setOrigin(ORIGIN)
         .setVersionMetaKey(VERSION_META_KEY)
@@ -166,7 +171,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
             // unmanaged
             createRequest.setSettings(
                 createSettings(
-                    NEEDS_UPGRADE_VERSION,
+                    NEEDS_UPGRADE_INDEX_VERSION,
                     descriptor.isInternal() ? INTERNAL_UNMANAGED_FLAG_VALUE : EXTERNAL_UNMANAGED_FLAG_VALUE
                 )
             );
@@ -194,7 +199,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         Assert.assertThat(indexStats.getIndex(indexName).getTotal().getDocs().getCount(), is((long) INDEX_DOC_COUNT));
     }
 
-    static Settings createSettings(Version creationVersion, int flagSettingValue) {
+    static Settings createSettings(IndexVersion creationVersion, int flagSettingValue) {
         return indexSettings(creationVersion, 1, 0).put(FlAG_SETTING_KEY, flagSettingValue).build();
     }
 

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
@@ -263,7 +264,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         .setAliasName(".second-internal-managed-alias")
         .setPrimaryIndex(".second-int-man-old")
         .setType(SystemIndexDescriptor.Type.INTERNAL_MANAGED)
-        .setSettings(createSettings(Version.V_7_0_0, 0))
+        .setSettings(createSettings(IndexVersion.V_7_0_0, 0))
         .setMappings(createMapping(true, true))
         .setOrigin(ORIGIN)
         .setVersionMetaKey(VERSION_META_KEY)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -87,9 +86,9 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
         VersionStats stats = VersionStats.of(metadata, Collections.emptyList());
         assertThat(stats.versionStats(), equalTo(Collections.emptySet()));
 
-        metadata = new Metadata.Builder().put(indexMeta("foo", Version.CURRENT, 4), true)
-            .put(indexMeta("bar", Version.CURRENT, 3), true)
-            .put(indexMeta("baz", Version.V_7_0_0, 2), true)
+        metadata = new Metadata.Builder().put(indexMeta("foo", IndexVersion.current(), 4), true)
+            .put(indexMeta("bar", IndexVersion.current(), 3), true)
+            .put(indexMeta("baz", IndexVersion.V_7_0_0, 2), true)
             .build();
         stats = VersionStats.of(metadata, Collections.emptyList());
         assertThat(stats.versionStats().size(), equalTo(2));
@@ -137,7 +136,7 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
         assertThat(stats.versionStats(), containsInAnyOrder(s1, s2));
     }
 
-    private static IndexMetadata indexMeta(String name, Version version, int primaryShards) {
+    private static IndexMetadata indexMeta(String name, IndexVersion version, int primaryShards) {
         return new IndexMetadata.Builder(name).settings(indexSettings(version, primaryShards, randomIntBetween(0, 3))).build();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,6 +42,7 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
@@ -112,8 +112,7 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
             Metadata.Builder metadata = Metadata.builder();
             for (String index : allIndices) {
                 metadata.put(
-                    IndexMetadata.builder(index)
-                        .settings(indexSettings(Version.CURRENT.minimumIndexCompatibilityVersion(), between(1, 10), between(0, 2)))
+                    IndexMetadata.builder(index).settings(indexSettings(IndexVersion.MINIMUM_COMPATIBLE, between(1, 10), between(0, 2)))
                 );
             }
             clusterState = newClusterState(metadata.build(), discoNodes.build());
@@ -182,8 +181,7 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
             Metadata.Builder metadata = Metadata.builder();
             for (String index : allIndices) {
                 metadata.put(
-                    IndexMetadata.builder(index)
-                        .settings(indexSettings(Version.CURRENT.minimumIndexCompatibilityVersion(), between(1, 10), between(1, 3)))
+                    IndexMetadata.builder(index).settings(indexSettings(IndexVersion.MINIMUM_COMPATIBLE, between(1, 10), between(1, 3)))
                 );
             }
             clusterState = newClusterState(metadata.build(), discoNodes.build());
@@ -303,8 +301,7 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
             Metadata.Builder metadata = Metadata.builder();
             for (String index : allIndices) {
                 metadata.put(
-                    IndexMetadata.builder(index)
-                        .settings(indexSettings(Version.CURRENT.minimumIndexCompatibilityVersion(), between(1, 10), between(0, 3)))
+                    IndexMetadata.builder(index).settings(indexSettings(IndexVersion.MINIMUM_COMPATIBLE, between(1, 10), between(0, 3)))
                 );
             }
             clusterState = newClusterState(metadata.build(), discoNodes.build());
@@ -426,8 +423,7 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
             Metadata.Builder metadata = Metadata.builder();
             for (String index : allIndices) {
                 metadata.put(
-                    IndexMetadata.builder(index)
-                        .settings(indexSettings(Version.CURRENT.minimumIndexCompatibilityVersion(), between(2, 10), between(0, 2)))
+                    IndexMetadata.builder(index).settings(indexSettings(IndexVersion.MINIMUM_COMPATIBLE, between(2, 10), between(0, 2)))
                 );
             }
             clusterState = newClusterState(metadata.build(), discoNodes.build());
@@ -523,8 +519,7 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
             Metadata.Builder metadata = Metadata.builder();
             for (String index : allIndices) {
                 metadata.put(
-                    IndexMetadata.builder(index)
-                        .settings(indexSettings(Version.CURRENT.minimumIndexCompatibilityVersion(), between(1, 10), between(0, 2)))
+                    IndexMetadata.builder(index).settings(indexSettings(IndexVersion.MINIMUM_COMPATIBLE, between(1, 10), between(0, 2)))
                 );
             }
             clusterState = newClusterState(metadata.build(), discoNodes.build());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -100,7 +100,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         Settings.builder().build();
         Metadata.Builder metaBuilder = Metadata.builder();
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
-            .settings(settings(Version.fromString("6.8.0"))) // latest V6 released version
+            .settings(settings(IndexVersion.fromId(6080099))) // latest V6 released version
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifierTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.test.index.IndexVersionUtils;
 
 import java.util.Collections;
 
-import static org.elasticsearch.test.VersionUtils.randomIndexCompatibleVersion;
 import static org.hamcrest.Matchers.equalTo;
 
 public class IndexMetadataVerifierTests extends ESTestCase {
@@ -153,7 +152,7 @@ public class IndexMetadataVerifierTests extends ESTestCase {
     }
 
     private static IndexMetadata.Builder newIndexMetaBuilder(String name, Settings indexSettings) {
-        final Settings settings = indexSettings(randomIndexCompatibleVersion(random()), between(1, 5), between(0, 5)).put(
+        final Settings settings = indexSettings(IndexVersionUtils.randomCompatibleVersion(random()), between(1, 5), between(0, 5)).put(
             IndexMetadata.SETTING_CREATION_DATE,
             randomNonNegativeLong()
         ).put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID(random())).put(indexSettings).build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -1765,12 +1765,12 @@ public class MetadataTests extends ESTestCase {
     public void testHiddenAliasValidation() {
         final String hiddenAliasName = "hidden_alias";
 
-        IndexMetadata hidden1 = buildIndexWithAlias("hidden1", hiddenAliasName, true, Version.CURRENT, false);
-        IndexMetadata hidden2 = buildIndexWithAlias("hidden2", hiddenAliasName, true, Version.CURRENT, false);
-        IndexMetadata hidden3 = buildIndexWithAlias("hidden3", hiddenAliasName, true, Version.CURRENT, false);
+        IndexMetadata hidden1 = buildIndexWithAlias("hidden1", hiddenAliasName, true, IndexVersion.current(), false);
+        IndexMetadata hidden2 = buildIndexWithAlias("hidden2", hiddenAliasName, true, IndexVersion.current(), false);
+        IndexMetadata hidden3 = buildIndexWithAlias("hidden3", hiddenAliasName, true, IndexVersion.current(), false);
 
-        IndexMetadata nonHidden = buildIndexWithAlias("nonhidden1", hiddenAliasName, false, Version.CURRENT, false);
-        IndexMetadata unspecified = buildIndexWithAlias("nonhidden2", hiddenAliasName, null, Version.CURRENT, false);
+        IndexMetadata nonHidden = buildIndexWithAlias("nonhidden1", hiddenAliasName, false, IndexVersion.current(), false);
+        IndexMetadata unspecified = buildIndexWithAlias("nonhidden2", hiddenAliasName, null, IndexVersion.current(), false);
 
         {
             // Should be ok:
@@ -1863,14 +1863,14 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testSystemAliasValidationMixedVersionSystemAndRegularFails() {
-        final Version random7xVersion = VersionUtils.randomVersionBetween(
+        final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            Version.V_7_0_0,
-            VersionUtils.getPreviousVersion(Version.V_8_0_0)
+            IndexVersion.V_7_0_0,
+            IndexVersionUtils.getPreviousVersion(IndexVersion.V_8_0_0)
         );
-        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
+        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
         final IndexMetadata oldVersionSystem = buildIndexWithAlias(".oldVersionSystem", SYSTEM_ALIAS_NAME, null, random7xVersion, true);
-        final IndexMetadata regularIndex = buildIndexWithAlias("regular1", SYSTEM_ALIAS_NAME, false, Version.CURRENT, false);
+        final IndexMetadata regularIndex = buildIndexWithAlias("regular1", SYSTEM_ALIAS_NAME, false, IndexVersion.current(), false);
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -1891,8 +1891,8 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testSystemAliasValidationNewSystemAndRegularFails() {
-        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
-        final IndexMetadata regularIndex = buildIndexWithAlias("regular1", SYSTEM_ALIAS_NAME, false, Version.CURRENT, false);
+        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
+        final IndexMetadata regularIndex = buildIndexWithAlias("regular1", SYSTEM_ALIAS_NAME, false, IndexVersion.current(), false);
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -1913,26 +1913,26 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testSystemAliasOldSystemAndNewRegular() {
-        final Version random7xVersion = VersionUtils.randomVersionBetween(
+        final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            Version.V_7_0_0,
-            VersionUtils.getPreviousVersion(Version.V_8_0_0)
+            IndexVersion.V_7_0_0,
+            IndexVersionUtils.getPreviousVersion(IndexVersion.V_8_0_0)
         );
         final IndexMetadata oldVersionSystem = buildIndexWithAlias(".oldVersionSystem", SYSTEM_ALIAS_NAME, null, random7xVersion, true);
-        final IndexMetadata regularIndex = buildIndexWithAlias("regular1", SYSTEM_ALIAS_NAME, false, Version.CURRENT, false);
+        final IndexMetadata regularIndex = buildIndexWithAlias("regular1", SYSTEM_ALIAS_NAME, false, IndexVersion.current(), false);
 
         // Should be ok:
         metadataWithIndices(oldVersionSystem, regularIndex);
     }
 
     public void testSystemIndexValidationAllRegular() {
-        final Version random7xVersion = VersionUtils.randomVersionBetween(
+        final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            Version.V_7_0_0,
-            VersionUtils.getPreviousVersion(Version.V_8_0_0)
+            IndexVersion.V_7_0_0,
+            IndexVersionUtils.getPreviousVersion(IndexVersion.V_8_0_0)
         );
-        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
-        final IndexMetadata currentVersionSystem2 = buildIndexWithAlias(".system2", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
+        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
+        final IndexMetadata currentVersionSystem2 = buildIndexWithAlias(".system2", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
         final IndexMetadata oldVersionSystem = buildIndexWithAlias(".oldVersionSystem", SYSTEM_ALIAS_NAME, null, random7xVersion, true);
 
         // Should be ok
@@ -1940,13 +1940,13 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testSystemAliasValidationAllSystemSomeOld() {
-        final Version random7xVersion = VersionUtils.randomVersionBetween(
+        final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
             random(),
-            Version.V_7_0_0,
-            VersionUtils.getPreviousVersion(Version.V_8_0_0)
+            IndexVersion.V_7_0_0,
+            IndexVersionUtils.getPreviousVersion(IndexVersion.V_8_0_0)
         );
-        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
-        final IndexMetadata currentVersionSystem2 = buildIndexWithAlias(".system2", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
+        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
+        final IndexMetadata currentVersionSystem2 = buildIndexWithAlias(".system2", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
         final IndexMetadata oldVersionSystem = buildIndexWithAlias(".oldVersionSystem", SYSTEM_ALIAS_NAME, null, random7xVersion, true);
 
         // Should be ok:
@@ -1954,8 +1954,8 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testSystemAliasValidationAll8x() {
-        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
-        final IndexMetadata currentVersionSystem2 = buildIndexWithAlias(".system2", SYSTEM_ALIAS_NAME, null, Version.CURRENT, true);
+        final IndexMetadata currentVersionSystem = buildIndexWithAlias(".system1", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
+        final IndexMetadata currentVersionSystem2 = buildIndexWithAlias(".system2", SYSTEM_ALIAS_NAME, null, IndexVersion.current(), true);
 
         // Should be ok
         metadataWithIndices(currentVersionSystem, currentVersionSystem2);
@@ -1973,7 +1973,7 @@ public class MetadataTests extends ESTestCase {
         String indexName,
         String aliasName,
         @Nullable Boolean aliasIsHidden,
-        Version indexCreationVersion,
+        IndexVersion indexCreationVersion,
         boolean isSystem
     ) {
         final AliasMetadata.Builder aliasMetadata = new AliasMetadata.Builder(aliasName);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentType;
@@ -584,7 +584,7 @@ public class IndexRoutingTests extends ESTestCase {
     }
 
     public void testRoutingPathBwc() throws IOException {
-        Version version = VersionUtils.randomIndexCompatibleVersion(random());
+        IndexVersion version = IndexVersionUtils.randomCompatibleVersion(random());
         IndexRouting routing = indexRoutingForPath(version, 8, "dim.*,other.*,top");
         /*
          * These when we first added routing_path. If these values change
@@ -627,10 +627,10 @@ public class IndexRoutingTests extends ESTestCase {
     }
 
     private IndexRouting indexRoutingForPath(int shards, String path) {
-        return indexRoutingForPath(Version.CURRENT, shards, path);
+        return indexRoutingForPath(IndexVersion.current(), shards, path);
     }
 
-    private IndexRouting indexRoutingForPath(Version createdVersion, int shards, String path) {
+    private IndexRouting indexRoutingForPath(IndexVersion createdVersion, int shards, String path) {
         return IndexRouting.fromIndexMetadata(
             IndexMetadata.builder("test")
                 .settings(settings(createdVersion).put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), path))

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.cluster.routing.allocation.allocator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
@@ -45,6 +44,7 @@ import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.StoppableExecutorServiceWrapper;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -120,7 +120,7 @@ public class ClusterAllocationSimulationTests extends ESAllocationTestCase {
                 metadataBuilder.put(
                     IndexMetadata.builder(indexName)
                         .settings(
-                            indexSettings(Version.CURRENT, shardCount, replicaCount).put(
+                            indexSettings(IndexVersion.current(), shardCount, replicaCount).put(
                                 IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".fake_tier",
                                 tier
                             )

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -416,7 +416,7 @@ public class IndexSettingsTests extends ESTestCase {
         IndexMetadata metadata = IndexMetadata.builder("index")
             .system(true)
             .settings(
-                indexSettings(Version.CURRENT, 1, 1).put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                indexSettings(IndexVersion.current(), 1, 1).put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "stateless")
                     .put(INDEX_FAST_REFRESH_SETTING.getKey(), true)
                     .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE)

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -77,7 +77,7 @@ import org.elasticsearch.test.CorruptionUtils;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -719,7 +719,7 @@ public class RecoverySourceHandlerTests extends MapperServiceTestCase {
 
         final IndexMetadata.Builder indexMetadata = IndexMetadata.builder("test")
             .settings(
-                indexSettings(VersionUtils.randomVersion(random()), between(1, 5), between(0, 5)).put(
+                indexSettings(IndexVersionUtils.randomVersion(random()), between(1, 5), between(0, 5)).put(
                     IndexMetadata.SETTING_INDEX_UUID,
                     UUIDs.randomBase64UUID(random())
                 )

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1305,13 +1305,6 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /** Return consistent index settings for the provided index version, shard- and replica-count. */
-    @Deprecated
-    public static Settings.Builder indexSettings(Version indexVersionCreated, int shards, int replicas) {
-        return settings(indexVersionCreated).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shards)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicas);
-    }
-
-    /** Return consistent index settings for the provided index version, shard- and replica-count. */
     public static Settings.Builder indexSettings(IndexVersion indexVersionCreated, int shards, int replicas) {
         return settings(indexVersionCreated).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shards)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicas);

--- a/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
@@ -93,7 +93,9 @@ public class IndexVersionUtils {
     }
 
     public static IndexVersion getPreviousMajorVersion(IndexVersion version) {
-        return IndexVersion.fromId(((version.id() / 1_000_000) - 1) * 1_000_000);
+        int id = ((version.id() / 1_000_000) - 1) * 1_000_000;
+        if (id <= 8_000_000) id += 99;  // v8.0.0 and before had an extra 99 added to all numbers
+        return IndexVersion.fromId(id);
     }
 
     public static IndexVersion getNextVersion(IndexVersion version) {

--- a/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
@@ -92,6 +92,10 @@ public class IndexVersionUtils {
         return ALL_VERSIONS.get(place - 1);
     }
 
+    public static IndexVersion getPreviousMajorVersion(IndexVersion version) {
+        return IndexVersion.fromId(((version.id() / 1_000_000) - 1) * 1_000_000);
+    }
+
     public static IndexVersion getNextVersion(IndexVersion version) {
         int place = Collections.binarySearch(ALL_VERSIONS, version);
         if (place < 0) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataConversionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataConversionTests.java
@@ -12,9 +12,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
 
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
-import static org.elasticsearch.test.VersionUtils.randomIndexCompatibleVersion;
 import static org.hamcrest.Matchers.equalTo;
 
 public class IndexMetadataConversionTests extends ESTestCase {
@@ -103,7 +103,7 @@ public class IndexMetadataConversionTests extends ESTestCase {
     }
 
     public static IndexMetadata newIndexMeta(String name, Settings indexSettings) {
-        final Settings settings = indexSettings(randomIndexCompatibleVersion(random()), between(1, 5), between(0, 5)).put(
+        final Settings settings = indexSettings(IndexVersionUtils.randomCompatibleVersion(random()), between(1, 5), between(0, 5)).put(
             IndexMetadata.SETTING_CREATION_DATE,
             randomNonNegativeLong()
         ).put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID(random())).put(indexSettings).build();

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.deprecation;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
@@ -160,7 +159,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             + "} }";
 
         IndexMetadata simpleIndex = IndexMetadata.builder(randomAlphaOfLengthBetween(5, 10))
-            .settings(settings(Version.V_7_0_0))
+            .settings(settings(IndexVersion.V_7_0_0))
             .numberOfShards(1)
             .numberOfReplicas(1)
             .putMapping(simpleMapping)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgraderTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgraderTests.java
@@ -7,17 +7,17 @@
 
 package org.elasticsearch.xpack.searchablesnapshots.upgrade;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.ShardLimitValidator;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
 import static org.hamcrest.Matchers.equalTo;
@@ -107,7 +107,7 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
     }
 
     private Settings normal() {
-        return settings(VersionUtils.randomVersion(random())).build();
+        return settings(IndexVersionUtils.randomVersion(random())).build();
     }
 
     /**
@@ -116,7 +116,11 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
      */
     private Settings partialNeedsUpgrade() {
         return searchableSnapshotSettings(
-            VersionUtils.randomVersionBetween(random(), Version.V_7_12_0, VersionUtils.getPreviousVersion(Version.V_8_0_0)),
+            IndexVersionUtils.randomVersionBetween(
+                random(),
+                IndexVersion.V_7_12_0,
+                IndexVersionUtils.getPreviousVersion(IndexVersion.V_8_0_0)
+            ),
             true
         );
     }
@@ -126,7 +130,10 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
      */
     private Settings partial_7_13plus() {
         return shardLimitGroupFrozen(
-            searchableSnapshotSettings(VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT), true)
+            searchableSnapshotSettings(
+                IndexVersionUtils.randomVersionBetween(random(), IndexVersion.V_7_13_0, IndexVersion.current()),
+                true
+            )
         );
     }
 
@@ -134,14 +141,17 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
      * This is an illegal state, but we simulate it to capture that we do the version check
      */
     private Settings partial_8plusNoShardLimit() {
-        return searchableSnapshotSettings(VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, Version.CURRENT), true);
+        return searchableSnapshotSettings(
+            IndexVersionUtils.randomVersionBetween(random(), IndexVersion.V_8_0_0, IndexVersion.current()),
+            true
+        );
     }
 
     private Settings full() {
-        return searchableSnapshotSettings(VersionUtils.randomVersion(random()), false);
+        return searchableSnapshotSettings(IndexVersionUtils.randomVersion(random()), false);
     }
 
-    private Settings searchableSnapshotSettings(Version version, boolean partial) {
+    private Settings searchableSnapshotSettings(IndexVersion version, boolean partial) {
         Settings.Builder settings = settings(version);
         settings.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), SEARCHABLE_SNAPSHOT_STORE_TYPE);
         if (partial || randomBoolean()) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -57,6 +57,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -459,7 +460,7 @@ public class SecurityTests extends ESTestCase {
         DiscoveryNode node = DiscoveryNodeUtils.create("foo");
         int indexFormat = randomBoolean() ? INTERNAL_MAIN_INDEX_FORMAT : INTERNAL_MAIN_INDEX_FORMAT - 1;
         IndexMetadata indexMetadata = IndexMetadata.builder(SECURITY_MAIN_ALIAS)
-            .settings(settings(VersionUtils.randomIndexCompatibleVersion(random())).put(INDEX_FORMAT_SETTING.getKey(), indexFormat))
+            .settings(settings(IndexVersionUtils.randomCompatibleVersion(random())).put(INDEX_FORMAT_SETTING.getKey(), indexFormat))
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();


### PR DESCRIPTION
Move most uses of `ESTestCase.indexSettings(Version)` to use `IndexVersion` instead. Note the new method in `IndexVersionUtils`, which assumes a (light) semver policy that wasn't previously specified - but is likely to be followed in the future.

There are a couple more complicated uses still remaining