### PR TITLE
Change cluster stats synonyms keys

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -850,12 +850,12 @@ Contains statistics about synonyms defined in <<analysis-synonym-tokenfilter,syn
 .Properties of `synonyms` objects
 [%collapsible%open]
 ======
-`synonyms`::
+`inline`::
 (object)
 Inline synonyms defined using `synonyms` configuration in synonym or synonym graph token filters.
 
 +
-.Properties of `synonyms` objects
+.Properties of `inline` objects
 [%collapsible%open]
 =======
 
@@ -870,12 +870,12 @@ Two synonyms configurations with the same synonyms will count as separate ocurre
 Number of indices that use inline synonyms configuration for synonyms token filters.
 =======
 
-`synonyms_path`::
+`paths`::
 (object)
 Contains statistics about synonym files defined as `synonyms_path` in <<analysis-synonym-tokenfilter,synonym>> and <<analysis-synonym-graph-tokenfilter,synonym graph>> token filters configuration.
 
 +
-.Properties of `synonyms_path` objects
+.Properties of `paths` objects
 [%collapsible%open]
 =======
 `count`::
@@ -887,12 +887,12 @@ Occurrences of unique synonym paths in selected nodes.
 Number of indices that use `synonyms_path` configuration for synonyms token filters.
 =======
 
-`synonyms_sets`::
+`sets`::
 (object)
 Contains statistics about synonyms sets configured as `synonyms_set` in <<analysis-synonym-tokenfilter,synonym>> and <<analysis-synonym-graph-tokenfilter,synonym graph>> token filters configuration.
 
 +
-.Properties of `synonyms_sets` objects
+.Properties of `sets` objects
 [%collapsible%open]
 =======
 `count`::

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/20_analysis_stats_synonyms.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/20_analysis_stats_synonyms.yml
@@ -98,9 +98,9 @@
       cluster.stats: {}
 
   - length: { indices.analysis.synonyms: 3 }
-  - match: { indices.analysis.synonyms.synonyms.count: 4 }
-  - match: { indices.analysis.synonyms.synonyms.index_count: 3 }
-  - match: { indices.analysis.synonyms.synonyms_path.count: 3 }
-  - match: { indices.analysis.synonyms.synonyms_path.index_count: 1 }
-  - match: { indices.analysis.synonyms.synonyms_set.count: 3 }
-  - match: { indices.analysis.synonyms.synonyms_set.index_count: 3 }
+  - match: { indices.analysis.synonyms.inline.count: 4 }
+  - match: { indices.analysis.synonyms.inline.index_count: 3 }
+  - match: { indices.analysis.synonyms.paths.count: 3 }
+  - match: { indices.analysis.synonyms.paths.index_count: 1 }
+  - match: { indices.analysis.synonyms.sets.count: 3 }
+  - match: { indices.analysis.synonyms.sets.index_count: 3 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -47,6 +47,16 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
 
     private static final Set<String> SYNONYM_FILTER_TYPES = Set.of("synonym", "synonym_graph");
 
+    // Maps the synonyms token filter configurations to the stats keys used
+    static final Map<String, String> SYNONYM_STATS_KEYS_FOR_CONFIG = Map.of(
+        "synonyms",
+        "inline",
+        "synonyms_set",
+        "sets",
+        "synonyms_path",
+        "paths"
+    );
+
     /**
      * Create {@link AnalysisStats} from the given cluster state.
      */
@@ -217,7 +227,10 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
                     synonymRuleType = "synonyms";
                     isInline = true;
                 }
-                SynonymsStats stat = synonymsStats.computeIfAbsent(synonymRuleType, id -> new SynonymsStats());
+                SynonymsStats stat = synonymsStats.computeIfAbsent(
+                    SYNONYM_STATS_KEYS_FOR_CONFIG.get(synonymRuleType),
+                    id -> new SynonymsStats()
+                );
                 if (synonymIdsUsedInIndices.add(synonymRuleType + indexName)) {
                     stat.indexCount++;
                 }
@@ -405,7 +418,6 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         toXContentCollection(builder, params, "built_in_analyzers", usedBuiltInAnalyzers);
         builder.field("synonyms");
         builder.map(usedSynonyms);
-
         builder.endObject();
 
         return builder;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStatsTests.java
@@ -26,7 +26,7 @@ import java.util.TreeMap;
 
 public class AnalysisStatsTests extends AbstractWireSerializingTestCase<AnalysisStats> {
 
-    private static final String[] SYNONYM_RULES_TYPES = { "synonyms", "synonyms_set", "synonyms_path" };
+    private static final Set<String> SYNONYM_RULES_TYPES = AnalysisStats.SYNONYM_STATS_KEYS_FOR_CONFIG.keySet();
 
     @Override
     protected Reader<AnalysisStats> instanceReader() {
@@ -439,9 +439,9 @@ public class AnalysisStatsTests extends AbstractWireSerializingTestCase<Analysis
         expectedSynonymInlineStats.indexCount = 3;
 
         Map<String, SynonymsStats> expectedSynonymStats = new TreeMap<>();
-        expectedSynonymStats.put("synonyms_set", expectedSynonymSetStats);
-        expectedSynonymStats.put("synonyms_path", expectedSynonymPathStats);
-        expectedSynonymStats.put("synonyms", expectedSynonymInlineStats);
+        expectedSynonymStats.put("sets", expectedSynonymSetStats);
+        expectedSynonymStats.put("paths", expectedSynonymPathStats);
+        expectedSynonymStats.put("inline", expectedSynonymInlineStats);
 
         assertEquals(expectedSynonymStats, analysisStats.getUsedSynonyms());
     }


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/97900. Change cluster stats synonyms keys so they are more meaningful and concise.

Instead of:
```json
    {
      "synonyms": {
        "synonyms_set": {
          "count": 2,
          "index_count": 1
        },
        "synonyms_path": {
          "count": 5,
          "index_count": 3
        },
        "synonyms": {
          "count": 2,
          "index_count": 10
        }
      }
```

We will have:
```json
    {
      "synonyms": {
        "sets": {
          "count": 2,
          "index_count": 1
        },
        "paths": {
          "count": 5,
          "index_count": 3
        },
        "inline": {
          "count": 2,
          "index_count": 10
        }
      }
```