### PR TITLE
Refactor TokenService to reuse and hide the doc search method

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -109,23 +109,24 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
             return;
         }
 
-        tokenService.searchActiveTokens(realm.name(), containsMetadata(tokenMetadata), ActionListener.wrap(tokens -> {
-            LOGGER.debug("Found [{}] token pairs to invalidate for SAML metadata [{}]", tokens.size(), tokenMetadata);
-            if (tokens.isEmpty()) {
-                listener.onResponse(0);
-            } else {
-                tokenService.invalidateAllTokens(tokens, ActionListener.wrap(tokensInvalidationResult -> {
-                    if (LOGGER.isInfoEnabled() && tokensInvalidationResult.getErrors().isEmpty() == false) {
-                        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
-                            tokensInvalidationResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                            LOGGER.info("Failed to invalidate some SAML access or refresh tokens {}", Strings.toString(builder));
-                        }
+        tokenService.invalidateActiveTokens(
+            realm.name(),
+            null,
+            containsMetadata((tokenMetadata)),
+            ActionListener.wrap(tokensInvalidationResult -> {
+                if (LOGGER.isInfoEnabled() && tokensInvalidationResult.getErrors().isEmpty() == false) {
+                    try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+                        tokensInvalidationResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                        LOGGER.info("Failed to invalidate some SAML access or refresh tokens {}", Strings.toString(builder));
                     }
-                    // return only the total of active tokens for users of the realm, i.e. not the number of actually invalidated tokens
-                    listener.onResponse(tokens.size());
-                }, listener::onFailure));
-            }
-        }, listener::onFailure));
+                }
+                // return only the total of active tokens for users of the realm, i.e. not the number of actually invalidated tokens
+                int totalTokensFound = tokensInvalidationResult.getInvalidatedTokens().size() + tokensInvalidationResult
+                    .getPreviouslyInvalidatedTokens()
+                    .size() + tokensInvalidationResult.getErrors().size();
+                listener.onResponse(totalTokensFound);
+            }, listener::onFailure)
+        );
     }
 
     private Predicate<Map<String, Object>> containsMetadata(Map<String, Object> requiredMetadata) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -109,7 +109,7 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
             return;
         }
 
-        tokenService.findActiveTokensForRealm(realm.name(), containsMetadata(tokenMetadata), ActionListener.wrap(tokens -> {
+        tokenService.searchActiveTokens(realm.name(), containsMetadata(tokenMetadata), ActionListener.wrap(tokens -> {
             LOGGER.debug("Found [{}] token pairs to invalidate for SAML metadata [{}]", tokens.size(), tokenMetadata);
             if (tokens.isEmpty()) {
                 listener.onResponse(0);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
@@ -39,7 +39,7 @@ public final class TransportInvalidateTokenAction extends HandledTransportAction
             listener::onFailure
         );
         if (Strings.hasText(request.getUserName()) || Strings.hasText(request.getRealmName())) {
-            tokenService.invalidateActiveTokensForRealmAndUser(request.getRealmName(), request.getUserName(), invalidateListener);
+            tokenService.invalidateActiveTokens(request.getRealmName(), request.getUserName(), null, invalidateListener);
         } else if (request.getTokenType() == InvalidateTokenRequest.Type.ACCESS_TOKEN) {
             tokenService.invalidateAccessToken(request.getTokenString(), invalidateListener);
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1227,7 +1227,7 @@ public final class TokenService {
             assert tokenDoc.primaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM : "expected an assigned primary term";
             final UpdateRequestBuilder updateRequest = client.prepareUpdate(refreshedTokenIndex.aliasName(), tokenDoc.id())
                 .setDoc("refresh_token", updateMap)
-                .setFetchSource(true)
+                .setFetchSource(logger.isDebugEnabled())
                 .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
                 .setIfSeqNo(tokenDoc.seqNo())
                 .setIfPrimaryTerm(tokenDoc.primaryTerm());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1614,8 +1614,8 @@ public final class TokenService {
     }
 
     /**
-     * Find stored refresh and access tokens that have not been invalidated or expired, and were issued against
-     * the specified realm.
+     * Search for refresh and access tokens that have not been invalidated or expired, and, optionally, that were issued against
+     * the specified realm and pass the predicate test on the token doc source (also optional).
      *
      * @param realmName The name of the realm for which to get the tokens
      * @param filter    an optional Predicate to test the source of the found documents against

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -761,29 +761,15 @@ public final class TokenService {
             logger.trace("No realm name or username provided");
             listener.onFailure(new IllegalArgumentException("realm name or username must be provided"));
         } else {
-            if (Strings.isNullOrEmpty(realmName)) {
-                findActiveTokensForUser(username, ActionListener.wrap(tokenTuples -> {
-                    if (tokenTuples.isEmpty()) {
-                        logger.warn("No tokens to invalidate for realm [{}] and username [{}]", realmName, username);
-                        listener.onResponse(TokensInvalidationResult.emptyResult(RestStatus.OK));
-                    } else {
-                        invalidateAllTokens(tokenTuples, listener);
-                    }
-                }, listener::onFailure));
-            } else {
-                Predicate<Map<String, Object>> filter = null;
-                if (Strings.hasText(username)) {
-                    filter = isOfUser(username);
+            Predicate<Map<String, Object>> filter = Strings.hasText(username) ? isOfUser(username) : null;
+            searchActiveTokens(realmName, filter, ActionListener.wrap(tokenTuples -> {
+                if (tokenTuples.isEmpty()) {
+                    logger.warn("No tokens to invalidate for realm [{}] and username [{}]", realmName, username);
+                    listener.onResponse(TokensInvalidationResult.emptyResult(RestStatus.OK));
+                } else {
+                    invalidateAllTokens(tokenTuples, listener);
                 }
-                findActiveTokensForRealm(realmName, filter, ActionListener.wrap(tokenTuples -> {
-                    if (tokenTuples.isEmpty()) {
-                        logger.warn("No tokens to invalidate for realm [{}] and username [{}]", realmName, username);
-                        listener.onResponse(TokensInvalidationResult.emptyResult(RestStatus.OK));
-                    } else {
-                        invalidateAllTokens(tokenTuples, listener);
-                    }
-                }, listener::onFailure));
-            }
+            }, listener::onFailure));
         }
     }
 
@@ -1638,44 +1624,40 @@ public final class TokenService {
      * @param filter    an optional Predicate to test the source of the found documents against
      * @param listener  The listener to notify upon completion
      */
-    public void findActiveTokensForRealm(
-        String realmName,
+    public void searchActiveTokens(
+        @Nullable String realmName,
         @Nullable Predicate<Map<String, Object>> filter,
         ActionListener<Collection<Tuple<UserToken, String>>> listener
     ) {
         ensureEnabled();
-        if (Strings.isNullOrEmpty(realmName)) {
-            listener.onFailure(new IllegalArgumentException("realm name is required"));
-            return;
-        }
         sourceIndicesWithTokensAndRun(ActionListener.wrap(indicesWithTokens -> {
             if (indicesWithTokens.isEmpty()) {
                 listener.onResponse(Collections.emptyList());
             } else {
                 final Instant now = clock.instant();
-                final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
-                    .filter(QueryBuilders.termQuery("doc_type", TOKEN_DOC_TYPE))
-                    .filter(QueryBuilders.termQuery("access_token.realm", realmName))
-                    .filter(
-                        QueryBuilders.boolQuery()
-                            .should(
-                                QueryBuilders.boolQuery()
-                                    .must(QueryBuilders.termQuery("access_token.invalidated", false))
-                                    .must(QueryBuilders.rangeQuery("access_token.user_token.expiration_time").gte(now.toEpochMilli()))
-                            )
-                            .should(
-                                QueryBuilders.boolQuery()
-                                    .must(QueryBuilders.termQuery("refresh_token.invalidated", false))
-                                    .must(
-                                        QueryBuilders.rangeQuery("creation_time")
-                                            .gte(
-                                                now.toEpochMilli() - TimeValue.timeValueHours(
-                                                    ExpiredTokenRemover.MAXIMUM_TOKEN_LIFETIME_HOURS
-                                                ).millis()
-                                            )
-                                    )
-                            )
-                    );
+                final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("doc_type", TOKEN_DOC_TYPE));
+                if (Strings.isNullOrEmpty(realmName) == false) {
+                    boolQuery.filter(QueryBuilders.termQuery("access_token.realm", realmName));
+                }
+                boolQuery.filter(
+                    QueryBuilders.boolQuery()
+                        .should(
+                            QueryBuilders.boolQuery()
+                                .must(QueryBuilders.termQuery("access_token.invalidated", false))
+                                .must(QueryBuilders.rangeQuery("access_token.user_token.expiration_time").gte(now.toEpochMilli()))
+                        )
+                        .should(
+                            QueryBuilders.boolQuery()
+                                .must(QueryBuilders.termQuery("refresh_token.invalidated", false))
+                                .must(
+                                    QueryBuilders.rangeQuery("creation_time")
+                                        .gte(
+                                            now.toEpochMilli() - TimeValue.timeValueHours(ExpiredTokenRemover.MAXIMUM_TOKEN_LIFETIME_HOURS)
+                                                .millis()
+                                        )
+                                )
+                        )
+                );
                 final Supplier<ThreadContext.StoredContext> supplier = client.threadPool().getThreadContext().newRestorableContext(false);
                 try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(SECURITY_ORIGIN)) {
                     final SearchRequest request = client.prepareSearch(indicesWithTokens.toArray(new String[0]))
@@ -1690,66 +1672,6 @@ public final class TokenService {
                         request,
                         new ContextPreservingActionListener<>(supplier, listener),
                         (SearchHit hit) -> filterAndParseHit(hit, filter)
-                    );
-                }
-            }
-        }, listener::onFailure));
-    }
-
-    /**
-     * Find stored refresh and access tokens that have not been invalidated or expired, and were issued for
-     * the specified user.
-     *
-     * @param username The user for which to get the tokens
-     * @param listener The listener to notify upon completion
-     */
-    public void findActiveTokensForUser(String username, ActionListener<Collection<Tuple<UserToken, String>>> listener) {
-        ensureEnabled();
-        if (Strings.isNullOrEmpty(username)) {
-            listener.onFailure(new IllegalArgumentException("username is required"));
-            return;
-        }
-        sourceIndicesWithTokensAndRun(ActionListener.wrap(indicesWithTokens -> {
-            if (indicesWithTokens.isEmpty()) {
-                listener.onResponse(Collections.emptyList());
-            } else {
-                final Instant now = clock.instant();
-                final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
-                    .filter(QueryBuilders.termQuery("doc_type", TOKEN_DOC_TYPE))
-                    .filter(
-                        QueryBuilders.boolQuery()
-                            .should(
-                                QueryBuilders.boolQuery()
-                                    .must(QueryBuilders.termQuery("access_token.invalidated", false))
-                                    .must(QueryBuilders.rangeQuery("access_token.user_token.expiration_time").gte(now.toEpochMilli()))
-                            )
-                            .should(
-                                QueryBuilders.boolQuery()
-                                    .must(QueryBuilders.termQuery("refresh_token.invalidated", false))
-                                    .must(
-                                        QueryBuilders.rangeQuery("creation_time")
-                                            .gte(
-                                                now.toEpochMilli() - TimeValue.timeValueHours(
-                                                    ExpiredTokenRemover.MAXIMUM_TOKEN_LIFETIME_HOURS
-                                                ).millis()
-                                            )
-                                    )
-                            )
-                    );
-                final Supplier<ThreadContext.StoredContext> supplier = client.threadPool().getThreadContext().newRestorableContext(false);
-                try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(SECURITY_ORIGIN)) {
-                    final SearchRequest request = client.prepareSearch(indicesWithTokens.toArray(new String[0]))
-                        .setScroll(DEFAULT_KEEPALIVE_SETTING.get(settings))
-                        .setQuery(boolQuery)
-                        .setVersion(false)
-                        .setSize(1000)
-                        .setFetchSource(true)
-                        .request();
-                    ScrollHelper.fetchAllByEntity(
-                        client,
-                        request,
-                        new ContextPreservingActionListener<>(supplier, listener),
-                        (SearchHit hit) -> filterAndParseHit(hit, isOfUser(username))
                     );
                 }
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1616,6 +1616,7 @@ public final class TokenService {
     /**
      * Search for refresh and access tokens that have not been invalidated or expired, and, optionally, that were issued against
      * the specified realm and pass the predicate test on the token doc source (also optional).
+     * Note that searches on the tokens index is discouraged, so please avoid using this method, if possible.
      *
      * @param realmName The name of the realm for which to get the tokens
      * @param filter    an optional Predicate to test the source of the found documents against


### PR DESCRIPTION
`TokenService` now reuses a single method that actually searches
for token documents. The method is only used for token invalidations.
The token doc search method is modified to private access level,
as searches on the tokens index is discouraged.