### PR TITLE
Implement ObjectPath#toString

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ObjectPath.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ObjectPath.java
@@ -166,4 +166,9 @@ public class ObjectPath {
         }
         return builder;
     }
+
+    @Override
+    public String toString() {
+        return "ObjectPath["  + object + "]";
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ObjectPath.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ObjectPath.java
@@ -169,6 +169,6 @@ public class ObjectPath {
 
     @Override
     public String toString() {
-        return "ObjectPath["  + object + "]";
+        return "ObjectPath[" + object + "]";
     }
 }


### PR DESCRIPTION
If a REST test fails because of something unexpected in a response, it's
useful to be able to see the full response. This commit adds a
`toString()` implementation to `ObjectPath` to help with this kind of
debugging.