### PR TITLE
Enable reset-feature-state action on serverless

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestResetFeatureStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestResetFeatureStateAction.java
@@ -15,12 +15,15 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
 
 /** Rest handler for feature state reset requests */
+@ServerlessScope(Scope.INTERNAL)
 public class RestResetFeatureStateAction extends BaseRestHandler {
 
     @Override


### PR DESCRIPTION
This action exists primarily for testing purposes and is useful when testing serverless projects