### PR TITLE
Mark `HasPrivileges` API public

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesAction.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
  * REST handler that tests whether a user has the specified
  * {@link RoleDescriptor.IndicesPrivileges privileges}
  */
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestHasPrivilegesAction extends SecurityBaseRestHandler {
 
     private final SecurityContext securityContext;


### PR DESCRIPTION
The `HasPrivileges` API is called, among other places, within Kibana on behalf of the logged-in user. Therefore, scope it to public.