### PR TITLE
[8.9] Enhance regex performance with duplicate wildcards (#98176)

### DIFF
--- a/docs/changelog/98176.yaml
+++ b/docs/changelog/98176.yaml
@@ -1,0 +1,5 @@
+pr: 98176
+summary: Enhance regex performance with duplicate wildcards
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/regex/Regex.java
+++ b/server/src/main/java/org/elasticsearch/common/regex/Regex.java
@@ -177,8 +177,12 @@ public class Regex {
                 // str.endsWith(pattern.substring(1)), but avoiding the construction of pattern.substring(1):
                 return str.regionMatches(str.length() - pattern.length() + 1, pattern, 1, pattern.length() - 1);
             } else if (nextIndex == 1) {
-                // Double wildcard "**" - skipping the first "*"
-                return simpleMatchWithNormalizedStrings(pattern.substring(1), str);
+                // Double wildcard "**" detected - skipping all "*"
+                int wildcards = nextIndex + 1;
+                while (wildcards < pattern.length() && pattern.charAt(wildcards) == '*') {
+                    wildcards++;
+                }
+                return simpleMatchWithNormalizedStrings(pattern.substring(wildcards - 1), str);
             }
             final String part = pattern.substring(1, nextIndex);
             int partIndex = str.indexOf(part);

--- a/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
@@ -78,6 +78,28 @@ public class RegexTests extends ESTestCase {
         assertFalse(Regex.simpleMatch("fff******ddd", "fffabcdd"));
     }
 
+    public void testArbitraryWildcardMatch() {
+        final String prefix = randomAlphaOfLengthBetween(1, 20);
+        final String suffix = randomAlphaOfLengthBetween(1, 20);
+        final String pattern1 = "*".repeat(randomIntBetween(1, 1000));
+        // dd***
+        assertTrue(Regex.simpleMatch(prefix + pattern1, prefix + randomAlphaOfLengthBetween(10, 20), randomBoolean()));
+        // ***dd
+        assertTrue(Regex.simpleMatch(pattern1 + suffix, randomAlphaOfLengthBetween(10, 20) + suffix, randomBoolean()));
+        // dd***dd
+        assertTrue(Regex.simpleMatch(prefix + pattern1 + suffix, prefix + randomAlphaOfLengthBetween(10, 20) + suffix, randomBoolean()));
+        // dd***dd***dd
+        final String middle = randomAlphaOfLengthBetween(1, 20);
+        final String pattern2 = "*".repeat(randomIntBetween(1, 1000));
+        assertTrue(
+            Regex.simpleMatch(
+                prefix + pattern1 + middle + pattern2 + suffix,
+                prefix + randomAlphaOfLengthBetween(10, 20) + middle + randomAlphaOfLengthBetween(10, 20) + suffix,
+                randomBoolean()
+            )
+        );
+    }
+
     public void testSimpleMatch() {
         for (int i = 0; i < 1000; i++) {
             final String matchingString = randomAlphaOfLength(between(0, 50));


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Enhance regex performance with duplicate wildcards (#98176)