### PR TITLE
Fix concurrent refresh for access tokens

### DIFF
--- a/docs/changelog/98011.yaml
+++ b/docs/changelog/98011.yaml
@@ -1,5 +1,0 @@
-pr: 98011
-summary: Fix concurrent refresh for access tokens
-area: Authentication
-type: bug
-issues: []

--- a/docs/changelog/98011.yaml
+++ b/docs/changelog/98011.yaml
@@ -1,0 +1,5 @@
+pr: 98011
+summary: Fix concurrent refresh for access tokens
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -585,7 +585,6 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
         assertThat(e, throwableWithMessage(containsString("token has already been refreshed more than 30 seconds in the past")));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85697")
     public void testRefreshingMultipleTimesWithinWindowSucceeds() throws Exception {
         final Clock clock = Clock.systemUTC();
         final List<String> tokens = Collections.synchronizedList(new ArrayList<>());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1376,7 +1376,7 @@ public final class TokenService {
                         RAW_TOKEN_BYTES_LENGTH,
                         RAW_TOKEN_DOC_ID_BYTES_LENGTH
                     );
-                    tokenDocId = Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest());
+                    tokenDocId = getTokenDocumentId(Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest()));
                 } else {
                     tokenDocId = getTokenDocumentId(hashTokenString(decryptedTokens[0]));
                 }


### PR DESCRIPTION
Fixes a fallout from https://github.com/elastic/elasticsearch/pull/97395 .

This also unmutes the test that ought to have caught the bug: https://github.com/elastic/elasticsearch/issues/85697.
I think the new refresh token logic is different enough to not worry about the same timing issues that affected the test in the first place, when it was muted.  

Fixes: https://github.com/elastic/elasticsearch/issues/85697