### PR TITLE
Collect additional object store stats for S3

### DIFF
--- a/docs/changelog/98083.yaml
+++ b/docs/changelog/98083.yaml
@@ -1,5 +1,5 @@
 pr: 98083
-summary: Collect additional object store stas for S3
+summary: Collect additional object store stats for S3
 area: Snapshot/Restore
 type: enhancement
 issues: []

--- a/docs/changelog/98083.yaml
+++ b/docs/changelog/98083.yaml
@@ -1,0 +1,5 @@
+pr: 98083
+summary: Collect additional object store stas for S3
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -195,6 +195,7 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
         // Ignore PutMultipartObject for comparison since failed multipart upload requests (null response) are not counted for sdk stats
         Map<String, Long> sdkRequestCounts = repositoryStats.requestCounts;
         assertThat(sdkRequestCounts.get("AbortMultipartObject"), greaterThan(0L));
+        assertThat(sdkRequestCounts.get("DeleteObjects"), greaterThan(0L));
 
         final Map<String, Long> mockCalls = getMockRequestCounts();
 
@@ -395,7 +396,7 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
                 trackRequest("PutObject");
             } else if (Regex.simpleMatch("POST /*/?delete", request)) {
                 trackRequest("DeleteObjects");
-            } else if (Regex.simpleMatch("DELETE /*/*?*uploadId=*", request)) {
+            } else if (Regex.simpleMatch("DELETE /*/*?uploadId=*", request)) {
                 trackRequest("AbortMultipartObject");
             }
         }

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -192,7 +192,6 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
             }
         }).filter(Objects::nonNull).map(Repository::stats).reduce(RepositoryStats::merge).get();
 
-        // Ignore PutMultipartObject for comparison since failed multipart upload requests (null response) are not counted for sdk stats
         Map<String, Long> sdkRequestCounts = repositoryStats.requestCounts;
         assertThat(sdkRequestCounts.get("AbortMultipartObject"), greaterThan(0L));
         assertThat(sdkRequestCounts.get("DeleteObjects"), greaterThan(0L));

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -140,6 +141,16 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
             builder.put(S3ClientSettings.REGION.getConcreteSettingForNamespace("test").getKey(), region);
         }
         return builder.build();
+    }
+
+    @Override
+    protected Map<String, Long> getMockRequestCounts() {
+        Map<String, Long> mockRequestCounts = super.getMockRequestCounts();
+        if (false == mockRequestCounts.containsKey("AbortMultipartObject")) {
+            mockRequestCounts = new HashMap<>(mockRequestCounts);
+            mockRequestCounts.put("AbortMultipartObject", 0L);
+        }
+        return mockRequestCounts;
     }
 
     @Override
@@ -323,6 +334,10 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
                 trackRequest("PutMultipartObject");
             } else if (Regex.simpleMatch("PUT /*/*", request)) {
                 trackRequest("PutObject");
+            } else if (Regex.simpleMatch("POST /*/?delete", request)) {
+                trackRequest("DeleteObjects");
+            } else if (Regex.simpleMatch("DELETE /*/*?*uploadId=*", request)) {
+                trackRequest("AbortMultipartObject");
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -217,7 +217,11 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
             }
         }).filter(Objects::nonNull).map(Repository::stats).reduce(RepositoryStats::merge).get();
 
-        Map<String, Long> sdkRequestCounts = repositoryStats.requestCounts;
+        // Since no abort request is made, filter it out from the stats (also ensure it is 0) before comparing to the mock counts
+        Map<String, Long> sdkRequestCounts = repositoryStats.requestCounts.entrySet()
+            .stream()
+            .filter(entry -> false == ("AbortMultipartObject".equals(entry.getKey()) && entry.getValue() == 0L))
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
         final Map<String, Long> mockCalls = getMockRequestCounts();
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -226,7 +226,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
         assertEquals(assertionErrorMsg, mockCalls, sdkRequestCounts);
     }
 
-    private Map<String, Long> getMockRequestCounts() {
+    protected Map<String, Long> getMockRequestCounts() {
         for (HttpHandler h : handlers.values()) {
             while (h instanceof DelegatingHttpHandler) {
                 if (h instanceof HttpStatsCollectorHandler) {


### PR DESCRIPTION
This PR adds additional stats collectiosn for s3, including Delete and Abort. It also fixes an issue where ListNextBatchObject is not metered.
