### PR TITLE
[DOCS] Update range aggregation example

### DIFF
--- a/docs/reference/aggregations/bucket/range-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/range-aggregation.asciidoc
@@ -338,7 +338,25 @@ with latency metrics (in milliseconds) for different networks:
 
 [source,console]
 ----
-PUT metrics_index/_doc/1
+PUT metrics_index
+{
+  "mappings": {
+    "properties": {
+      "network": {
+        "properties": {
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "latency_histo": {
+         "type": "histogram"
+      }
+    }
+  }
+}
+
+PUT metrics_index/_doc/1?refresh
 {
   "network.name" : "net-1",
   "latency_histo" : {
@@ -347,7 +365,7 @@ PUT metrics_index/_doc/1
    }
 }
 
-PUT metrics_index/_doc/2
+PUT metrics_index/_doc/2?refresh
 {
   "network.name" : "net-2",
   "latency_histo" : {
@@ -385,24 +403,24 @@ return the following output:
       "buckets": [
         {
           "key": "*-2.0",
-          "to": 2,
+          "to": 2.0,
           "doc_count": 11
         },
         {
           "key": "2.0-3.0",
-          "from": 2,
-          "to": 3,
+          "from": 2.0,
+          "to": 3.0,
           "doc_count": 0
         },
         {
           "key": "3.0-10.0",
-          "from": 3,
-          "to": 10,
+          "from": 3.0,
+          "to": 10.0,
           "doc_count": 55
         },
         {
           "key": "10.0-*",
-          "from": 10,
+          "from": 10.0,
           "doc_count": 31
         }
       ]
@@ -410,7 +428,7 @@ return the following output:
   }
 }
 ----
-// TESTRESPONSE[skip:test not setup]
+// TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 
 [IMPORTANT]
 ========


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/96974, this PR updates the range agg docs, so the code example  for running range aggs on histogram fields is 1) fully reproducible (by adding a mapping) and 2) tested.