### PR TITLE
Fix link to removed Cloud snapshot and restore page

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -94,9 +94,8 @@ cluster. You can also use the `found-snapshots` repository for your own
 
 The `found-snapshots` repository is specific to each deployment. However, you
 can restore snapshots from another deployment's `found-snapshots` repository if
-the deployments are under the same account and in the same region. See
-{cloud}/ec_share_a_repository_across_clusters.html[Share a repository across
-clusters].
+the deployments are under the same account and in the same region. See the Cloud
+{cloud}/ec-snapshot-restore.html[Snapshot and restore] documentation to learn more.
 
 {ess} deployments also support the following repository types:
 

--- a/docs/reference/tab-widgets/snapshot-repo.asciidoc
+++ b/docs/reference/tab-widgets/snapshot-repo.asciidoc
@@ -4,9 +4,8 @@ When you create a cluster, {ess} automatically registers a default
 supports {search-snaps}.
 
 The `found-snapshots` repository is specific to your cluster. To use another
-cluster's default repository, see
-{cloud}/ec_share_a_repository_across_clusters.html[Share a repository across
-clusters].
+cluster's default repository, refer to the Cloud
+{cloud}/ec-snapshot-restore.html[Snapshot and restore] documentation.
 
 You can also use any of the following custom repository types with {search-snaps}:
 


### PR DESCRIPTION
This should fix some broken links resulting from the Cloud ms-96 version bump. These fixes probably aren't ideal, but I'd like to get a clean build, and then once MS-96 is live we can improve the text if required.

```
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.12/use-elasticsearch-for-time-series-data.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.13/use-elasticsearch-for-time-series-data.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.14/use-elasticsearch-for-time-series-data.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.15/use-elasticsearch-for-time-series-data.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.16/snapshots-register-repository.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.16/snapshots-restore-snapshot.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec-restoring-snapshots.html#ec-restore-across-clusters
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.16/use-elasticsearch-for-time-series-data.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.17/snapshots-register-repository.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.17/snapshots-restore-snapshot.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec-restoring-snapshots.html#ec-restore-across-clusters
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.17/use-elasticsearch-for-time-series-data.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/8.0/snapshots-register-repository.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec_share_a_repository_across_clusters.html
```

Rel: https://github.com/elastic/cloud/issues/117192