### PR TITLE
Forcibly terminate test cluster nodes at the end of tests

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -129,7 +129,7 @@ public interface ClusterHandle extends Closeable {
     void upgradeToVersion(Version version);
 
     /**
-     * Cleans up any resources created by this cluster.
+     * Cleans up any resources created by this cluster. Calling this method will forcibly terminate any running nodes.
      */
     void close();
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -96,7 +96,7 @@ public class LocalClusterHandle implements ClusterHandle {
 
     @Override
     public void close() {
-        stop(false);
+        stop(true);
 
         executor.shutdownNow();
         try {


### PR DESCRIPTION
It's not necessary to do a graceful shutdown at the end of integration tests. The cluster won't be reused and instead we wait for shutdown handlers to run unnecessarily, extending test runtime.