### PR TITLE
Universal Profiling: Update hostmetadata mapping

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
@@ -144,6 +144,9 @@
                 "name": {
                   "type": "keyword"
                 },
+                "machine": {
+                  "type": "keyword"
+                },
                 "kernel_version": {
                   "type": "version"
                 },

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -40,7 +40,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     private static final Logger logger = LogManager.getLogger(ProfilingIndexTemplateRegistry.class);
     // history (please add a comment why you increased the version here)
     // version 1: initial
-    public static final int INDEX_TEMPLATE_VERSION = 1;
+    // version 2: Added 'profiling.host.machine' keyword mapping to profiling-hosts
+    public static final int INDEX_TEMPLATE_VERSION = 2;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 1;

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingDataStreamManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingDataStreamManagerTests.java
@@ -243,11 +243,12 @@ public class ProfilingDataStreamManagerTests extends ESTestCase {
         DiscoveryNode node = DiscoveryNodeUtils.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
         templatesCreated.set(true);
+        int nextIndexTemplateVersion = ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION + 1;
 
         ProfilingDataStreamManager.ProfilingDataStream ds = ProfilingDataStreamManager.ProfilingDataStream.of(
             "profiling-test",
             1,
-            new Migration.Builder().migrateToIndexTemplateVersion(2).addProperty("test", "keyword")
+            new Migration.Builder().migrateToIndexTemplateVersion(nextIndexTemplateVersion).addProperty("test", "keyword")
         );
 
         managedDataStreams = List.of(ds);
@@ -264,11 +265,12 @@ public class ProfilingDataStreamManagerTests extends ESTestCase {
         DiscoveryNode node = DiscoveryNodeUtils.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
         templatesCreated.set(true);
+        int nextIndexTemplateVersion = ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION + 1;
 
         ProfilingDataStreamManager.ProfilingDataStream ds = ProfilingDataStreamManager.ProfilingDataStream.of(
             "profiling-test",
             1,
-            new Migration.Builder().migrateToIndexTemplateVersion(2).addProperty("test", "keyword")
+            new Migration.Builder().migrateToIndexTemplateVersion(nextIndexTemplateVersion).addProperty("test", "keyword")
         );
         ProfilingDataStreamManager.ProfilingDataStream ds2 = ProfilingDataStreamManager.ProfilingDataStream.of("profiling-no-change", 1
         // no migration specified, should not be changed
@@ -276,7 +278,7 @@ public class ProfilingDataStreamManagerTests extends ESTestCase {
 
         managedDataStreams = List.of(ds, ds2);
         // index is out of date and should be migrated
-        indexTemplateVersion = 2;
+        indexTemplateVersion = nextIndexTemplateVersion;
         ClusterChangedEvent event = createClusterChangedEvent(managedDataStreams, nodes);
 
         AtomicInteger mappingUpdates = new AtomicInteger(0);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexManagerTests.java
@@ -273,12 +273,13 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         DiscoveryNode node = DiscoveryNodeUtils.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
         templatesCreated.set(true);
+        int nextIndexTemplateVersion = ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION + 1;
 
         ProfilingIndexManager.ProfilingIndex idx = ProfilingIndexManager.ProfilingIndex.regular(
             "profiling-test",
             1,
             ProfilingIndexManager.OnVersionBump.KEEP_OLD,
-            new Migration.Builder().migrateToIndexTemplateVersion(2)
+            new Migration.Builder().migrateToIndexTemplateVersion(nextIndexTemplateVersion)
                 .addProperty("test", "keyword")
                 .dynamicSettings(
                     Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(30)).build()
@@ -293,7 +294,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
 
         managedIndices = List.of(idx, idx2);
         // index is out of date and should be migrated
-        indexTemplateVersion = 2;
+        indexTemplateVersion = nextIndexTemplateVersion;
         ClusterChangedEvent event = createClusterChangedEvent(managedIndices, nodes);
 
         AtomicInteger mappingUpdates = new AtomicInteger(0);


### PR DESCRIPTION
### Summary

- Added 'profiling.host.machine' keyword mapping to profiling-hosts
- Updated tests

Also see: https://github.com/elastic/prodfiler/pull/3708/commits/2e996774ad4cfafc96f191978fd869cb7897c8d3