### PR TITLE
[8.8] Fix broken links to Cloud snapshot restore info (#98213)

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -101,9 +101,8 @@ cluster. You can also use the `found-snapshots` repository for your own
 
 The `found-snapshots` repository is specific to each deployment. However, you
 can restore snapshots from another deployment's `found-snapshots` repository if
-the deployments are under the same account and in the same region. See
-{cloud}/ec_share_a_repository_across_clusters.html[Share a repository across
-clusters].
+the deployments are under the same account and in the same region. See the Cloud
+{cloud}/ec-snapshot-restore.html[Snapshot and restore] documentation to learn more.
 
 {ess} deployments also support the following repository types:
 

--- a/docs/reference/tab-widgets/snapshot-repo.asciidoc
+++ b/docs/reference/tab-widgets/snapshot-repo.asciidoc
@@ -4,9 +4,8 @@ When you create a cluster, {ess} automatically registers a default
 supports {search-snaps}.
 
 The `found-snapshots` repository is specific to your cluster. To use another
-cluster's default repository, see
-{cloud}/ec_share_a_repository_across_clusters.html[Share a repository across
-clusters].
+cluster's default repository, refer to the Cloud
+{cloud}/ec-snapshot-restore.html[Snapshot and restore] documentation.
 
 You can also use any of the following custom repository types with {search-snaps}:
 


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix broken links to Cloud snapshot restore info (#98213)