### PR TITLE
Fix SharedClusterSnapshotRestoreIT testSnapshotFileFailureDuringSnapshot

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -348,6 +348,9 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setSettings(
                     Settings.builder()
                         .put("location", randomRepoPath())
+                        // io exception writing index.latest won't fail anything which makes assertions below complicated, so we disable
+                        // index.latest
+                        .put(BlobStoreRepository.SUPPORT_URL_REPO.getKey(), false)
                         .put("random", randomAlphaOfLength(10))
                         .put("random_control_io_exception_rate", 0.2)
                 )


### PR DESCRIPTION
This test was broken by #98069 which makes it so failures around writing index.latest get counted as mock repository failures. Since a failure to write index.latest doesn't break a snapshot, this tripped a test assertion.
Rather than change either the repo behavior (which I suppose has its reasons for stateless) I think we can just turn off writing index.latest here to keep things simple.

closes #98128