### PR TITLE
[DOCS] Node stats API: fix descriptions of 'cache_size' and 'cache_count'

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -682,12 +682,11 @@ Number of query cache misses.
 
 `cache_size`::
 (integer)
-Size, in bytes, of the query cache.
+Current number of cached queries.
 
 `cache_count`::
 (integer)
-Count of queries
-in the query cache.
+Total number of all queries that have been cached.
 
 `evictions`::
 (integer)


### PR DESCRIPTION
Fixes the descriptions of `cache_size` and `cache_count` in the [Node stats API docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html#cluster-nodes-stats-api-response-body).

Closes https://github.com/elastic/elasticsearch/issues/95510