### PR TITLE
[DOCS] Add 'boost' parameter to match query

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -65,6 +65,17 @@ See <<query-dsl-match-query-synonyms,Use synonyms with match query>> for an
 example.
 --
 
+`boost`::
++
+--
+(Optional, float) Floating point number used to decrease or increase the
+<<relevance-scores,relevance scores>> of the query. Defaults to `1.0`.
+
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+--
+
 `fuzziness`::
 (Optional, string) Maximum edit distance allowed for matching. See <<fuzziness>>
 for valid values and more information. See <<query-dsl-match-query-fuzziness>>


### PR DESCRIPTION
The [multi-match query docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-multi-match-query.html) point to the [match query documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query.html) for a description of `boost`, but `boost` is not mentioned in the match query documentation. This PR fixes that.

I've taken the `boost` description that's already used in the docs for other queries, like [query string query](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-top-level-params).

Closes https://github.com/elastic/elasticsearch/issues/97441