### PR TITLE
Fix admonition about initial_master_nodes

### DIFF
--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -27,15 +27,18 @@ node:
   if it is not possible to use the `node.name` of the node and there are
   multiple nodes sharing a single IP address.
 
-IMPORTANT: After the cluster has formed, remove the `cluster.initial_master_nodes`
-setting from each node's configuration. It should not be set for
-master-ineligible nodes, master-eligible nodes joining an existing cluster, or
-nodes which are restarting.
-+
+[IMPORTANT]
+====
+After the cluster has formed, remove the `cluster.initial_master_nodes` setting
+from each node's configuration. It should not be set for master-ineligible
+nodes, master-eligible nodes joining an existing cluster, or nodes which are
+restarting.
+
 If you leave `cluster.initial_master_nodes` in place once the cluster has
 formed then there is a risk that a future misconfiguration may result in
 bootstrapping a new cluster alongside your existing cluster. It may not be
 possible to recover from this situation without losing data.
+====
 
 The simplest way to create a new cluster is for you to select one of your
 master-eligible nodes that will bootstrap itself into a single-node cluster,


### PR DESCRIPTION
Admonition paragraphs cannot be combined with a `+` continuation mark.
This commit fixes the formatting by using an admonition block instead.