### PR TITLE
[ML] add metric for autoscaling downscale

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/autoscaling/MlAutoscalingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/autoscaling/MlAutoscalingStats.java
@@ -17,6 +17,7 @@ public record MlAutoscalingStats(
     int nodes,
     long perNodeMemoryInBytes,
     long modelMemoryInBytesSum,
+    int processorsSum,
     int minNodes,
     long extraSingleNodeModelMemoryInBytes,
     int extraSingleNodeProcessors,
@@ -31,6 +32,7 @@ public record MlAutoscalingStats(
             in.readVInt(), // nodes
             in.readVLong(),  // perNodeMemoryInBytes
             in.readVLong(), // modelMemoryInBytes
+            in.readVInt(), // processorsSum
             in.readVInt(), // minNodes
             in.readVLong(), // extraSingleNodeModelMemoryInBytes
             in.readVInt(), // extraSingleNodeProcessors
@@ -46,6 +48,7 @@ public record MlAutoscalingStats(
         out.writeVInt(nodes);
         out.writeVLong(perNodeMemoryInBytes);
         out.writeVLong(modelMemoryInBytesSum);
+        out.writeVLong(processorsSum);
         out.writeVInt(minNodes);
         out.writeVLong(extraSingleNodeModelMemoryInBytes);
         out.writeVInt(extraSingleNodeProcessors);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/autoscaling/MlAutoscalingStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/autoscaling/MlAutoscalingStatsTests.java
@@ -19,6 +19,7 @@ public class MlAutoscalingStatsTests extends AbstractWireSerializingTestCase<MlA
             randomIntBetween(0, 100), // nodes
             randomNonNegativeLong(), // perNodeMemoryInBytes
             randomNonNegativeLong(), // modelMemoryInBytes
+            randomIntBetween(0, 100), // processorsSum
             randomIntBetween(0, 100), // minNodes
             randomNonNegativeLong(), // extraSingleNodeModelMemoryInBytes
             randomIntBetween(0, 100), // extraSingleNodeProcessors

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetMlAutoscalingStats.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetMlAutoscalingStats.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -39,6 +40,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
 
     private final Client client;
     private final MlMemoryTracker mlMemoryTracker;
+    private final Settings settings;
 
     @Inject
     public TransportGetMlAutoscalingStats(
@@ -48,6 +50,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
         Client client,
+        Settings settings,
         MlMemoryTracker mlMemoryTracker
     ) {
         super(
@@ -63,6 +66,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
         );
         this.client = client;
         this.mlMemoryTracker = mlMemoryTracker;
+        this.settings = settings;
     }
 
     @Override
@@ -76,6 +80,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
                 parentTaskAssigningClient,
                 request.timeout(),
                 mlMemoryTracker,
+                settings,
                 ActionListener.wrap(autoscalingResources -> listener.onResponse(new Response(autoscalingResources)), listener::onFailure)
             );
         } else {
@@ -94,6 +99,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
                             parentTaskAssigningClient,
                             request.timeout(),
                             mlMemoryTracker,
+                            settings,
                             ActionListener.wrap(
                                 autoscalingResources -> listener.onResponse(new Response(autoscalingResources)),
                                 listener::onFailure

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -64,6 +64,7 @@ public final class MlAutoscalingResourceTracker {
             .map(DiscoveryNode::getId)
             .toArray(String[]::new);
 
+        // this value is only used iff > 0 and iff all nodes have the same container size
         long modelMemoryAvailableFirstNode = mlNodes.length > 0
             ? NativeMemoryCalculator.allowedBytesForMl(clusterState.nodes().get(mlNodes[0]), settings).orElse(0L)
             : 0L;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -358,6 +358,7 @@ public final class MlAutoscalingResourceTracker {
             )
             .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
 
+        // we define least loaded exclusively on memory, not CPU load
         Optional<Map.Entry<String, MlJobRequirements>> leastLoadedNodeAndMemoryUsage = perNodeMlJobRequirementSum.entrySet()
             .stream()
             .min(Comparator.comparingLong(entry -> entry.getValue().memory));
@@ -368,7 +369,6 @@ public final class MlAutoscalingResourceTracker {
 
         assert leastLoadedNodeAndMemoryUsage.get().getValue().memory >= 0L;
 
-        // this currently only works based on memory, not processors
         String candidateNode = leastLoadedNodeAndMemoryUsage.get().getKey();
         List<MlJobRequirements> candidateJobRequirements = perNodeJobRequirements.get(candidateNode);
         perNodeMlJobRequirementSum.remove(candidateNode);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -97,6 +97,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         null
                     )
                 ),
+                memory / 2,
                 listener
             ),
             stats -> {
@@ -131,6 +132,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         null
                     )
                 ),
+                memory / 2,
                 listener
             ),
             stats -> {
@@ -240,31 +242,31 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
         );
     }
 
-    public void testTryRemoveNodeMemory() {
+    public void testTryRemoveOneNode() {
         assertEquals(
-            600L,
-            MlAutoscalingResourceTracker.tryRemoveNodeMemory(
+            true,
+            MlAutoscalingResourceTracker.tryRemoveOneNode(
                 Map.of("node_a", List.of(100L, 200L, 300L), "node_b", List.of(200L, 300L), "node_c", List.of(10L, 10L, 10L, 10L, 10L)),
                 600L
             )
         );
 
         assertEquals(
-            0L,
-            MlAutoscalingResourceTracker.tryRemoveNodeMemory(
+            false,
+            MlAutoscalingResourceTracker.tryRemoveOneNode(
                 Map.of("node_a", List.of(100L, 200L, 300L), "node_b", List.of(280L, 300L), "node_c", List.of(10L, 10L, 10L, 10L, 10L)),
                 600L
             )
         );
 
-        assertEquals(0L, MlAutoscalingResourceTracker.tryRemoveNodeMemory(Map.of("node_a", List.of(10L, 10L, 10L, 10L, 10L)), 600L));
+        assertEquals(false, MlAutoscalingResourceTracker.tryRemoveOneNode(Map.of("node_a", List.of(10L, 10L, 10L, 10L, 10L)), 600L));
 
-        assertEquals(0L, MlAutoscalingResourceTracker.tryRemoveNodeMemory(Collections.emptyMap(), 999L));
+        assertEquals(false, MlAutoscalingResourceTracker.tryRemoveOneNode(Collections.emptyMap(), 999L));
 
         // solvable case with optimal packing, but not possible if badly packed
         assertEquals(
-            0L,
-            MlAutoscalingResourceTracker.tryRemoveNodeMemory(
+            false,
+            MlAutoscalingResourceTracker.tryRemoveOneNode(
                 Map.of(
                     "node_a",
                     List.of(100L, 200L, 300L),
@@ -279,8 +281,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
 
         // same with smaller jobs, that can be re-arranged
         assertEquals(
-            1000L,
-            MlAutoscalingResourceTracker.tryRemoveNodeMemory(
+            true,
+            MlAutoscalingResourceTracker.tryRemoveOneNode(
                 Map.of(
                     "node_a",
                     List.of(100L, 200L, 300L),
@@ -294,8 +296,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
         );
 
         assertEquals(
-            1000L,
-            MlAutoscalingResourceTracker.tryRemoveNodeMemory(
+            true,
+            MlAutoscalingResourceTracker.tryRemoveOneNode(
                 Map.of(
                     "node_a",
                     List.of(100L, 200L, 300L),
@@ -309,8 +311,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
         );
 
         assertEquals(
-            1000L,
-            MlAutoscalingResourceTracker.tryRemoveNodeMemory(
+            true,
+            MlAutoscalingResourceTracker.tryRemoveOneNode(
                 Map.of(
                     "node_a",
                     List.of(100L, 200L, 300L),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -71,13 +71,13 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
         }
     }
 
-    public void testGetMemoryAndCpu() throws InterruptedException {
+    public void testGetMemoryAndProcessors() throws InterruptedException {
         MlAutoscalingContext mlAutoscalingContext = new MlAutoscalingContext();
         MlMemoryTracker mockTracker = mock(MlMemoryTracker.class);
 
         long memory = randomLongBetween(100, 1_000_000);
         this.<MlAutoscalingStats>assertAsync(
-            listener -> MlAutoscalingResourceTracker.getMemoryAndCpu(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
                 mlAutoscalingContext,
                 mockTracker,
                 Map.of(
@@ -114,7 +114,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
 
         // simulate 1 small, 1 bigger node
         this.<MlAutoscalingStats>assertAsync(
-            listener -> MlAutoscalingResourceTracker.getMemoryAndCpu(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
                 mlAutoscalingContext,
                 mockTracker,
                 Map.of(
@@ -421,7 +421,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
         );
     }
 
-    public void testCheckIfJobsCanBeMovedInLeastEfficientWayCpuAndMemory() {
+    public void testCheckIfJobsCanBeMovedInLeastEfficientWayProcessorsAndMemory() {
         assertEquals(
             0L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -433,7 +433,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // fits memory-wise, but not CPU
+        // fits memory-wise, but not processors
         assertEquals(
             10L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -444,7 +444,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
-        // fits CPU, but not memory
+        // fits processors, but not memory
         assertEquals(
             10L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -481,7 +481,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // special CPU placement
+        // special processor placement
         assertEquals(
             0L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -508,7 +508,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // special CPU placement, but doesn't fit due to open job limit
+        // special processor placement, but doesn't fit due to open job limit
         assertEquals(
             30L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -535,7 +535,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // plenty of space, but no CPU
+        // plenty of space, but no processor
         assertEquals(
             40L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -560,7 +560,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // CPU available, but not in combination with memory
+        // processor available, but not in combination with memory
         assertEquals(
             30L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
@@ -773,8 +773,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
         );
     }
 
-    public void testCheckIfOneNodeCouldBeRemovedCpuAndMemory() {
-        // plenty of CPU and memory
+    public void testCheckIfOneNodeCouldBeRemovedProcessorAndMemory() {
+        // plenty of processors and memory
         assertEquals(
             true,
             MlAutoscalingResourceTracker.checkIfOneNodeCouldBeRemoved(
@@ -798,7 +798,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // cpu limit
+        // processors limit
         assertEquals(
             false,
             MlAutoscalingResourceTracker.checkIfOneNodeCouldBeRemoved(
@@ -846,7 +846,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             )
         );
 
-        // 1 node with some jobs that require CPU
+        // 1 node with some jobs that require processors
         assertEquals(
             false,
             MlAutoscalingResourceTracker.checkIfOneNodeCouldBeRemoved(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -99,6 +99,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     )
                 ),
                 memory / 2,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
                 listener
             ),
             stats -> {
@@ -134,6 +135,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     )
                 ),
                 memory / 2,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
                 listener
             ),
             stats -> {
@@ -151,16 +153,18 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             0L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
                 List.of(MlJobRequirements.of(10L, 0)),
-                Map.of("node_a", 100L),
-                1000L
+                Map.of("node_a", MlJobRequirements.of(100L, 0)),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
         assertEquals(
             10L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
                 List.of(MlJobRequirements.of(10L, 0)),
-                Map.of("node_a", 995L),
-                1000L
+                Map.of("node_a", MlJobRequirements.of(995L, 0)),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -175,8 +179,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(10L, 0),
                     MlJobRequirements.of(10L, 0)
                 ),
-                Map.of("node_a", 976L, "node_b", 986L, "node_c", 967L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(976L, 0),
+                    "node_b",
+                    MlJobRequirements.of(986L, 0),
+                    "node_c",
+                    MlJobRequirements.of(967L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -190,8 +202,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(10L, 0),
                     MlJobRequirements.of(10L, 0)
                 ),
-                Map.of("node_a", 980L, "node_b", 990L, "node_c", 970L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(980L, 0),
+                    "node_b",
+                    MlJobRequirements.of(990L, 0),
+                    "node_c",
+                    MlJobRequirements.of(970L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -208,8 +228,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(10L, 0),
                     MlJobRequirements.of(10L, 0)
                 ),
-                Map.of("node_a", 976L, "node_b", 986L, "node_c", 967L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(976L, 0),
+                    "node_b",
+                    MlJobRequirements.of(986L, 0),
+                    "node_c",
+                    MlJobRequirements.of(967L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
         assertEquals(
@@ -224,8 +252,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(10L, 0),
                     MlJobRequirements.of(40L, 0)
                 ),
-                Map.of("node_a", 976L, "node_b", 946L, "node_c", 967L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(976L, 0),
+                    "node_b",
+                    MlJobRequirements.of(946L, 0),
+                    "node_c",
+                    MlJobRequirements.of(967L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -241,8 +277,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(60L, 0),
                     MlJobRequirements.of(70L, 0)
                 ), // 280, with better packing this could return 20 + 50
-                Map.of("node_a", 886L, "node_b", 926L, "node_c", 967L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(886L, 0),
+                    "node_b",
+                    MlJobRequirements.of(926L, 0),
+                    "node_c",
+                    MlJobRequirements.of(967L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -258,8 +302,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(60L, 0),
                     MlJobRequirements.of(70L, 0)
                 ), // 280, solvable with optimal packing
-                Map.of("node_a", 886L, "node_b", 906L, "node_c", 917L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(886L, 0),
+                    "node_b",
+                    MlJobRequirements.of(906L, 0),
+                    "node_c",
+                    MlJobRequirements.of(917L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -275,8 +327,16 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                     MlJobRequirements.of(60L, 0),
                     MlJobRequirements.of(70L, 0)
                 ), // 280, solvable with optimal packing
-                Map.of("node_a", 866L, "node_b", 886L, "node_c", 917L),
-                1000L
+                Map.of(
+                    "node_a",
+                    MlJobRequirements.of(866L, 0),
+                    "node_b",
+                    MlJobRequirements.of(886L, 0),
+                    "node_c",
+                    MlJobRequirements.of(917L, 0)
+                ),
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -284,8 +344,9 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             500L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
                 List.of(MlJobRequirements.of(500L, 0), MlJobRequirements.of(200L, 0)),
-                Map.of("node_a", 1400L, "node_b", 1700L),
-                2000L
+                Map.of("node_a", MlJobRequirements.of(1400L, 0), "node_b", MlJobRequirements.of(1700L, 0)),
+                2000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -294,21 +355,28 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
                 List.of(MlJobRequirements.of(500L, 0), MlJobRequirements.of(200L, 0)),
                 Collections.emptyMap(),
-                2000L
+                2000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
-        );
-
-        assertEquals(
-            0L,
-            MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(Collections.emptyList(), Collections.emptyMap(), 2000L)
         );
 
         assertEquals(
             0L,
             MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
                 Collections.emptyList(),
-                Map.of("node_a", 1400L, "node_b", 1700L),
-                2000L
+                Collections.emptyMap(),
+                2000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+            )
+        );
+
+        assertEquals(
+            0L,
+            MlAutoscalingResourceTracker.checkIfJobsCanBeMovedInLeastEfficientWay(
+                Collections.emptyList(),
+                Map.of("node_a", MlJobRequirements.of(1400L, 0), "node_b", MlJobRequirements.of(1700L, 0)),
+                2000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
     }
@@ -331,7 +399,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                600L
+                600L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -352,7 +421,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                600L
+                600L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -369,11 +439,19 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                600L
+                600L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
-        assertEquals(false, MlAutoscalingResourceTracker.checkIfOneNodeCouldBeRemoved(Collections.emptyMap(), 999L));
+        assertEquals(
+            false,
+            MlAutoscalingResourceTracker.checkIfOneNodeCouldBeRemoved(
+                Collections.emptyMap(),
+                999L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+            )
+        );
 
         // solvable case with optimal packing, but not possible if badly packed
         assertEquals(
@@ -394,7 +472,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                1000L
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -421,7 +500,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                1000L
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -447,7 +527,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                1000L
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
 
@@ -473,7 +554,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         MlJobRequirements.of(10L, 0)
                     )
                 ),
-                1000L
+                1000L,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
             )
         );
     }


### PR DESCRIPTION
this PR adds the `removeNodeMemoryInBytes` metric, which is aimed for the controller to make an auto-scaling decision to downscale. The algorithm makes worst case assumptions and only returns a value if all jobs can be placed on other nodes for sure. This is necessary because we can not make assumptions about the placement.

relates #97362