### PR TITLE
[7.16] [Docs] Fix links to Cloud snapshot and restore docs (#98228)

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -590,8 +590,7 @@ DELETE _data_stream/logs-my_app-default
 === Restore to a different cluster
 
 TIP: {ess} can help you restore snapshots from other deployments. See
-{cloud}/ec-restoring-snapshots.html#ec-restore-across-clusters[Restore across
-clusters].
+{cloud}/ec-restoring-snapshots.html[Work with snapshots].
 
 Snapshots aren't tied to a particular cluster or a cluster name. You can create
 a snapshot in one cluster and restore it in another


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.16`:
 - [[Docs] Fix links to Cloud snapshot and restore docs (#98228)](https://github.com/elastic/elasticsearch/pull/98228)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)