### PR TITLE
[8.9] [DOCS] Node stats API: fix descriptions of 'cache_size' and 'cache_count' (#98092)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -682,12 +682,11 @@ Number of query cache misses.
 
 `cache_size`::
 (integer)
-Size, in bytes, of the query cache.
+Current number of cached queries.
 
 `cache_count`::
 (integer)
-Count of queries
-in the query cache.
+Total number of all queries that have been cached.
 
 `evictions`::
 (integer)


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [DOCS] Node stats API: fix descriptions of 'cache_size' and 'cache_count' (#98092)