### PR TITLE
Small improvements to TransportGetSettingsAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -23,12 +23,13 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.unmodifiableMap;
@@ -57,7 +58,7 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
             GetSettingsRequest::new,
             indexNameExpressionResolver,
             GetSettingsResponse::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT
         );
         this.settingsFilter = settingsFilter;
         this.indexScopedSettings = indexedScopedSettings;
@@ -80,9 +81,12 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
         ClusterState state,
         ActionListener<GetSettingsResponse> listener
     ) {
-        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
-        Map<String, Settings> indexToSettings = new HashMap<>();
-        Map<String, Settings> indexToDefaultSettings = new HashMap<>();
+        assert Transports.assertNotTransportThread("O(indices) work is too much for a transport thread");
+        final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
+        final Map<String, Settings> indexToSettings = Maps.newHashMapWithExpectedSize(concreteIndices.length);
+        final Map<String, Settings> indexToDefaultSettings = request.includeDefaults()
+            ? Maps.newHashMapWithExpectedSize(concreteIndices.length)
+            : null;
         for (Index concreteIndex : concreteIndices) {
             IndexMetadata indexMetadata = state.getMetadata().index(concreteIndex);
             if (indexMetadata == null) {
@@ -99,7 +103,7 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
             }
 
             indexToSettings.put(concreteIndex.getName(), indexSettings);
-            if (request.includeDefaults()) {
+            if (indexToDefaultSettings != null) {
                 Settings defaultSettings = settingsFilter.filter(indexScopedSettings.diff(indexSettings, Settings.EMPTY));
                 if (isFilteredRequest(request)) {
                     defaultSettings = defaultSettings.filter(k -> Regex.simpleMatch(request.names(), k));
@@ -107,6 +111,11 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
                 indexToDefaultSettings.put(concreteIndex.getName(), defaultSettings);
             }
         }
-        listener.onResponse(new GetSettingsResponse(unmodifiableMap(indexToSettings), unmodifiableMap(indexToDefaultSettings)));
+        listener.onResponse(
+            new GetSettingsResponse(
+                unmodifiableMap(indexToSettings),
+                indexToDefaultSettings == null ? Map.of() : unmodifiableMap(indexToDefaultSettings)
+            )
+        );
     }
 }


### PR DESCRIPTION
This action shouldn't run on a transport worker since it does
`O(#indices)` work, so this commit moves it to `MANAGEMENT`. It also
appropriately sizes the maps used in the computation to avoid any
resizing overhead.