### PR TITLE
Add logging for testScaleDuringSplitOrClone

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.NodeRoles;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingCapacityAction;
 import org.elasticsearch.xpack.autoscaling.action.PutAutoscalingPolicyAction;
@@ -394,6 +395,12 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         );
     }
 
+    @TestLogging(
+        reason = "Debugging https://github.com/elastic/elasticsearch/issues/96764",
+        value = "org.elasticsearch.cluster.InternalClusterInfoService:TRACE"
+            + ",org.elasticsearch.xpack.autoscaling.action:TRACE"
+            + ",org.elasticsearch.cluster.routing.allocation:DEBUG"
+    )
     public void testScaleDuringSplitOrClone() throws Exception {
         internalCluster().startMasterOnlyNode();
         final String dataNode1Name = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/96764
