### PR TITLE
[DOCS] Remove 'settings' from resume follower API

### DIFF
--- a/docs/reference/ccr/apis/follow-request-body.asciidoc
+++ b/docs/reference/ccr/apis/follow-request-body.asciidoc
@@ -2,6 +2,7 @@
   (object) Settings to override from the leader index. Note that certain
   settings can not be overrode (e.g., `index.number_of_shards`).
 
+// tag::ccr-resume-follow-request-body[]
 `max_read_request_operation_count`::
   (integer) The maximum number of operations to pull per read from the remote
   cluster.
@@ -101,3 +102,4 @@ values for the above described index follow request parameters:
 }
 
 --------------------------------------------------
+// end::ccr-resume-follow-request-body[]

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -68,7 +68,7 @@ returns, the follower index will resume fetching operations from the leader inde
 
 [[ccr-post-resume-follow-request-body]]
 ==== {api-request-body-title}
-include::../follow-request-body.asciidoc[]
+include::../follow-request-body.asciidoc[tag=ccr-resume-follow-request-body]
 
 [[ccr-post-resume-follow-examples]]
 ==== {api-examples-title}


### PR DESCRIPTION
The [resume follower API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html#ccr-post-resume-follow-request-body) lists `settings` as a request body parameter. However, `settings` is not allowed for this API, as reported in https://github.com/elastic/elasticsearch/issues/87864. This PR fixes that.

Closes https://github.com/elastic/elasticsearch/issues/87864