### PR TITLE
[ML] Fixing apm trace context set multiple times with model download

### DIFF
--- a/docs/changelog/98140.yaml
+++ b/docs/changelog/98140.yaml
@@ -1,5 +1,5 @@
 pr: 98140
-summary: 'Fix APM tracing being set for `CancellableTask` in `TransportLoadTrainedModelPackage`'
+summary: 'Fix ELSER model download when APM tracing is enabled'
 area: Machine Learning
 type: bug
 issues:

--- a/docs/changelog/98140.yaml
+++ b/docs/changelog/98140.yaml
@@ -1,6 +1,0 @@
-pr: 98140
-summary: 'Fix APM tracing being set for `CancellableTask` in `TransportLoadTrainedModelPackage`'
-area: Machine Learning
-type: bug
-issues:
- - 98122

--- a/docs/changelog/98140.yaml
+++ b/docs/changelog/98140.yaml
@@ -1,5 +1,5 @@
 pr: 98140
-summary: Fixing apm trace context set multiple times with model download
+summary: 'Fix APM tracing being set for `CancellableTask` in `TransportLoadTrainedModelPackage`'
 area: Machine Learning
 type: bug
 issues:

--- a/docs/changelog/98140.yaml
+++ b/docs/changelog/98140.yaml
@@ -1,0 +1,6 @@
+pr: 98140
+summary: Fixing apm trace context set multiple times with model download
+area: Machine Learning
+type: bug
+issues:
+ - 98122

--- a/docs/changelog/98140.yaml
+++ b/docs/changelog/98140.yaml
@@ -1,6 +1,0 @@
-pr: 98140
-summary: 'Fix ELSER model download when APM tracing is enabled'
-area: Machine Learning
-type: bug
-issues:
- - 98122

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -193,7 +193,7 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
             public CancellableTask createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
                 return new CancellableTask(id, type, action, downloadModelTaskDescription(request.getModelId()), parentTaskId, headers);
             }
-        });
+        }, false);
     }
 
     private static void recordError(Client client, String modelId, AtomicReference<Exception> exceptionRef, Exception e) {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/98122

This PR fixes and issue where the task created to track the trained model download was enabling a trace request when it should not have.

## Testing

I was able to reproduce the issue by build a local distribution and using the following `elasticsearch.yml` settings

```
tracing.apm.enabled: true
tracing.apm.agent.server_url: "<apm url>"
tracing.apm.agent.secret_token: "<token>"
tracing.apm.agent.environment: "<environment>"
tracing.apm.agent.transaction_sample_rate: 1.0
xpack.security.enabled: true
xpack.license.self_generated.type: "trial"
```

Ping me for the settings to use.

Without the fix this produces:

`PUT http://localhost:9200/_ml/trained_models/.elser_model_1?wait_for_completion=true`

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "value for key [apm.local.context] already present"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "value for key [apm.local.context] already present"
  },
  "status": 400
}
```

With the fix, the model is downloaded successfully.