### PR TITLE
Allow aggs to disable offloading sequential collection

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -226,12 +226,15 @@ public abstract class AggregationBuilder
      * depending on what {@link #supportsOffloadingSequentialCollection()} returns.
      */
     public boolean supportsConcurrentExecution() {
+        if (isInSortOrderExecutionRequired()) {
+            return false;
+        }
         for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
             if (builder.supportsOffloadingSequentialCollection() == false || builder.supportsConcurrentExecution() == false) {
                 return false;
             }
         }
-        return isInSortOrderExecutionRequired() == false;
+        return true;
     }
 
     /**
@@ -241,6 +244,9 @@ public abstract class AggregationBuilder
      * Note: aggregations that don't support offloading sequential collection, don't support concurrency by definition.
      */
     public boolean supportsOffloadingSequentialCollection() {
+        if (isInSortOrderExecutionRequired()) {
+            return false;
+        }
         for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
             if (builder.supportsOffloadingSequentialCollection() == false) {
                 return false;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -220,15 +220,33 @@ public abstract class AggregationBuilder
     }
 
     /**
-     * Return false if this aggregation or any of the child aggregations does not support concurrent search
+     * Return false if this aggregation or any of the child aggregations does not support concurrent search.
+     * As a result, such aggregation will always be executed sequentially despite concurrency is enabled for the query phase.
+     * Note: aggregations that don't support concurrency, may or may not support offloading their collection to the search worker threads,
+     * depending on what {@link #supportsOffloadingSequentialCollection()} returns.
      */
     public boolean supportsConcurrentExecution() {
         for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
-            if (builder.supportsConcurrentExecution() == false) {
+            if (builder.supportsOffloadingSequentialCollection() || builder.supportsConcurrentExecution() == false) {
                 return false;
             }
         }
         return isInSortOrderExecutionRequired() == false;
+    }
+
+    /**
+     * Returns false if this aggregation or any of its child aggregations does not support offloading its sequential collection
+     * to a separate thread. As a result, such aggregation will always be executed sequentially, and fully in the search thread,
+     * without offloading its collection to the search worker threads.
+     * Note: aggregations that don't support offloading sequential collection, don't support concurrency by definition.
+     */
+    public boolean supportsOffloadingSequentialCollection() {
+        for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
+            if (builder.supportsOffloadingSequentialCollection() == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -230,11 +230,11 @@ public abstract class AggregationBuilder
             return false;
         }
         for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
-            if (builder.supportsOffloadingSequentialCollection() == false || builder.supportsConcurrentExecution() == false) {
+            if (builder.supportsConcurrentExecution() == false) {
                 return false;
             }
         }
-        return true;
+        return supportsOffloadingSequentialCollection();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -227,7 +227,7 @@ public abstract class AggregationBuilder
      */
     public boolean supportsConcurrentExecution() {
         for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
-            if (builder.supportsOffloadingSequentialCollection() || builder.supportsConcurrentExecution() == false) {
+            if (builder.supportsOffloadingSequentialCollection() == false || builder.supportsConcurrentExecution() == false) {
                 return false;
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -97,7 +97,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
     }
 
     @Override
-    public boolean supportsConcurrentExecution() {
+    public boolean supportsOffloadingSequentialCollection() {
         return false;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
@@ -81,7 +81,7 @@ public class NestedAggregationBuilder extends AbstractAggregationBuilder<NestedA
     }
 
     @Override
-    public boolean supportsConcurrentExecution() {
+    public boolean supportsOffloadingSequentialCollection() {
         return false;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -113,7 +113,7 @@ public final class CardinalityAggregationBuilder extends ValuesSourceAggregation
     }
 
     @Override
-    public boolean supportsConcurrentExecution() {
+    public boolean supportsOffloadingSequentialCollection() {
         return false;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -89,8 +89,6 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     /** Script to extract a collection of numeric values from the 'numbers' field **/
     public static final String NUMERIC_VALUES_SCRIPT = "doc['numbers']";
 
-    public static final int HASHER_DEFAULT_SEED = 17;
-
     @Override
     protected ScriptService getMockScriptService() {
         final Map<String, Function<Map<String, Object>, Object>> scripts = new HashMap<>();

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -68,8 +68,8 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertTrue(bucketBuilder.supportsConcurrentExecution());
         bucketBuilder.subAggregation(builder);
         assertThat(bucketBuilder.supportsConcurrentExecution(), equalTo(supportsConcurrency));
-        if (bucketBuilder.supportsConcurrentExecution() == false) {
-            assertFalse(bucketBuilder.supportsOffloadingSequentialCollection());
+        if (bucketBuilder.supportsConcurrentExecution()) {
+            assertTrue(bucketBuilder.supportsOffloadingSequentialCollection());
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -61,8 +61,8 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
     public void testSupportsConcurrentExecution() {
         AB builder = createTestAggregatorBuilder();
         boolean supportsConcurrency = builder.supportsConcurrentExecution();
-        if (supportsConcurrency == false) {
-            assertFalse(builder.supportsOffloadingSequentialCollection());
+        if (supportsConcurrency) {
+            assertTrue(builder.supportsOffloadingSequentialCollection());
         }
         AggregationBuilder bucketBuilder = new HistogramAggregationBuilder("test");
         assertTrue(bucketBuilder.supportsConcurrentExecution());

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -61,10 +61,25 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
     public void testSupportsConcurrentExecution() {
         AB builder = createTestAggregatorBuilder();
         boolean supportsConcurrency = builder.supportsConcurrentExecution();
+        if (supportsConcurrency == false) {
+            assertFalse(builder.supportsOffloadingSequentialCollection());
+        }
         AggregationBuilder bucketBuilder = new HistogramAggregationBuilder("test");
-        assertThat(bucketBuilder.supportsConcurrentExecution(), equalTo(true));
+        assertTrue(bucketBuilder.supportsConcurrentExecution());
         bucketBuilder.subAggregation(builder);
         assertThat(bucketBuilder.supportsConcurrentExecution(), equalTo(supportsConcurrency));
+        if (bucketBuilder.supportsConcurrentExecution() == false) {
+            assertFalse(bucketBuilder.supportsOffloadingSequentialCollection());
+        }
+    }
+
+    public void testSupportsOffloadingSequentialCollection() {
+        AB builder = createTestAggregatorBuilder();
+        boolean supportsOffloadingSequentialCollection = builder.supportsOffloadingSequentialCollection();
+        AggregationBuilder bucketBuilder = new HistogramAggregationBuilder("test");
+        assertTrue(bucketBuilder.supportsOffloadingSequentialCollection());
+        bucketBuilder.subAggregation(builder);
+        assertThat(bucketBuilder.supportsOffloadingSequentialCollection(), equalTo(supportsOffloadingSequentialCollection));
     }
 
     /**


### PR DESCRIPTION
In #98204 we are introducing unconditional offloading of collection to a separate thread pool, even for requests of phases that don't enable search concurrency. It turns out that some aggs don't support offloading their collection to a separate thread, as their postCollect method is executed on the search thread which trips a lucene assertion around reusing data structures pulled from the search worker thread.

With this commit we allow aggs to specify when they don't support offloading their sequential collection. Such aggs are a subset of the ones that already declare that they don't support concurrency entirely.

Relates to #96023