### PR TITLE
Remove unnecessary locking in SparseFileTracker

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -416,12 +416,9 @@ public class SparseFileTracker {
     }
 
     private void onGapSuccess(final Range gapRange) {
-        final ProgressListenableActionFuture completionListener;
-
         synchronized (mutex) {
             assert invariant();
             assert assertPendingRangeExists(gapRange);
-            completionListener = gapRange.completionListener;
             ranges.remove(gapRange);
 
             final SortedSet<Range> prevRanges = ranges.headSet(gapRange);
@@ -460,7 +457,7 @@ public class SparseFileTracker {
             assert invariant();
         }
 
-        completionListener.onResponse(gapRange.end);
+        gapRange.completionListener.onResponse(gapRange.end);
     }
 
     private void maybeUpdateCompletePointer(Range gapRange) {
@@ -471,32 +468,24 @@ public class SparseFileTracker {
         }
     }
 
-    private void onGapProgress(final Range gapRange, long value) {
-        final ProgressListenableActionFuture completionListener;
-
+    private boolean assertGapRangePending(Range gapRange) {
         synchronized (mutex) {
             assert invariant();
             assert assertPendingRangeExists(gapRange);
-            completionListener = gapRange.completionListener;
-            assert invariant();
         }
-
-        completionListener.onProgress(value);
+        return true;
     }
 
     private void onGapFailure(final Range gapRange, Exception e) {
-        final ProgressListenableActionFuture completionListener;
-
         synchronized (mutex) {
             assert invariant();
             assert assertPendingRangeExists(gapRange);
-            completionListener = gapRange.completionListener;
             final boolean removed = ranges.remove(gapRange);
             assert removed : gapRange + " not found";
             assert invariant();
         }
 
-        completionListener.onFailure(e);
+        gapRange.completionListener.onFailure(e);
     }
 
     private boolean invariant() {
@@ -565,7 +554,8 @@ public class SparseFileTracker {
         }
 
         public void onProgress(long value) {
-            onGapProgress(range, value);
+            assert assertGapRangePending(range);
+            range.completionListener.onProgress(value);
         }
 
         public void onFailure(Exception e) {


### PR DESCRIPTION
These callbacks don't need to synchronize outside of assertions since the listener field is final -> remove synchronization and move assertion on progress to a separate method. This might help performance a little, since the onProgress callback can become rather hot during cache writing.
