### PR TITLE
Draft: Randomizing executors in some unit tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -372,7 +372,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             doAggregationPostCollection(firstCollector);
             return collectorManager.reduce(Collections.singletonList(firstCollector));
         } else {
-            if (-1 < 0) throw new IllegalStateException("Expected, concurrent search path hit.");
             final List<C> collectors = new ArrayList<>(leafSlices.length);
             collectors.add(firstCollector);
             final ScoreMode scoreMode = firstCollector.scoreMode();

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -372,6 +372,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             doAggregationPostCollection(firstCollector);
             return collectorManager.reduce(Collections.singletonList(firstCollector));
         } else {
+            if (-1 < 0) throw new IllegalStateException("Expected, concurrent search path hit.");
             final List<C> collectors = new ArrayList<>(leafSlices.length);
             collectors.add(firstCollector);
             final ScoreMode scoreMode = firstCollector.scoreMode();

--- a/server/src/test/java/org/elasticsearch/search/SearchCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchCancellationTests.java
@@ -55,8 +55,10 @@ public class SearchCancellationTests extends ESTestCase {
         // we need at least 2 segments - so no merges should be allowed
         w.w.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
         w.setDoRandomForceMerge(false);
+        // TODO this might need more documents if we want to hit the concurrent search path more often
         indexRandomDocuments(w, TestUtil.nextInt(random(), 2, 20));
         w.flush();
+        // TODO this might need more documents if we want to hit the concurrent search path more often
         indexRandomDocuments(w, TestUtil.nextInt(random(), 1, 20));
         reader = w.getReader();
         w.close();
@@ -79,14 +81,21 @@ public class SearchCancellationTests extends ESTestCase {
         reader = null;
     }
 
-    public void testAddingCancellationActions() throws IOException {
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
+    private ContextIndexSearcher createSearcher() throws IOException {
+        // TODO maybe randomize setting executor here
+        return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            1,
+            true,
+            null
         );
+    }
+
+    public void testAddingCancellationActions() throws IOException {
+        ContextIndexSearcher searcher = createSearcher();
         NullPointerException npe = expectThrows(NullPointerException.class, () -> searcher.addQueryCancellation(null));
         assertEquals("cancellation runnable should not be null", npe.getMessage());
 
@@ -99,13 +108,7 @@ public class SearchCancellationTests extends ESTestCase {
     public void testCancellableCollector() throws IOException {
         TotalHitCountCollector collector1 = new TotalHitCountCollector();
         Runnable cancellation = () -> { throw new TaskCancelledException("cancelled"); };
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
-        );
+        ContextIndexSearcher searcher = createSearcher();
 
         searcher.search(new MatchAllDocsQuery(), collector1);
         assertThat(collector1.getTotalHits(), equalTo(reader.numDocs()));
@@ -126,13 +129,7 @@ public class SearchCancellationTests extends ESTestCase {
                 throw new TaskCancelledException("cancelled");
             }
         };
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
-        );
+        ContextIndexSearcher searcher = createSearcher();
         searcher.addQueryCancellation(cancellation);
         CompiledAutomaton automaton = new CompiledAutomaton(new RegExp("a.*").toAutomaton());
 
@@ -188,13 +185,7 @@ public class SearchCancellationTests extends ESTestCase {
                 throw new TaskCancelledException("cancelled");
             }
         };
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
-        );
+        ContextIndexSearcher searcher = createSearcher();
         searcher.addQueryCancellation(cancellation);
         final LeafReader leaf = searcher.getIndexReader().leaves().get(0).reader();
         expectThrows(TaskCancelledException.class, () -> leaf.getFloatVectorValues(KNN_FIELD_NAME));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
@@ -79,12 +79,15 @@ public class TimeSeriesCancellationTests extends ESTestCase {
     }
 
     public void testLowLevelCancellationActions() throws IOException {
+        // TODO randomly set executor for parallel collection here
         ContextIndexSearcher searcher = new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            1,
+            true,
+            null
         );
         TimeSeriesIndexSearcher timeSeriesIndexSearcher = new TimeSeriesIndexSearcher(searcher, List.of(() -> {
             throw new TaskCancelledException("Cancel");

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
@@ -12,7 +12,6 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Sort;
@@ -79,16 +78,7 @@ public class TimeSeriesCancellationTests extends ESTestCase {
     }
 
     public void testLowLevelCancellationActions() throws IOException {
-        // TODO randomly set executor for parallel collection here
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            1,
-            true,
-            null
-        );
+        ContextIndexSearcher searcher = newContextSearcher(reader);
         TimeSeriesIndexSearcher timeSeriesIndexSearcher = new TimeSeriesIndexSearcher(searcher, List.of(() -> {
             throw new TaskCancelledException("Cancel");
         }));

--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.search.internal;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.document.Document;
@@ -101,6 +103,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
+@Repeat(iterations = 100)
 public class ContextIndexSearcherTests extends ESTestCase {
     public void testIntersectScorerAndRoleBits() throws Exception {
         final Directory directory = newDirectory();
@@ -340,46 +343,58 @@ public class ContextIndexSearcherTests extends ESTestCase {
 
         DocumentSubsetDirectoryReader filteredReader = new DocumentSubsetDirectoryReader(reader, cache, roleQuery);
 
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            filteredReader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
-        );
+        ThreadPoolExecutor executor = null;
+        try {
+            if (randomBoolean()) {
+                executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(randomIntBetween(2, 5));
+            }
+            ContextIndexSearcher searcher = new ContextIndexSearcher(
+                filteredReader,
+                IndexSearcher.getDefaultSimilarity(),
+                IndexSearcher.getDefaultQueryCache(),
+                IndexSearcher.getDefaultQueryCachingPolicy(),
+                1,
+                true,
+                executor
+            );
 
-        for (LeafReaderContext context : searcher.getIndexReader().leaves()) {
-            assertThat(context.reader(), instanceOf(SequentialStoredFieldsLeafReader.class));
-            SequentialStoredFieldsLeafReader lf = (SequentialStoredFieldsLeafReader) context.reader();
-            assertNotNull(lf.getSequentialStoredFieldsReader());
+            for (LeafReaderContext context : searcher.getIndexReader().leaves()) {
+                assertThat(context.reader(), instanceOf(SequentialStoredFieldsLeafReader.class));
+                SequentialStoredFieldsLeafReader lf = (SequentialStoredFieldsLeafReader) context.reader();
+                assertNotNull(lf.getSequentialStoredFieldsReader());
+            }
+            // Assert wrapping
+            assertEquals(ExitableDirectoryReader.class, searcher.getIndexReader().getClass());
+            for (LeafReaderContext lrc : searcher.getIndexReader().leaves()) {
+                assertEquals(ExitableLeafReader.class, lrc.reader().getClass());
+                assertNotEquals(ExitableTerms.class, lrc.reader().terms("foo").getClass());
+                assertNotEquals(ExitablePointValues.class, lrc.reader().getPointValues("point").getClass());
+            }
+            searcher.addQueryCancellation(() -> {
+            });
+            for (LeafReaderContext lrc : searcher.getIndexReader().leaves()) {
+                assertEquals(ExitableTerms.class, lrc.reader().terms("foo").getClass());
+                assertEquals(ExitablePointValues.class, lrc.reader().getPointValues("point").getClass());
+            }
+
+            // Searching a non-existing term will trigger a null scorer
+            assertEquals(0, searcher.count(new TermQuery(new Term("non_existing_field", "non_existing_value"))));
+
+            assertEquals(1, searcher.count(new TermQuery(new Term("foo", "bar"))));
+
+            // make sure scorers are created only once, see #1725
+            assertEquals(1, searcher.count(new CreateScorerOnceQuery(new MatchAllDocsQuery())));
+
+            TopDocs topDocs = searcher.search(new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "bar"))), 3f), 1);
+            assertEquals(1, topDocs.totalHits.value);
+            assertEquals(1, topDocs.scoreDocs.length);
+            assertEquals(3f, topDocs.scoreDocs[0].score, 0);
+        } finally {
+            executor.shutdown();
         }
-        // Assert wrapping
-        assertEquals(ExitableDirectoryReader.class, searcher.getIndexReader().getClass());
-        for (LeafReaderContext lrc : searcher.getIndexReader().leaves()) {
-            assertEquals(ExitableLeafReader.class, lrc.reader().getClass());
-            assertNotEquals(ExitableTerms.class, lrc.reader().terms("foo").getClass());
-            assertNotEquals(ExitablePointValues.class, lrc.reader().getPointValues("point").getClass());
-        }
-        searcher.addQueryCancellation(() -> {});
-        for (LeafReaderContext lrc : searcher.getIndexReader().leaves()) {
-            assertEquals(ExitableTerms.class, lrc.reader().terms("foo").getClass());
-            assertEquals(ExitablePointValues.class, lrc.reader().getPointValues("point").getClass());
-        }
-
-        // Searching a non-existing term will trigger a null scorer
-        assertEquals(0, searcher.count(new TermQuery(new Term("non_existing_field", "non_existing_value"))));
-
-        assertEquals(1, searcher.count(new TermQuery(new Term("foo", "bar"))));
-
-        // make sure scorers are created only once, see #1725
-        assertEquals(1, searcher.count(new CreateScorerOnceQuery(new MatchAllDocsQuery())));
-
-        TopDocs topDocs = searcher.search(new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "bar"))), 3f), 1);
-        assertEquals(1, topDocs.totalHits.value);
-        assertEquals(1, topDocs.scoreDocs.length);
-        assertEquals(3f, topDocs.scoreDocs[0].score, 0);
 
         IOUtils.close(reader, w, dir);
+
     }
 
     public void testComputeSlices() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
@@ -57,6 +57,7 @@ public class QueryProfilerTests extends ESTestCase {
     public static void setup() throws IOException {
         dir = newDirectory();
         RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+        // might need more documents if we want to hit the concurrent search path more often
         final int numDocs = TestUtil.nextInt(random(), 1, 20);
         for (int i = 0; i < numDocs; ++i) {
             final int numHoles = random().nextInt(5);
@@ -69,12 +70,15 @@ public class QueryProfilerTests extends ESTestCase {
         }
         reader = w.getReader();
         w.close();
+        // TODO randomly set executor for parallel collection here
         searcher = new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             TrivialQueryCachingPolicy.ALWAYS,
-            true
+            1,
+            true,
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -70,16 +71,13 @@ public class QueryProfilerTests extends ESTestCase {
         }
         reader = w.getReader();
         w.close();
-        // TODO randomly set executor for parallel collection here
-        searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            TrivialQueryCachingPolicy.ALWAYS,
-            1,
-            true,
-            null
-        );
+    }
+
+    @Before
+    public void initSearcher() throws IOException {
+        if (searcher == null) {
+            searcher = newContextSearcher(reader, TrivialQueryCachingPolicy.ALWAYS);
+        }
     }
 
     @After

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.search.query;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnByteVectorField;
@@ -57,7 +55,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.Collections;
 
-@Repeat(iterations = 100)
 public class QueryPhaseTimeoutTests extends IndexShardTestCase {
 
     private static Directory dir;
@@ -120,16 +117,8 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
         closeShards(indexShard);
     }
 
-    private static ContextIndexSearcher newContextSearcher(IndexReader reader) throws IOException {
-        return new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            LuceneTestCase.MAYBE_CACHE_POLICY,
-            1,
-            true,
-            randomBoolean() ? threadPoolExecutor : null
-        );
+    private ContextIndexSearcher createContextSearcher(IndexReader reader) throws IOException {
+        return newContextSearcher(reader, randomBoolean() ? threadPoolExecutor : null, LuceneTestCase.MAYBE_CACHE_POLICY, true);
     }
 
     public void testScorerTimeoutTerms() throws IOException {
@@ -258,7 +247,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
     }
 
     private TestSearchContext createSearchContextWithTimeout(TimeoutQuery query, int size) throws IOException {
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader)) {
+        TestSearchContext context = new TestSearchContext(null, indexShard, createContextSearcher(reader)) {
             @Override
             public long getRelativeTimeInMillis() {
                 return query.shouldTimeout ? 1L : 0L;
@@ -271,7 +260,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
     }
 
     private TestSearchContext createSearchContext(Query query, int size) throws IOException {
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        TestSearchContext context = new TestSearchContext(null, indexShard, createContextSearcher(reader));
         context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
         context.parsedQuery(new ParsedQuery(query));
         context.setSize(size);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -447,12 +447,15 @@ public abstract class AggregatorTestCase extends ESTestCase {
         SearchContext ctx = mock(SearchContext.class);
         try {
             when(ctx.searcher()).thenReturn(
+                // TODO maybe randomly use parallel executor here
                 new ContextIndexSearcher(
                     searchExecutionContext.searcher().getIndexReader(),
                     searchExecutionContext.searcher().getSimilarity(),
                     DisabledQueryCache.INSTANCE,
                     TrivialQueryCachingPolicy.NEVER,
-                    false
+                    1,
+                    false,
+                    null
                 )
             );
         } catch (IOException e) {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -453,9 +453,10 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     searchExecutionContext.searcher().getSimilarity(),
                     DisabledQueryCache.INSTANCE,
                     TrivialQueryCachingPolicy.NEVER,
-                    1,
                     false,
-                    null
+                    null,
+                    -1,
+                    -1
                 )
             );
         } catch (IOException e) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.test.AbstractBuilderTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.xpack.core.security.SecurityContext;
@@ -180,16 +179,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
             when(searchExecutionContext.toQuery(new TermsQueryBuilder("field", values[i]))).thenReturn(parsedQuery);
 
             DirectoryReader wrappedDirectoryReader = wrapper.apply(directoryReader);
-            // TODO randomly set executor for parallel collection here
-            IndexSearcher indexSearcher = new ContextIndexSearcher(
-                wrappedDirectoryReader,
-                IndexSearcher.getDefaultSimilarity(),
-                IndexSearcher.getDefaultQueryCache(),
-                IndexSearcher.getDefaultQueryCachingPolicy(),
-                1,
-                true,
-                null
-            );
+            IndexSearcher indexSearcher = newContextSearcher(wrappedDirectoryReader);
 
             int expectedHitCount = valuesHitCount[i];
             logger.info("Going to verify hit count with query [{}] with expected total hits [{}]", parsedQuery.query(), expectedHitCount);
@@ -313,16 +303,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
         DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(directory), shardId);
         DirectoryReader wrappedDirectoryReader = wrapper.apply(directoryReader);
-        // TODO randomly set executor for parallel collection here
-        IndexSearcher indexSearcher = new ContextIndexSearcher(
-            wrappedDirectoryReader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            1,
-            true,
-            null
-        );
+        IndexSearcher indexSearcher = newContextSearcher(wrappedDirectoryReader);
 
         ScoreDoc[] hits = indexSearcher.search(new MatchAllDocsQuery(), 1000).scoreDocs;
         Set<Integer> actualDocIds = new HashSet<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -180,12 +180,15 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
             when(searchExecutionContext.toQuery(new TermsQueryBuilder("field", values[i]))).thenReturn(parsedQuery);
 
             DirectoryReader wrappedDirectoryReader = wrapper.apply(directoryReader);
+            // TODO randomly set executor for parallel collection here
             IndexSearcher indexSearcher = new ContextIndexSearcher(
                 wrappedDirectoryReader,
                 IndexSearcher.getDefaultSimilarity(),
                 IndexSearcher.getDefaultQueryCache(),
                 IndexSearcher.getDefaultQueryCachingPolicy(),
-                true
+                1,
+                true,
+                null
             );
 
             int expectedHitCount = valuesHitCount[i];
@@ -310,12 +313,15 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
         DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(directory), shardId);
         DirectoryReader wrappedDirectoryReader = wrapper.apply(directoryReader);
+        // TODO randomly set executor for parallel collection here
         IndexSearcher indexSearcher = new ContextIndexSearcher(
             wrappedDirectoryReader,
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            1,
+            true,
+            null
         );
 
         ScoreDoc[] hits = indexSearcher.search(new MatchAllDocsQuery(), 1000).scoreDocs;


### PR DESCRIPTION
In order to test concurrent search execution in unit tests more often, this draft shows some
places where we might want to randomly set ContextIndexSearcher executors or increase test document sizes to
increase the likelihood of creating more segments and thus more slices for concurrent search execution.

This PR deliberately modifies the concurrent search path to throw an IllegalStateException to get a feeling for how
likely this path is executed in tests. 