### PR TITLE
Disable disk watermarks when stateless is enabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1494,6 +1494,15 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered(properties)), properties);
     }
 
+    public static Setting<Boolean> boolSetting(
+        String key,
+        Function<Settings, String> defaultValueFn,
+        Validator<Boolean> validator,
+        Property... properties
+    ) {
+        return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered(properties)), validator, properties);
+    }
+
     static boolean parseBoolean(String b, String key, boolean isFiltered) {
         try {
             return Booleans.parseBoolean(b);


### PR DESCRIPTION
This PR changes the default value of the `cluster.routing.allocation.disk.threshold_enabled` setting when stateless is enabled (ie when `stateless.enabled: true`). It has the consequence of disabling disk watermarks altogether.

This change also ensure that `threshold_enabled` cannot be updated to `true` too.

Relates ES-6305