### PR TITLE
Cleanup Transport*VotingConfigExclusionsActionTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.action.admin.cluster.configuration;
 
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -38,7 +37,6 @@ import org.junit.BeforeClass;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static java.util.Collections.emptySet;
@@ -117,9 +115,8 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
         setState(clusterService, builder);
     }
 
-    public void testClearsVotingConfigExclusions() throws InterruptedException {
+    public void testClearsVotingConfigExclusions() {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final SetOnce<ActionResponse.Empty> responseHolder = new SetOnce<>();
 
         final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
         clearVotingConfigExclusionsRequest.setWaitForRemoval(false);
@@ -128,19 +125,16 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
             ClearVotingConfigExclusionsAction.NAME,
             clearVotingConfigExclusionsRequest,
             expectSuccess(r -> {
-                responseHolder.set(r);
+                assertNotNull(r);
+                assertThat(clusterService.getClusterApplierService().state().getVotingConfigExclusions(), empty());
                 countDownLatch.countDown();
             })
         );
-
-        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-        assertNotNull(responseHolder.get());
-        assertThat(clusterService.getClusterApplierService().state().getVotingConfigExclusions(), empty());
+        safeAwait(countDownLatch);
     }
 
-    public void testTimesOutIfWaitingForNodesThatAreNotRemoved() throws InterruptedException {
+    public void testTimesOutIfWaitingForNodesThatAreNotRemoved() {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final SetOnce<TransportException> responseHolder = new SetOnce<>();
 
         final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
         clearVotingConfigExclusionsRequest.setTimeout(TimeValue.timeValueMillis(100));
@@ -149,34 +143,31 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
             ClearVotingConfigExclusionsAction.NAME,
             clearVotingConfigExclusionsRequest,
             expectError(e -> {
-                responseHolder.set(e);
+                assertThat(
+                    clusterService.getClusterApplierService().state().getVotingConfigExclusions(),
+                    containsInAnyOrder(otherNode1Exclusion, otherNode2Exclusion)
+                );
+                final Throwable rootCause = e.getRootCause();
+                assertThat(rootCause, instanceOf(ElasticsearchTimeoutException.class));
+                assertThat(
+                    rootCause.getMessage(),
+                    startsWith("timed out waiting for removal of nodes; if nodes should not be removed, set ?wait_for_removal=false. [")
+                );
                 countDownLatch.countDown();
             })
         );
-
-        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-        assertThat(
-            clusterService.getClusterApplierService().state().getVotingConfigExclusions(),
-            containsInAnyOrder(otherNode1Exclusion, otherNode2Exclusion)
-        );
-        final Throwable rootCause = responseHolder.get().getRootCause();
-        assertThat(rootCause, instanceOf(ElasticsearchTimeoutException.class));
-        assertThat(
-            rootCause.getMessage(),
-            startsWith("timed out waiting for removal of nodes; if nodes should not be removed, set ?wait_for_removal=false. [")
-        );
+        safeAwait(countDownLatch);
     }
 
-    public void testSucceedsIfNodesAreRemovedWhileWaiting() throws InterruptedException {
+    public void testSucceedsIfNodesAreRemovedWhileWaiting() {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final SetOnce<ActionResponse.Empty> responseHolder = new SetOnce<>();
 
         transportService.sendRequest(
             localNode,
             ClearVotingConfigExclusionsAction.NAME,
             new ClearVotingConfigExclusionsRequest(),
             expectSuccess(r -> {
-                responseHolder.set(r);
+                assertThat(clusterService.getClusterApplierService().state().getVotingConfigExclusions(), empty());
                 countDownLatch.countDown();
             })
         );
@@ -185,13 +176,11 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
         builder.nodes(DiscoveryNodes.builder(clusterService.state().nodes()).remove(otherNode1).remove(otherNode2));
         setState(clusterService, builder);
 
-        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-        assertThat(clusterService.getClusterApplierService().state().getVotingConfigExclusions(), empty());
+        safeAwait(countDownLatch);
     }
 
     public void testCannotClearVotingConfigurationWhenItIsDisabled() {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final SetOnce<TransportException> exceptionHolder = new SetOnce<>();
 
         reconfigurator.disableUserVotingConfigModifications();
 
@@ -200,15 +189,13 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
             ClearVotingConfigExclusionsAction.NAME,
             new ClearVotingConfigExclusionsRequest(),
             expectError(e -> {
-                exceptionHolder.set(e);
+                final Throwable rootCause = e.getRootCause();
+                assertThat(rootCause, instanceOf(IllegalStateException.class));
+                assertThat(rootCause.getMessage(), startsWith("Unable to modify the voting configuration"));
                 countDownLatch.countDown();
             })
         );
-
         safeAwait(countDownLatch);
-        final Throwable rootCause = exceptionHolder.get().getRootCause();
-        assertThat(rootCause, instanceOf(IllegalStateException.class));
-        assertThat(rootCause.getMessage(), startsWith("Unable to modify the voting configuration"));
     }
 
     private TransportResponseHandler<ActionResponse.Empty> expectSuccess(Consumer<ActionResponse.Empty> onResponse) {
@@ -224,6 +211,7 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
         Consumer<TransportException> onException
     ) {
         return new TransportResponseHandler<>() {
+
             @Override
             public ActionResponse.Empty read(StreamInput in) {
                 return ActionResponse.Empty.INSTANCE;


### PR DESCRIPTION
This pull request fixes #98057 

The assertions have been moved into the handlers where they can be, and the calls to `countDownLatch.await()` as been replaced by `safeAwait.`

Attempting to replace `TransportResponseHandler` with `ActionListenerResponseHandler` seems to be less concise due to the need to implement an `ActionListener` for its constructor, which then requires the introduction of a new method to keep things DRY.

