### PR TITLE
Handling the case when an xpack info transport action does not exist

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
@@ -58,6 +58,18 @@ public class TransportXPackInfoActionTests extends ESTestCase {
                 return null;
             });
         }
+        /*
+         * Now we add a feature that is not present in the system at all (for example, its plugin has been removed from the build). We want
+         * to make sure that we correctly report that the feature is not available.
+         */
+        XPackInfoFeatureAction missingFeature = randomValueOtherThanMany(
+            featureSets::containsKey,
+            () -> randomFrom(XPackInfoFeatureAction.ALL)
+        );
+        featureSets.put(missingFeature, new FeatureSet(missingFeature.name(), false, false));
+        when(client.executeLocally(eq(missingFeature), any(ActionRequest.class), any(ActionListener.class))).thenAnswer(answer -> {
+            throw new IllegalStateException("failed to find action to execute");
+        });
 
         TransportXPackInfoAction action = new TransportXPackInfoAction(
             mock(TransportService.class),


### PR DESCRIPTION
If we have removed an xpack plugin from the build that contained one of the actions listed in [`org.elasticsearch.xpack.core.action.XPackInfoFeatureAction.ALL`](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoFeatureAction.java#L53), then when we run TransportXPackInfoAction it can blow up with an IllegalStateException because the action is not found. This PR more gracefully handles that case by checking whether the node is aware of the action, and reporting that the feature is not available.