### PR TITLE
Fixed failing test that depends on synonyms feature

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -134,7 +134,7 @@ tasks.named("yamlRestTest").configure {
 // So we disable the test if the build is a snapshot where unreleased feature is enabled by default
 tasks.named("yamlRestTest").configure {
   if (BuildParams.isSnapshotBuild()) {
-    systemProperty 'tests.rest.blacklist', ['reference/rest-api/usage/*']
+    systemProperty 'tests.rest.blacklist', 'reference/rest-api/usage/*'
   }
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -101,6 +101,7 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
   requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.8.0")
+  requiresFeature 'es.synonyms_api_feature_flag_enabled', Version.fromString("8.9.0")
 
   // build the cluster with all plugins
   project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
@@ -124,6 +125,7 @@ tasks.named("yamlRestTest").configure {
   }
   if (BuildParams.isSnapshotBuild() == false) {
     systemProperty 'es.dlm_feature_flag_enabled', 'true'
+    systemProperty 'es.synonyms_api_feature_flag_enabled', 'true'
   }
 }
 
@@ -132,7 +134,7 @@ tasks.named("yamlRestTest").configure {
 // So we disable the test if the build is a snapshot where unreleased feature is enabled by default
 tasks.named("yamlRestTest").configure {
   if (BuildParams.isSnapshotBuild()) {
-    systemProperty 'tests.rest.blacklist', 'reference/rest-api/usage/*'
+    systemProperty 'tests.rest.blacklist', ['reference/rest-api/usage/*']
   }
 }
 

--- a/docs/reference/migration/apis/feature-migration.asciidoc
+++ b/docs/reference/migration/apis/feature-migration.asciidoc
@@ -142,7 +142,6 @@ Example response:
   "migration_status" : "NO_MIGRATION_NEEDED"
 }
 --------------------------------------------------
-// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/97780]
 
 When you submit a POST request to the `_migration/system_features` endpoint to
 start the migration process, the response indicates what features will be

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/FeatureStateResetApiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/FeatureStateResetApiIT.java
@@ -73,11 +73,13 @@ public class FeatureStateResetApiIT extends ESIntegTestCase {
 
         // call the reset API
         ResetFeatureStateResponse apiResponse = client().execute(ResetFeatureStateAction.INSTANCE, new ResetFeatureStateRequest()).get();
-        Collection<ResetFeatureStateResponse.ResetFeatureStateStatus> successStatuses = Arrays.asList(
-            ResetFeatureStateResponse.ResetFeatureStateStatus.success("SystemIndexTestPlugin"),
-            ResetFeatureStateResponse.ResetFeatureStateStatus.success("SecondSystemIndexTestPlugin"),
-            ResetFeatureStateResponse.ResetFeatureStateStatus.success("EvilSystemIndexTestPlugin"),
-            ResetFeatureStateResponse.ResetFeatureStateStatus.success("tasks")
+        Collection<ResetFeatureStateResponse.ResetFeatureStateStatus> successStatuses = new ArrayList<>(
+            Arrays.asList(
+                ResetFeatureStateResponse.ResetFeatureStateStatus.success("SystemIndexTestPlugin"),
+                ResetFeatureStateResponse.ResetFeatureStateStatus.success("SecondSystemIndexTestPlugin"),
+                ResetFeatureStateResponse.ResetFeatureStateStatus.success("EvilSystemIndexTestPlugin"),
+                ResetFeatureStateResponse.ResetFeatureStateStatus.success("tasks")
+            )
         );
         if (SynonymsAPI.isEnabled()) {
             successStatuses.add(ResetFeatureStateResponse.ResetFeatureStateStatus.success("synonyms"));


### PR DESCRIPTION
Release builds are failing because some integration tests check synonyms system index, which is feature dependant.

This will no longer be a problem in main as the feature flag for synonyms sets has been removed in https://github.com/elastic/elasticsearch/pull/97962

Closes https://github.com/elastic/elasticsearch/issues/97780, https://github.com/elastic/elasticsearch/issues/97949