### PR TITLE
GlobalAggregator should call rewrite() before createWeight()

### DIFF
--- a/docs/changelog/98091.yaml
+++ b/docs/changelog/98091.yaml
@@ -1,0 +1,6 @@
+pr: 98091
+summary: '`GlobalAggregator` should call rewrite() before `createWeight()`'
+area: Aggregations
+type: bug
+issues:
+ - 98076

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/global_with_aliases.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/global_with_aliases.yml
@@ -1,0 +1,30 @@
+"global agg with a terms filtered alias":
+  - skip:
+      version: "- 8.9.99"
+      reason: Fixed in 8.10
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"name": "one"}'
+          - '{"index": {}}'
+          - '{"name": "two"}'
+          - '{"index": {}}'
+          - '{"name": "two"}'
+
+  - do:
+      indices.put_alias:
+        index: test
+        name: test-filtered
+        body: {"filter": {"terms": {"name": [ "one" ] }}}
+
+  - do:
+      search:
+        index: test-filtered
+        body:
+          aggs:
+            all_docs:
+              global: {}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -31,7 +31,9 @@ public class GlobalAggregator extends BucketsAggregator implements SingleBucketA
         throws IOException {
 
         super(name, subFactories, context, null, CardinalityUpperBound.ONE, metadata);
-        weight = context.filterQuery(new MatchAllDocsQuery()).createWeight(context.searcher(), scoreMode(), 1.0f);
+        weight = context.searcher()
+            .rewrite(context.filterQuery(new MatchAllDocsQuery()))
+            .createWeight(context.searcher(), scoreMode(), 1.0f);
     }
 
     @Override


### PR DESCRIPTION
Some queries need to be rewritten before they support Weights; TermsQuery
has recently changed to require this, for example.  The GlobalAggregator was
not calling rewrite() on possible alias filters, meaning that an index alias with
a terms filter would cause an exception when combined with a global agg.

Fixes #98076 