### PR TITLE
[8.9] Update field-mapping.asciidoc that Epoch format is not supported as dynamic date format (#98338)

### DIFF
--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -216,6 +216,11 @@ GET my-index-000001/_mapping
 --------------------------------------------------
 ====
 
+[NOTE]
+====
+Epoch formats (`epoch_millis` and `epoch_second`) are not supported as dynamic date formats.
+====
+
 [[numeric-detection]]
 ==== Numeric detection
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Update field-mapping.asciidoc that Epoch format is not supported as dynamic date format (#98338)](https://github.com/elastic/elasticsearch/pull/98338)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)