### PR TITLE
Avoid lifecycle NPE in the data stream lifecycle usage API

### DIFF
--- a/docs/changelog/98260.yaml
+++ b/docs/changelog/98260.yaml
@@ -1,0 +1,5 @@
+pr: 98260
+summary: Avoid NPE
+area: Data streams
+type: bug
+issues: []

--- a/docs/changelog/98260.yaml
+++ b/docs/changelog/98260.yaml
@@ -1,5 +1,5 @@
 pr: 98260
-summary: Avoid NPE
+summary: Avoid lifecycle NPE in the data stream lifecycle usage API
 area: Data streams
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
@@ -89,7 +89,8 @@ public class RolloverConfiguration implements Writeable, ToXContentObject {
      * Evaluates the automatic conditions and converts the whole configuration to XContent.
      * For the automatic conditions is also adds the suffix [automatic]
      */
-    public XContentBuilder evaluateAndConvertToXContent(XContentBuilder builder, Params params, TimeValue retention) throws IOException {
+    public XContentBuilder evaluateAndConvertToXContent(XContentBuilder builder, Params params, @Nullable TimeValue retention)
+        throws IOException {
         builder.startObject();
         concreteConditions.toXContentFragment(builder, params);
         for (String automaticCondition : automaticConditions) {

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -90,19 +90,21 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
             Map<String, DataStream> dataStreamMap = new HashMap<>();
             for (int dataStreamCount = 0; dataStreamCount < randomInt(200); dataStreamCount++) {
                 boolean hasLifecycle = randomBoolean();
-                long retentionMillis;
+                Long retentionMillis;
                 if (hasLifecycle) {
-                    retentionMillis = randomLongBetween(1000, 100000);
+                    retentionMillis = randomBoolean() ? randomLongBetween(1000, 100000) : null;
                     count.incrementAndGet();
-                    totalRetentionTimes.addAndGet(retentionMillis);
-                    if (retentionMillis < minRetention.get()) {
-                        minRetention.set(retentionMillis);
-                    }
-                    if (retentionMillis > maxRetention.get()) {
-                        maxRetention.set(retentionMillis);
+                    if (retentionMillis != null) {
+                        totalRetentionTimes.addAndGet(retentionMillis);
+                        if (retentionMillis < minRetention.get()) {
+                            minRetention.set(retentionMillis);
+                        }
+                        if (retentionMillis > maxRetention.get()) {
+                            maxRetention.set(retentionMillis);
+                        }
                     }
                 } else {
-                    retentionMillis = 0;
+                    retentionMillis =  0L;
                 }
                 List<Index> indices = new ArrayList<>();
                 for (int indicesCount = 0; indicesCount < randomIntBetween(1, 10); indicesCount++) {

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -90,11 +90,13 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
             Map<String, DataStream> dataStreamMap = new HashMap<>();
             for (int dataStreamCount = 0; dataStreamCount < randomInt(200); dataStreamCount++) {
                 boolean hasLifecycle = randomBoolean();
-                Long retentionMillis;
+                DataStreamLifecycle lifecycle;
                 if (hasLifecycle) {
-                    retentionMillis = randomBoolean() ? randomLongBetween(1000, 100000) : null;
-                    count.incrementAndGet();
-                    if (retentionMillis != null) {
+                    if (randomBoolean()) {
+                        lifecycle = new DataStreamLifecycle(null, null);
+                    } else {
+                        long retentionMillis = randomLongBetween(1000, 100000);
+                        count.incrementAndGet();
                         totalRetentionTimes.addAndGet(retentionMillis);
                         if (retentionMillis < minRetention.get()) {
                             minRetention.set(retentionMillis);
@@ -102,9 +104,10 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
                         if (retentionMillis > maxRetention.get()) {
                             maxRetention.set(retentionMillis);
                         }
+                        lifecycle = DataStreamLifecycle.newBuilder().dataRetention(retentionMillis).build();
                     }
                 } else {
-                    retentionMillis =  0L;
+                    lifecycle = null;
                 }
                 List<Index> indices = new ArrayList<>();
                 for (int indicesCount = 0; indicesCount < randomIntBetween(1, 10); indicesCount++) {
@@ -122,7 +125,7 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
                     systemDataStream,
                     randomBoolean(),
                     IndexMode.STANDARD,
-                    hasLifecycle ? DataStreamLifecycle.newBuilder().dataRetention(retentionMillis).build() : null
+                    lifecycle
                 );
                 dataStreamMap.put(dataStream.getName(), dataStream);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportAction.java
@@ -61,6 +61,7 @@ public class DataStreamLifecycleUsageTransportAction extends XPackUsageFeatureTr
         final Collection<DataStream> dataStreams = state.metadata().dataStreams().values();
         LongSummaryStatistics retentionStats = dataStreams.stream()
             .filter(ds -> ds.getLifecycle() != null)
+            .filter(ds -> ds.getLifecycle().getEffectiveDataRetention() != null)
             .collect(Collectors.summarizingLong(ds -> ds.getLifecycle().getEffectiveDataRetention().getMillis()));
         long dataStreamsWithLifecycles = retentionStats.getCount();
         long minRetention = dataStreamsWithLifecycles == 0 ? 0 : retentionStats.getMin();


### PR DESCRIPTION
The lifecycle effective retention can be null.

This avoids a NPE in the Lifecycle usage API.