### PR TITLE
[Docs] Fix links to Cloud snapshot and restore docs

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -613,8 +613,7 @@ DELETE _data_stream/logs-my_app-default
 === Restore to a different cluster
 
 TIP: {ess} can help you restore snapshots from other deployments. See
-{cloud}/ec-restoring-snapshots.html#ec-restore-across-clusters[Restore across
-clusters].
+{cloud}/ec-restoring-snapshots.html[Work with snapshots].
 
 Snapshots aren't tied to a particular cluster or a cluster name. You can create
 a snapshot in one cluster and restore it in another


### PR DESCRIPTION
Fixing broken link errors in the Cloud MS-96 docs, like these:
```
18:30:07 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/8.1/snapshots-restore-snapshot.html contains broken links to:
18:30:07 INFO:build_docs:   - en/cloud/current/ec-restoring-snapshots.html#ec-restore-across-clusters
```