### PR TITLE
Skip synonyms API tests for 8.9

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-synonyms-3


### PR DESCRIPTION
Removes synonyms tests from 8.9 - they are active from 8.10 forwards.

Closes https://github.com/elastic/elasticsearch/issues/98134