### PR TITLE
Update field-mapping.asciidoc that Epoch format is not supported as dynamic date format

### DIFF
--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -216,6 +216,11 @@ GET my-index-000001/_mapping
 --------------------------------------------------
 ====
 
+[NOTE]
+====
+Epoch format is not supported as dynamic date format.
+====
+
 [[numeric-detection]]
 ==== Numeric detection
 

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -218,7 +218,7 @@ GET my-index-000001/_mapping
 
 [NOTE]
 ====
-Epoch format is not supported as dynamic date format.
+Epoch formats (`epoch_millis` and `epoch_second`) are not supported as dynamic date formats.
 ====
 
 [[numeric-detection]]


### PR DESCRIPTION
Update field-mapping.asciidoc that Epoch format is not supported as dynamic date format per https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java#L430-L431
```java
if (formatter.toString().startsWith("epoch_")) {
  throw new MapperParsingException("Epoch [" + formatter + "] is not supported as dynamic date format");
}
```

It's in the code but not documented, and this PR is to document it explicitly.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`? 
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
