### PR TITLE
[ML] Detect infinite loop in the tokenizer

### DIFF
--- a/docs/changelog/98206.yaml
+++ b/docs/changelog/98206.yaml
@@ -1,5 +1,5 @@
 pr: 98206
-summary: Detect infinite loop in the tokenizer
+summary: Detect infinite loop in the WordPiece tokenizer
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/98206.yaml
+++ b/docs/changelog/98206.yaml
@@ -1,0 +1,5 @@
+pr: 98206
+summary: Detect infinite loop in the tokenizer
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
@@ -365,7 +365,9 @@ public abstract class NlpTokenizer implements Releasable {
                 // and the sequence ending in a long word that tokenizes
                 // to a number of elements greater than the difference
                 // between span and 2nd sequence length
-                throw new IllegalStateException("tokenization cannot be satisfied with the current span setting");
+                throw new IllegalStateException(
+                    "Tokenization cannot be satisfied with the current span setting. Consider decreasing the span setting"
+                );
             }
 
             // try to back up our split so that it starts at the first whole word

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
@@ -315,11 +315,13 @@ public abstract class NlpTokenizer implements Releasable {
         if (span > trueMaxSeqLength) {
             throw new IllegalArgumentException(
                 Strings.format(
-                    "Unable to do sequence pair tokenization: the combined first sequence and span length [%d + %d = %d tokens] "
-                        + "is longer than the max sequence length [%d tokens]. Reduce the size of the [span] window.",
+                    "Unable to do sequence pair tokenization: the combined first sequence, span length and delimiting tokens"
+                        + " [%d + %d + %d = %d tokens] is longer than the max sequence length [%d tokens]."
+                        + " Reduce the size of the [span] window.",
                     tokenIdsSeq1.size(),
                     span,
-                    tokenIdsSeq1.size() + span,
+                    extraTokens,
+                    tokenIdsSeq1.size() + span + extraTokens,
                     maxSequenceLength()
                 )
             );
@@ -355,6 +357,17 @@ public abstract class NlpTokenizer implements Releasable {
             spanPrev = span;
             int prevSplitStart = splitStartPos;
             splitStartPos = splitEndPos - span;
+            if (splitStartPos <= prevSplitStart) {
+                // Tokenization is not progressing, the start pos has
+                // not moved forward leading to an infinite loop.
+                // In practice this is probably due to the span
+                // setting being very close to the 2nd sequence length
+                // and the sequence ending in a long word that tokenizes
+                // to a number of elements greater than the difference
+                // between span and 2nd sequence length
+                throw new IllegalStateException("tokenization cannot be satisfied with the current span setting");
+            }
+
             // try to back up our split so that it starts at the first whole word
             if (splitStartPos < tokenIdsSeq2.size()) {
                 while (splitStartPos > (prevSplitStart + 1)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -650,8 +650,8 @@ public class BertTokenizerTests extends ESTestCase {
             assertThat(
                 iae.getMessage(),
                 containsString(
-                    "Unable to do sequence pair tokenization: the combined first sequence and span length [4 + 5 = 9 tokens] "
-                        + "is longer than the max sequence length [8 tokens]. Reduce the size of the [span] window."
+                    "Unable to do sequence pair tokenization: the combined first sequence, span length and delimiting tokens "
+                        + "[4 + 5 + 3 = 12 tokens] is longer than the max sequence length [8 tokens]. Reduce the size of the [span] window."
                 )
             );
         }
@@ -781,5 +781,33 @@ public class BertTokenizerTests extends ESTestCase {
             Tokenizer preTokenizer = analyzer.createTokenizer();
             assertThat(preTokenizer, instanceOf(WhitespaceTokenizer.class));
         }
+    }
+
+    public void testDetectInfiniteLoop() {
+        // These settings are known to produce an infinite loop.
+        // question and context are longer than max sequence length
+        // so the input must be spanned. With a span setting of 4
+        // there is only 1 more token that can go into the context part:
+        // question = 5 tokens
+        // CLS & SEP = 3
+        // Span = 4
+        // total = 12 tokens.
+        // max sequence length = 13
+        //
+        // Because the word 'Elasticsearch' maps to more than 1 token
+        // it is not possible to fit it into the window so the term
+        // is taken out, the algorithm backs up and next time round
+        // the loop it is in the same situation.
+        String question = "is Elasticsearch fun?";
+        String context = "Pancake day is fun with Elasticsearch and little red car";
+        int span = 4;
+        int maxSequenceLength = 13;
+
+        BertTokenization tokenization = new BertTokenization(false, true, maxSequenceLength, Tokenization.Truncate.NONE, span);
+        BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, tokenization).build();
+
+        var e = expectThrows(IllegalStateException.class, () -> tokenizer.tokenize(question, context, Tokenization.Truncate.NONE, span, 0));
+        assertThat(e.getMessage(), containsString("tokenization cannot be satisfied with the current span setting"));
+
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -807,7 +807,7 @@ public class BertTokenizerTests extends ESTestCase {
         BertTokenizer tokenizer = BertTokenizer.builder(TEST_CASED_VOCAB, tokenization).build();
 
         var e = expectThrows(IllegalStateException.class, () -> tokenizer.tokenize(question, context, Tokenization.Truncate.NONE, span, 0));
-        assertThat(e.getMessage(), containsString("tokenization cannot be satisfied with the current span setting"));
+        assertThat(e.getMessage(), containsString("Tokenization cannot be satisfied with the current span setting"));
 
     }
 }


### PR DESCRIPTION
While investigating #98167 I hit a scenario where the tokeniser can go into an infinite loop. The problem occurs tokenising for question answering models where the question and context is longer than the max sequence length and needs to be split over multiple requests. The question is always including in each request followed by a section of the context taken from a sliding window. 

When the span setting (overlap) is very close to the length of the context part and the context ends in a word that tokenises to more than one token the tokeniser can enter an infinite loop. 

The PR is labelled a bug fix but in real world usage it is very unlikely to occur as the span and max sequence length settings used to reproduce the error in the unit test are not practical settings. 

I also updated an error message as the values it shows were incorrect