### PR TITLE
[8.9] Add require data stream lifecycle feature flag (#98024)

### DIFF
--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -155,4 +155,7 @@ if (BuildParams.isSnapshotBuild() == false) {
   tasks.named("test").configure {
     systemProperty 'es.untrusted_remote_cluster_feature_flag_registered', 'true'
   }
+  tasks.named("internalClusterTest").configure {
+    systemProperty 'es.dlm_feature_flag_enabled', 'true'
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - Add require data stream lifecycle feature flag (#98024) (b9f05cb1)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)