### PR TITLE
Minor cleanups searchable snapshot index inputs

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
@@ -253,11 +253,6 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
     }
 
     @Override
-    public CachedBlobContainerIndexInput clone() {
-        return (CachedBlobContainerIndexInput) super.clone();
-    }
-
-    @Override
     protected MetadataCachingIndexInput doSlice(
         String sliceName,
         long sliceOffset,
@@ -272,7 +267,7 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
             fileInfo,
             context,
             stats,
-            this.offset + sliceOffset,
+            sliceOffset,
             sliceCompoundFileOffset,
             sliceLength,
             cacheFileReference,

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -171,11 +171,6 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
     }
 
     @Override
-    public FrozenIndexInput clone() {
-        return (FrozenIndexInput) super.clone();
-    }
-
-    @Override
     protected MetadataCachingIndexInput doSlice(
         String sliceName,
         long sliceOffset,
@@ -190,7 +185,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
             fileInfo,
             context,
             stats,
-            this.offset + sliceOffset,
+            sliceOffset,
             sliceCompoundFileOffset,
             sliceLength,
             cacheFileReference,

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -87,7 +87,7 @@ public abstract class MetadataCachingIndexInput extends BufferedIndexInput {
     /**
      * Range of bytes that should be cached in the blob cache for the current index input's footer. This footer byte range should only be
      * required for slices of CFS files; regular files already have their footers extracted from the
-     * {@link BlobStoreIndexShardSnapshot.FileInfo} (see method {@link MetadataCachingIndexInput#maybeReadChecksumFromFileInfo}).
+     * {@link BlobStoreIndexShardSnapshot.FileInfo} (see method {@link #maybeReadChecksumFromFileInfo}).
      */
     private final ByteRange footerBlobCacheByteRange;
 
@@ -96,7 +96,7 @@ public abstract class MetadataCachingIndexInput extends BufferedIndexInput {
     protected final BlobStoreIndexShardSnapshot.FileInfo fileInfo;
     protected final IOContext context;
     protected final IndexInputStats stats;
-    protected final long offset;
+    private final long offset;
     private final long length;
 
     // the following are only mutable so they can be adjusted after cloning/slicing
@@ -452,7 +452,7 @@ public abstract class MetadataCachingIndexInput extends BufferedIndexInput {
      * @param readLength The number of bytes to read
      */
     protected InputStream openInputStreamFromBlobStore(final long position, final long readLength) throws IOException {
-        assert MetadataCachingIndexInput.assertCurrentThreadMayAccessBlobStore();
+        assert assertCurrentThreadMayAccessBlobStore();
         if (fileInfo.numberOfParts() == 1L) {
             assert position + readLength <= fileInfo.length()
                 : "cannot read [" + position + "-" + (position + readLength) + "] from [" + fileInfo + "]";
@@ -519,12 +519,12 @@ public abstract class MetadataCachingIndexInput extends BufferedIndexInput {
 
     @Override
     protected final void readInternal(ByteBuffer b) throws IOException {
-        assert MetadataCachingIndexInput.assertCurrentThreadIsNotCacheFetchAsync();
+        assert assertCurrentThreadIsNotCacheFetchAsync();
 
         final int bytesToRead = b.remaining();
         // We can detect that we're going to read the last 16 bytes (that contains the footer checksum) of the file. Such reads are often
         // executed when opening a Directory and since we have the checksum in the snapshot metadata we can use it to fill the ByteBuffer.
-        if (MetadataCachingIndexInput.maybeReadChecksumFromFileInfo(fileInfo, getAbsolutePosition(), isClone, b)) {
+        if (maybeReadChecksumFromFileInfo(fileInfo, getAbsolutePosition(), isClone, b)) {
             logger.trace("read footer of file [{}], bypassing all caches", fileInfo.physicalName());
         } else {
             final long position = getAbsolutePosition();
@@ -562,13 +562,9 @@ public abstract class MetadataCachingIndexInput extends BufferedIndexInput {
 
     @Override
     public final void close() throws IOException {
-        if (closed.compareAndSet(false, true)) {
-            if (isClone == false) {
-                stats.incrementCloseCount();
-            }
-            if (isClone == false) {
-                cacheFileReference.releaseOnClose();
-            }
+        if (closed.compareAndSet(false, true) && isClone == false) {
+            stats.incrementCloseCount();
+            cacheFileReference.releaseOnClose();
         }
     }
 
@@ -628,7 +624,7 @@ public abstract class MetadataCachingIndexInput extends BufferedIndexInput {
         }
         final MetadataCachingIndexInput slice = doSlice(
             sliceName,
-            sliceOffset,
+            this.offset + sliceOffset,
             sliceLength,
             sliceHeaderByteRange,
             sliceFooterByteRange,


### PR DESCRIPTION
We can clean up a little more here, no need for redundant clone methods and also no need for redundant computation of the slice offsets.
