### PR TITLE
QL: Minor refactoring to planner and tests

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedNamedExpression.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedNamedExpression.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.ql.type.DataType;
 
 import java.util.List;
 
-abstract class UnresolvedNamedExpression extends NamedExpression implements Unresolvable {
+public abstract class UnresolvedNamedExpression extends NamedExpression implements Unresolvable {
 
     UnresolvedNamedExpression(Source source, List<Expression> children) {
         super(source, "<unresolved>", children, new NameId());

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
@@ -69,7 +69,7 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
         }
     }
 
-    private final Iterable<Batch<TreeType>> batches = batches();
+    private Iterable<Batch<TreeType>> batches = null;
 
     protected abstract Iterable<RuleExecutor.Batch<TreeType>> batches();
 
@@ -138,6 +138,9 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
         long totalDuration = 0;
 
         Map<Batch<TreeType>, List<Transformation>> transformations = new LinkedHashMap<>();
+        if (batches == null) {
+            batches = batches();
+        }
 
         for (Batch<TreeType> batch : batches) {
             int batchRuns = 0;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/KeywordEsField.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/KeywordEsField.java
@@ -57,6 +57,10 @@ public class KeywordEsField extends EsField {
         return precision;
     }
 
+    public boolean getNormalized() {
+        return normalized;
+    }
+
     @Override
     public Exact getExactInfo() {
         return new Exact(normalized == false, "Normalized keyword field cannot be used for exact match operations");

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ReflectionUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ReflectionUtils.java
@@ -20,7 +20,7 @@ public class ReflectionUtils {
         for (Type type = clazz.getGenericSuperclass(); clazz != Object.class; type = clazz.getGenericSuperclass()) {
             if (type instanceof ParameterizedType) {
                 Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
-                if (typeArguments.length != 2 && typeArguments.length != 1) {
+                if (typeArguments.length > 3 || typeArguments.length < 1) {
                     throw new QlIllegalArgumentException(
                         "Unexpected number of type arguments {} for {}",
                         Arrays.toString(typeArguments),

--- a/x-pack/plugin/ql/src/test/resources/mapping-one-field.json
+++ b/x-pack/plugin/ql/src/test/resources/mapping-one-field.json
@@ -1,0 +1,7 @@
+{
+    "properties" : {
+        "emp_no" : {
+            "type" : "integer"
+        }
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/AnalyzerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/AnalyzerTests.java
@@ -116,7 +116,7 @@ public class AnalyzerTests extends ESTestCase {
         // see https://github.com/elastic/elasticsearch/issues/81577
         // The query itself is not supported (using aggregates in a sub-select) but it shouldn't bring down ES
         LogicalPlan plan = analyze(
-            "SELECT salary AS salary, salary AS s FROM (SELECT ROUND(AVG(salary)) AS salary FROM test_emp GROUP BY gender) "
+            "SELECT salary AS salary, salary AS s FROM (SELECT ROUND(AVG(salary)) AS salary FROM test GROUP BY gender) "
                 + "WHERE s > 48000 OR salary > 46000"
         );
         // passing the analysis step should succeed

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/SqlParserTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/SqlParserTests.java
@@ -364,6 +364,33 @@ public class SqlParserTests extends ESTestCase {
         );
     }
 
+    public void testQuotedIndexName() {
+        Project plan = project(parseStatement("SELECT * FROM \"foo,bar\""));
+
+        assertThat(plan.child(), instanceOf(UnresolvedRelation.class));
+        UnresolvedRelation relation = (UnresolvedRelation) plan.child();
+        assertEquals("foo,bar", relation.table().index());
+        assertNull(relation.table().cluster());
+    }
+
+    public void testQuotedIndexNameWithCluster() {
+        Project plan = project(parseStatement("SELECT * FROM elastic:\"foo,bar\""));
+
+        assertThat(plan.child(), instanceOf(UnresolvedRelation.class));
+        UnresolvedRelation relation = (UnresolvedRelation) plan.child();
+        assertEquals("foo,bar", relation.table().index());
+        assertEquals("elastic", relation.table().cluster());
+    }
+
+    public void testQuotedIndexNameWithQuotedCluster() {
+        Project plan = project(parseStatement("SELECT * FROM \"elastic\":\"foo,bar\""));
+
+        assertThat(plan.child(), instanceOf(UnresolvedRelation.class));
+        UnresolvedRelation relation = (UnresolvedRelation) plan.child();
+        assertEquals("foo,bar", relation.table().index());
+        assertEquals("elastic", relation.table().cluster());
+    }
+
     private LogicalPlan parseStatement(String sql) {
         return new SqlParser().createStatement(sql);
     }


### PR DESCRIPTION
This PR is a backport of some changes from another branch.
It's mostly small refactoring and a few more tests:
- lazy loading of batches in RuleExecutor
- new getter on KeywordEsField: getNormalized()
- ReflectionUtils allows ParameterizedType with three arguments
- Analyzer and parser tests