### PR TITLE
Move optimized bulk numeric read methods into BlobCacheBufferedIndexInput

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/BlobCacheBufferedIndexInput.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/BlobCacheBufferedIndexInput.java
@@ -256,6 +256,63 @@ public abstract class BlobCacheBufferedIndexInput extends IndexInput implements 
         return buffer.getLong((int) index);
     }
 
+    @Override
+    public void readFloats(float[] dst, int offset, int len) throws IOException {
+        int remainingDst = len;
+        while (remainingDst > 0) {
+            int cnt = Math.min(buffer.remaining() / Float.BYTES, remainingDst);
+            buffer.asFloatBuffer().get(dst, offset + len - remainingDst, cnt);
+            buffer.position(buffer.position() + Float.BYTES * cnt);
+            remainingDst -= cnt;
+            if (remainingDst > 0) {
+                if (buffer.hasRemaining()) {
+                    dst[offset + len - remainingDst] = Float.intBitsToFloat(readInt());
+                    --remainingDst;
+                } else {
+                    refill();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readLongs(long[] dst, int offset, int len) throws IOException {
+        int remainingDst = len;
+        while (remainingDst > 0) {
+            int cnt = Math.min(buffer.remaining() / Long.BYTES, remainingDst);
+            buffer.asLongBuffer().get(dst, offset + len - remainingDst, cnt);
+            buffer.position(buffer.position() + Long.BYTES * cnt);
+            remainingDst -= cnt;
+            if (remainingDst > 0) {
+                if (buffer.hasRemaining()) {
+                    dst[offset + len - remainingDst] = readLong();
+                    --remainingDst;
+                } else {
+                    refill();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readInts(int[] dst, int offset, int len) throws IOException {
+        int remainingDst = len;
+        while (remainingDst > 0) {
+            int cnt = Math.min(buffer.remaining() / Integer.BYTES, remainingDst);
+            buffer.asIntBuffer().get(dst, offset + len - remainingDst, cnt);
+            buffer.position(buffer.position() + Integer.BYTES * cnt);
+            remainingDst -= cnt;
+            if (remainingDst > 0) {
+                if (buffer.hasRemaining()) {
+                    dst[offset + len - remainingDst] = readInt();
+                    --remainingDst;
+                } else {
+                    refill();
+                }
+            }
+        }
+    }
+
     protected void refill() throws IOException {
         long start = bufferStart + buffer.position();
         long end = start + bufferSize;


### PR DESCRIPTION
Sorry for the noise, this is a follow-up to #98158. The bulk methods should just live in this class, instead getting introduced through a subclass in stateless.
