### PR TITLE
[8.9] [DOCS] Add 'boost' paramater to match query (#98108)

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -65,6 +65,17 @@ See <<query-dsl-match-query-synonyms,Use synonyms with match query>> for an
 example.
 --
 
+`boost`::
++
+--
+(Optional, float) Floating point number used to decrease or increase the
+<<relevance-scores,relevance scores>> of the query. Defaults to `1.0`.
+
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+--
+
 `fuzziness`::
 (Optional, string) Maximum edit distance allowed for matching. See <<fuzziness>>
 for valid values and more information. See <<query-dsl-match-query-fuzziness>>


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [DOCS] Add 'boost' paramater to match query (#98108)