### PR TITLE
Added checks for not specifying a body in PUT requests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -5,9 +5,6 @@ setup:
 
 ---
 "Create synonyms with no ID creates ID automatically":
-  - skip:
-      version: " - 8.9.99"
-      reason: Fixed for 8.10.0
   - do:
       synonyms.put:
         synonyms_set: test-update-synonyms

--- a/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymRuleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymRuleAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.synonyms.SynonymRule;
 import org.elasticsearch.synonyms.SynonymsManagementAPIService;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -60,10 +61,11 @@ public class PutSynonymRuleAction extends ActionType<SynonymUpdateResponse> {
 
         public Request(String synonymsSetId, String synonymRuleId, BytesReference content, XContentType contentType) throws IOException {
             this.synonymsSetId = synonymsSetId;
-            this.synonymRule = PARSER.apply(
-                XContentHelper.createParser(XContentParserConfiguration.EMPTY, content, contentType),
-                synonymRuleId
-            );
+            try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, content, contentType)) {
+                this.synonymRule = PARSER.apply(parser, synonymRuleId);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to parse: " + content.utf8ToString(), e);
+            }
         }
 
         Request(String synonymsSetId, SynonymRule synonymRule) {

--- a/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/PutSynonymsAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.synonyms.SynonymRule;
 import org.elasticsearch.synonyms.SynonymsManagementAPIService;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -61,7 +62,11 @@ public class PutSynonymsAction extends ActionType<SynonymUpdateResponse> {
 
         public Request(String synonymsSetId, BytesReference content, XContentType contentType) throws IOException {
             this.synonymsSetId = synonymsSetId;
-            this.synonymRules = PARSER.apply(XContentHelper.createParser(XContentParserConfiguration.EMPTY, content, contentType), null);
+            try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, content, contentType)) {
+                this.synonymRules = PARSER.apply(parser, null);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to parse: " + content.utf8ToString(), e);
+            }
         }
 
         Request(String synonymsSetId, SynonymRule[] synonymRules) {

--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymRuleActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymRuleActionTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.synonyms.RestPutSynonymRuleAction;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpNodeClient;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.util.Map;
+
+public class PutSynonymRuleActionTests extends ESTestCase {
+
+    public void testEmptyRequestBody() throws Exception {
+        RestPutSynonymRuleAction action = new RestPutSynonymRuleAction();
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
+            .withParams(Map.of("synonymsSet", "testSet", "synonymRuleId", "testRule"))
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+            expectThrows(IllegalArgumentException.class, () -> action.handleRequest(request, channel, nodeClient));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.synonyms.RestPutSynonymsAction;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpNodeClient;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.util.Map;
+
+public class PutSynonymsActionTests extends ESTestCase {
+
+    public void testEmptyRequestBody() throws Exception {
+        RestPutSynonymsAction action = new RestPutSynonymsAction();
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
+            .withParams(Map.of("synonymsSet", "test"))
+            .build();
+
+        FakeRestChannel channel = new FakeRestChannel(request, false, 0);
+        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+            expectThrows(IllegalArgumentException.class, () -> action.handleRequest(request, channel, nodeClient));
+        }
+    }
+}


### PR DESCRIPTION
When no body is specified in PUT requests, a 500 error is returned.

This PR solves that. I haven't added YAML tests for it as we _need_ to specify the body for the PUT requests. Any ideas on how to test this using YAML are welcome 😄 