### PR TITLE
Read the lifecycle only mode cluster setting from the cluster settings

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -98,7 +98,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         this.threadPool = threadPool;
         this.xContentRegistry = xContentRegistry;
         this.clusterService = clusterService;
-        if (isDataStreamsLifecycleOnlyMode(settings) == false) {
+        if (isDataStreamsLifecycleOnlyMode(clusterService.getSettings()) == false) {
             this.lifecyclePolicies = getLifecycleConfigs().stream()
                 .map(config -> config.load(LifecyclePolicyConfig.DEFAULT_X_CONTENT_REGISTRY))
                 .toList();
@@ -261,7 +261,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     }
 
     private void addLegacyTemplatesIfMissing(ClusterState state) {
-        if (isDataStreamsLifecycleOnlyMode(settings)) {
+        if (isDataStreamsLifecycleOnlyMode(clusterService.getSettings())) {
             // data stream lifecycle cannot be configured via legacy templates
             return;
         }
@@ -540,7 +540,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     }
 
     private void addIndexLifecyclePoliciesIfMissing(ClusterState state) {
-        if (isDataStreamsLifecycleOnlyMode(state.getMetadata().settings())) {
+        if (isDataStreamsLifecycleOnlyMode(clusterService.getSettings())) {
             logger.trace("running in data stream lifecycle only mode. skipping the installation of ILM policies.");
             return;
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -72,6 +72,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
         doAnswer(withResponse(AcknowledgedResponse.TRUE)).when(indicesAdminClient).putTemplate(any(), any());
 
         clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
         xContentRegistry = new NamedXContentRegistry(
             CollectionUtils.appendToCopy(

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/AbstractProfilingPersistenceManager.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
@@ -94,7 +95,7 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
             return;
         }
 
-        if (isAllResourcesCreated(event) == false) {
+        if (isAllResourcesCreated(event, clusterService.getSettings()) == false) {
             logger.trace("Skipping index creation; not all required resources are present yet");
             return;
         }
@@ -116,8 +117,8 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         }
     }
 
-    protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
-        return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state());
+    protected boolean isAllResourcesCreated(ClusterChangedEvent event, Settings settings) {
+        return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state(), settings);
     }
 
     /**

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -294,7 +294,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
         }
     }
 
-    public static boolean isAllResourcesCreated(ClusterState state) {
+    public static boolean isAllResourcesCreated(ClusterState state, Settings settings) {
         for (String componentTemplate : COMPONENT_TEMPLATE_CONFIGS.keySet()) {
             if (state.metadata().componentTemplates().containsKey(componentTemplate) == false) {
                 return false;
@@ -305,7 +305,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
                 return false;
             }
         }
-        if (isDataStreamsLifecycleOnlyMode(state.metadata().settings()) == false) {
+        if (isDataStreamsLifecycleOnlyMode(settings) == false) {
             for (LifecyclePolicyConfig lifecyclePolicy : LIFECYCLE_POLICY_CONFIGS) {
                 IndexLifecycleMetadata ilmMetadata = state.metadata().custom(IndexLifecycleMetadata.TYPE);
                 if (ilmMetadata == null || ilmMetadata.getPolicies().containsKey(lifecyclePolicy.getPolicyName()) == false) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -55,7 +55,7 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
     ) {
         boolean pluginEnabled = getValue(state, XPackSettings.PROFILING_ENABLED);
         boolean resourceManagementEnabled = getValue(state, ProfilingPlugin.PROFILING_TEMPLATES_ENABLED);
-        boolean resourcesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state);
+        boolean resourcesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state, clusterService.getSettings());
         listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated));
     }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingDataStreamManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingDataStreamManagerTests.java
@@ -84,7 +84,7 @@ public class ProfilingDataStreamManagerTests extends ESTestCase {
         indexTemplateVersion = ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION;
         datastreamManager = new ProfilingDataStreamManager(threadPool, client, clusterService) {
             @Override
-            protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
+            protected boolean isAllResourcesCreated(ClusterChangedEvent event, Settings settings) {
                 return templatesCreated.get();
             }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexManagerTests.java
@@ -84,7 +84,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         indexTemplateVersion = ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION;
         indexManager = new ProfilingIndexManager(threadPool, client, clusterService) {
             @Override
-            protected boolean isAllResourcesCreated(ClusterChangedEvent event) {
+            protected boolean isAllResourcesCreated(ClusterChangedEvent event, Settings settings) {
                 return templatesCreated.get();
             }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -101,6 +101,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         }).when(indicesAdminClient).putTemplate(any(PutIndexTemplateRequest.class), any(ActionListener.class));
 
         clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         List<NamedXContentRegistry.Entry> entries = new ArrayList<>(ClusterModule.getNamedXWriteables());
         entries.addAll(
             Arrays.asList(


### PR DESCRIPTION
The `IndexTemplateRegistry` child classes live in various modules and plugins, yet they all need to read the up-to-date value of the cluster setting that's registered in a different module (in this case the `data_streams.lifecycle_only.mode` setting).

This makes it so setting is read from the `clusterService.settings` object which already contains all the settings from all the plugins.


