### PR TITLE
Hiding data stream lifecycle documentation in released docs

### DIFF
--- a/docs/reference/data-management.asciidoc
+++ b/docs/reference/data-management.asciidoc
@@ -9,15 +9,15 @@ The data you store in {es} generally falls into one of two categories:
 * Content: a collection of items you want to search, such as a catalog of products
 * Time series data: a stream of continuously-generated timestamped data, such as log entries
 
-Content might be frequently updated,
-but the value of the content remains relatively constant over time.
-You want to be able to retrieve items quickly regardless of how old they are.
+Content might be frequently updated, 
+but the value of the content remains relatively constant over time. 
+You want to be able to retrieve items quickly regardless of how old they are. 
 
-Time series data keeps accumulating over time, so you need strategies for
-balancing the value of the data against the cost of storing it.
-As it ages, it tends to become less important and less-frequently accessed,
-so you can move it to less expensive, less performant hardware.
-For your oldest data, what matters is that you have access to the data.
+Time series data keeps accumulating over time, so you need strategies for 
+balancing the value of the data against the cost of storing it. 
+As it ages, it tends to become less important and less-frequently accessed, 
+so you can move it to less expensive, less performant hardware. 
+For your oldest data, what matters is that you have access to the data. 
 It's ok if queries take longer to complete.
 
 ifeval::["{release-state}"=="unreleased"]

--- a/docs/reference/data-management.asciidoc
+++ b/docs/reference/data-management.asciidoc
@@ -41,7 +41,7 @@ Data older than this period can be deleted by {es}.
 * Define <<data-tiers, multiple tiers>> of data nodes with different performance characteristics.
 * Automatically transition indices through the data tiers according to your performance needs and retention policies.
 * Leverage <<searchable-snapshots, searchable snapshots>> stored in a remote repository to provide resiliency 
-for your older indices while reducing operating costs and maintaining search performance. 
+for your older indices while reducing operating costs and maintaining search performance.  
 * Perform <<async-search-intro, asynchronous searches>> of data stored on less-performant hardware.
 
 ifeval::["{release-state}"=="unreleased"]

--- a/docs/reference/data-management.asciidoc
+++ b/docs/reference/data-management.asciidoc
@@ -40,8 +40,8 @@ endif::[]
 Data older than this period can be deleted by {es}.
 * Define <<data-tiers, multiple tiers>> of data nodes with different performance characteristics.
 * Automatically transition indices through the data tiers according to your performance needs and retention policies.
-* Leverage <<searchable-snapshots, searchable snapshots>> stored in a remote repository to provide resiliency
-for your older indices while reducing operating costs and maintaining search performance.
+* Leverage <<searchable-snapshots, searchable snapshots>> stored in a remote repository to provide resiliency 
+for your older indices while reducing operating costs and maintaining search performance. 
 * Perform <<async-search-intro, asynchronous searches>> of data stored on less-performant hardware.
 
 ifeval::["{release-state}"=="unreleased"]

--- a/docs/reference/data-management.asciidoc
+++ b/docs/reference/data-management.asciidoc
@@ -9,17 +9,18 @@ The data you store in {es} generally falls into one of two categories:
 * Content: a collection of items you want to search, such as a catalog of products
 * Time series data: a stream of continuously-generated timestamped data, such as log entries
 
-Content might be frequently updated, 
-but the value of the content remains relatively constant over time. 
-You want to be able to retrieve items quickly regardless of how old they are. 
+Content might be frequently updated,
+but the value of the content remains relatively constant over time.
+You want to be able to retrieve items quickly regardless of how old they are.
 
-Time series data keeps accumulating over time, so you need strategies for 
-balancing the value of the data against the cost of storing it. 
-As it ages, it tends to become less important and less-frequently accessed, 
-so you can move it to less expensive, less performant hardware. 
-For your oldest data, what matters is that you have access to the data. 
+Time series data keeps accumulating over time, so you need strategies for
+balancing the value of the data against the cost of storing it.
+As it ages, it tends to become less important and less-frequently accessed,
+so you can move it to less expensive, less performant hardware.
+For your oldest data, what matters is that you have access to the data.
 It's ok if queries take longer to complete.
 
+ifeval::["{release-state}"=="unreleased"]
 To help you manage your data, {es} offers you:
 
 * <<index-lifecycle-management, {ilm-cap}>> ({ilm-init}) to manage both indices and data streams and it is fully customisable, and
@@ -27,6 +28,11 @@ To help you manage your data, {es} offers you:
 common lifecycle management needs.
 
 preview::["The built-in data stream lifecycle is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but this feature is not subject to the support SLA of official GA features."]
+endif::[]
+ifeval::["{release-state}"=="released"]
+To help you manage your data, {es} offers you <<index-lifecycle-management, {ilm-cap}>> ({ilm-init}) to manage both indices and data
+streams and it is fully customisable.
+endif::[]
 
 **{ilm-init}** can be used to manage both indices and data streams and it allows you to:
 
@@ -34,16 +40,18 @@ preview::["The built-in data stream lifecycle is in technical preview and may be
 Data older than this period can be deleted by {es}.
 * Define <<data-tiers, multiple tiers>> of data nodes with different performance characteristics.
 * Automatically transition indices through the data tiers according to your performance needs and retention policies.
-* Leverage <<searchable-snapshots, searchable snapshots>> stored in a remote repository to provide resiliency 
-for your older indices while reducing operating costs and maintaining search performance.  
+* Leverage <<searchable-snapshots, searchable snapshots>> stored in a remote repository to provide resiliency
+for your older indices while reducing operating costs and maintaining search performance.
 * Perform <<async-search-intro, asynchronous searches>> of data stored on less-performant hardware.
 
+ifeval::["{release-state}"=="unreleased"]
 **Data stream lifecycle** is less feature rich but is focused on simplicity, so it allows you to easily:
 
 * Define the retention period of your data. The retention period is the minimum time your data will be stored in {es}.
 Data older than this period can be deleted by {es} at a later time.
 * Improve the performance of your data stream by performing background operations that will optimise the way your data
 stream is stored.
+endif::[]
 --
 
 include::ilm/index.asciidoc[]

--- a/docs/reference/data-streams/data-stream-apis.asciidoc
+++ b/docs/reference/data-streams/data-stream-apis.asciidoc
@@ -12,6 +12,7 @@ The following APIs are available for managing <<data-streams,data streams>>:
 * <<promote-data-stream-api>>
 * <<modify-data-streams-api>>
 
+ifeval::["{release-state}"=="unreleased"]
 [[data-stream-lifecycle-api]]
 The following APIs are available for managing the built-in lifecycle of data streams:
 
@@ -19,6 +20,7 @@ The following APIs are available for managing the built-in lifecycle of data str
 * <<data-streams-get-lifecycle,Get data stream lifecycle>> preview:[]
 * <<data-streams-delete-lifecycle,Delete data stream lifecycle>> preview:[]
 * <<data-streams-explain-lifecycle,Explain data stream lifecycle>> preview:[]
+endif::[]
 
 The following API is available for <<tsds,time series data streams>>:
 
@@ -41,6 +43,7 @@ include::{es-repo-dir}/data-streams/promote-data-stream-api.asciidoc[]
 
 include::{es-repo-dir}/data-streams/modify-data-streams-api.asciidoc[]
 
+ifeval::["{release-state}"=="unreleased"]
 include::{es-repo-dir}/data-streams/lifecycle/apis/put-lifecycle.asciidoc[]
 
 include::{es-repo-dir}/data-streams/lifecycle/apis/get-lifecycle.asciidoc[]
@@ -48,5 +51,6 @@ include::{es-repo-dir}/data-streams/lifecycle/apis/get-lifecycle.asciidoc[]
 include::{es-repo-dir}/data-streams/lifecycle/apis/delete-lifecycle.asciidoc[]
 
 include::{es-repo-dir}/data-streams/lifecycle/apis/explain-lifecycle.asciidoc[]
+endif::[]
 
 include::{es-repo-dir}/indices/downsample-data-stream.asciidoc[]

--- a/docs/reference/data-streams/lifecycle/index.asciidoc
+++ b/docs/reference/data-streams/lifecycle/index.asciidoc
@@ -1,5 +1,6 @@
 [role="xpack"]
 [[data-stream-lifecycle]]
+ifeval::["{release-state}"=="unreleased"]
 == Data stream lifecycle
 
 preview::[]
@@ -62,3 +63,4 @@ because it is applied on the data stream level and not on the individual backing
 include::tutorial-manage-new-data-stream.asciidoc[]
 
 include::tutorial-manage-existing-data-stream.asciidoc[]
+endif::[]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1882,6 +1882,7 @@ Refer to <<example-watches>> for other Watcher examples.
 
 Refer to <<fix-watermark-errors>>.
 
+ifeval::["{release-state}"=="unreleased"]
 [role="exclude",id="dlm-delete-lifecycle"]
 === Delete the lifecycle of a data stream
 
@@ -1901,6 +1902,7 @@ Refer to <<data-streams-get-lifecycle,Get data stream lifecycle API>>.
 === Update the lifecycle of a data stream
 
 Refer to <<data-streams-delete-lifecycle,Update data stream lifecycle API>>.
+endif::[]
 
 [role="exclude",id="get-synonyms"]
 === Get synonyms set API

--- a/docs/reference/settings/data-stream-lifecycle-settings.asciidoc
+++ b/docs/reference/settings/data-stream-lifecycle-settings.asciidoc
@@ -1,5 +1,6 @@
 [role="xpack"]
 [[data-stream-lifecycle-settings]]
+ifeval::["{release-state}"=="unreleased"]
 === Data stream lifecycle settings in {es}
 [subs="attributes"]
 ++++
@@ -49,3 +50,4 @@ If specified, this is the timestamp used to calculate the backing index generati
 setting if you create a backing index that contains older data and want to ensure that the retention period or
 other parts of the lifecycle will be applied based on the data's original timestamp and not the timestamp they got
 indexed. Specified as a Unix epoch value in milliseconds.
+endif::[]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -54,7 +54,9 @@ include::settings/health-diagnostic-settings.asciidoc[]
 
 include::settings/ilm-settings.asciidoc[]
 
+ifeval::["{release-state}"=="unreleased"]
 include::settings/data-stream-lifecycle-settings.asciidoc[]
+endif::[]
 
 include::modules/indices/index_management.asciidoc[]
 


### PR DESCRIPTION
The data stream lifecycle documents have been causing confusion since the data stream lifecycle feature is still behind a feature flag. This PR hides those documents in our released documentation.