### PR TITLE
Fix qualified export for serverless metering

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -371,7 +371,7 @@ module org.elasticsearch.server {
 
     exports org.elasticsearch.action.datastreams.lifecycle;
     exports org.elasticsearch.action.downsample;
-    exports org.elasticsearch.plugins.internal to co.elastic.elasticsearch.metering, org.elasticsearch.settings.secure;
+    exports org.elasticsearch.plugins.internal to org.elasticsearch.metering, org.elasticsearch.settings.secure;
 
     provides java.util.spi.CalendarDataProvider with org.elasticsearch.common.time.IsoCalendarDataProvider;
     provides org.elasticsearch.xcontent.ErrorOnUnknown with org.elasticsearch.common.xcontent.SuggestingErrorOnUnknown;


### PR DESCRIPTION
the module name of serverless metering is org.elasticsearch.metering previously an incorrect name co.elastic.metering was used
