### PR TITLE
[8.9] Fix DataStreamLifecycleServiceRuntimeSecurityIT (#98143)

### DIFF
--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -429,6 +429,7 @@ tasks.named("internalClusterTest").configure {
    * to keep direct memory usage under control.
    */
   systemProperty 'es.transport.buffer.size', '256k'
+  systemProperty 'es.dlm_feature_flag_enabled', 'true'
 }
 
 addQaCheckDependencies(project)


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Fix DataStreamLifecycleServiceRuntimeSecurityIT (#98143)