### PR TITLE
Do not store default template with search application if it is not sp…

### DIFF
--- a/docs/changelog/98138.yaml
+++ b/docs/changelog/98138.yaml
@@ -1,5 +1,0 @@
-pr: 98138
-summary: Do not store default template with search application if it is not sp…
-area: Application
-type: tech debt
-issues: []

--- a/docs/changelog/98138.yaml
+++ b/docs/changelog/98138.yaml
@@ -1,0 +1,5 @@
+pr: 98138
+summary: Do not store default template with search application if it is not sp…
+area: Application
+type: tech debt
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/100_usage.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/100_usage.yml
@@ -44,6 +44,12 @@ teardown:
         name: test-search-application-1
         body:
           indices: [ "test-index1" ]
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
   - do:
       xpack.usage: {}
@@ -62,6 +68,12 @@ teardown:
         name: test-search-application-2
         body:
           indices: [ "test-index1" ]
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
   - do:
       search_application.put_behavioral_analytics:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -188,18 +188,16 @@ teardown:
       features: warnings
 
   - do:
-      search_application.put:
-        name: test-updated-search-application
-        body:
-          indices: [ "test-index1", "test-index2" ]
-          template:
-            script:
-              source:
-                query:
-                  query_string:
-                    query: "{{query_string}}"
+        warnings:
+          - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
+        search_application.put:
+          name: test-updated-search-application
+          body:
+            indices: [ "test-index1", "test-index2" ]
 
   - do:
+      warnings:
+        - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
       search_application.put:
         name: test-updated-search-application
         body:
@@ -266,6 +264,12 @@ teardown:
         create: true
         body:
           indices: [ "test-index1" ]
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
   - match: { result: "created" }
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -183,7 +183,7 @@ teardown:
               type: "string"
 
 ---
-"Update Search Application with null template, results in default template being applied":
+"Update Search Application with null template":
   - do:
       search_application.put:
         name: test-updated-search-application
@@ -216,14 +216,7 @@ teardown:
       search_application.get:
         name: test-updated-search-application
 
-  - match:
-      template:
-        script:
-          source: "{\n  \"query\": {\n    \"query_string\": {\n        \"query\": \"{{query_string}}\",\n        \"default_field\": \"{{default_field}}\"\n        }\n    }\n}\n"
-          lang: "mustache"
-          params:
-            query_string: "*"
-            default_field: "*"
+  - match: { template: null }
 
 ---
 "Update Search Application - Dictionary is not a valid JSON Schema":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -184,6 +184,9 @@ teardown:
 
 ---
 "Update Search Application with null template":
+  - skip:
+      features: warnings
+
   - do:
       search_application.put:
         name: test-updated-search-application
@@ -213,10 +216,19 @@ teardown:
   - match: { test-index4.aliases.test-updated-search-application: { } }
 
   - do:
+      warnings:
+        - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
       search_application.get:
         name: test-updated-search-application
 
-  - match: { template: null }
+  - match:
+      template:
+        script:
+          source: "{\n  \"query\": {\n    \"query_string\": {\n        \"query\": \"{{query_string}}\",\n        \"default_field\": \"{{default_field}}\"\n        }\n    }\n}\n"
+          lang: "mustache"
+          params:
+            query_string: "*"
+            default_field: "*"
 
 ---
 "Update Search Application - Dictionary is not a valid JSON Schema":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -1,4 +1,7 @@
 setup:
+  - skip:
+      features: warnings
+
   - do:
       indices.create:
         index: test-index1
@@ -9,6 +12,7 @@ setup:
               number_of_replicas: 0
 
   - do:
+
       indices.create:
         index: test-index2
         body:
@@ -34,6 +38,8 @@ setup:
                 type: string
 
   - do:
+      warnings:
+        - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
       search_application.put:
         name: test-search-application-2
         body:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -84,25 +84,14 @@ teardown:
   - gte: { updated_at_millis: 0 }
 
 ---
-"Get Search Application with no template specified returns default template":
+"Get Search Application with no template specified returns null template":
   - do:
       search_application.get:
         name: test-search-application-2
 
   - match: { name: "test-search-application-2" }
   - match: { analytics_collection_name: "test-analytics" }
-  - match: {
-    template: {
-      script: {
-        source:  "{\n  \"query\": {\n    \"query_string\": {\n        \"query\": \"{{query_string}}\",\n        \"default_field\": \"{{default_field}}\"\n        }\n    }\n}\n",
-        params: {
-            query_string: "*",
-            default_field: "*"
-        },
-        lang: "mustache"
-      }
-    }
-  }
+  - match: { template: null }
   - gte: { updated_at_millis: 0 }
 
 ---

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -84,14 +84,30 @@ teardown:
   - gte: { updated_at_millis: 0 }
 
 ---
-"Get Search Application with no template specified returns null template":
+"Get Search Application with no template specified returns default template with warning header":
+  - skip:
+      features: warnings
+
   - do:
+      warnings:
+        - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
       search_application.get:
         name: test-search-application-2
 
   - match: { name: "test-search-application-2" }
   - match: { analytics_collection_name: "test-analytics" }
-  - match: { template: null }
+  - match: {
+    template: {
+      script: {
+        source: "{\n  \"query\": {\n    \"query_string\": {\n        \"query\": \"{{query_string}}\",\n        \"default_field\": \"{{default_field}}\"\n        }\n    }\n}\n",
+        params: {
+          query_string: "*",
+          default_field: "*"
+        },
+        lang: "mustache"
+      }
+    }
+  }
   - gte: { updated_at_millis: 0 }
 
 ---

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
@@ -12,6 +12,12 @@ setup:
         name: test-search-application-to-delete
         body:
           indices: [ "test-index" ]
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
 ---
 teardown:
@@ -23,7 +29,7 @@ teardown:
 ---
 "Delete search application fails for unprivileged user":
   - skip:
-      features: [headers, warnings]
+      features: headers
 
   - do:
       catch: unauthorized
@@ -32,8 +38,6 @@ teardown:
         name: test-search-application-to-delete
 
   - do:
-      warnings:
-        - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
       search_application.get:
         name: test-search-application-to-delete
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
@@ -23,7 +23,7 @@ teardown:
 ---
 "Delete search application fails for unprivileged user":
   - skip:
-      features: headers
+      features: [headers, warnings]
 
   - do:
       catch: unauthorized
@@ -32,6 +32,8 @@ teardown:
         name: test-search-application-to-delete
 
   - do:
+      warnings:
+        - "Using default search application template which is subject to change. We recommend storing a template to avoid breaking changes."
       search_application.get:
         name: test-search-application-to-delete
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -23,6 +23,12 @@ setup:
         body:
           indices: [ "test-index1" ]
           analytics_collection_name: "test-analytics1"
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
   - do:
       search_application.put:
@@ -30,6 +36,12 @@ setup:
         body:
           indices: [ "test-index2" ]
           analytics_collection_name: "test-analytics2"
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
   - do:
       search_application.put:
@@ -37,6 +49,12 @@ setup:
         body:
           indices: [ "test-index1", "test-index2" ]
           analytics_collection_name: "test-another-analytics"
+          template:
+            script:
+              source:
+                query:
+                  query_string:
+                    query: "{{query_string}}"
 
 ---
 teardown:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -49,6 +49,9 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  */
 public class SearchApplication implements Writeable, ToXContentObject {
 
+    public static final String NO_TEMPLATE_STORED_WARNING = "Using default search application template which is subject to change. "
+        + "We recommend storing a template to avoid breaking changes.";
+
     private final String name;
     private final String[] indices;
     private final long updatedAtMillis;
@@ -229,8 +232,12 @@ public class SearchApplication implements Writeable, ToXContentObject {
         return searchApplicationTemplate;
     }
 
+    public boolean hasStoredTemplate() {
+        return searchApplicationTemplate != null;
+    }
+
     public SearchApplicationTemplate searchApplicationTemplateOrDefault() {
-        return searchApplicationTemplate != null ? searchApplicationTemplate : SearchApplicationTemplate.DEFAULT_TEMPLATE;
+        return hasStoredTemplate() ? searchApplicationTemplate : SearchApplicationTemplate.DEFAULT_TEMPLATE;
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -228,10 +228,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         return updatedAtMillis;
     }
 
-    public @Nullable SearchApplicationTemplate searchApplicationTemplate() {
-        return searchApplicationTemplate;
-    }
-
     public boolean hasStoredTemplate() {
         return searchApplicationTemplate != null;
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -82,9 +82,7 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
         this.analyticsCollectionName = analyticsCollectionName;
         this.updatedAtMillis = updatedAtMillis;
-        this.searchApplicationTemplate = searchApplicationTemplate != null
-            ? searchApplicationTemplate
-            : SearchApplicationTemplate.DEFAULT_TEMPLATE;
+        this.searchApplicationTemplate = searchApplicationTemplate;
     }
 
     public SearchApplication(StreamInput in) throws IOException {
@@ -229,6 +227,10 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
     public @Nullable SearchApplicationTemplate searchApplicationTemplate() {
         return searchApplicationTemplate;
+    }
+
+    public SearchApplicationTemplate searchApplicationTemplateOrDefault() {
+        return searchApplicationTemplate != null ? searchApplicationTemplate : SearchApplicationTemplate.DEFAULT_TEMPLATE;
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.application.search;
 
 import org.elasticsearch.common.ValidationException;
-import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -44,11 +43,6 @@ public class SearchApplicationTemplateService {
         template.validateTemplateParams(templateParams);
         final Map<String, Object> renderedTemplateParams = renderTemplateParams(template, templateParams);
         final Script script = template.script();
-
-        if (searchApplication.hasStoredTemplate() == false) {
-            HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
-        }
-
         TemplateScript compiledTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(renderedTemplateParams);
         final String requestSource = SearchTemplateHelper.stripTrailingComma(compiledTemplate.execute());
         XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
@@ -71,11 +65,6 @@ public class SearchApplicationTemplateService {
     public Map<String, Object> renderTemplate(SearchApplication searchApplication, Map<String, Object> queryParams)
         throws ValidationException {
         final SearchApplicationTemplate template = searchApplication.searchApplicationTemplateOrDefault();
-
-        if (searchApplication.hasStoredTemplate() == false) {
-            HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
-        }
-
         return renderTemplateParams(template, queryParams);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.application.search;
 
 import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -44,6 +45,10 @@ public class SearchApplicationTemplateService {
         final Map<String, Object> renderedTemplateParams = renderTemplateParams(template, templateParams);
         final Script script = template.script();
 
+        if (searchApplication.hasStoredTemplate() == false) {
+            HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
+        }
+
         TemplateScript compiledTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(renderedTemplateParams);
         final String requestSource = SearchTemplateHelper.stripTrailingComma(compiledTemplate.execute());
         XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
@@ -66,6 +71,11 @@ public class SearchApplicationTemplateService {
     public Map<String, Object> renderTemplate(SearchApplication searchApplication, Map<String, Object> queryParams)
         throws ValidationException {
         final SearchApplicationTemplate template = searchApplication.searchApplicationTemplateOrDefault();
+
+        if (searchApplication.hasStoredTemplate() == false) {
+            HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
+        }
+
         return renderTemplateParams(template, queryParams);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
@@ -39,9 +39,9 @@ public class SearchApplicationTemplateService {
 
     public SearchSourceBuilder renderQuery(SearchApplication searchApplication, Map<String, Object> templateParams) throws IOException,
         ValidationException {
-        final SearchApplicationTemplate template = searchApplication.searchApplicationTemplate();
+        final SearchApplicationTemplate template = searchApplication.searchApplicationTemplateOrDefault();
         template.validateTemplateParams(templateParams);
-        final Map<String, Object> renderedTemplateParams = renderTemplate(searchApplication, templateParams);
+        final Map<String, Object> renderedTemplateParams = renderTemplateParams(template, templateParams);
         final Script script = template.script();
 
         TemplateScript compiledTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(renderedTemplateParams);
@@ -65,13 +65,14 @@ public class SearchApplicationTemplateService {
      */
     public Map<String, Object> renderTemplate(SearchApplication searchApplication, Map<String, Object> queryParams)
         throws ValidationException {
+        final SearchApplicationTemplate template = searchApplication.searchApplicationTemplateOrDefault();
+        return renderTemplateParams(template, queryParams);
+    }
 
-        final SearchApplicationTemplate template = searchApplication.searchApplicationTemplate();
+    private Map<String, Object> renderTemplateParams(SearchApplicationTemplate template, Map<String, Object> queryParams) {
         final Script script = template.script();
-
         Map<String, Object> mergedTemplateParams = new HashMap<>(script.getParams());
         mergedTemplateParams.putAll(queryParams);
-
         return mergedTemplateParams;
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/PutSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/PutSearchApplicationAction.java
@@ -69,7 +69,7 @@ public class PutSearchApplicationAction extends ActionType<PutSearchApplicationA
                 validationException = addValidationError("indices are missing", validationException);
             }
 
-            if (searchApp.searchApplicationTemplate() != null && searchApp.searchApplicationTemplate().script() == null) {
+            if (searchApp.searchApplicationTemplateOrDefault().script() == null) {
                 validationException = addValidationError("script required for template", validationException);
             }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
@@ -55,15 +55,15 @@ public class TransportGetSearchApplicationAction extends HandledTransportAction<
                     }
                     if (searchApplication.hasStoredTemplate() == false) {
                         HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
-                        return new GetSearchApplicationAction.Response(
-                            searchApplication.name(),
-                            searchApplication.indices(),
-                            searchApplication.analyticsCollectionName(),
-                            searchApplication.updatedAtMillis(),
-                            searchApplication.searchApplicationTemplateOrDefault()
-                        );
                     }
-                    return new GetSearchApplicationAction.Response(searchApplication);
+                    // Construct a new object to ensure we backfill the stored application with the default template
+                    return new GetSearchApplicationAction.Response(
+                        searchApplication.name(),
+                        searchApplication.indices(),
+                        searchApplication.analyticsCollectionName(),
+                        searchApplication.updatedAtMillis(),
+                        searchApplication.searchApplicationTemplateOrDefault()
+                    );
                 }))
             )
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
@@ -18,7 +18,9 @@ import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.search.SearchApplication;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
+import org.elasticsearch.xpack.application.search.SearchApplicationTemplate;
 
 public class TransportGetSearchApplicationAction extends HandledTransportAction<
     GetSearchApplicationAction.Request,
@@ -51,6 +53,16 @@ public class TransportGetSearchApplicationAction extends HandledTransportAction<
                 (l, searchApplication) -> systemIndexService.checkAliasConsistency(searchApplication, l.safeMap(inconsistentIndices -> {
                     for (String key : inconsistentIndices.keySet()) {
                         HeaderWarning.addWarning(key + " " + inconsistentIndices.get(key));
+                    }
+                    if (searchApplication.hasStoredTemplate() == false) {
+                        HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
+                        return new GetSearchApplicationAction.Response(
+                            searchApplication.name(),
+                            searchApplication.indices(),
+                            searchApplication.analyticsCollectionName(),
+                            searchApplication.updatedAtMillis(),
+                            SearchApplicationTemplate.DEFAULT_TEMPLATE
+                        );
                     }
                     return new GetSearchApplicationAction.Response(searchApplication);
                 }))

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.search.SearchApplication;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
-import org.elasticsearch.xpack.application.search.SearchApplicationTemplate;
 
 public class TransportGetSearchApplicationAction extends HandledTransportAction<
     GetSearchApplicationAction.Request,
@@ -61,7 +60,7 @@ public class TransportGetSearchApplicationAction extends HandledTransportAction<
                             searchApplication.indices(),
                             searchApplication.analyticsCollectionName(),
                             searchApplication.updatedAtMillis(),
-                            SearchApplicationTemplate.DEFAULT_TEMPLATE
+                            searchApplication.searchApplicationTemplateOrDefault()
                         );
                     }
                     return new GetSearchApplicationAction.Response(searchApplication);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportPutSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportPutSearchApplicationAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -46,6 +47,9 @@ public class TransportPutSearchApplicationAction extends HandledTransportAction<
     ) {
         SearchApplication app = request.getSearchApplication();
         boolean create = request.create();
+        if (app.hasStoredTemplate() == false) {
+            HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
+        }
         systemIndexService.putSearchApplication(app, create, listener.map(r -> new PutSearchApplicationAction.Response(r.getResult())));
 
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
@@ -86,7 +86,7 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(getSearchApp, equalTo(searchApp));
         checkAliases(searchApp);
 
-        assertNull(getSearchApp.searchApplicationTemplate());
+        assertFalse(getSearchApp.hasStoredTemplate());
 
         expectThrows(VersionConflictEngineException.class, () -> awaitPutSearchApplication(searchApp, true));
 
@@ -107,7 +107,7 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(getSearchApp2, equalTo(searchApp2));
         checkAliases(searchApp2);
 
-        assertThat(getSearchApp2.searchApplicationTemplate(), equalTo(SearchApplicationTemplate.DEFAULT_TEMPLATE));
+        assertThat(getSearchApp2.searchApplicationTemplateOrDefault(), equalTo(SearchApplicationTemplate.DEFAULT_TEMPLATE));
 
         resp2 = awaitPutSearchApplication(searchApp2, false);
         assertThat(resp2.status(), equalTo(RestStatus.OK));
@@ -153,7 +153,7 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(newResp.getIndex(), equalTo(SEARCH_APPLICATION_CONCRETE_INDEX_NAME));
         SearchApplication getNewSearchApp = awaitGetSearchApplication(searchApp.name());
         assertThat(searchApp, equalTo(getNewSearchApp));
-        assertThat(searchApp.searchApplicationTemplate(), equalTo(getNewSearchApp.searchApplicationTemplate()));
+        assertThat(searchApp.searchApplicationTemplateOrDefault(), equalTo(getNewSearchApp.searchApplicationTemplateOrDefault()));
         checkAliases(searchApp);
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
@@ -69,6 +69,7 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testCreateSearchApplication() throws Exception {
+        // Default case - no template specified
         final SearchApplication searchApp = new SearchApplication(
             "my_search_app",
             new String[] { "index_1" },
@@ -85,9 +86,31 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(getSearchApp, equalTo(searchApp));
         checkAliases(searchApp);
 
-        assertThat(getSearchApp.searchApplicationTemplate(), equalTo(SearchApplicationTemplate.DEFAULT_TEMPLATE));
+        assertNull(getSearchApp.searchApplicationTemplate());
 
         expectThrows(VersionConflictEngineException.class, () -> awaitPutSearchApplication(searchApp, true));
+
+        // With template specified
+        final SearchApplication searchApp2 = new SearchApplication(
+            "my_search_app2",
+            new String[] { "index_2" },
+            null,
+            System.currentTimeMillis(),
+            SearchApplicationTemplate.DEFAULT_TEMPLATE
+        );
+
+        IndexResponse resp2 = awaitPutSearchApplication(searchApp2, true);
+        assertThat(resp2.status(), equalTo(RestStatus.CREATED));
+        assertThat(resp2.getIndex(), equalTo(SEARCH_APPLICATION_CONCRETE_INDEX_NAME));
+
+        SearchApplication getSearchApp2 = awaitGetSearchApplication(searchApp2.name());
+        assertThat(getSearchApp2, equalTo(searchApp2));
+        checkAliases(searchApp2);
+
+        assertThat(getSearchApp2.searchApplicationTemplate(), equalTo(SearchApplicationTemplate.DEFAULT_TEMPLATE));
+
+        resp2 = awaitPutSearchApplication(searchApp2, false);
+        assertThat(resp2.status(), equalTo(RestStatus.OK));
     }
 
     private void checkAliases(SearchApplication searchApp) {


### PR DESCRIPTION
If users do not specify a template when creating or updating their search application, we no longer store the default search template. Instead, the default search template is loaded at search time if no stored template exists. 

Updated response for `GET /_application/search_application/<appname>`: 
```
{
    "name": "puggles",
    "updated_at_millis": 1690981129366,
    "template": null
}
```

The `GET /_application/search_application/_search` API call will still work as normal, but will load in the current default template if none is stored with the search application. 

The default template has not changed. 

Warning headers will be returned from `GET` and `PUT` commands if the search application does not have a stored template. 