### PR TITLE
Improve testclusters shutdown logging

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1213,12 +1213,12 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         try {
             processHandle.onExit().get(ES_DESTROY_TIMEOUT, ES_DESTROY_TIMEOUT_UNIT);
         } catch (InterruptedException e) {
-            LOGGER.info("Interrupted while waiting for ES process", e);
+            LOGGER.info("[{}] Interrupted while waiting for ES process", name, e);
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
-            LOGGER.info("Failure while waiting for process to exist", e);
+            LOGGER.info("[{}] Failure while waiting for process to exist", name, e);
         } catch (TimeoutException e) {
-            LOGGER.info("Timed out waiting for process to exit", e);
+            LOGGER.info("[{}] Timed out waiting for process to exit", name, e);
         }
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
@@ -117,7 +117,11 @@ public final class ProcessUtils {
                 if (processHandle.isAlive() == false) {
                     return;
                 }
-                LOGGER.info("Process did not terminate after {}, stopping it forcefully", PROCESS_DESTROY_TIMEOUT);
+                LOGGER.info(
+                    "Process did not terminate after {}, stopping it forcefully: {}",
+                    PROCESS_DESTROY_TIMEOUT,
+                    processHandle.info()
+                );
                 processHandle.destroyForcibly();
             }
 
@@ -147,9 +151,9 @@ public final class ProcessUtils {
                 return processHandle.isAlive() == false;
             });
         } catch (ExecutionException e) {
-            LOGGER.info("Failure while waiting for process to exist", e);
+            LOGGER.info("Failure while waiting for process to exit: {}", processHandle.info(), e);
         } catch (TimeoutException e) {
-            LOGGER.info("Timed out waiting for process to exit", e);
+            LOGGER.info("Timed out waiting for process to exit: {}", processHandle.info(), e);
         }
     }
 


### PR DESCRIPTION
Today the logging when shutting down a node does not indicate to which
node it pertains. This commit adds a little more detail to aid with
debugging.