### PR TITLE
[8.9] Enable data stream lifecycle feature flag in x-pack plugin tests (98050) (#98133)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -224,6 +224,8 @@ testClusters.configureEach {
   extraConfigFile serviceTokens.name, serviceTokens
 
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
+  requiresFeature 'es.inference_rescorer_feature_flag_enabled', Version.fromString("8.10.0")
+  requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 tasks.register('enforceApiSpecsConvention').configure {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Enable data stream lifecycle feature flag in x-pack plugin tests (98050) (#98133)](https://github.com/elastic/elasticsearch/pull/98133)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)