### PR TITLE
[Fleet][Security Solution] Update Kibana System and Fleet Server index permissions to enable File Operations

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -214,6 +214,20 @@ GET /_security/service/elastic/fleet-server
         },
         {
           "names": [
+            ".fleet-fileds*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
+        {
+          "names": [
             "synthetics-*"
           ],
           "privileges": [

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -173,6 +173,11 @@ class KibanaOwnedReservedRoleDescriptors {
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-fileds*")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
                 // Fleet telemetry queries Agent Logs indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-elastic_agent*").privileges("read").build(),
                 // Legacy "Alerts as data" used in Security Solution.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -173,11 +173,7 @@ class KibanaOwnedReservedRoleDescriptors {
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".fleet-fileds*")
-                    .privileges("all")
-                    .allowRestrictedIndices(true)
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".fleet-fileds*").privileges("all").allowRestrictedIndices(true).build(),
                 // Fleet telemetry queries Agent Logs indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-elastic_agent*").privileges("read").build(),
                 // Legacy "Alerts as data" used in Security Solution.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -151,7 +151,9 @@ public class InternalUsers {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(
                         // System data stream for result history of fleet actions (see Fleet#fleetActionsResultsDescriptor)
-                        ".fleet-actions-results"
+                        ".fleet-actions-results",
+                        // System data streams for storing uploaded file data for Agent diagnostics and Endpoint response actions
+                        ".fleet-fileds*"
                     )
                     .privileges(
                         "delete_index",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -753,7 +753,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".fleet-enrollment-api-keys",
             ".fleet-policies",
             ".fleet-actions-results",
-            ".fleet-servers"
+            ".fleet-servers",
+            ".fleet-fileds",
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
 
         final IndexAbstraction dotFleetSecretsIndex = mockIndexAbstraction(".fleet-secrets");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -754,7 +754,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".fleet-policies",
             ".fleet-actions-results",
             ".fleet-servers",
-            ".fleet-fileds",
+            ".fleet-fileds"
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
 
         final IndexAbstraction dotFleetSecretsIndex = mockIndexAbstraction(".fleet-secrets");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.security.authz.permission.SimpleRole;
 import org.elasticsearch.xpack.core.security.support.MetadataUtils;
 import org.elasticsearch.xpack.core.security.test.TestRestrictedIndices;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.xpack.core.security.test.TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7;
@@ -228,10 +229,10 @@ public class InternalUsersTests extends ESTestCase {
         assertThat(role.application(), is(ApplicationPermission.NONE));
         assertThat(role.remoteIndices(), is(RemoteIndicesPermission.NONE));
 
-        final String allowedSystemDataStream = ".fleet-actions-results";
+        final List<String> allowedSystemDataStreams = Arrays.asList(".fleet-actions-results", ".fleet-fileds*");
         for (var group : role.indices().groups()) {
             if (group.allowRestrictedIndices()) {
-                assertThat(group.indices(), arrayContaining(allowedSystemDataStream));
+                assertThat(group.indices(), arrayContaining(allowedSystemDataStreams.toArray(new String[0])));
             }
         }
 
@@ -251,13 +252,15 @@ public class InternalUsersTests extends ESTestCase {
             true
         );
 
-        checkIndexAccess(role, randomFrom(sampleIndexActions), allowedSystemDataStream, true);
-        checkIndexAccess(
-            role,
-            randomFrom(sampleIndexActions),
-            DataStream.BACKING_INDEX_PREFIX + allowedSystemDataStream + randomAlphaOfLengthBetween(4, 8),
-            true
-        );
+        allowedSystemDataStreams.forEach(allowedSystemDataStream -> {
+            checkIndexAccess(role, randomFrom(sampleIndexActions), allowedSystemDataStream, true);
+            checkIndexAccess(
+                role,
+                randomFrom(sampleIndexActions),
+                DataStream.BACKING_INDEX_PREFIX + allowedSystemDataStream + randomAlphaOfLengthBetween(4, 8),
+                true
+            );
+        });
 
         checkIndexAccess(role, randomFrom(sampleIndexActions), randomFrom(TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES), false);
     }

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-data.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-data.json
@@ -13,7 +13,7 @@
     "settings": {
       "index.auto_expand_replicas": "0-1",
       "index.hidden": true,
-      "index.lifecycle.name": ".fleet-fileds-fromhost-data-ilm-policy"
+      "index.lifecycle.name": ".fleet-file-fromhost-data-ilm-policy"
     },
     "mappings": {
       "_doc": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-meta.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-meta.json
@@ -13,7 +13,7 @@
     "settings": {
       "index.auto_expand_replicas": "0-1",
       "index.hidden": true,
-      "index.lifecycle.name": "fleet-file-fromhost-meta-ilm-policy"
+      "index.lifecycle.name": ".fleet-file-fromhost-meta-ilm-policy"
     },
     "mappings": {
       "_doc": {

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -233,6 +233,20 @@ public class ServiceAccountIT extends ESRestTestCase {
                 },
                 {
                   "names": [
+                    ".fleet-fileds*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
                     "synthetics-*"
                   ],
                   "privileges": [

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -127,6 +127,11 @@ final class ElasticServiceAccounts {
                     .allowRestrictedIndices(true)
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-fileds*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
                     .indices("synthetics-*")
                     // Fleet Server needs "read" privilege to be able to retrieve multi-agent docs
                     .privileges("read", "write", "create_index", "auto_configure")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -245,7 +245,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             ".fleet-policies-leader" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-servers" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-artifacts" + randomAlphaOfLengthBetween(1, 20),
-            ".fleet-actions-results" + randomAlphaOfLengthBetween(1, 20)
+            ".fleet-actions-results" + randomAlphaOfLengthBetween(1, 20),
+            ".fleet-fileds" + randomAlphaOfLengthBetween(1, 20),
         ).forEach(index -> {
             final IndexAbstraction dotFleetIndex = mockIndexAbstraction(index);
             assertThat(role.indices().allowedIndicesMatcher(DeleteAction.NAME).test(dotFleetIndex), is(true));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -246,7 +246,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             ".fleet-servers" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-artifacts" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-actions-results" + randomAlphaOfLengthBetween(1, 20),
-            ".fleet-fileds" + randomAlphaOfLengthBetween(1, 20),
+            ".fleet-fileds" + randomAlphaOfLengthBetween(1, 20)
         ).forEach(index -> {
             final IndexAbstraction dotFleetIndex = mockIndexAbstraction(index);
             assertThat(role.indices().allowedIndicesMatcher(DeleteAction.NAME).test(dotFleetIndex), is(true));


### PR DESCRIPTION
This addresses an issue where file permissions for `kibana_system` and `elastic/fleet-server` were not set up with the right permissions for file operations in Fleet and Security such as requesting Agent Diagnostics and file related Endpoint response actions.

Specifically, we need to grant permissions for the `.fleet-fileds` indices.

Before this change, we get permissions issues when requesting Agent diagnostics from the host

![image](https://github.com/elastic/elasticsearch/assets/56395104/6342f84b-cbd0-4b1f-a5d5-b13176492b63)

![image](https://github.com/elastic/elasticsearch/assets/56395104/ae1e3785-8c39-46dc-af10-f1868422e74a)

After this change, we are able to get the diagnostics file
![image](https://github.com/elastic/elasticsearch/assets/56395104/52a7a772-0cdc-4808-afa1-8e093f089344)

In addition to the above changes, we needed to grant the right permissions to ensure that we can perform rollovers via lifecycle management.

More info in this ticket: https://github.com/elastic/kibana/issues/162760
