### PR TITLE
Add require data stream lifecycle feature flag

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -38,6 +38,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
       requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
+      requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
     }
 
     tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {


### PR DESCRIPTION
We haven't added the `requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")` to the `mixed-cluster` tests. 

Closes https://github.com/elastic/elasticsearch/issues/97953