### PR TITLE
[buildkite] Move periodic pipeline schedule to a separate trigger job

### DIFF
--- a/.buildkite/pipelines/periodic.trigger.yml
+++ b/.buildkite/pipelines/periodic.trigger.yml
@@ -1,0 +1,16 @@
+steps:
+  - trigger: elasticsearch-periodic
+    label: Trigger periodic pipeline for main
+    async: true
+    build:
+      branch: main
+  - trigger: elasticsearch-periodic
+    label: Trigger periodic pipeline for 8.9
+    async: true
+    build:
+      branch: "8.9"
+  - trigger: elasticsearch-periodic
+    label: Trigger periodic pipeline for 7.17
+    async: true
+    build:
+      branch: "7.17"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -92,7 +92,41 @@ spec:
         elasticsearch-team: {}
         ml-core: {}
         everyone:
-          access_level: READ_ONLY
+          access_level: BUILD_AND_READ
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: none
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-periodic-trigger
+  description: Triggers periodic pipeline for all required branches
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-periodic-trigger
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: group:elasticsearch-team
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: ":elasticsearch: Triggers periodic pipeline for all required branches"
+      name: elasticsearch / periodic / trigger
+    spec:
+      repository: elastic/elasticsearch
+      pipeline_file: .buildkite/pipelines/periodic.trigger.yml
+      branch_configuration: main
+      teams:
+        elasticsearch-team: {}
+        ml-core: {}
+        everyone:
+          access_level: BUILD_AND_READ
       provider_settings:
         build_branches: false
         build_pull_requests: false
@@ -102,4 +136,4 @@ spec:
         Periodically on main:
           branch: main
           cronline: "0 0,8,16 * * * America/New_York"
-          message: "Tests and checks that are run 3x daily"
+          message: "Triggers pipelines 3x daily"


### PR DESCRIPTION
- Move the periodic pipeline schedule to a separate trigger pipeline
- Add the other version branches

Why? Because it allows us to make it dynamic very soon, so that we won't need to edit yaml files around version bumps. And we also won't need to wait for Terrazzo to deploy changes.