### PR TITLE
Rename template resources artifact

### DIFF
--- a/x-pack/plugin/core/template-resources/build.gradle
+++ b/x-pack/plugin/core/template-resources/build.gradle
@@ -2,7 +2,7 @@
 apply plugin: 'elasticsearch.build'
 
 base {
-  archivesName = 'elasticsearch-x-pack-template-resources'
+  archivesName = 'x-pack-template-resources'
 }
 
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
Skip elasticsearch prefix to match existing naming convention of other artifact.