### PR TITLE
Make EQL missing events serialization compatible with 8.9.1

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -305,6 +305,8 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
                 }
             }
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_038)) {
+                // for BWC, 8.9.1+ does not have "missing" attribute, but it considers events with an empty index "" as missing events
+                // see https://github.com/elastic/elasticsearch/pull/98130
                 out.writeBoolean(missing);
             }
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -284,7 +284,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_038)) {
                 missing = in.readBoolean();
             } else {
-                missing = false;
+                missing = index.isEmpty();
             }
         }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -8,8 +8,11 @@ package org.elasticsearch.xpack.eql.action;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
@@ -24,6 +27,7 @@ import org.elasticsearch.xpack.eql.action.EqlSearchResponse.Event;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse.Sequence;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -289,5 +293,16 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
             );
         }
         return mutatedEvents;
+    }
+
+    public void testEmptyIndexAsMissingEvent() throws IOException {
+        Event event = new Event("", "", new BytesArray("{}".getBytes(StandardCharsets.UTF_8)), null);
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(TransportVersion.V_8_500_020);// 8.9.1
+        event.writeTo(out);
+        ByteArrayStreamInput in = new ByteArrayStreamInput(out.bytes().array());
+        in.setTransportVersion(TransportVersion.V_8_500_020);
+        Event event2 = Event.readFrom(in);
+        assertTrue(event2.missing());
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -284,7 +284,7 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
                     e.id(),
                     e.source(),
                     version.onOrAfter(TransportVersion.V_7_13_0) ? e.fetchFields() : null,
-                    version.onOrAfter(TransportVersion.V_8_500_038) ? e.missing() : false
+                    version.onOrAfter(TransportVersion.V_8_500_038) ? e.missing() : e.index().isEmpty()
                 )
             );
         }


### PR DESCRIPTION
After back-porting https://github.com/elastic/elasticsearch/pull/97718 to v 8.9.1 (see https://github.com/elastic/elasticsearch/pull/98130), we introduced a slightly different way of serializing missing events: in v 8.9.x an event with empty index is considered a missing event (no `missing` attribute serialization to avoid incompatibilities with the serialization protocol).
This PR adds this logic also to 8.10+ when dealing with streams from older versions.