### PR TITLE
Backport EQL async missing events fix to 8.9, see #97718 and #98097

### DIFF
--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
@@ -39,7 +39,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         super(in);
         nodeName = in.readString();
         if (in.getTransportVersion().before(TransportVersion.V_8_500_041)
-            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
+            || in.getTransportVersion().id() == TransportVersion.V_8_500_049.id()) {
             Version.readVersion(in);
         }
 
@@ -103,7 +103,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(nodeName);
         if (out.getTransportVersion().before(TransportVersion.V_8_500_041)
-            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
+            || out.getTransportVersion().id() == TransportVersion.V_8_500_049.id()) {
             Version.writeVersion(Version.CURRENT, out);
         }
 

--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
@@ -38,7 +38,8 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     MainResponse(StreamInput in) throws IOException {
         super(in);
         nodeName = in.readString();
-        if (in.getTransportVersion().before(TransportVersion.V_8_500_041)) {
+        if (in.getTransportVersion().before(TransportVersion.V_8_500_041)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             Version.readVersion(in);
         }
 
@@ -48,10 +49,12 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         // the lucene version was previously read by inferring from either Version or IndexVersion.
         // Now the lucene version is read explicitly.
         String wireLuceneVersion = null;
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_037)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_037)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             wireLuceneVersion = in.readString();
         } else {
-            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_031)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_031)
+                && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 wireLuceneVersion = IndexVersion.readVersion(in).luceneVersion().toString();
             }
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_019)) {
@@ -99,7 +102,8 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(nodeName);
-        if (out.getTransportVersion().before(TransportVersion.V_8_500_041)) {
+        if (out.getTransportVersion().before(TransportVersion.V_8_500_041)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             Version.writeVersion(Version.CURRENT, out);
         }
 
@@ -108,10 +112,12 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         // for those versions until the new format has propagated through serverless. Additionally,
         // the lucene version was previously inferred from either Version or IndexVersion.
         // Now the lucene version is written explicitly.
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_037)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_037)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeString(luceneVersion);
         } else {
-            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_031)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_031)
+                && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 IndexVersion.writeVersion(IndexVersion.current(), out);
             }
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_019)) {

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -180,7 +180,9 @@ public record Build(
 
     public static Build readBuild(StreamInput in) throws IOException {
         final String flavor;
-        if (in.getTransportVersion().before(TransportVersion.V_8_3_0) || in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_039)) {
+        if (in.getTransportVersion().before(TransportVersion.V_8_3_0)
+            || in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_039)
+                && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             flavor = in.readString();
         } else {
             flavor = "default";
@@ -194,7 +196,8 @@ public record Build(
         final String minWireVersion;
         final String minIndexVersion;
         final String displayString;
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_041)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_041)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             minWireVersion = in.readString();
             minIndexVersion = in.readString();
             displayString = in.readString();
@@ -211,7 +214,8 @@ public record Build(
 
     public static void writeBuild(Build build, StreamOutput out) throws IOException {
         if (out.getTransportVersion().before(TransportVersion.V_8_3_0)
-            || out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_039)) {
+            || out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_039)
+                && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeString(build.flavor());
         }
         out.writeString(build.type().displayName());
@@ -219,7 +223,8 @@ public record Build(
         out.writeString(build.date());
         out.writeBoolean(build.isSnapshot());
         out.writeString(build.qualifiedVersion());
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_041)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_041)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeString(build.minWireCompatVersion());
             out.writeString(build.minIndexCompatVersion());
             out.writeString(build.displayString());

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -171,9 +171,13 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_046 = registerTransportVersion(8_500_046, "61666d4c-a4f0-40db-8a3d-4806718247c5");
     public static final TransportVersion V_8_500_047 = registerTransportVersion(8_500_047, "4b1682fe-c37e-4184-80f6-7d57fcba9b3d");
     public static final TransportVersion V_8_500_048 = registerTransportVersion(8_500_048, "f9658aa5-f066-4edb-bcb9-40bf256c9294");
+    // V_8_500_049 used to backport of EQL missing events fix to in 8.9
+    // https://github.com/elastic/elasticsearch/commit/9ab8f71b01bba55a39664be8b74a1a3bcd57cf3e
+    public static final TransportVersion V_8_500_049 = registerTransportVersion(8_500_049, "42b43816-a3f3-430f-87c5-a54ec37e574c");
+    public static final TransportVersion V_8_500_050 = registerTransportVersion(8_500_050, "44016124-e960-46e8-9033-67f3ad73d274");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_048);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_050);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -270,7 +270,8 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         usedBuiltInTokenizers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
         usedBuiltInTokenFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
         usedBuiltInAnalyzers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        if (input.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)) {
+        if (input.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)
+            && input.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             usedSynonyms = input.readImmutableMap(SynonymsStats::new);
         } else {
             usedSynonyms = Collections.emptyMap();
@@ -287,7 +288,8 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         out.writeCollection(usedBuiltInTokenizers);
         out.writeCollection(usedBuiltInTokenFilters);
         out.writeCollection(usedBuiltInAnalyzers);
-        if (out.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)) {
+        if (out.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeMap(usedSynonyms, StreamOutput::writeString, (o, v) -> v.writeTo(o));
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersRequest.java
@@ -44,14 +44,17 @@ public class ReloadAnalyzersRequest extends BroadcastRequest<ReloadAnalyzersRequ
     public ReloadAnalyzersRequest(StreamInput in) throws IOException {
         super(in);
         this.resource = in.readOptionalString();
-        this.preview = in.getTransportVersion().onOrAfter(PREVIEW_OPTION_TRANSPORT_VERSION) && in.readBoolean();
+        this.preview = in.getTransportVersion().onOrAfter(PREVIEW_OPTION_TRANSPORT_VERSION)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()
+            && in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalString(resource);
-        if (out.getTransportVersion().onOrAfter(PREVIEW_OPTION_TRANSPORT_VERSION)) {
+        if (out.getTransportVersion().onOrAfter(PREVIEW_OPTION_TRANSPORT_VERSION)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeBoolean(preview);
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/AbstractNamedDiffable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AbstractNamedDiffable.java
@@ -25,6 +25,7 @@ public abstract class AbstractNamedDiffable<T extends NamedDiffable<T>> implemen
     @Override
     public Diff<T> diff(T previousState) {
         if (this.get().equals(previousState)) {
+            // TODO what about backport version checks?
             return new CompleteNamedDiff<>(previousState.getWriteableName(), previousState.getMinimalSupportedVersion());
         } else {
             return new CompleteNamedDiff<>(get());

--- a/server/src/main/java/org/elasticsearch/cluster/NamedDiffableValueSerializer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NamedDiffableValueSerializer.java
@@ -31,11 +31,13 @@ public class NamedDiffableValueSerializer<T extends NamedDiffable<T>> extends Di
 
     @Override
     public boolean supportsVersion(Diff<T> value, TransportVersion version) {
+        // TODO how to do backport version checks here?
         return version.onOrAfter(((NamedDiff<?>) value).getMinimalSupportedVersion());
     }
 
     @Override
     public boolean supportsVersion(T value, TransportVersion version) {
+        // TODO how to do backport version checks here?
         return version.onOrAfter(value.getMinimalSupportedVersion());
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -163,7 +163,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
             out.writeOptionalWriteable(dataRetention);
         }
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_026)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_026)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeOptionalWriteable(downsampling);
         }
     }
@@ -174,7 +175,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         } else {
             dataRetention = null;
         }
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_026)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_026)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             downsampling = in.readOptionalWriteable(Downsampling::read);
         } else {
             downsampling = null;

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -344,7 +344,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             }
         }
         this.roles = Collections.unmodifiableSortedSet(roles);
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_024)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_024)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             versionInfo = new VersionInformation(Version.readVersion(in), IndexVersion.readVersion(in), IndexVersion.readVersion(in));
         } else {
             versionInfo = inferVersionInformation(Version.readVersion(in));
@@ -381,7 +382,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             o.writeString(role.roleNameAbbreviation());
             o.writeBoolean(role.canContainData());
         });
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_024)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_024)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             Version.writeVersion(versionInfo.nodeVersion(), out);
             IndexVersion.writeVersion(versionInfo.minIndexVersion(), out);
             IndexVersion.writeVersion(versionInfo.maxIndexVersion(), out);

--- a/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
@@ -62,6 +62,7 @@ public class VersionCheckingStreamOutput extends StreamOutput {
     }
 
     private void checkVersionCompatibility(VersionedNamedWriteable namedWriteable) {
+        // TODO how to do backport checks here?
         if (namedWriteable.getMinimalSupportedVersion().after(getTransportVersion())) {
             throw new IllegalArgumentException(
                 "["

--- a/server/src/main/java/org/elasticsearch/common/io/stream/VersionedNamedWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/VersionedNamedWriteable.java
@@ -39,6 +39,7 @@ public interface VersionedNamedWriteable extends NamedWriteable {
      * @return true if the custom should be serialized and false otherwise
      */
     static <T extends VersionedNamedWriteable> boolean shouldSerialize(final StreamOutput out, final T custom) {
+        // TODO how to do backport checks here?
         return out.getTransportVersion().onOrAfter(custom.getMinimalSupportedVersion());
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
@@ -38,14 +38,16 @@ public class MatchNoneQueryBuilder extends AbstractQueryBuilder<MatchNoneQueryBu
      */
     public MatchNoneQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_029)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_029)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             rewriteReason = in.readOptionalString();
         }
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_029)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_029)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeOptionalString(rewriteReason);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -165,7 +165,8 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         settings.fuzzyPrefixLength(in.readVInt());
         settings.fuzzyMaxExpansions(in.readVInt());
         settings.fuzzyTranspositions(in.readBoolean());
-        if (in.getTransportVersion().onOrAfter(TYPE_FIELD_ADDED_VERSION)) {
+        if (in.getTransportVersion().onOrAfter(TYPE_FIELD_ADDED_VERSION)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             this.type = MultiMatchQueryBuilder.Type.readFromStream(in);
         } else {
             this.type = DEFAULT_TYPE;
@@ -192,7 +193,8 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         out.writeVInt(settings.fuzzyPrefixLength());
         out.writeVInt(settings.fuzzyMaxExpansions());
         out.writeBoolean(settings.fuzzyTranspositions());
-        if (out.getTransportVersion().onOrAfter(TYPE_FIELD_ADDED_VERSION)) {
+        if (out.getTransportVersion().onOrAfter(TYPE_FIELD_ADDED_VERSION)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             type.writeTo(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/TermsSetQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermsSetQueryBuilder.java
@@ -78,7 +78,8 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
         this.values = (List<?>) in.readGenericValue();
         this.minimumShouldMatchField = in.readOptionalString();
         this.minimumShouldMatchScript = in.readOptionalWriteable(Script::new);
-        if (in.getTransportVersion().onOrAfter(MINIMUM_SHOULD_MATCH_ADDED_VERSION)) {
+        if (in.getTransportVersion().onOrAfter(MINIMUM_SHOULD_MATCH_ADDED_VERSION)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             this.minimumShouldMatch = in.readOptionalString();
         }
     }
@@ -89,7 +90,8 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
         out.writeGenericValue(values);
         out.writeOptionalString(minimumShouldMatchField);
         out.writeOptionalWriteable(minimumShouldMatchScript);
-        if (out.getTransportVersion().onOrAfter(MINIMUM_SHOULD_MATCH_ADDED_VERSION)) {
+        if (out.getTransportVersion().onOrAfter(MINIMUM_SHOULD_MATCH_ADDED_VERSION)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeOptionalString(minimumShouldMatch);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/downsample/DownsampleIndexerAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/downsample/DownsampleIndexerAction.java
@@ -68,7 +68,9 @@ public class DownsampleIndexerAction extends ActionType<DownsampleIndexerAction.
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030) && in.readBoolean()) {
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030)
+                && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()
+                && in.readBoolean()) {
                 this.indexStartTimeMillis = in.readVLong();
                 this.indexEndTimeMillis = in.readVLong();
             } else {
@@ -131,7 +133,8 @@ public class DownsampleIndexerAction extends ActionType<DownsampleIndexerAction.
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030)
+                && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 out.writeBoolean(true);
                 out.writeVLong(indexStartTimeMillis);
                 out.writeVLong(indexEndTimeMillis);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelDefinitionPartAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelDefinitionPartAction.java
@@ -91,7 +91,8 @@ public class PutTrainedModelDefinitionPartAction extends ActionType<Acknowledged
             this.part = in.readVInt();
             this.totalDefinitionLength = in.readVLong();
             this.totalParts = in.readVInt();
-            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)
+                && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 this.allowOverwriting = in.readBoolean();
             } else {
                 this.allowOverwriting = false;
@@ -148,7 +149,8 @@ public class PutTrainedModelDefinitionPartAction extends ActionType<Acknowledged
             out.writeVInt(part);
             out.writeVLong(totalDefinitionLength);
             out.writeVInt(totalParts);
-            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)
+                && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 out.writeBoolean(allowOverwriting);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelVocabularyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelVocabularyAction.java
@@ -91,7 +91,8 @@ public class PutTrainedModelVocabularyAction extends ActionType<AcknowledgedResp
             } else {
                 this.scores = List.of();
             }
-            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)
+                && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 this.allowOverwriting = in.readBoolean();
             } else {
                 this.allowOverwriting = false;
@@ -139,7 +140,8 @@ public class PutTrainedModelVocabularyAction extends ActionType<AcknowledgedResp
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
                 out.writeCollection(scores, StreamOutput::writeDouble);
             }
-            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_043)
+                && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                 out.writeBoolean(allowOverwriting);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupShardStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupShardStatus.java
@@ -140,7 +140,9 @@ public class RollupShardStatus implements Task.Status {
         numSent = in.readLong();
         numIndexed = in.readLong();
         numFailed = in.readLong();
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030) && in.readBoolean()) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()
+            && in.readBoolean()) {
             totalShardDocCount = in.readVLong();
             lastSourceTimestamp = in.readVLong();
             lastTargetTimestamp = in.readVLong();
@@ -250,7 +252,8 @@ public class RollupShardStatus implements Task.Status {
         out.writeLong(numSent);
         out.writeLong(numIndexed);
         out.writeLong(numFailed);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_030)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeBoolean(true);
             out.writeVLong(totalShardDocCount);
             out.writeVLong(lastSourceTimestamp);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
@@ -141,7 +141,8 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
         } else {
             this.clusters = null;
         }
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_035)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_035)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             this.completionTimeMillis = in.readOptionalVLong();
         } else {
             this.completionTimeMillis = null;
@@ -166,7 +167,8 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
             // optional since only CCS uses is; it is null for local-only searches
             out.writeOptionalWriteable(clusters);
         }
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_035)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_035)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeOptionalVLong(completionTimeMillis);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateResponse.java
@@ -27,7 +27,8 @@ public class AuthenticateResponse extends ActionResponse implements ToXContent {
     public AuthenticateResponse(StreamInput in) throws IOException {
         super(in);
         authentication = new Authentication(in);
-        if (in.getTransportVersion().onOrAfter(VERSION_OPERATOR_FIELD)) {
+        if (in.getTransportVersion().onOrAfter(VERSION_OPERATOR_FIELD)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             operator = in.readBoolean();
         } else {
             operator = false;
@@ -50,7 +51,8 @@ public class AuthenticateResponse extends ActionResponse implements ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         authentication.writeTo(out);
-        if (out.getTransportVersion().onOrAfter(VERSION_OPERATOR_FIELD)) {
+        if (out.getTransportVersion().onOrAfter(VERSION_OPERATOR_FIELD)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeBoolean(operator);
         }
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelDefinitionPartActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelDefinitionPartActionRequestTests.java
@@ -71,7 +71,7 @@ public class PutTrainedModelDefinitionPartActionRequestTests extends AbstractBWC
 
     @Override
     protected Request mutateInstanceForVersion(Request instance, TransportVersion version) {
-        if (version.before(TransportVersion.V_8_500_043)) {
+        if (version.before(TransportVersion.V_8_500_043) || version.id() == TransportVersion.V_8_500_049.id()) {
             return new Request(
                 instance.getModelId(),
                 instance.getDefinition(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceConfigItemTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceConfigItemTestCase.java
@@ -89,6 +89,7 @@ public abstract class InferenceConfigItemTestCase<T extends VersionedNamedWritea
     @Override
     protected List<TransportVersion> bwcVersions() {
         T obj = createTestInstance();
+        // TODO how to do backport checks here?
         return getAllBWCVersions().stream().filter(v -> v.onOrAfter(obj.getMinimalSupportedVersion())).collect(Collectors.toList());
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -72,7 +72,8 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
 
     public QueryRuleCriteria(StreamInput in) throws IOException {
         this.criteriaType = in.readEnum(QueryRuleCriteriaType.class);
-        if (in.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
+        if (in.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)
+            && in.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             this.criteriaMetadata = in.readOptionalString();
             this.criteriaValues = in.readOptionalList(StreamInput::readGenericValue);
         } else {
@@ -84,7 +85,8 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(criteriaType);
-        if (out.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
+        if (out.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)
+            && out.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             out.writeOptionalString(criteriaMetadata);
             out.writeOptionalCollection(criteriaValues, StreamOutput::writeGenericValue);
         } else {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
@@ -48,7 +48,7 @@ public class GetQueryRulesetActionResponseBWCSerializingTests extends AbstractBW
 
     @Override
     protected GetQueryRulesetAction.Response mutateInstanceForVersion(GetQueryRulesetAction.Response instance, TransportVersion version) {
-        if (version.before(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
+        if (version.before(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION) || version.id() == TransportVersion.V_8_500_049.id()) {
             List<QueryRule> rules = new ArrayList<>();
             for (QueryRule rule : instance.queryRuleset().rules()) {
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
@@ -50,7 +50,7 @@ public class PutQueryRulesetActionRequestBWCSerializingTests extends AbstractBWC
     @Override
     protected PutQueryRulesetAction.Request mutateInstanceForVersion(PutQueryRulesetAction.Request instance, TransportVersion version) {
 
-        if (version.before(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
+        if (version.before(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION) || version.id() == TransportVersion.V_8_500_049.id()) {
             List<QueryRule> rules = new ArrayList<>();
             for (QueryRule rule : instance.queryRuleset().rules()) {
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -360,7 +360,7 @@ public final class TokenService {
             final BytesReference tokenDocument;
             try {
                 final String userTokenId;
-                if (tokenVersion.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+                if (tokenVersion.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH) && tokenVersion.id() != TransportVersion.V_8_500_049.id()) {
                     assert accessTokenBytes.length == RAW_TOKEN_BYTES_TOTAL_LENGTH;
                     MessageDigest userTokenIdDigest = sha256();
                     userTokenIdDigest.update(accessTokenBytes, RAW_TOKEN_BYTES_LENGTH, RAW_TOKEN_DOC_ID_BYTES_LENGTH);
@@ -532,7 +532,8 @@ public final class TokenService {
                     }
                     Map<String, Object> accessSource = (Map<String, Object>) response.getSource().get("access_token");
                     Map<String, Object> refreshSource = (Map<String, Object>) response.getSource().get("refresh_token");
-                    boolean versionGetForRefresh = tokenVersion.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH);
+                    boolean versionGetForRefresh = tokenVersion.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)
+                        && tokenVersion.id() != TransportVersion.V_8_500_049.id();
                     if (accessSource == null) {
                         onFailure.accept(new IllegalStateException("token document is missing the access_token field"));
                     } else if (accessSource.containsKey("user_token") == false) {
@@ -604,7 +605,7 @@ public final class TokenService {
         try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)), bytes.length)) {
             final TransportVersion version = TransportVersion.readVersion(in);
             in.setTransportVersion(version);
-            if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+            if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH) && version.id() != TransportVersion.V_8_500_049.id()) {
                 byte[] accessTokenBytes = in.readByteArray();
                 if (accessTokenBytes.length != RAW_TOKEN_BYTES_TOTAL_LENGTH) {
                     logger.debug(
@@ -1044,7 +1045,7 @@ public final class TokenService {
             try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)), bytes.length)) {
                 final TransportVersion version = TransportVersion.readVersion(in);
                 in.setTransportVersion(version);
-                if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+                if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH) && version.id() != TransportVersion.V_8_500_049.id()) {
                     final byte[] refreshTokenBytes = in.readByteArray();
                     if (refreshTokenBytes.length != RAW_TOKEN_BYTES_TOTAL_LENGTH) {
                         logger.debug(
@@ -1369,7 +1370,8 @@ public final class TokenService {
                 // We expect this to protect against race conditions that manifest within few ms
                 final Iterator<TimeValue> backoff = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(10), 8).iterator();
                 final String tokenDocId;
-                if (refreshTokenStatus.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+                if (refreshTokenStatus.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)
+                    && refreshTokenStatus.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                     MessageDigest userTokenIdDigest = sha256();
                     userTokenIdDigest.update(
                         Base64.getUrlDecoder().decode(decryptedTokens[0]),
@@ -2068,7 +2070,7 @@ public final class TokenService {
 
     public String prependVersionAndEncodeAccessToken(TransportVersion version, byte[] accessTokenBytes) throws IOException,
         GeneralSecurityException {
-        if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+        if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH) && version.id() != TransportVersion.V_8_500_049.id()) {
             try (BytesStreamOutput out = new BytesStreamOutput(VERSION_BYTES + RAW_TOKEN_BYTES_TOTAL_LENGTH)) {
                 out.setTransportVersion(version);
                 TransportVersion.writeVersion(version, out);
@@ -2114,7 +2116,7 @@ public final class TokenService {
     }
 
     public static String prependVersionAndEncodeRefreshToken(TransportVersion version, byte[] refreshTokenBytes) throws IOException {
-        if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+        if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH) && version.id() != TransportVersion.V_8_500_049.id()) {
             try (BytesStreamOutput out = new BytesStreamOutput(VERSION_BYTES + RAW_TOKEN_BYTES_TOTAL_LENGTH)) {
                 out.setTransportVersion(version);
                 TransportVersion.writeVersion(version, out);
@@ -2211,7 +2213,7 @@ public final class TokenService {
     }
 
     Tuple<byte[], byte[]> getRandomTokenBytes(TransportVersion version, boolean includeRefreshToken) {
-        if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+        if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH) && version.id() != TransportVersion.V_8_500_049.id()) {
             byte[] accessTokenBytes = getRandomBytes(RAW_TOKEN_BYTES_TOTAL_LENGTH);
             if (includeRefreshToken) {
                 byte[] refreshTokenBytes = new byte[RAW_TOKEN_BYTES_TOTAL_LENGTH];

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -1107,7 +1107,8 @@ public class TokenServiceTests extends ESTestCase {
                         XContentHelper.convertToMap(XContentType.JSON.xContent(), Strings.toString(builder), false)
                     );
                     accessTokenMap.put("invalidated", isInvalidated);
-                    if (userToken.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+                    if (userToken.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)
+                        && userToken.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
                         accessTokenMap.put(
                             "token",
                             Base64.getUrlEncoder().withoutPadding().encodeToString(sha256().digest(accessTokenBytes))
@@ -1144,7 +1145,8 @@ public class TokenServiceTests extends ESTestCase {
 
     // public for tests
     public static String tokenDocIdFromAccessTokenBytes(byte[] accessTokenBytes, TransportVersion tokenVersion) {
-        if (tokenVersion.onOrAfter(TokenService.VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+        if (tokenVersion.onOrAfter(TokenService.VERSION_GET_TOKEN_DOC_FOR_REFRESH)
+            && tokenVersion.id() != TransportVersion.V_8_500_049.id()) {
             MessageDigest userTokenIdDigest = sha256();
             userTokenIdDigest.update(accessTokenBytes, RAW_TOKEN_BYTES_LENGTH, RAW_TOKEN_DOC_ID_BYTES_LENGTH);
             return Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest());
@@ -1165,7 +1167,8 @@ public class TokenServiceTests extends ESTestCase {
         UserToken userToken = buildUserToken(tokenService, accessTokenBytes, authentication, null, Map.of());
         final String storedAccessToken;
         final String storedRefreshToken;
-        if (userToken.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+        if (userToken.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)
+            && userToken.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             storedAccessToken = Base64.getUrlEncoder().withoutPadding().encodeToString(sha256().digest(accessTokenBytes));
             storedRefreshToken = Base64.getUrlEncoder().withoutPadding().encodeToString(sha256().digest(refreshTokenBytes));
         } else if (userToken.getTransportVersion().onOrAfter(TokenService.VERSION_HASHED_TOKENS)) {
@@ -1201,7 +1204,8 @@ public class TokenServiceTests extends ESTestCase {
             source = XContentTestUtils.convertToXContent(sourceAsMap, XContentType.JSON);
         }
         final BytesReference docSource = source;
-        if (userToken.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
+        if (userToken.getTransportVersion().onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)
+            && userToken.getTransportVersion().id() != TransportVersion.V_8_500_049.id()) {
             doAnswer(invocationOnMock -> {
                 GetRequest request = (GetRequest) invocationOnMock.getArguments()[0];
                 @SuppressWarnings("unchecked")


### PR DESCRIPTION
Needed to backport fix https://github.com/elastic/elasticsearch/pull/97718, that allows to properly manage async missing events in EQL, to v 8.9

The fix involves the serialization of a new field added to Event.
To properly handle TransportVersion checks we are:
- adding a new constant `TransportVersion.V_8_500_049` for v 8.9
- adding a new constant `TransportVersion.V_8_500_050` for v 8.10
- modifying all the checks after `TransportVersion.V_8_500_020` not related to this fix, so that they exclude `TransportVersion.V_8_500_049`