### PR TITLE
Add forcibly argument to test cluster stop node method

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -34,7 +34,7 @@ public interface ClusterHandle extends Closeable {
      * Stops the node at a given index.
      * @param index of the node to stop
      */
-    void stopNode(int index);
+    void stopNode(int index, boolean forcibly);
 
     /**
      * Restarts the cluster. Effectively the same as calling {@link #stop(boolean)} followed by {@link #start()}

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/DefaultElasticsearchCluster.java
@@ -55,9 +55,9 @@ public class DefaultElasticsearchCluster<S extends ClusterSpec, H extends Cluste
     }
 
     @Override
-    public void stopNode(int index) {
+    public void stopNode(int index, boolean forcibly) {
         checkHandle();
-        handle.stopNode(index);
+        handle.stopNode(index, forcibly);
     }
 
     @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -76,7 +76,7 @@ public class LocalClusterHandle implements ClusterHandle {
     public void stop(boolean forcibly) {
         if (started.getAndSet(false)) {
             LOGGER.info("Stopping Elasticsearch test cluster '{}', forcibly: {}", name, forcibly);
-            execute(() -> nodes.parallelStream().forEach(n -> n.stop(forcibly)));
+            execute(() -> nodes.parallelStream().forEach(n -> stopNode(nodes.indexOf(n), forcibly)));
         } else {
             // Make sure the process is stopped, otherwise wait
             execute(() -> nodes.parallelStream().forEach(Node::waitForExit));
@@ -167,7 +167,7 @@ public class LocalClusterHandle implements ClusterHandle {
         return nodes.get(index).getPid();
     }
 
-    public void stopNode(int index) {
+    public void stopNode(int index, boolean forcibly) {
         nodes.get(index).stop(false);
     }
 


### PR DESCRIPTION
Adds the typical `forcibly` parameter to the `stopNode` method to allow specifying whether a node should be forcibly terminated or not. Also refactors the `stop` method to call `stopNode` allowing subclasses to extend this behavior more easily.