### PR TITLE
Storing nodeId explicitly in TaskInfo

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/TransportRethrottleActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/TransportRethrottleActionTests.java
@@ -103,6 +103,7 @@ public class TransportRethrottleActionTests extends ESTestCase {
                     "test",
                     "test",
                     "test",
+                    "test",
                     status,
                     0,
                     0,
@@ -136,6 +137,7 @@ public class TransportRethrottleActionTests extends ESTestCase {
             tasks.add(
                 new TaskInfo(
                     new TaskId("test", 123),
+                    "test",
                     "test",
                     "test",
                     "test",

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -861,6 +861,7 @@ public class TasksIT extends ESIntegTestCase {
                 new TaskInfo(
                     new TaskId("fake", 1),
                     "test",
+                    "fake",
                     "test",
                     "",
                     null,

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -176,9 +176,10 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_051 = registerTransportVersion(8_500_051, "a28b43bc-bb5f-4406-afcf-26900aa98a71");
     public static final TransportVersion V_8_500_052 = registerTransportVersion(8_500_052, "2d382b3d-9838-4cce-84c8-4142113e5c2b");
     public static final TransportVersion V_8_500_053 = registerTransportVersion(8_500_053, "aa603bae-01e2-380a-8950-6604468e8c6d");
+    public static final TransportVersion V_8_500_054 = registerTransportVersion(8_500_054, "7831c609-0df1-42d6-aa97-8a346c389ef");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_053);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_054);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/server/src/main/java/org/elasticsearch/tasks/Task.java
@@ -138,6 +138,7 @@ public class Task {
         return new TaskInfo(
             new TaskId(localNodeId, getId()),
             getType(),
+            localNodeId,
             getAction(),
             description,
             status,

--- a/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.tasks;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -40,6 +41,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public record TaskInfo(
     TaskId taskId,
     String type,
+    String node,
     String action,
     String description,
     Task.Status status,
@@ -61,9 +63,11 @@ public record TaskInfo(
      * Read from a stream.
      */
     public static TaskInfo from(StreamInput in) throws IOException {
+        TaskId taskId = TaskId.readFromStream(in);
         return new TaskInfo(
-            TaskId.readFromStream(in),
+            taskId,
             in.readString(),
+            in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_054) ? in.readString() : taskId.getNodeId(),
             in.readString(),
             in.readOptionalString(),
             in.readOptionalNamedWriteable(Task.Status.class),
@@ -80,6 +84,9 @@ public record TaskInfo(
     public void writeTo(StreamOutput out) throws IOException {
         taskId.writeTo(out);
         out.writeString(type);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_054)) {
+            out.writeString(node);
+        }
         out.writeString(action);
         out.writeOptionalString(description);
         out.writeOptionalNamedWriteable(status);
@@ -97,7 +104,7 @@ public record TaskInfo(
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field("node", taskId.getNodeId());
+        builder.field("node", node);
         builder.field("id", taskId.getId());
         builder.field("type", type);
         builder.field("action", action);
@@ -136,7 +143,8 @@ public record TaskInfo(
 
     public static final ConstructingObjectParser<TaskInfo, Void> PARSER = new ConstructingObjectParser<>("task_info", true, a -> {
         int i = 0;
-        TaskId id = new TaskId((String) a[i++], (Long) a[i++]);
+        String node = (String) a[i++];
+        TaskId id = new TaskId(node, (Long) a[i++]);
         String type = (String) a[i++];
         String action = (String) a[i++];
         String description = (String) a[i++];
@@ -157,6 +165,7 @@ public record TaskInfo(
         return new TaskInfo(
             id,
             type,
+            node,
             action,
             description,
             status,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskTests.java
@@ -29,6 +29,7 @@ public class TaskTests extends ESTestCase {
         TaskInfo taskInfo = new TaskInfo(
             new TaskId(nodeId, taskId),
             "test_type",
+            nodeId,
             "test_action",
             "test_description",
             null,

--- a/server/src/test/java/org/elasticsearch/tasks/ListTasksResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/ListTasksResponseTests.java
@@ -56,6 +56,7 @@ public class ListTasksResponseTests extends AbstractXContentTestCase<ListTasksRe
         TaskInfo info = new TaskInfo(
             new TaskId("node1", 1),
             "dummy-type",
+            "node1",
             "dummy-action",
             "dummy-description",
             null,

--- a/server/src/test/java/org/elasticsearch/tasks/TaskInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskInfoTests.java
@@ -60,12 +60,13 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
 
     @Override
     protected TaskInfo mutateInstance(TaskInfo info) {
-        switch (between(0, 9)) {
+        switch (between(0, 10)) {
             case 0:
                 TaskId taskId = new TaskId(info.taskId().getNodeId() + randomAlphaOfLength(5), info.taskId().getId());
                 return new TaskInfo(
                     taskId,
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -80,6 +81,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type() + randomAlphaOfLength(5),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -94,6 +96,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action() + randomAlphaOfLength(5),
                     info.description(),
                     info.status(),
@@ -108,6 +111,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description() + randomAlphaOfLength(5),
                     info.status(),
@@ -123,6 +127,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     newStatus,
@@ -137,6 +142,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -151,6 +157,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -176,6 +183,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -191,6 +199,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -212,6 +221,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                 return new TaskInfo(
                     info.taskId(),
                     info.type(),
+                    info.node(),
                     info.action(),
                     info.description(),
                     info.status(),
@@ -222,13 +232,29 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
                     info.parentTaskId(),
                     headers
                 );
+            case 10:
+                return new TaskInfo(
+                    info.taskId(),
+                    info.type(),
+                    randomAlphaOfLength(10),
+                    info.action(),
+                    info.description(),
+                    info.status(),
+                    info.startTime(),
+                    info.runningTimeNanos(),
+                    info.cancellable(),
+                    info.cancelled(),
+                    info.parentTaskId(),
+                    info.headers()
+                );
             default:
                 throw new IllegalStateException();
         }
     }
 
     static TaskInfo randomTaskInfo() {
-        TaskId taskId = randomTaskId();
+        String nodeId = randomAlphaOfLength(5);
+        TaskId taskId = randomTaskId(nodeId);
         String type = randomAlphaOfLength(5);
         String action = randomAlphaOfLength(5);
         Task.Status status = randomBoolean() ? randomRawTaskStatus() : null;
@@ -237,13 +263,14 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
         long runningTimeNanos = randomNonNegativeLong();
         boolean cancellable = randomBoolean();
         boolean cancelled = cancellable && randomBoolean();
-        TaskId parentTaskId = randomBoolean() ? TaskId.EMPTY_TASK_ID : randomTaskId();
+        TaskId parentTaskId = randomBoolean() ? TaskId.EMPTY_TASK_ID : randomTaskId(randomAlphaOfLength(5));
         Map<String, String> headers = randomBoolean()
             ? Collections.emptyMap()
             : Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5));
         return new TaskInfo(
             taskId,
             type,
+            nodeId,
             action,
             description,
             status,
@@ -256,8 +283,8 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
         );
     }
 
-    private static TaskId randomTaskId() {
-        return new TaskId(randomAlphaOfLength(5), randomLong());
+    private static TaskId randomTaskId(String nodeId) {
+        return new TaskId(nodeId, randomLong());
     }
 
     private static RawTaskStatus randomRawTaskStatus() {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichStatsResponseTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichStatsResponseTests.java
@@ -61,7 +61,8 @@ public class EnrichStatsResponseTests extends AbstractWireSerializingTestCase<En
     }
 
     public static TaskInfo randomTaskInfo() {
-        TaskId taskId = new TaskId(randomAlphaOfLength(5), randomLong());
+        String nodeId = randomAlphaOfLength(5);
+        TaskId taskId = new TaskId(nodeId, randomLong());
         String type = randomAlphaOfLength(5);
         String action = randomAlphaOfLength(5);
         String description = randomAlphaOfLength(5);
@@ -76,6 +77,7 @@ public class EnrichStatsResponseTests extends AbstractWireSerializingTestCase<En
         return new TaskInfo(
             taskId,
             type,
+            nodeId,
             action,
             description,
             null,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
@@ -177,6 +177,7 @@ public class MlDailyMaintenanceServiceTests extends ESTestCase {
         TaskInfo taskInfo = new TaskInfo(
             new TaskId("test", 123),
             "test",
+            "test",
             DeleteJobAction.NAME,
             "delete-job-" + jobId,
             null,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TaskRetrieverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TaskRetrieverTests.java
@@ -200,6 +200,7 @@ public class TaskRetrieverTests extends ESTestCase {
                     "test",
                     "test",
                     "test",
+                    "test",
                     null,
                     0,
                     0,


### PR DESCRIPTION
This PR makes the node ID an explicit part of the TaskInfo object in the response of GetTaskAction. This way it can be filtered out of the response without having to alter the taskId.