### PR TITLE
[ML] Add accessor to GetDatafeedsStatsAction.Response

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -186,6 +186,10 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
                 return timingStats;
             }
 
+            public RunningState getRunningState() {
+                return runningState;
+            }
+
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
                 builder.startObject();


### PR DESCRIPTION
This is necessary to support response filtering in serverless.