### PR TITLE
[ML] Make estimate model memory API cancellable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
@@ -13,6 +13,9 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -99,6 +102,11 @@ public class EstimateModelMemoryAction extends ActionType<EstimateModelMemoryAct
                 return e;
             }
             return null;
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, "estimate_model_memory", parentTaskId, headers);
         }
 
         public AnalysisConfig getAnalysisConfig() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestEstimateModelMemoryAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestEstimateModelMemoryAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.EstimateModelMemoryAction;
 
@@ -38,6 +39,7 @@ public class RestEstimateModelMemoryAction extends BaseRestHandler {
         EstimateModelMemoryAction.Request request = EstimateModelMemoryAction.Request.parseRequest(
             restRequest.contentOrSourceParamParser()
         );
-        return channel -> client.execute(EstimateModelMemoryAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel ->  new RestCancellableNodeClient(client, restRequest.getHttpChannel())
+            .execute(EstimateModelMemoryAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }


### PR DESCRIPTION
This change should make estimate model memory API cancellable

issue: #88010
