### PR TITLE
Revert "Prevent user changes to the voting config exclusions in atomic-register based coordination"

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
-import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -58,7 +57,6 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
     );
 
     private volatile int maxVotingConfigExclusions;
-    private final Reconfigurator reconfigurator;
 
     @Inject
     public TransportAddVotingConfigExclusionsAction(
@@ -68,8 +66,7 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        Reconfigurator reconfigurator
+        IndexNameExpressionResolver indexNameExpressionResolver
     ) {
         super(
             AddVotingConfigExclusionsAction.NAME,
@@ -86,7 +83,6 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
 
         maxVotingConfigExclusions = MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING, this::setMaxVotingConfigExclusions);
-        this.reconfigurator = reconfigurator;
     }
 
     private void setMaxVotingConfigExclusions(int maxVotingConfigExclusions) {
@@ -100,7 +96,6 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
         ClusterState state,
         ActionListener<ActionResponse.Empty> listener
     ) throws Exception {
-        reconfigurator.ensureVotingConfigCanBeModified();
 
         resolveVotingConfigExclusionsAndCheckMaximum(request, state, maxVotingConfigExclusions);
         // throws IAE if no nodes matched or maximum exceeded

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
-import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -42,7 +41,6 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
     ActionResponse.Empty> {
 
     private static final Logger logger = LogManager.getLogger(TransportClearVotingConfigExclusionsAction.class);
-    private final Reconfigurator reconfigurator;
 
     @Inject
     public TransportClearVotingConfigExclusionsAction(
@@ -50,8 +48,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        Reconfigurator reconfigurator
+        IndexNameExpressionResolver indexNameExpressionResolver
     ) {
         super(
             ClearVotingConfigExclusionsAction.NAME,
@@ -65,7 +62,6 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
             in -> ActionResponse.Empty.INSTANCE,
             ThreadPool.Names.SAME
         );
-        this.reconfigurator = reconfigurator;
     }
 
     @Override
@@ -75,7 +71,6 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
         ClusterState initialState,
         ActionListener<ActionResponse.Empty> listener
     ) throws Exception {
-        reconfigurator.ensureVotingConfigCanBeModified();
 
         final long startTimeMillis = threadPool.relativeTimeInMillis();
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
@@ -148,11 +148,6 @@ public class Reconfigurator {
         return clusterState;
     }
 
-    public void ensureVotingConfigCanBeModified() {
-        // Temporary workaround until #98055 is tackled
-        // no-op
-    }
-
     record VotingConfigNode(String id, boolean live, boolean currentMaster, boolean inCurrentConfig)
         implements
             Comparable<VotingConfigNode> {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/stateless/SingleNodeReconfigurator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/stateless/SingleNodeReconfigurator.java
@@ -49,10 +49,4 @@ public class SingleNodeReconfigurator extends Reconfigurator {
             )
             .build();
     }
-
-    @Override
-    public void ensureVotingConfigCanBeModified() {
-        assert false;
-        throw new IllegalStateException("Voting configuration cannot be modified using atomic-register based coordination");
-    }
 }

--- a/server/src/main/java/org/elasticsearch/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoveryModule.java
@@ -91,7 +91,6 @@ public class DiscoveryModule {
     );
 
     private final Coordinator coordinator;
-    private final Reconfigurator reconfigurator;
 
     public DiscoveryModule(
         Settings settings,
@@ -183,7 +182,7 @@ public class DiscoveryModule {
                 );
         }
 
-        this.reconfigurator = getReconfigurator(settings, clusterSettings, clusterCoordinationPlugins);
+        var reconfigurator = getReconfigurator(settings, clusterSettings, clusterCoordinationPlugins);
         var preVoteCollectorFactory = getPreVoteCollectorFactory(clusterCoordinationPlugins);
         var leaderHeartbeatService = getLeaderHeartbeatService(settings, clusterCoordinationPlugins);
 
@@ -282,9 +281,5 @@ public class DiscoveryModule {
 
     public Coordinator getCoordinator() {
         return coordinator;
-    }
-
-    public Reconfigurator getReconfigurator() {
-        return reconfigurator;
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -44,7 +44,6 @@ import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.coordination.CoordinationDiagnosticsService;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.coordination.MasterHistoryService;
-import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.coordination.StableMasterHealthIndicatorService;
 import org.elasticsearch.cluster.desirednodes.DesiredNodesSettingsValidator;
 import org.elasticsearch.cluster.metadata.IndexMetadataVerifier;
@@ -1082,7 +1081,6 @@ public class Node implements Closeable {
                 b.bind(SnapshotsInfoService.class).toInstance(snapshotsInfoService);
                 b.bind(GatewayMetaState.class).toInstance(gatewayMetaState);
                 b.bind(Coordinator.class).toInstance(discoveryModule.getCoordinator());
-                b.bind(Reconfigurator.class).toInstance(discoveryModule.getReconfigurator());
                 {
                     processRecoverySettings(settingsModule.getClusterSettings(), recoverySettings);
                     final SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(repositoryService);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
-import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -47,7 +46,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static java.util.Collections.emptySet;
@@ -73,7 +71,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
     private ClusterStateObserver clusterStateObserver;
     private ClusterSettings clusterSettings;
     private int staticMaximum;
-    private FakeReconfigurator reconfigurator;
 
     @BeforeClass
     public static void createThreadPoolAndClusterService() {
@@ -119,7 +116,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         }
         final Settings nodeSettings = nodeSettingsBuilder.build();
         clusterSettings = new ClusterSettings(nodeSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        reconfigurator = new FakeReconfigurator();
 
         new TransportAddVotingConfigExclusionsAction(
             nodeSettings,
@@ -128,8 +124,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
             clusterService,
             threadPool,
             new ActionFilters(emptySet()),
-            TestIndexNameExpressionResolver.newInstance(threadPool.getThreadContext()),
-            reconfigurator
+            TestIndexNameExpressionResolver.newInstance(threadPool.getThreadContext())
         ); // registers action
 
         transportService.start();
@@ -481,28 +476,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         assertThat(rootCause.getMessage(), startsWith("timed out waiting for voting config exclusions [{other1}"));
     }
 
-    public void testCannotAddVotingConfigExclusionsWhenItIsDisabled() {
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final SetOnce<TransportException> exceptionHolder = new SetOnce<>();
-
-        reconfigurator.disableUserVotingConfigModifications();
-
-        transportService.sendRequest(
-            localNode,
-            AddVotingConfigExclusionsAction.NAME,
-            new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[] { "other1" }, TimeValue.timeValueMillis(100)),
-            expectError(e -> {
-                exceptionHolder.set(e);
-                countDownLatch.countDown();
-            })
-        );
-
-        safeAwait(countDownLatch);
-        final Throwable rootCause = exceptionHolder.get().getRootCause();
-        assertThat(rootCause, instanceOf(IllegalStateException.class));
-        assertThat(rootCause.getMessage(), startsWith("Unable to modify the voting configuration"));
-    }
-
     private TransportResponseHandler<ActionResponse.Empty> expectSuccess(Consumer<ActionResponse.Empty> onResponse) {
         return responseHandler(onResponse, e -> { throw new AssertionError("unexpected", e); });
     }
@@ -582,25 +555,6 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         @Override
         public void onTimeout(TimeValue timeout) {
             throw new AssertionError("unexpected timeout");
-        }
-    }
-
-    static class FakeReconfigurator extends Reconfigurator {
-        private final AtomicBoolean canModifyVotingConfiguration = new AtomicBoolean(true);
-
-        FakeReconfigurator() {
-            super(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
-        }
-
-        @Override
-        public void ensureVotingConfigCanBeModified() {
-            if (canModifyVotingConfiguration.get() == false) {
-                throw new IllegalStateException("Unable to modify the voting configuration");
-            }
-        }
-
-        void disableUserVotingConfigModifications() {
-            canModifyVotingConfiguration.set(false);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -2037,8 +2037,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             mockPlugins,
             getClientWrapper(),
             forbidPrivateIndexSettings(),
-            forceSingleDataPath(),
-            autoManageVotingExclusions()
+            forceSingleDataPath()
         );
     }
 
@@ -2441,11 +2440,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
      * @see SuiteScopeTestCase
      */
     protected void setupSuiteScopeCluster() throws Exception {}
-
-    protected boolean autoManageVotingExclusions() {
-        // Temporary workaround until #98055 is tackled
-        return true;
-    }
 
     private static boolean isSuiteScopedTest(Class<?> clazz) {
         return clazz.getAnnotation(SuiteScopeTestCase.class) != null;

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -244,7 +244,6 @@ public final class InternalTestCluster extends TestCluster {
 
     private ServiceDisruptionScheme activeDisruptionScheme;
     private final Function<Client, Client> clientWrapper;
-    private final boolean autoManageVotingExclusions;
 
     /**
      * Default value of bootstrapMasterNodeIndex, indicating that bootstrapping should happen automatically.
@@ -287,8 +286,7 @@ public final class InternalTestCluster extends TestCluster {
             mockPlugins,
             clientWrapper,
             true,
-            false,
-            true
+            false
         );
     }
 
@@ -306,8 +304,7 @@ public final class InternalTestCluster extends TestCluster {
         final Collection<Class<? extends Plugin>> mockPlugins,
         final Function<Client, Client> clientWrapper,
         final boolean forbidPrivateIndexSettings,
-        final boolean forceSingleDataPath,
-        final boolean autoManageVotingExclusions
+        final boolean forceSingleDataPath
     ) {
         super(clusterSeed);
         this.autoManageMasterNodes = autoManageMasterNodes;
@@ -315,7 +312,6 @@ public final class InternalTestCluster extends TestCluster {
         this.forbidPrivateIndexSettings = forbidPrivateIndexSettings;
         this.baseDir = baseDir;
         this.clusterName = clusterName;
-        this.autoManageVotingExclusions = autoManageVotingExclusions;
         if (minNumDataNodes < 0 || maxNumDataNodes < 0) {
             throw new IllegalArgumentException("minimum and maximum number of data nodes must be >= 0");
         }
@@ -1891,7 +1887,7 @@ public final class InternalTestCluster extends TestCluster {
     private Set<String> excludeMasters(Collection<NodeAndClient> nodeAndClients) {
         assert Thread.holdsLock(this);
         final Set<String> excludedNodeNames = new HashSet<>();
-        if (autoManageVotingExclusions && autoManageMasterNodes && nodeAndClients.size() > 0) {
+        if (autoManageMasterNodes && nodeAndClients.size() > 0) {
 
             final long currentMasters = nodes.values().stream().filter(NodeAndClient::isMasterEligible).count();
             final long stoppingMasters = nodeAndClients.stream().filter(NodeAndClient::isMasterEligible).count();
@@ -1921,7 +1917,7 @@ public final class InternalTestCluster extends TestCluster {
 
     private void removeExclusions(Set<String> excludedNodeIds) {
         assert Thread.holdsLock(this);
-        if (autoManageVotingExclusions && excludedNodeIds.isEmpty() == false) {
+        if (excludedNodeIds.isEmpty() == false) {
             logger.info("removing voting config exclusions for {} after restart/shutdown", excludedNodeIds);
             try {
                 Client client = getRandomNodeAndClient(node -> excludedNodeIds.contains(node.name) == false).client();


### PR DESCRIPTION
Reverts elastic/elasticsearch#97959

It looks like there are quite a few yaml tests in stateless that try to modify the voting configuration, I'll revert this PR until I figure out which ones should be skipped.