### PR TITLE
Document Frozen and Cold Indexinputs better and refactor slightly

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
@@ -31,8 +31,8 @@ public class BlobCacheUtils {
         return ByteSizeUnit.BYTES.toIntBytes(l);
     }
 
-    public static void throwEOF(long channelPos, long len, Object file) throws EOFException {
-        throw new EOFException(format("unexpected EOF reading [%d-%d] from %s", channelPos, channelPos + len, file));
+    public static void throwEOF(long channelPos, long len) throws EOFException {
+        throw new EOFException(format("unexpected EOF reading [%d-%d]", channelPos, channelPos + len));
     }
 
     public static void ensureSeek(long pos, IndexInput input) throws IOException {
@@ -74,12 +74,11 @@ public class BlobCacheUtils {
      *
      * Most of its arguments are there simply to make the message of the {@link EOFException} more informative.
      */
-    public static int readSafe(InputStream inputStream, ByteBuffer copyBuffer, long rangeStart, long remaining, Object cacheFileReference)
-        throws IOException {
+    public static int readSafe(InputStream inputStream, ByteBuffer copyBuffer, long rangeStart, long remaining) throws IOException {
         final int len = (remaining < copyBuffer.remaining()) ? toIntBytes(remaining) : copyBuffer.remaining();
         final int bytesRead = Streams.read(inputStream, copyBuffer, len);
         if (bytesRead <= 0) {
-            throwEOF(rangeStart, remaining, cacheFileReference);
+            throwEOF(rangeStart, remaining);
         }
         return bytesRead;
     }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -153,7 +153,6 @@ public class SharedBytes extends AbstractRefCounted {
      * @param length number of bytes to copy
      * @param progressUpdater callback to invoke with the number of copied bytes as they are copied
      * @param buf bytebuffer to use for writing
-     * @param cacheFile object that describes the cached file, only used in logging and exception throwing as context information
      * @throws IOException on failure
      */
     public static void copyToCacheFileAligned(
@@ -163,13 +162,12 @@ public class SharedBytes extends AbstractRefCounted {
         long relativePos,
         long length,
         LongConsumer progressUpdater,
-        ByteBuffer buf,
-        final Object cacheFile
+        ByteBuffer buf
     ) throws IOException {
         long bytesCopied = 0L;
         long remaining = length;
         while (remaining > 0L) {
-            final int bytesRead = BlobCacheUtils.readSafe(input, buf, relativePos, remaining, cacheFile);
+            final int bytesRead = BlobCacheUtils.readSafe(input, buf, relativePos, remaining);
             if (buf.hasRemaining()) {
                 break;
             }
@@ -207,7 +205,6 @@ public class SharedBytes extends AbstractRefCounted {
      * @param relativePos position in {@code byteBufferReference}
      * @param length number of bytes to read
      * @param byteBufferReference buffer reference
-     * @param cacheFile cache file reference used for exception messages only
      * @return number of bytes read
      * @throws IOException on failure
      */
@@ -216,8 +213,7 @@ public class SharedBytes extends AbstractRefCounted {
         long channelPos,
         long relativePos,
         long length,
-        final ByteBufferReference byteBufferReference,
-        Object cacheFile
+        final ByteBufferReference byteBufferReference
     ) throws IOException {
         if (length == 0L) {
             return 0;
@@ -228,7 +224,7 @@ public class SharedBytes extends AbstractRefCounted {
             try {
                 bytesRead = fc.read(dup, channelPos);
                 if (bytesRead == -1) {
-                    BlobCacheUtils.throwEOF(channelPos, dup.remaining(), cacheFile);
+                    BlobCacheUtils.throwEOF(channelPos, dup.remaining());
                 }
             } finally {
                 byteBufferReference.release();

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
@@ -17,6 +17,6 @@ public class BlobCacheUtilsTests extends ESTestCase {
     public void testReadSafeThrows() {
         final ByteBuffer buffer = ByteBuffer.allocate(randomIntBetween(1, 1025));
         final int remaining = randomIntBetween(1, 1025);
-        expectThrows(EOFException.class, () -> BlobCacheUtils.readSafe(BytesArray.EMPTY.streamInput(), buffer, 0, remaining, null));
+        expectThrows(EOFException.class, () -> BlobCacheUtils.readSafe(BytesArray.EMPTY.streamInput(), buffer, 0, remaining));
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirec
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -118,8 +117,7 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
         assert rangeToRead.isSubRangeOf(rangeToWrite) : rangeToRead + " vs " + rangeToWrite;
         assert rangeToRead.length() == b.remaining() : b.remaining() + " vs " + rangeToRead;
 
-        final Future<Integer> populateCacheFuture = populateAndRead(b, position, length, cacheFile, rangeToWrite);
-        final int bytesRead = populateCacheFuture.get();
+        final int bytesRead = populateAndRead(b, position, cacheFile, rangeToWrite).get();
         assert bytesRead == length : bytesRead + " vs " + length;
     }
 
@@ -191,7 +189,7 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
                     if (isCancelled.get()) {
                         return -1L;
                     }
-                    final int bytesRead = readSafe(input, copyBuffer, range.start(), remainingBytes, cacheFileReference);
+                    final int bytesRead = readSafe(input, copyBuffer, range.start(), remainingBytes);
                     // The range to prewarm in cache
                     final long readStart = range.start() + totalBytesRead;
                     final ByteRange rangeToWrite = ByteRange.of(readStart, readStart + bytesRead);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -134,7 +134,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
                     length,
                     cacheFile
                 );
-                final int read = SharedBytes.readCacheFile(channel, pos, relativePos, len, byteBufferReference, cacheFile);
+                final int read = SharedBytes.readCacheFile(channel, pos, relativePos, len, byteBufferReference);
                 stats.addCachedBytesRead(read);
                 return read;
             }, (channel, channelPos, relativePos, len, progressUpdater) -> {
@@ -156,8 +156,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
                         relativePos,
                         len,
                         progressUpdater,
-                        writeBuffer.get().clear(),
-                        cacheFile
+                        writeBuffer.get().clear()
                     );
                     final long endTimeNanos = stats.currentTimeNanos();
                     stats.addCachedBytesWritten(len, endTimeNanos - startTimeNanos);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -27,6 +27,7 @@ import org.elasticsearch.core.Streams;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.snapshots.blobstore.SlicedInputStream;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.cache.blob.BlobStoreCacheService;
@@ -44,7 +45,6 @@ import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.LongConsumer;
 
 import static org.elasticsearch.blobcache.BlobCacheUtils.throwEOF;
 import static org.elasticsearch.blobcache.BlobCacheUtils.toIntBytes;
@@ -231,7 +231,6 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
     private void readWithBlobCache(ByteBuffer b, ByteRange blobCacheByteRange) throws Exception {
         final long position = getAbsolutePosition();
         final int length = b.remaining();
-
         final CacheFile cacheFile = cacheFileReference.get();
 
         // Can we serve the read directly from disk? If so, do so and don't worry about anything else.
@@ -240,103 +239,167 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
             assert read == length : read + " vs " + length;
             return read;
         });
-
         if (waitingForRead != null) {
+            // yes, serving directly from disk because we had the bytes on disk already or had an ongoing download running for them
             final Integer read = waitingForRead.get();
             assert read == length;
             return;
         }
 
+        // we did not find the bytes on disk, try the cache index before falling back to the blob store
         final CachedBlob cachedBlob = directory.getCachedBlob(fileInfo.physicalName(), blobCacheByteRange);
-        assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || cachedBlob.from() <= position;
-        assert cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY || length <= cachedBlob.length();
-
         if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
-            // We would have liked to find a cached entry but we did not find anything: the cache on the disk will be requested
-            // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
-            // {start, end} where positions are relative to the whole file.
-
-            // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
-            // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
-            final Future<Integer> populateCacheFuture = populateAndRead(b, position, length, cacheFile, blobCacheByteRange);
-
-            fillIndexCache(cacheFile, blobCacheByteRange);
-            if (compoundFileOffset > 0L
-                && blobCacheByteRange.equals(headerBlobCacheByteRange)
-                && footerBlobCacheByteRange.isEmpty() == false) {
-                fillIndexCache(cacheFile, footerBlobCacheByteRange);
-            }
-
-            final int bytesRead = populateCacheFuture.get();
-            assert bytesRead == length : bytesRead + " vs " + length;
+            fillBlobCacheIndex(b, blobCacheByteRange, position, cacheFile);
         } else {
-            final int sliceOffset = toIntBytes(position - cachedBlob.from());
-            assert sliceOffset + length <= cachedBlob.to()
-                : "reading " + length + " bytes from " + sliceOffset + " exceed cached blob max position " + cachedBlob.to();
-
-            logger.trace("reading [{}] bytes of file [{}] at position [{}] using cache index", length, fileInfo.physicalName(), position);
-            final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(sliceOffset, length).iterator();
-            BytesRef bytesRef;
-            int copiedBytes = 0;
-            while ((bytesRef = cachedBytesIterator.next()) != null) {
-                b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
-                copiedBytes += bytesRef.length;
-            }
-            assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
-            stats.addIndexCacheBytesRead(cachedBlob.length());
-
-            try {
-                final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
-                cacheFile.populateAndRead(
-                    cachedRange,
-                    cachedRange,
-                    channel -> cachedBlob.length(),
-                    (channel, from, to, progressUpdater) -> {
-                        final long startTimeNanos = stats.currentTimeNanos();
-                        final BytesRefIterator iterator = cachedBlob.bytes()
-                            .slice(toIntBytes(from - cachedBlob.from()), toIntBytes(to - from))
-                            .iterator();
-                        long writePosition = from;
-                        BytesRef current;
-                        while ((current = iterator.next()) != null) {
-                            final ByteBuffer byteBuffer = ByteBuffer.wrap(current.bytes, current.offset, current.length);
-                            while (byteBuffer.remaining() > 0) {
-                                writePosition += positionalWrite(channel, writePosition, byteBuffer);
-                                progressUpdater.accept(writePosition);
-                            }
-                        }
-                        assert writePosition == to : writePosition + " vs " + to;
-                        final long endTimeNanos = stats.currentTimeNanos();
-                        stats.addCachedBytesWritten(to - from, endTimeNanos - startTimeNanos);
-                        logger.trace("copied bytes [{}-{}] of file [{}] from cache index to disk", from, to, fileInfo);
-                    },
-                    directory.cacheFetchAsyncExecutor()
-                );
-            } catch (Exception e) {
-                logger.debug(
-                    () -> format(
-                        "failed to store bytes [%s-%s] of file [%s] obtained from index cache",
-                        cachedBlob.from(),
-                        cachedBlob.to(),
-                        fileInfo
-                    ),
-                    e
-                );
-                // oh well, no big deal, at least we can return them to the caller.
-            }
+            readAndCopyFromBlobCacheIndex(b, position, cacheFile, cachedBlob);
         }
     }
 
-    protected Future<Integer> populateAndRead(ByteBuffer b, long position, int length, CacheFile cacheFile, ByteRange rangeToWrite) {
-        final ByteRange rangeToRead = ByteRange.of(position, position + length);
+    /**
+     * Fills {@code b} starting at {@code position} the same way {@link #readAndCopyFromBlobCacheIndex} does but reads directly from the
+     * blob store.
+     * Caches the requested {@code blobCacheByteRange} containing {@code position} from the blob-store and stores it in the internal cache
+     * index as well as writes it to local disk into a {@link CacheFile}. This is used for ranges that should be stored in the internal
+     * cache index but haven't been found during a read attempt.
+     *
+     * @param b buffer to fill with the request byte range
+     * @param blobCacheByteRange byte range to cache in the internal index
+     * @param position position in the file to start reading from
+     * @param cacheFile cache file for this operation
+     * @throws Exception on failure
+     */
+    private void fillBlobCacheIndex(ByteBuffer b, ByteRange blobCacheByteRange, long position, CacheFile cacheFile) throws Exception {
+        // We would have liked to find a cached entry, but we did not find anything: the cache on the disk will be requested,
+        // so we compute the region of the file we would like to have the next time. The region is expressed as a tuple of
+        // {start, end} where positions are relative to the whole file.
+        final int length = b.remaining();
+        // We must fill in a cache miss even if CACHE_NOT_READY since the cache index is only created on the first put.
+        // TODO TBD use a different trigger for creating the cache index and avoid a put in the CACHE_NOT_READY case.
+        final Future<Integer> populateCacheFuture = populateAndRead(b, position, cacheFile, blobCacheByteRange);
+
+        fillIndexCache(cacheFile, blobCacheByteRange);
+        if (compoundFileOffset > 0L && blobCacheByteRange.equals(headerBlobCacheByteRange) && footerBlobCacheByteRange.isEmpty() == false) {
+            fillIndexCache(cacheFile, footerBlobCacheByteRange);
+        }
+
+        final int bytesRead = populateCacheFuture.get();
+        assert bytesRead == length : bytesRead + " vs " + length;
+    }
+
+    /**
+     * Copies a byte range found in the internal cache index to a local {@link CacheFile} and reads the section starting from
+     * {@code position} into {@code b}, reading as many bytes as are remaining in {code b}. This is used whenever a range that should be
+     * stored in a local cache file wasn't found in the cache file but could be read from the cache index without having to reach out to
+     * the blob store itself.
+     *
+     * @param b buffer to fill with the request byte range
+     * @param position position in the file to start reading from
+     * @param cacheFile cache file for this operation
+     * @param cachedBlob cached blob found in the internal cache index
+     * @throws IOException on failure
+     */
+    private void readAndCopyFromBlobCacheIndex(ByteBuffer b, long position, CacheFile cacheFile, CachedBlob cachedBlob) throws IOException {
+        final int length = b.remaining();
+        final int sliceOffset = toIntBytes(position - cachedBlob.from());
+        assert sliceOffset + length <= cachedBlob.to()
+            : "reading " + length + " bytes from " + sliceOffset + " exceed cached blob max position " + cachedBlob.to();
+
+        logger.trace("reading [{}] bytes of file [{}] at position [{}] using cache index", length, fileInfo.physicalName(), position);
+        final BytesRefIterator cachedBytesIterator = cachedBlob.bytes().slice(sliceOffset, length).iterator();
+        BytesRef bytesRef;
+        int copiedBytes = 0;
+        while ((bytesRef = cachedBytesIterator.next()) != null) {
+            b.put(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+            copiedBytes += bytesRef.length;
+        }
+        assert copiedBytes == length : "copied " + copiedBytes + " but expected " + length;
+        stats.addIndexCacheBytesRead(cachedBlob.length());
+
+        copyToCacheFile(cacheFile, cachedBlob);
+    }
+
+    /**
+     * Copy a {@code cachedBlob} from internal cache index to the given {@code cacheFile}.
+     * @param cacheFile file to copy to
+     * @param cachedBlob cache blob to copy from
+     */
+    private void copyToCacheFile(CacheFile cacheFile, CachedBlob cachedBlob) {
+        try {
+            final ByteRange cachedRange = ByteRange.of(cachedBlob.from(), cachedBlob.to());
+            cacheFile.populateAndRead(cachedRange, cachedRange, channel -> cachedBlob.length(), (channel, from, to, progressUpdater) -> {
+                final long startTimeNanos = stats.currentTimeNanos();
+                final BytesRefIterator iterator = cachedBlob.bytes()
+                    .slice(toIntBytes(from - cachedBlob.from()), toIntBytes(to - from))
+                    .iterator();
+                long writePosition = from;
+                BytesRef current;
+                while ((current = iterator.next()) != null) {
+                    final ByteBuffer byteBuffer = ByteBuffer.wrap(current.bytes, current.offset, current.length);
+                    while (byteBuffer.remaining() > 0) {
+                        writePosition += positionalWrite(channel, writePosition, byteBuffer);
+                        progressUpdater.accept(writePosition);
+                    }
+                }
+                assert writePosition == to : writePosition + " vs " + to;
+                final long endTimeNanos = stats.currentTimeNanos();
+                stats.addCachedBytesWritten(to - from, endTimeNanos - startTimeNanos);
+                logger.trace("copied bytes [{}-{}] of file [{}] from cache index to disk", from, to, fileInfo);
+            }, directory.cacheFetchAsyncExecutor());
+        } catch (Exception e) {
+            // ignore exceptions during copying, we already read the bytes on another thread so failing to copy to local disk does not
+            // break anything functionally
+            logger.debug(
+                () -> format(
+                    "failed to store bytes [%s-%s] of file [%s] obtained from index cache",
+                    cachedBlob.from(),
+                    cachedBlob.to(),
+                    fileInfo
+                ),
+                e
+            );
+        }
+    }
+
+    /**
+     * Read from given {@code cacheFile} into {@code b}, starting at the given {@code position} and reading as many bytes as are remaining
+     * {@code b} while storing {@code rangeToWrite} in the cache file.
+     *
+     * @param b buffer to read into
+     * @param position position in the file to start reading from
+     * @param cacheFile file to read from
+     * @param rangeToWrite range to read from the blob store and store in the cache file
+     * @return future that resolves to the number of bytes read
+     */
+    protected Future<Integer> populateAndRead(ByteBuffer b, long position, CacheFile cacheFile, ByteRange rangeToWrite) {
+        final ByteRange rangeToRead = ByteRange.of(position, position + b.remaining());
         assert rangeToRead.isSubRangeOf(rangeToWrite) : rangeToRead + " vs " + rangeToWrite;
-        assert rangeToRead.length() == b.remaining() : b.remaining() + " vs " + rangeToRead;
 
         return cacheFile.populateAndRead(
             rangeToWrite,
             rangeToRead,
             channel -> readCacheFile(channel, position, b),
-            this::writeCacheFile,
+            (fc, start, end, progressUpdater) -> {
+                assert assertFileChannelOpen(fc);
+                assert ThreadPool.assertCurrentThreadPool(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
+                final ByteBuffer copyBuffer = writeBuffer.get().clear();
+                logger.trace("writing range [{}-{}] to cache file [{}]", start, end, cacheFileReference);
+
+                long bytesCopied = 0L;
+                long remaining = end - start;
+                final long startTimeNanos = stats.currentTimeNanos();
+                try (InputStream input = openInputStreamFromBlobStore(start, end - start)) {
+                    while (remaining > 0L) {
+                        final int bytesRead = BlobCacheUtils.readSafe(input, copyBuffer, start, remaining);
+                        positionalWrite(fc, start + bytesCopied, copyBuffer.flip());
+                        copyBuffer.clear();
+                        bytesCopied += bytesRead;
+                        remaining -= bytesRead;
+                        progressUpdater.accept(start + bytesCopied);
+                    }
+                    final long endTimeNanos = stats.currentTimeNanos();
+                    stats.addCachedBytesWritten(bytesCopied, endTimeNanos - startTimeNanos);
+                }
+            },
             directory.cacheFetchAsyncExecutor()
         );
     }
@@ -351,35 +414,10 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
         assert assertFileChannelOpen(fc);
         final int bytesRead = Channels.readFromFileChannel(fc, position, buffer);
         if (bytesRead == -1) {
-            throwEOF(position, buffer.remaining(), cacheFileReference);
+            throwEOF(position, buffer.remaining());
         }
         stats.addCachedBytesRead(bytesRead);
         return bytesRead;
-    }
-
-    private void writeCacheFile(final FileChannel fc, final long start, final long end, final LongConsumer progressUpdater)
-        throws IOException {
-        assert assertFileChannelOpen(fc);
-        assert ThreadPool.assertCurrentThreadPool(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
-        final long length = end - start;
-        final ByteBuffer copyBuffer = writeBuffer.get().clear();
-        logger.trace("writing range [{}-{}] to cache file [{}]", start, end, cacheFileReference);
-
-        long bytesCopied = 0L;
-        long remaining = end - start;
-        final long startTimeNanos = stats.currentTimeNanos();
-        try (InputStream input = openInputStreamFromBlobStore(start, length)) {
-            while (remaining > 0L) {
-                final int bytesRead = BlobCacheUtils.readSafe(input, copyBuffer, start, remaining, cacheFileReference);
-                positionalWrite(fc, start + bytesCopied, copyBuffer.flip());
-                copyBuffer.clear();
-                bytesCopied += bytesRead;
-                remaining -= bytesRead;
-                progressUpdater.accept(start + bytesCopied);
-            }
-            final long endTimeNanos = stats.currentTimeNanos();
-            stats.addCachedBytesWritten(bytesCopied, endTimeNanos - startTimeNanos);
-        }
     }
 
     private void fillIndexCache(CacheFile cacheFile, ByteRange indexCacheMiss) {
@@ -432,7 +470,7 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
                 try (InputStream input = openInputStreamFromBlobStore(position, length)) {
                     final int bytesRead = Streams.read(input, b, length);
                     if (bytesRead < length) {
-                        throwEOF(position, length - bytesRead, cacheFileReference);
+                        throwEOF(position, length - bytesRead);
                     }
                     final long endTimeNanos = stats.currentTimeNanos();
                     stats.addDirectBytesRead(bytesRead, endTimeNanos - startTimeNanos);
@@ -442,12 +480,12 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
                 e.addSuppressed(inner);
             }
         }
-        throw new IOException("failed to read data from cache", e);
+        throw new IOException("failed to read data from cache for [" + cacheFileReference + "]", e);
     }
 
     /**
      * Opens an {@link InputStream} for the given range of bytes which reads the data directly from the blob store. If the requested range
-     * spans multiple blobs then this stream will request them in turn.
+     * spans multiple blobs then this stream will request them in turn using.
      *
      * @param position The start of the range of bytes to read, relative to the start of the corresponding Lucene file.
      * @param readLength The number of bytes to read
@@ -459,32 +497,37 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
                 : "cannot read [" + position + "-" + (position + readLength) + "] from [" + fileInfo + "]";
             stats.addBlobStoreBytesRequested(readLength);
             return directory.blobContainer().readBlob(fileInfo.name(), position, readLength);
-        } else {
-            final int startPart = getPartNumberForPosition(position);
-            final int endPart = getPartNumberForPosition(position + readLength - 1);
+        }
+        return openInputStreamMultipleParts(position, readLength);
+    }
 
-            for (int currentPart = startPart; currentPart <= endPart; currentPart++) {
+    /**
+     * Used by {@link #openInputStreamFromBlobStore} when reading a range that is split across multiple file parts/blobs.
+     * See {@link BlobStoreRepository#chunkSize()}.
+     */
+    private SlicedInputStream openInputStreamMultipleParts(long position, long readLength) {
+        final int startPart = getPartNumberForPosition(position);
+        final int endPart = getPartNumberForPosition(position + readLength - 1);
+
+        for (int currentPart = startPart; currentPart <= endPart; currentPart++) {
+            final long startInPart = (currentPart == startPart) ? getRelativePositionInPart(position) : 0L;
+            final long endInPart;
+            endInPart = currentPart == endPart ? getRelativePositionInPart(position + readLength - 1) + 1 : fileInfo.partBytes(currentPart);
+            stats.addBlobStoreBytesRequested(endInPart - startInPart);
+        }
+
+        return new SlicedInputStream(endPart - startPart + 1) {
+            @Override
+            protected InputStream openSlice(int slice) throws IOException {
+                final int currentPart = startPart + slice;
                 final long startInPart = (currentPart == startPart) ? getRelativePositionInPart(position) : 0L;
                 final long endInPart;
                 endInPart = currentPart == endPart
                     ? getRelativePositionInPart(position + readLength - 1) + 1
                     : fileInfo.partBytes(currentPart);
-                stats.addBlobStoreBytesRequested(endInPart - startInPart);
+                return directory.blobContainer().readBlob(fileInfo.partName(currentPart), startInPart, endInPart - startInPart);
             }
-
-            return new SlicedInputStream(endPart - startPart + 1) {
-                @Override
-                protected InputStream openSlice(int slice) throws IOException {
-                    final int currentPart = startPart + slice;
-                    final long startInPart = (currentPart == startPart) ? getRelativePositionInPart(position) : 0L;
-                    final long endInPart;
-                    endInPart = currentPart == endPart
-                        ? getRelativePositionInPart(position + readLength - 1) + 1
-                        : fileInfo.partBytes(currentPart);
-                    return directory.blobContainer().readBlob(fileInfo.partName(currentPart), startInPart, endInPart - startInPart);
-                }
-            };
-        }
+        };
     }
 
     /**


### PR DESCRIPTION
Move things into a couple more methods and add some documentation. Also, some minor cleanups around logger usage and inlining some single-use, never-skipped methods to make things easier to follow.
Outside of removing the weird passing of `Object` to `throwEOF` that I replaced with re throwing IO exceptions with the file as part of the rethrow message (just to save some complexity) no functional changes in this whatsoever.