### PR TITLE
Fix test

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -43,7 +43,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.tasks.RemovedTaskListener;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
@@ -606,18 +605,13 @@ public class TasksIT extends ESIntegTestCase {
             for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
                 ((MockTaskManager) transportService.getTaskManager()).addListener(new MockTaskManagerListener() {
                     @Override
-                    public void waitForTaskCompletion(Task task) {
-                        waitForWaitingToStart.countDown();
-                    }
+                    public void waitForTaskCompletion(Task task) {}
 
                     @Override
                     public void onTaskRegistered(Task task) {}
 
                     @Override
-                    public void onTaskUnregistered(Task task) {}
-
-                    @Override
-                    public void subscribeForRemovedTasks(RemovedTaskListener removedTaskListener) {
+                    public void onTaskUnregistered(Task task) {
                         waitForWaitingToStart.countDown();
                     }
                 });


### PR DESCRIPTION
Was able to reliably (1-7% failures on 100 test batch) reproduce it if I add 2ms thread sleep between lines 112 and 113.
https://github.com/elastic/elasticsearch/blob/57457e2b48aa5baa227c1ddfdc981f0b8ddb8440/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java#L112-L118

Initial test objective is to grab task reference while it goes through `WaitForCompletion` logic in *TransportListTasksAction#processTasks*

To my mind, unblocking test thread in `registerRemovedTaskListener ` line 112 (current version) is faulty since reference on a running task is not obtained yet (it is happens in line 118), so it matter of luck whether (test thread) `wait` action can see task reference

#97923 