### PR TITLE
Mute test in feature-migration.asciidoc

### DIFF
--- a/docs/reference/migration/apis/feature-migration.asciidoc
+++ b/docs/reference/migration/apis/feature-migration.asciidoc
@@ -142,7 +142,7 @@ Example response:
   "migration_status" : "NO_MIGRATION_NEEDED"
 }
 --------------------------------------------------
-
+// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/97780]
 
 When you submit a POST request to the `_migration/system_features` endpoint to
 start the migration process, the response indicates what features will be


### PR DESCRIPTION

Mutes the test referenced in the following issue for 8.9: https://github.com/elastic/elasticsearch/pull/97780


Links to builds, failures, and related PRs: 

- https://gradle-enterprise.elastic.co/s/6rfluzkg5jjba/console-log?task=:docs:yamlRestTest
- https://github.com/elastic/elasticsearch/pull/97781
- https://github.com/elastic/elasticsearch/pull/97841
- https://elastic.slack.com/archives/CP2CWK44D/p1690907947534949
