### PR TITLE
Change test tear down to only remove resources created by the test

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -74,9 +74,9 @@ PUT /_data_stream/new-data-stream
 
 [source,console]
 ----
-DELETE /_data_stream/*
+DELETE /_data_stream/my-data-stream*,new-data-stream*
 
-DELETE /_index_template/*
+DELETE /_index_template/my-data-stream-template,new-data-stream-template
 
 DELETE /_ilm/policy/my-data-stream-policy
 ----

--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -43,9 +43,9 @@ PUT /my-data-stream/_create/bfspvnIBr7VVZlfp2lqX?refresh=wait_for
 
 [source,console]
 ----
-DELETE /_data_stream/*
+DELETE /_data_stream/my-data-stream*
 
-DELETE /_index_template/*
+DELETE /_index_template/my-data-stream-template
 ----
 // TEARDOWN
 ////

--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -41,8 +41,8 @@ POST /my-data-stream-two/_rollover/
 ////
 [source,console]
 ----
-DELETE /_data_stream/*
-DELETE /_index_template/*
+DELETE /_data_stream/my-data-stream*
+DELETE /_index_template/template
 ----
 // TEARDOWN
 ////


### PR DESCRIPTION
Test failure https://github.com/elastic/elasticsearch/issues/93457 indicates that the `DELETE _index_template/*` is trying to delete composable templates that are still in use by `.slm-history-x`. Theoretically, `DELETE /_data_stream/*` should have deleted all data streams which should have made the `DELETE _index_template/*` successful but it appears that sometimes this doesn't happen. It might be a timing/refresh issue (since we have no indication that the deletion failed). 

This failed in feb and I haven't seen any failures since, however I would like to try to reduce the flakiness. So, I am proposing to change the clean up of the data streams and the composeable templates to something lighter. We can delete only the resources created in the test.

Fixes: https://github.com/elastic/elasticsearch/issues/93457