### PR TITLE
Fork publication using FakeThreadPoolMasterService#taskExecutor

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1074,7 +1074,6 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 );
                 masterService = new AckedFakeThreadPoolMasterService(
                     localNode.getId(),
-                    "test",
                     threadPool,
                     runnable -> deterministicTaskQueue.scheduleNow(onNode(runnable))
                 );
@@ -1722,12 +1721,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
         AckCollector nextAckCollector = new AckCollector();
         boolean publicationMayFail = false;
 
-        AckedFakeThreadPoolMasterService(
-            String nodeName,
-            String serviceName,
-            ThreadPool threadPool,
-            Consumer<Runnable> onTaskAvailableToRun
-        ) {
+        AckedFakeThreadPoolMasterService(String nodeName, ThreadPool threadPool, Consumer<Runnable> onTaskAvailableToRun) {
             super(nodeName, threadPool, onTaskAvailableToRun);
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
@@ -79,8 +79,8 @@ public class FakeThreadPoolMasterService extends MasterService {
         AckListener ackListener,
         ActionListener<Void> publicationListener
     ) {
-        // fork the publication to add a little extra room for concurrent activity here
-        threadPool.generic().execute(threadPool.getThreadContext().preserveContext(new Runnable() {
+        // allow to fork the publication to add a little extra room for concurrent activity here
+        taskExecutor.accept(threadPool.getThreadContext().preserveContext(new Runnable() {
             @Override
             public void run() {
                 FakeThreadPoolMasterService.super.publish(clusterStatePublicationEvent, wrapAckListener(ackListener), publicationListener);


### PR DESCRIPTION
Today in `FakeThreadPoolMasterService` we fork the publication task
using `threadPool.generic()`. But we already have a custom executor in
our hands, `taskExecutor`, so there's no need to use a different one for
the publication task.