### PR TITLE
[DOCS] Fix HDR parameter for the percentile agg

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -355,7 +355,7 @@ GET latency/_search
 This option can lead to improved accuracy (relative error close to 0.01% for millions of samples in some
 cases) but then percentile queries take 2x-10x longer to complete.
 
-==== HDR Histogram
+==== HDR histogram
 
 https://github.com/HdrHistogram/HdrHistogram[HDR Histogram] (High Dynamic Range Histogram) is an alternative implementation
 that can be useful when calculating percentiles for latency measurements as it can be faster than the t-digest implementation
@@ -364,7 +364,7 @@ as a number of significant digits). This means that if data is recorded with val
 (3,600,000,000 microseconds) in a histogram set to 3 significant digits, it will maintain a value resolution of 1 microsecond
 for values up to 1 millisecond and 3.6 seconds (or better) for the maximum tracked value (1 hour).
 
-The HDR Histogram can be used by specifying the `method` parameter in the request:
+The HDR Histogram can be used by specifying the `hdr` parameter in the request:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Fixes a typo in the percentile aggregation docs: the `method` parameter for HDR histograms [should be `hdr`](https://github.com/elastic/elasticsearch-specification/blob/main/specification/_types/aggregations/metric.ts#L148), as reported by @achyutjhunjhunwala 