### PR TITLE
Use pwrite for writing to SharedBytes

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -97,10 +97,10 @@ public class SharedBytes extends AbstractRefCounted {
             int mapCount = Math.toIntExact(fileSize / mapSize) + (lastMapSize == 0 ? 0 : 1);
             MappedByteBuffer[] mmaps = new MappedByteBuffer[mapCount];
             for (int i = 0; i < mapCount - 1; i++) {
-                mmaps[i] = fileChannel.map(FileChannel.MapMode.READ_WRITE, (long) mapSize * i, mapSize);
+                mmaps[i] = fileChannel.map(FileChannel.MapMode.READ_ONLY, (long) mapSize * i, mapSize);
             }
             mmaps[mapCount - 1] = fileChannel.map(
-                FileChannel.MapMode.READ_WRITE,
+                FileChannel.MapMode.READ_ONLY,
                 (long) mapSize * (mapCount - 1),
                 lastMapSize == 0 ? mapSize : lastMapSize
             );
@@ -110,7 +110,6 @@ public class SharedBytes extends AbstractRefCounted {
                     mmaps[i / regionsPerMmap].slice(Math.toIntExact((i % regionsPerMmap) * regionSize), Math.toIntExact(regionSize))
                 );
             }
-            fileChannel.close();
         } else {
             for (int i = 0; i < numRegions; i++) {
                 ios[i] = new IO(i, null);
@@ -293,14 +292,7 @@ public class SharedBytes extends AbstractRefCounted {
             assert position % PAGE_SIZE == 0;
             assert src.remaining() % PAGE_SIZE == 0;
             checkOffsets(position, src.remaining());
-            final int bytesWritten;
-            if (mmap) {
-                bytesWritten = src.remaining();
-                mappedByteBuffer.put(Math.toIntExact(position - pageStart), src, src.position(), bytesWritten);
-                src.position(src.position() + bytesWritten);
-            } else {
-                bytesWritten = fileChannel.write(src, position);
-            }
+            int bytesWritten = fileChannel.write(src, position);
             writeBytes.accept(bytesWritten);
             return bytesWritten;
         }


### PR DESCRIPTION
There isn't much point in using mmap for writing to `SharedBytes` and its memory effects aren't entirely predictable. It's much harder for the kernel to efficiently work out when to flush the written bytes with mmap in most cases.
I could not find any indication that this would not be safe concurrency-wise on any of the OS we support either. 
=> This makes me much more comfortable with the idea of enabling mmap-ed io on Frozen by default and should give us better performance all around by likely consuming less memory for writes that could be used for paging in things to be read (note that with the way the cache works, we will often write a large 16M page only to frequently access a small portion of it later on).