### PR TITLE
Search Applications: remove indices array and rely on alias

### DIFF
--- a/docs/reference/search-application/apis/get-search-application.asciidoc
+++ b/docs/reference/search-application/apis/get-search-application.asciidoc
@@ -55,7 +55,6 @@ A sample response:
 ----
 {
     "name": "my-app",
-    "indices": [ "index1", "index2" ],
     "updated_at_millis": 1682105622204,
     "template": {
       "script": {

--- a/docs/reference/search-application/apis/list-search-applications.asciidoc
+++ b/docs/reference/search-application/apis/list-search-applications.asciidoc
@@ -62,12 +62,10 @@ A sample response:
   "count": 2,
   "results": [
     {
-      "name": "app-1",
-      "indices": [ "index1", "index2" ]
+      "name": "app-1"
     },
     {
-      "name": "app-2",
-      "indices": [ "index3", "index4" ]
+      "name": "app-2"
     }
   ],
   "updated_at_millis": 1682105622204

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -122,6 +122,13 @@ teardown:
   - is_true: ''
 
   - do:
+      indices.get_alias:
+        index: test-search-application
+
+  - match: { test-index1.aliases.test-search-application: {} }
+  - match: { test-index2.aliases.test-search-application: {} }
+
+  - do:
       search_application.get:
         name: test-search-application
   - match:
@@ -158,6 +165,18 @@ teardown:
               properties:
                 another_query_string:
                   type: "string"
+  - do:
+      indices.exists_alias:
+        name: another-test-search-application
+
+  - is_true: ''
+
+  - do:
+      indices.get_alias:
+        index: another-test-search-application
+
+  - match: { test-index1.aliases.another-test-search-application: {} }
+  - match: { test-index2.aliases.another-test-search-application: {} }
 
   - do:
       search_application.get:
@@ -197,6 +216,13 @@ teardown:
           template: null
 
   - match: { result: "updated" }
+
+  - do:
+      indices.get_alias:
+        index: test-updated-search-application
+
+  - match: { test-index3.aliases.test-updated-search-application: { } }
+  - match: { test-index4.aliases.test-updated-search-application: { } }
 
   - do:
       search_application.get:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -116,12 +116,6 @@ teardown:
   - match: { result: "created" }
 
   - do:
-      indices.exists_alias:
-        name: test-search-application
-
-  - is_true: ''
-
-  - do:
       indices.get_alias:
         index: test-search-application
 
@@ -165,12 +159,6 @@ teardown:
               properties:
                 another_query_string:
                   type: "string"
-  - do:
-      indices.exists_alias:
-        name: another-test-search-application
-
-  - is_true: ''
-
   - do:
       indices.get_alias:
         index: another-test-search-application

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -124,7 +124,6 @@ teardown:
   - do:
       search_application.get:
         name: test-search-application
-  - match: { indices: [ "test-index1", "test-index2" ] }
   - match:
       template:
         script:
@@ -176,8 +175,6 @@ teardown:
             another_query_string:
               type: "string"
 
-  - match: { indices: [ "test-index1", "test-index2" ] }
-
 ---
 "Update Search Application with null template, results in default template being applied":
   - do:
@@ -213,8 +210,6 @@ teardown:
           params:
             query_string: "*"
             default_field: "*"
-
-  - match: { indices: [ "test-index3", "test-index4" ] }
 
 ---
 "Update Search Application - Dictionary is not a valid JSON Schema":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -58,7 +58,6 @@ teardown:
         name: test-search-application-1
 
   - match: { name: "test-search-application-1" }
-  - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
   - match: {
     template: {
@@ -91,7 +90,6 @@ teardown:
         name: test-search-application-2
 
   - match: { name: "test-search-application-2" }
-  - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
   - match: {
     template: {
@@ -155,7 +153,6 @@ teardown:
         name: test-search-application-1
 
   - match: { name: "test-search-application-1" }
-  - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
   - match: {
     template: {

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -67,19 +67,16 @@ teardown:
 
   # Alphabetical order for results
   - match: { results.0.name: "another-test-search-application" }
-  - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
   - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-1" }
-  - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
   - gte: { results.1.updated_at_millis: 0 }
 
   - match: { results.2.name: "test-search-application-2" }
-  - match: { results.2.indices: [ "test-index2" ] }
   - match: { results.2.analytics_collection_name: "test-analytics2" }
   - match: { results.2.updated_at_millis: $updatedAtMillis2 }
   - gte: { results.2.updated_at_millis: 0 }
@@ -95,13 +92,11 @@ teardown:
   - match: { count: 3 }
 
   - match: { results.0.name: "test-search-application-1" }
-  - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
   - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-2" }
-  - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
   - gte: { results.1.updated_at_millis: 0 }
@@ -117,13 +112,11 @@ teardown:
   - match: { count: 3 }
 
   - match: { results.0.name: "another-test-search-application" }
-  - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
   - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-1" }
-  - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
   - gte: { results.1.updated_at_millis: 0 }
@@ -140,13 +133,11 @@ teardown:
   - match: { count: 2 }
 
   - match: { results.0.name: "test-search-application-1" }
-  - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
   - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-2" }
-  - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
   - gte: { results.1.updated_at_millis: 0 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
@@ -119,7 +118,7 @@ public class SearchApplication implements Writeable, ToXContentObject {
                 }
             }
             @SuppressWarnings("unchecked")
-            final String[] indices = ((List<String>) params[1]).toArray(String[]::new);
+            final String[] indices = (params[1] != null) ? ((List<String>) params[1]).toArray(String[]::new) : new String[0];
             final String analyticsCollectionName = (String) params[2];
             final Long maybeUpdatedAtMillis = (Long) params[3];
             long updatedAtMillis = (maybeUpdatedAtMillis != null ? maybeUpdatedAtMillis : System.currentTimeMillis());
@@ -139,7 +138,7 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
     static {
         PARSER.declareStringOrNull(optionalConstructorArg(), NAME_FIELD);
-        PARSER.declareStringArray(constructorArg(), INDICES_FIELD);
+        PARSER.declareStringArray(optionalConstructorArg(), INDICES_FIELD);
         PARSER.declareStringOrNull(optionalConstructorArg(), ANALYTICS_COLLECTION_NAME_FIELD);
         PARSER.declareLong(optionalConstructorArg(), UPDATED_AT_MILLIS_FIELD);
         PARSER.declareObjectOrNull(optionalConstructorArg(), (p, c) -> SearchApplicationTemplate.parse(p), null, TEMPLATE_FIELD);
@@ -183,7 +182,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(NAME_FIELD.getPreferredName(), name);
-        builder.field(INDICES_FIELD.getPreferredName(), indices);
         if (analyticsCollectionName != null) {
             builder.field(ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), analyticsCollectionName);
         }
@@ -239,7 +237,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         if (o == null || getClass() != o.getClass()) return false;
         SearchApplication app = (SearchApplication) o;
         return name.equals(app.name)
-            && Arrays.equals(indices, app.indices)
             && Objects.equals(analyticsCollectionName, app.analyticsCollectionName)
             && updatedAtMillis == app.updatedAtMillis()
             && Objects.equals(searchApplicationTemplate, app.searchApplicationTemplate);
@@ -247,9 +244,7 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(name, analyticsCollectionName, updatedAtMillis, searchApplicationTemplate);
-        result = 31 * result + Arrays.hashCode(indices);
-        return result;
+        return Objects.hash(name, analyticsCollectionName, updatedAtMillis, searchApplicationTemplate);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -459,7 +459,6 @@ public class SearchApplicationIndexService {
         final String resourceName = documentFields.get(SearchApplication.NAME_FIELD.getPreferredName()).getValue();
         return new SearchApplicationListItem(
             resourceName,
-            documentFields.get(SearchApplication.INDICES_FIELD.getPreferredName()).getValues().toArray(String[]::new),
             documentFields.get(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName()).getValue(),
             documentFields.get(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName()).getValue()
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -320,7 +320,6 @@ public class SearchApplicationIndexService {
             try (XContentBuilder source = XContentFactory.jsonBuilder(buffer)) {
                 source.startObject()
                     .field(SearchApplication.NAME_FIELD.getPreferredName(), app.name())
-                    .field(SearchApplication.INDICES_FIELD.getPreferredName(), app.indices())
                     .field(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), app.analyticsCollectionName())
                     .field(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName(), app.updatedAtMillis())
                     .directFieldAsBase64(
@@ -421,7 +420,6 @@ public class SearchApplicationIndexService {
                 .size(size)
                 .query(new QueryStringQueryBuilder(queryString))
                 .docValueField(SearchApplication.NAME_FIELD.getPreferredName())
-                .docValueField(SearchApplication.INDICES_FIELD.getPreferredName())
                 .docValueField(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName())
                 .docValueField(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName())
                 .storedFields(Collections.singletonList("_none_"))

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -164,10 +164,6 @@ public class SearchApplicationIndexService {
                     builder.field("type", "keyword");
                     builder.endObject();
 
-                    builder.startObject(SearchApplication.INDICES_FIELD.getPreferredName());
-                    builder.field("type", "keyword");
-                    builder.endObject();
-
                     builder.startObject(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName());
                     builder.field("type", "keyword");
                     builder.endObject();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationListItem.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationListItem.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -26,12 +25,10 @@ import java.util.Objects;
 public class SearchApplicationListItem implements Writeable, ToXContentObject {
 
     public static final ParseField NAME_FIELD = new ParseField("name");
-    public static final ParseField INDICES_FIELD = new ParseField("indices");
     public static final ParseField ANALYTICS_COLLECTION_NAME_FIELD = new ParseField("analytics_collection_name");
 
     public static final ParseField UPDATED_AT_MILLIS_FIELD = new ParseField("updated_at_millis");
     private final String name;
-    private final String[] indices;
     private final String analyticsCollectionName;
 
     private final long updatedAtMillis;
@@ -39,17 +36,13 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
     /**
      * Constructs a SearchApplicationListItem.
      *
-     * @param name The name of the search application
-     * @param indices The indices associated with the search application
+     * @param name                    The name of the search application
      * @param analyticsCollectionName The analytics collection associated with this application if one exists
-     * @param updatedAtMillis The timestamp in milliseconds when this search application was last updated.
+     * @param updatedAtMillis         The timestamp in milliseconds when this search application was last updated.
      */
-    public SearchApplicationListItem(String name, String[] indices, @Nullable String analyticsCollectionName, long updatedAtMillis) {
+    public SearchApplicationListItem(String name, @Nullable String analyticsCollectionName, long updatedAtMillis) {
         Objects.requireNonNull(name, "Name cannot be null on a SearchApplicationListItem");
         this.name = name;
-
-        Objects.requireNonNull(name, "Indices cannot be null on a SearchApplicationListItem");
-        this.indices = indices;
 
         this.analyticsCollectionName = analyticsCollectionName;
         this.updatedAtMillis = updatedAtMillis;
@@ -57,7 +50,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
 
     public SearchApplicationListItem(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.indices = in.readStringArray();
         this.analyticsCollectionName = in.readOptionalString();
         this.updatedAtMillis = in.readLong();
     }
@@ -66,7 +58,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(NAME_FIELD.getPreferredName(), name);
-        builder.field(INDICES_FIELD.getPreferredName(), indices);
         if (analyticsCollectionName != null) {
             builder.field(ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), analyticsCollectionName);
         }
@@ -78,7 +69,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeStringArray(indices);
         out.writeOptionalString(analyticsCollectionName);
         out.writeLong(updatedAtMillis);
     }
@@ -90,15 +80,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
      */
     public String name() {
         return name;
-    }
-
-    /**
-     * Returns the indices associated with the {@link SearchApplicationListItem}.
-     *
-     * @return the indices.
-     */
-    public String[] indices() {
-        return indices;
     }
 
     /**
@@ -125,15 +106,12 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         if (o == null || getClass() != o.getClass()) return false;
         SearchApplicationListItem item = (SearchApplicationListItem) o;
         return name.equals(item.name)
-            && Arrays.equals(indices, item.indices)
             && Objects.equals(analyticsCollectionName, item.analyticsCollectionName)
             && updatedAtMillis == item.updatedAtMillis;
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(name, analyticsCollectionName, updatedAtMillis);
-        result = 31 * result + Arrays.hashCode(indices);
-        return result;
+        return Objects.hash(name, analyticsCollectionName, updatedAtMillis);
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
@@ -191,15 +191,7 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         }
 
         {
-            for (String queryString : new String[] {
-                "*my_search_app_4*",
-                "name:my_search_app_4",
-                "my_search_app_4",
-                "*_4",
-                "indices:index_4",
-                "index_4",
-                "*_4" }) {
-
+            for (String queryString : new String[] { "*my_search_app_4*", "name:my_search_app_4", "my_search_app_4", "*_4", "*_4" }) {
                 SearchApplicationIndexService.SearchApplicationResult searchResponse = awaitListSearchApplication(queryString, 0, 10);
                 final List<SearchApplicationListItem> apps = searchResponse.items();
                 assertNotNull(apps);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
@@ -158,7 +158,6 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
             for (int i = 0; i < NUM_INDICES; i++) {
                 SearchApplicationListItem app = apps.get(i);
                 assertThat(app.name(), equalTo("my_search_app_" + i));
-                assertThat(app.indices(), equalTo(new String[] { "index_" + i }));
             }
         }
 
@@ -173,7 +172,6 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
                 int index = i + 5;
                 SearchApplicationListItem app = apps.get(i);
                 assertThat(app.name(), equalTo("my_search_app_" + index));
-                assertThat(app.indices(), equalTo(new String[] { "index_" + index }));
             }
         }
     }
@@ -208,7 +206,6 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
                 assertThat(apps.size(), equalTo(1));
                 assertThat(searchResponse.totalResults(), equalTo(1L));
                 assertThat(apps.get(0).name(), equalTo("my_search_app_4"));
-                assertThat(apps.get(0).indices(), equalTo(new String[] { "index_4" }));
             }
         }
     }
@@ -246,7 +243,6 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
             for (int i = 0; i < 4; i++) {
                 SearchApplicationListItem app = apps.get(i);
                 assertThat(app.name(), equalTo("my_search_app_" + i));
-                assertThat(app.indices(), equalTo(new String[] { "index_" + i }));
             }
         }
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationActionResponseSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationActionResponseSerializingTests.java
@@ -24,7 +24,7 @@ public class ListSearchApplicationActionResponseSerializingTests extends Abstrac
     private static ListSearchApplicationAction.Response randomSearchApplicationListItem() {
         return new ListSearchApplicationAction.Response(randomList(10, () -> {
             SearchApplication app = SearchApplicationTestUtils.randomSearchApplication();
-            return new SearchApplicationListItem(app.name(), app.indices(), app.analyticsCollectionName(), app.updatedAtMillis());
+            return new SearchApplicationListItem(app.name(), app.analyticsCollectionName(), app.updatedAtMillis());
         }), randomLongBetween(0, 1000));
     }
 


### PR DESCRIPTION
The search applications will no longer store their own list of indices, we will only rely on the alias.

This still keeps the `indices` attribute for `SearchApplication` instances, but the indices will not be stored in the system index and will not retrieved by the GET search and list search app APIs.
Removing the `indices` attribute from `SearchApplication` would have required a major refactor and I think it is much cleaner to still keep it.

A few notes:
- I need to follow up on removing/modifying the consistency check between search apps indices list and alias indices list. Can be done separately.
- Since we removed the `indices` list it will no longer be possible to use the list search apps API to query for search apps that have a given index.
