### PR TITLE
Remove whitespace from ILM metadata

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -145,7 +145,7 @@ public class IndexLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, true);
+        return Strings.toString(this, false, true);
     }
 
     public static class IndexLifecycleMetadataDiff implements NamedDiff<Metadata.Custom> {


### PR DESCRIPTION
`IndexLifecycleMetadata#toString` emits pretty-printed JSON which
produces a lot of noise when printing out the cluster state for
debugging purposes. This commit removes the pretty-printing to reduce
the line count and make it easier to skip.