### PR TITLE
Fix DataStreamLifecycleServiceRuntimeSecurityIT

### DIFF
--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -431,6 +431,7 @@ tasks.named("internalClusterTest").configure {
    * to keep direct memory usage under control.
    */
   systemProperty 'es.transport.buffer.size', '256k'
+  requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 addQaCheckDependencies(project)

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.Version
-
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -433,7 +431,7 @@ tasks.named("internalClusterTest").configure {
    * to keep direct memory usage under control.
    */
   systemProperty 'es.transport.buffer.size', '256k'
-  requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
+  systemProperty 'es.dlm_feature_flag_enabled', 'true'
 }
 
 addQaCheckDependencies(project)

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.Version
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.internal-cluster-test'


### PR DESCRIPTION
Enable the dlm feature for non-snapshot builds.

Fixes https://github.com/elastic/elasticsearch/issues/98142