### PR TITLE
Reduce forking in CCR repo

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
@@ -129,6 +129,7 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
 
         GetCcrRestoreFileChunkResponse(StreamInput streamInput) throws IOException {
             super(streamInput);
+            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC); // large responses must fork before deserialization
             offset = streamInput.readVLong();
             chunk = streamInput.readReleasableBytesReference();
         }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -146,7 +146,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             final Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                 threadPool,
                 "my_remote_cluster",
-                EsExecutors.DIRECT_EXECUTOR_SERVICE
+                threadPool.generic()
             );
 
             // Creating a restore session fails if index is not accessible


### PR DESCRIPTION
Today we deserialize the chunks received when creating a follower on the
CCR pool (prior to #97922 this was the transport thread) and then
manually fork off to the GENERIC pool to write the chunk to disk. It's
simpler just to do all this on the GENERIC pool to start with, so this
commit does that.