### PR TITLE
[7.13] Fix broken link to Cloud snapshot restore info (#98224)

### DIFF
--- a/docs/reference/tab-widgets/snapshot-repo.asciidoc
+++ b/docs/reference/tab-widgets/snapshot-repo.asciidoc
@@ -4,9 +4,8 @@ When you create a cluster, {ess} automatically registers a default
 supports {search-snaps}.
 
 The `found-snapshots` repository is specific to your cluster. To use another
-cluster's default repository, see
-{cloud}/ec_share_a_repository_across_clusters.html[Share a repository across
-clusters].
+cluster's default repository, refer to the Cloud
+{cloud}/ec-snapshot-restore.html[Snapshot and restore] documentation.
 
 You can also use any of the following custom repository types with {search-snaps}:
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Fix broken link to Cloud snapshot restore info (#98224)