### PR TITLE
Skipping the new stall_time_seconds test in error_query yaml test before version 8.10

### DIFF
--- a/test/external-modules/error-query/src/yamlRestTest/resources/rest-api-spec/test/error_query/20_stall_time.yml
+++ b/test/external-modules/error-query/src/yamlRestTest/resources/rest-api-spec/test/error_query/20_stall_time.yml
@@ -2,7 +2,11 @@
 #
 
 ---
-"Error query":
+"Error query with stall time":
+  - skip:
+      version: " - 8.9.99"
+      reason: stall_time_seconds error_query field added in 8.10
+
   - do:
       indices.create:
         index: test_exception


### PR DESCRIPTION
An oversight that was missed in https://github.com/elastic/elasticsearch/pull/98114