### PR TITLE
[Query rules bugfix] Fix error messages when no query rules index exists

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/199_query_rulesets_before_setup.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/199_query_rulesets_before_setup.yml
@@ -1,0 +1,26 @@
+setup:
+    - skip:
+          version: " - 8.9.99"
+          reason: Introduced in 8.10.0
+
+---
+"Get query ruleset returns a 404 when no query rulesets exist":
+  - do:
+      catch: "missing"
+      query_ruleset.get:
+        ruleset_id: test-i-dont-exist
+
+---
+"Delete query ruleset returns a 404 when no query rulesets exist":
+  - do:
+      catch: "missing"
+      query_ruleset.delete:
+          ruleset_id: test-i-dont-exist
+
+---
+"List query rulesets returns an empty list when no query rulesets exist":
+  - do:
+        query_ruleset.list: { }
+
+  - match: { count: 0 }
+

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/199_query_rulesets_before_setup.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/199_query_rulesets_before_setup.yml
@@ -6,14 +6,14 @@ setup:
 ---
 "Get query ruleset returns a 404 when no query rulesets exist":
   - do:
-      catch: "missing"
+      catch: /resource_not_found_exception/
       query_ruleset.get:
         ruleset_id: test-i-dont-exist
 
 ---
 "Delete query ruleset returns a 404 when no query rulesets exist":
   - do:
-      catch: "missing"
+      catch: /resource_not_found_exception/
       query_ruleset.delete:
           ruleset_id: test-i-dont-exist
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -10,12 +10,12 @@ package org.elasticsearch.xpack.application.rules;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DelegatingActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -49,7 +49,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
@@ -175,10 +174,12 @@ public class QueryRulesIndexService {
      */
     public void getQueryRuleset(String resourceName, ActionListener<QueryRuleset> listener) {
         final GetRequest getRequest = new GetRequest(QUERY_RULES_ALIAS_NAME).id(resourceName).realtime(true);
-        try {
-            clientWithOrigin.get(getRequest, new DelegatingIndexNotFoundActionListener<>(resourceName, listener, (l, getResponse) -> {
+
+        clientWithOrigin.get(getRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetResponse getResponse) {
                 if (getResponse.isExists() == false) {
-                    l.onFailure(new ResourceNotFoundException(resourceName));
+                    listener.onFailure(new ResourceNotFoundException(resourceName));
                     return;
                 }
                 final Map<String, Object> source = getResponse.getSource();
@@ -194,11 +195,18 @@ public class QueryRulesIndexService {
                     )
                     .collect(Collectors.toList());
                 final QueryRuleset res = new QueryRuleset(resourceName, rules);
-                l.onResponse(res);
-            }));
-        } catch (IndexNotFoundException e) {
-            listener.onFailure(new ResourceNotFoundException(resourceName));
-        }
+                listener.onResponse(res);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e instanceof IndexNotFoundException) {
+                    listener.onFailure(new ResourceNotFoundException(resourceName));
+                    return;
+                }
+                listener.onFailure(e);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
@@ -254,24 +262,26 @@ public class QueryRulesIndexService {
     }
 
     public void deleteQueryRuleset(String resourceName, ActionListener<DeleteResponse> listener) {
-        try {
-            final DeleteRequest deleteRequest = new DeleteRequest(QUERY_RULES_ALIAS_NAME).id(resourceName)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-            clientWithOrigin.delete(
-                deleteRequest,
-                new DelegatingIndexNotFoundActionListener<>(resourceName, listener, (l, deleteResponse) -> {
-                    if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                        l.onFailure(new ResourceNotFoundException(resourceName));
-                        return;
-                    }
-                    l.onResponse(deleteResponse);
-                })
-            );
-        } catch (IndexNotFoundException e) {
-            listener.onFailure(new ResourceNotFoundException(resourceName));
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
+        final DeleteRequest deleteRequest = new DeleteRequest(QUERY_RULES_ALIAS_NAME).id(resourceName)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        clientWithOrigin.delete(deleteRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(DeleteResponse deleteResponse) {
+                if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
+                    listener.onFailure(new ResourceNotFoundException(resourceName));
+                    return;
+                }
+                listener.onResponse(deleteResponse);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e instanceof IndexNotFoundException) {
+                    listener.onFailure(new ResourceNotFoundException(resourceName));
+                }
+                listener.onFailure(e);
+            }
+        });
     }
 
     /**
@@ -340,31 +350,6 @@ public class QueryRulesIndexService {
         }
 
         return new QueryRulesetListItem(rulesetId, numRules, queryRuleCriteriaTypeToCountMap);
-    }
-
-    static class DelegatingIndexNotFoundActionListener<T, R> extends DelegatingActionListener<T, R> {
-        private final BiConsumer<ActionListener<R>, T> bc;
-        private final String resourceName;
-
-        DelegatingIndexNotFoundActionListener(String resourceName, ActionListener<R> delegate, BiConsumer<ActionListener<R>, T> bc) {
-            super(delegate);
-            this.bc = bc;
-            this.resourceName = resourceName;
-        }
-
-        @Override
-        public void onResponse(T t) {
-            bc.accept(delegate, t);
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            if (e instanceof IndexNotFoundException) {
-                delegate.onFailure(new ResourceNotFoundException(resourceName, e));
-                return;
-            }
-            delegate.onFailure(e);
-        }
     }
 
     public record QueryRulesetResult(List<QueryRulesetListItem> rulesets, long totalResults) {}


### PR DESCRIPTION
Resolves an issue where we were returning `index_not_found_exception` on the `.query_rules` index when trying to use the CRUD API to `GET` or `DELETE` query rulesets when the system index does not exist. Now we catch them and return a generic resource not found exception. 

Verify using the commands: 

- `curl -u <creds> -XGET http://localhost:9200/_query_rules/i-dont-exist`
- `curl -u <creds> -XDELETE http://localhost:9200/_query_rules/i-dont-exist`

Response: 
```
{
  "error": {
    "root_cause": [
      {
        "type": "resource_not_found_exception",
        "reason": "i-dont-exist"
      }
    ],
    "type": "resource_not_found_exception",
    "reason": "i-dont-exist"
  },
  "status": 404
}
```