### PR TITLE
Minor CoordinatorTests logging fixes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactory.java
@@ -218,11 +218,12 @@ public class ElectionSchedulerFactory {
 
         @Override
         public String toString() {
-            return "ElectionScheduler{attempt=" + attempt + ", " + ElectionSchedulerFactory.this + "}";
+            return "ElectionScheduler{attempt=" + attempt + ",isClosed=" + isClosed.get() + "," + ElectionSchedulerFactory.this + "}";
         }
 
         @Override
         public void close() {
+            logger.trace("closing {}", this);
             boolean wasNotPreviouslyClosed = isClosed.compareAndSet(false, true);
             assert wasNotPreviouslyClosed;
         }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -730,10 +730,12 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 lastAcceptedState.getLastCommittedConfiguration(),
                 equalTo(lastAcceptedState.getLastAcceptedConfiguration())
             );
-            assertThat(
-                "current configuration is already optimal",
-                leader.improveConfiguration(lastAcceptedState),
-                sameInstance(lastAcceptedState)
+            leader.onNode(
+                () -> assertThat(
+                    "current configuration is already optimal",
+                    leader.improveConfiguration(lastAcceptedState),
+                    sameInstance(lastAcceptedState)
+                )
             );
 
             logger.info("checking linearizability of history with size {}: {}", history.size(), history);


### PR DESCRIPTION
Adds a little more detail to `ElectionSchedulerFactory`, and fixes the
wrapping of tasks in `DisruptableClusterApplierService` so that their
logs are decorated with the details of the owning node.