### PR TITLE
[ML] Safely drain deployment request queues before allowing node to shutdown

### DIFF
--- a/docs/changelog/98155.yaml
+++ b/docs/changelog/98155.yaml
@@ -1,0 +1,5 @@
+pr: 98155
+summary: Setting stopping and unsafe change
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -187,6 +187,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         List<Integer> cumulativeAllocations = new ArrayList<>(nodeRoutingTable.size());
         int allocationSum = 0;
         for (Map.Entry<String, RoutingInfo> routingEntry : nodeRoutingTable.entrySet()) {
+            // TODO started and not shutting down
             if (RoutingState.STARTED.equals(routingEntry.getValue().getState())) {
                 nodeIds.add(routingEntry.getKey());
                 allocationSum += routingEntry.getValue().getCurrentAllocations();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
@@ -116,7 +116,7 @@ public class MlLifeCycleService {
         boolean nodeHasDrainingQueues = metadata.allAssignments().values().stream().anyMatch(assignment -> {
             if (assignment.isRoutedToNode(nodeId)) {
                 RoutingInfo routingInfo = assignment.getNodeRoutingTable().get(nodeId);
-                logger.error(format("assignment is routed to shutting down nodeId %s state: %s", nodeId, routingInfo.getState()))
+                logger.error(format("assignment is routed to shutting down nodeId %s state: %s", nodeId, routingInfo.getState()));
                 return routingInfo.getState() == RoutingState.STOPPING;
             }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
@@ -117,13 +117,13 @@ public class MlLifeCycleService {
             if (assignment.isRoutedToNode(nodeId)) {
                 RoutingInfo routingInfo = assignment.getNodeRoutingTable().get(nodeId);
                 logger.error(format("assignment is routed to shutting down nodeId %s state: %s", nodeId, routingInfo.getState()));
-                return routingInfo.getState() == RoutingState.STOPPING;
+                return routingInfo.getState() != RoutingState.STOPPED;
             }
 
             return false;
         });
 
-        logger.error(format("nodeHasDrainingQueues: %s", nodeHasDrainingQueues));
+        logger.error(format("nodeHasDrainingQueues: %s nodeId %s", nodeHasDrainingQueues, nodeId));
 
         // TODO: currently only considering anomaly detection jobs - could extend in the future
         // Ignore failed jobs - the persistent task still exists to remember the failure (because no

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -242,6 +242,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
 
         // Get a list of nodes to send the requests to and the number of
         // documents for each node.
+        // TODO might need to do a check in this function to look for is node shutting down
         var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(request.numberOfDocuments());
         if (nodes.isEmpty()) {
             logger.trace(() -> format("[%s] model deployment not allocated to any node", assignment.getDeploymentId()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -227,6 +227,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
 
+        logger.error("Called removeRoutingToUnassignableNodes");
         for (TrainedModelAssignment assignment : metadata.allAssignments().values()) {
             Set<String> unassignableNodes = Sets.difference(assignment.getNodeRoutingTable().keySet(), assignableNodes);
 
@@ -244,6 +245,9 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 List<String> shuttingDownIds = partitions.get(true);
                 List<String> routedNodeIdsToRemove = partitions.get(false);
 
+                logger.error(format("Shutting down ids %s", shuttingDownIds));
+                logger.error(format("routedNodeIdsToRemove %s", routedNodeIdsToRemove));
+
                 TrainedModelAssignment.Builder assignmentBuilder = TrainedModelAssignment.Builder.fromAssignment(assignment);
                 routedNodeIdsToRemove.forEach(assignmentBuilder::removeRoutingEntry);
 
@@ -252,6 +256,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                         new RoutingStateAndReason(RoutingState.STOPPING, "node is shutting down")
                     );
 
+                    logger.error(format("Trying to set route to stopping for node %s", id));
                     // TODO ideally we'd get the routing table from the builder? that way we handle the chance that it's out of sync after
                     // the removal from above
                     var newRoutingInfo = routeUpdate.apply(assignment.getNodeRoutingTable().get(id));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -534,7 +534,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 logger.error(format("checking for shutting down node id: %s state: %s", nodeId, state));
 
                 if (currentState.metadata().nodeShutdowns().contains(nodeId)
-                    && (state == RoutingState.STARTED || state == RoutingState.STARTING)) {
+                    && state.isAnyOf(RoutingState.STARTED, RoutingState.STARTING)) {
                     foundShuttingDownNodeForAssignment = true;
                     logger.error(format("found a shutting down node while rebalancing node id: %s state: %s", nodeId, state));
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -510,8 +510,9 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         List<DiscoveryNode> nodes = getAssignableNodes(currentState);
         logger.debug(() -> format("assignable nodes are %s", nodes.stream().map(DiscoveryNode::getId).toList()));
         Map<DiscoveryNode, NodeLoad> nodeLoads = detectNodeLoads(nodes, currentState);
+        TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
         TrainedModelAssignmentRebalancer rebalancer = new TrainedModelAssignmentRebalancer(
-            TrainedModelAssignmentMetadata.fromState(currentState),
+            metadata,
             nodeLoads,
             nodeAvailabilityZoneMapper.buildMlNodesByAvailabilityZone(currentState),
             modelToAdd
@@ -519,6 +520,39 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         TrainedModelAssignmentMetadata.Builder rebalanced = rebalancer.rebalance();
         if (modelToAdd.isPresent()) {
             checkModelIsFullyAllocatedIfScalingIsNotPossible(modelToAdd.get().getDeploymentId(), rebalanced, nodes);
+        }
+
+        for (TrainedModelAssignment assignment : metadata.allAssignments().values()) {
+            boolean foundShuttingDownNodeForAssignment = false;
+            var nodeIds = assignment.getNodeRoutingTable().keySet();
+            TrainedModelAssignment.Builder assignmentBuilder = rebalanced.hasModelDeployment(assignment.getDeploymentId())
+                ? rebalanced.getAssignment(assignment.getDeploymentId())
+                : TrainedModelAssignment.Builder.fromAssignment(assignment);
+
+            for (String nodeId : nodeIds) {
+                RoutingState state = assignment.getNodeRoutingTable().get(nodeId).getState();
+                if (currentState.metadata().nodeShutdowns().contains(nodeId)
+                    && (state == RoutingState.STARTED || state == RoutingState.STARTING)) {
+                    foundShuttingDownNodeForAssignment = true;
+                    logger.error(format("found a shutting down node while rebalancing node id: %s state: %s", nodeId, state));
+
+                    var routeUpdate = RoutingInfoUpdate.updateStateAndReason(
+                        new RoutingStateAndReason(RoutingState.STOPPING, "node is shutting down")
+                    );
+
+                    var newRoutingInfo = routeUpdate.apply(assignment.getNodeRoutingTable().get(nodeId));
+
+                    assignmentBuilder.addRoutingEntry(nodeId, newRoutingInfo);
+                }
+            }
+
+            if (foundShuttingDownNodeForAssignment) {
+                if (rebalanced.hasModelDeployment(assignment.getDeploymentId())) {
+                    rebalanced.updateAssignment(assignment.getDeploymentId(), assignmentBuilder);
+                } else {
+                    rebalanced.addNewAssignment(assignment.getDeploymentId(), assignmentBuilder);
+                }
+            }
         }
         return rebalanced;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -531,6 +531,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
 
             for (String nodeId : nodeIds) {
                 RoutingState state = assignment.getNodeRoutingTable().get(nodeId).getState();
+                logger.error(format("checking for shutting down node id: %s state: %s", nodeId, state));
+
                 if (currentState.metadata().nodeShutdowns().contains(nodeId)
                     && (state == RoutingState.STARTED || state == RoutingState.STARTING)) {
                     foundShuttingDownNodeForAssignment = true;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -412,11 +412,28 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                         logger.error(format("going to start draining queue for %s", currentNode));
 
                         // TODO kick off async draining work
+                        // TODO remove this
+                        TrainedModelDeploymentTask task = deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
+                        if (task != null) {
+                            stopDeploymentAsync(
+                                task,
+                                NODE_NO_LONGER_REFERENCED,
+                                ActionListener.wrap(
+                                    r -> logger.error(() -> "[" + task.getDeploymentId() + "] stopped deployment after draining queue"),
+                                    e -> logger.error(
+                                        () -> "[" + task.getDeploymentId() + "] failed to fully stop deployment after draining queue",
+                                        e
+                                    )
+                                )
+                            );
+                        }
                     }
                 }
 
                 // This model is not routed to the current node at all
                 if (routingInfo == null) {
+
+                    logger.error("routing info was null");
                     TrainedModelDeploymentTask task = deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
                     if (task != null) {
                         stopDeploymentAsync(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -199,6 +199,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
     }
 
     public void stop() {
+        logger.error("called stop within TrainedModelAssignmentNodeService");
         stopped = true;
         ThreadPool.Cancellable cancellable = this.scheduledFuture;
         if (cancellable != null) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentService.java
@@ -53,6 +53,15 @@ public class TrainedModelAssignmentService {
         this.threadPool = Objects.requireNonNull(threadPool);
     }
 
+    public void updateTaskInfoState(
+        // SafeToShutdown.Request request,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
+        // TODO do we need to check for the presence of a master node?
+
+        // client.execute(UpdateSafeToShutdownFlag.INSTANCE, request, some listener);
+    }
+
     public void updateModelAssignmentState(
         UpdateTrainedModelAssignmentRoutingInfoAction.Request request,
         ActionListener<AcknowledgedResponse> listener

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -96,6 +96,11 @@ public class DeploymentManager {
         this.maxProcesses = maxProcesses;
     }
 
+    // TODO
+    public void waitForQueueToDrain() {
+
+    }
+
     public Optional<ModelStats> getStats(TrainedModelDeploymentTask task) {
         return Optional.ofNullable(processContextByAllocation.get(task.getId())).map(processContext -> {
             var stats = processContext.getResultProcessor().getResultStats();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -81,6 +81,7 @@ public class PyTorchResultProcessor {
         this.currentPeriodEndTimeMs = startTime + REPORTING_PERIOD_MS;
     }
 
+    // TODO likely going to need to drain something in here too
     public void registerRequest(String requestId, ActionListener<PyTorchResult> listener) {
         pendingResults.computeIfAbsent(requestId, k -> new PendingResult(listener));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -1376,8 +1376,10 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         for (String modelId : List.of(modelId1, modelId2)) {
             TrainedModelAssignment assignment = trainedModelAssignmentMetadata.getDeploymentAssignment(modelId);
             assertThat(assignment, is(notNullValue()));
-            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
+            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(2)));
             assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId1));
+            // TODO fix this
+            assertThat(assignment.getNodeRoutingTable().get(nodeId3).getState(), is(RoutingState.STOPPING));
         }
     }
 


### PR DESCRIPTION
DO NOT MERGE

This PR is for testing only and the fixes will be implemented in: https://github.com/elastic/elasticsearch/pull/98406

WIP

This PR addresses an issue where when a scale event happens the nodes that are removed do not let their queued up deployed model tasks drain before the node is removed. This causes things like a reindex that is leveraging elser to fail when a node scaling event occurs.

Fixes https://github.com/elastic/ml-team/issues/994

## Testing

<details><summary>To reproduce the issue</summary>

1. Create a cloud instance with a single zone and an ML node of 15 GB
2. Download and deploy the elser model
3. Adding the `gcs.client.default.credentials_file` setting
4. Restore the ml data snapshot

```
PUT _snapshot/ml-data-snapshot-share
{
  "type": "gcs",
  "settings": {
    "bucket": "ml-data-snapshots-7-share",
    "client": "default"
  }
}


POST _snapshot/ml-data-snapshot-share/msmarco-datasets/_restore?wait_for_completion=false
```

5. Create a new destination index for the reindex request

```
PUT msmarco-passage-collection-elser
{
  "mappings": {
    "properties": {
      "body": {
        "type": "text"
      },
      "ml": {
        "properties": {
          "tokens": {
            "type": "rank_features"
          }
        }
      }
    }
  }
}
```

6. Create a new ingest pipeline using elser

```
# Ingest pipeline for ELSER
PUT _ingest/pipeline/elser
{
  "processors": [
    {
      "inference": {
        "model_id": ".elser_model_1",
        "field_map": {
          "body": "text_field"
        },
        "target_field": "ml",
        "inference_config": {
          "text_expansion": {
            "results_field": "tokens"
          }
        }
      }
    }
  ]
}
```

7. Kick off a reindex async

```
# ELSER-ise the MS MARCO passage collection with reindex
POST _reindex?wait_for_completion=false
{
  "source": {
    "index": "msmarco-passage-collection",
    "size": 100
  },
  "dest": {
    "index": "msmarco-passage-collection-elser",
    "pipeline": "elser"
  }
}
```

8. Scale up the cluster to 2 zones each with a 30 GB ML node

</details>

<details><summary>TODO deploying the fix in the PR to test that the issue is fixed</summary>


</details>