### PR TITLE
[DOC+] ILM min_age interpretation

### DIFF
--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -149,6 +149,20 @@ POST /my-index-000001/_ilm/retry
 {ilm-init} subsequently attempts to re-run the step that failed. 
 You can use the <<ilm-explain-lifecycle,{ilm-init} Explain API>> to monitor the progress.
 
+
+[discrete]
+=== Common {ilm-init} setting issues
+
+[discrete]
+==== `min_age` calculation time
+
+When setting up an <<set-up-lifecycle-policy,ILM policy>> or <<getting-started-index-lifecycle-management,Automating Rollover with ILM>>, {ilm-init}'s `min_age` calculates from rollover time fallback index creation time.
+
+If <<ilm-rollover,ILM Rollover>> is used, the `min_age` calculates from the the index's rollover time. This is because the <<indices-rollover-index,Rollover API>> generates a new index and the new <<indices-get-settings,Index Setting's>> `creation_date` parameter is used in the calculation. If Rollover is not used within the ILM Policy then `min_age` is calculated off the original index’s `creation_date`. 
+
+You can override the time an index's `min_age` calculates from with either <<ilm-settings,ILM Setting>> `index.lifecycle.origination_date` or ` index.lifecycle.parse_origination_date `. 
+
+
 [discrete]
 === Common {ilm-init} errors
 

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -154,13 +154,13 @@ You can use the <<ilm-explain-lifecycle,{ilm-init} Explain API>> to monitor the 
 === Common {ilm-init} setting issues
 
 [discrete]
-==== `min_age` calculation time
+==== How `min_age` is calculated
 
-When setting up an <<set-up-lifecycle-policy,ILM policy>> or <<getting-started-index-lifecycle-management,Automating Rollover with ILM>>, {ilm-init}'s `min_age` calculates from rollover time fallback index creation time.
+When setting up an <<set-up-lifecycle-policy,{ilm-init} policy>> or <<getting-started-index-lifecycle-management,automating rollover with {ilm-init}>>, be aware that`min_age` can be relative to either the rollover time or the index creation time.
 
-If <<ilm-rollover,ILM Rollover>> is used, the `min_age` calculates from the the index's rollover time. This is because the <<indices-rollover-index,Rollover API>> generates a new index and the new <<indices-get-settings,Index Setting's>> `creation_date` parameter is used in the calculation. If Rollover is not used within the ILM Policy then `min_age` is calculated off the original index’s `creation_date`. 
+If you use <<ilm-rollover,{ilm-init} rollover>>, `min_age` is calculated relative to the time the index was rolled over. This is because the <<indices-rollover-index,rollover API>> generates a new index. The `creation_date` of the new index (retrievable via <<indices-get-settings>>) is used in the calculation. If you do not use rollover in the {ilm-init} policy, `min_age` is calculated relative to the `creation_date` of the original index.
 
-You can override the time an index's `min_age` calculates from with either <<ilm-settings,ILM Setting>> `index.lifecycle.origination_date` or ` index.lifecycle.parse_origination_date `. 
+You can override how `min_age` is calculated using the `index.lifecycle.origination_date` and `index.lifecycle.parse_origination_date` <<ilm-settings,{ilm-init} settings>>.
 
 
 [discrete]


### PR DESCRIPTION
👋 hiya, team!

From the time y'all helped me write this [ILM Troubleshooting blog](https://www.elastic.co/blog/troubleshooting-elasticsearch-ilm-common-issues-and-fixes) in 2021 and @jrodewig later helped me port errors to [this doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-error-handling.html) via https://github.com/elastic/elasticsearch/issues/75849, the remaining top-gotcha user's are still encountering in EO2023 is "Common issue 3" that ILM's `min_age` calculates off rollover time fallback index creation time. (Users consistently expect this to only calculate from creation time.)

This PR cross-pollinates the blog quote into the docs so that Support can link it to users and so it becomes Google-able.

> Common issue 3: min_age calculation clarification
> When working with customers, I have seen confusion about how min_age works. The min_age must increase between subsequent phases. If rollover is used, min_age is calculated off the rollover date. This is because rollover generates a new index and the new index’s creation date is used in the calculation. Otherwise, min_age is calculated off the original index’s creation date.