### PR TITLE
Expose template resources as directory

### DIFF
--- a/x-pack/plugin/core/template-resources/build.gradle
+++ b/x-pack/plugin/core/template-resources/build.gradle
@@ -9,3 +9,11 @@ tasks.named('forbiddenApisMain').configure {
   // lz4 does not depend on core, so only jdk signatures should be checked
   replaceSignatureFiles 'jdk-signatures'
 }
+
+// also make the resources available as directory to resolve it directly 
+// without the need for packing / unpacking when consumed
+var explodedBundleDir = project.getConfigurations().create("explodedBundleDir");
+explodedBundleDir.setCanBeResolved(false);
+explodedBundleDir.setCanBeConsumed(true);
+explodedBundleDir.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
+project.getArtifacts().add("explodedBundleDir", file('src/main/resources'));


### PR DESCRIPTION
This allows consuming projects to resolve the template resources as a directory and not as a zipped bundle.
This makes consuming this more effiecient.

Before: https://gradle-enterprise.elastic.co/s/ek3injaps6ipq/timeline) 
After: https://gradle-enterprise.elastic.co/s/ucv54pr4vmcwq/timeline
