### PR TITLE
Enable data stream lifecycle feature flag in x-pack plugin tests (98050)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -227,6 +227,9 @@ testClusters.configureEach {
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
   requiresFeature 'es.inference_rescorer_feature_flag_enabled', Version.fromString("8.10.0")
+  if (BuildParams.isSnapshotBuild() == false) {
+    requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
+  }
 }
 
 tasks.register('enforceApiSpecsConvention').configure {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -227,9 +227,7 @@ testClusters.configureEach {
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
   requiresFeature 'es.inference_rescorer_feature_flag_enabled', Version.fromString("8.10.0")
-  if (BuildParams.isSnapshotBuild() == false) {
-    requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
-  }
+  requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 tasks.register('enforceApiSpecsConvention').configure {


### PR DESCRIPTION
Added missing feature flag. The reason this used work was that we would not take into account the value of the feature flag in the usage response. This changed in https://github.com/elastic/elasticsearch/pull/97442 & https://github.com/elastic/elasticsearch/pull/97425.

Fixes: #98050