### PR TITLE
Implement RequestTrackingHttpChannel#toString

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -653,5 +653,10 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         public InetSocketAddress getRemoteAddress() {
             return inner.getRemoteAddress();
         }
+
+        @Override
+        public String toString() {
+            return inner.toString();
+        }
     }
 }


### PR DESCRIPTION
This appears in trace log messages (e.g. when using the REST request
tracer) and the default `toString()` implementation is kinda useless
there. This commit delegates to the inner channel so we can see the
local and remote addresses.