### PR TITLE
Checking that watcher history index is green before querying it

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.oneOf;
 
 public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97518")
     public void testTimeThrottle() throws Exception {
         String id = randomAlphaOfLength(20);
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client()).setId(id)
@@ -95,8 +94,8 @@ public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTest
 
     private void assertLatestHistoryEntry(String id, String expectedValue) throws Exception {
         assertBusy(() -> {
+            ensureGreen(HistoryStoreField.DATA_STREAM);
             refresh(HistoryStoreField.DATA_STREAM + "*");
-
             SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
                 .setSize(1)
                 .setSource(new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(termQuery("watch_id", id))))


### PR DESCRIPTION
Since watcher now writes history asynchronously, it is possible that we query the watcher history index in this test before its shards have been allocated. This query is done in an assertBusy block, but that doesn't catch a NoShardAvailableActionException. This change asserts that the index is green within the assertBusy block the way we do in #95926.
Closes #97518