### PR TITLE
Add require data stream lifecycle feature flag

### DIFF
--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -158,4 +158,7 @@ if (BuildParams.isSnapshotBuild() == false) {
   tasks.named("test").configure {
     systemProperty 'es.untrusted_remote_cluster_feature_flag_registered', 'true'
   }
+  tasks.named("internalClusterTest").configure {
+    systemProperty 'es.dlm_feature_flag_enabled', 'true'
+  }
 }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -68,7 +68,6 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97924")
     @SuppressWarnings("unchecked")
     public void testAction() throws Exception {
         assertUsageResults(0, 0, 0, 0.0, true);


### PR DESCRIPTION
Added the feature flag to the `x-pack/plugin/core` tests. The reason this used work was that we would not take into account the value of the feature flag in the usage response.  This changed in https://github.com/elastic/elasticsearch/pull/97442 & https://github.com/elastic/elasticsearch/pull/97425.

Fixes #97924 