### PR TITLE
Fork CCS remote-cluster responses

### DIFF
--- a/docs/changelog/98124.yaml
+++ b/docs/changelog/98124.yaml
@@ -1,0 +1,6 @@
+pr: 98124
+summary: Fork CCS remote-cluster responses
+area: Search
+type: bug
+issues:
+ - 97997

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -44,7 +44,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.CountDown;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -467,8 +467,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         ActionListener<SearchResponse> listener,
         BiConsumer<SearchRequest, ActionListener<SearchResponse>> localSearchConsumer
     ) {
-        // TODO pick a more appropriate executor for this work - see https://github.com/elastic/elasticsearch/issues/97997
-        final var remoteClientResponseExecutor = EsExecutors.DIRECT_EXECUTOR_SERVICE;
+        final var remoteClientResponseExecutor = threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION);
         if (localIndices == null && remoteIndices.size() == 1) {
             // if we are searching against a single remote cluster, we simply forward the original search request to such cluster
             // and we directly perform final reduction in the remote cluster


### PR DESCRIPTION
Today during CCS we process responses from remote clusters on the
transport worker thread, but that's not the right place for this work.
This commit moves it to the `SEARCH_COORDINATION` pool.

Closes #97997