### PR TITLE
Update TransportXPackInfoAction to only query features that are present

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
@@ -75,13 +75,16 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
         FeatureSetsInfo featureSetsInfo = null;
         if (request.getCategories().contains(XPackInfoRequest.Category.FEATURES)) {
             var featureSets = new HashSet<FeatureSet>();
+            List<String> actions = client.getActionNames();
             for (var infoAction : infoActions) {
-                // local actions are executed directly, not on a separate thread, so no thread safe collection is necessary
-                client.executeLocally(
-                    infoAction,
-                    request,
-                    listener.delegateFailureAndWrap((l, response) -> featureSets.add(response.getInfo()))
-                );
+                if (actions.contains(infoAction.name())) {
+                    // local actions are executed directly, not on a separate thread, so no thread safe collection is necessary
+                    client.executeLocally(
+                        infoAction,
+                        request,
+                        listener.delegateFailureAndWrap((l, response) -> featureSets.add(response.getInfo()))
+                    );
+                }
             }
             featureSetsInfo = new FeatureSetsInfo(featureSets);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
@@ -118,6 +118,7 @@ public class TransportXPackInfoActionTests extends ESTestCase {
     }
 
     // Tests where a particular feature is not present.
+    @SuppressWarnings("unchecked")
     public void testFeatureNotPresent() throws Exception {
         final int featureSetCount = randomIntBetween(2, 7);
         List<XPackInfoFeatureAction> totalFeatureSet = randomSubsetOf(featureSetCount, XPackInfoFeatureAction.ALL);


### PR DESCRIPTION
This commit updates the TransportXPackInfoAction to only query features that are present, i.e. features that have a monitor info action registered. This allows for some features to not be present, e.g. ES|QL, and maybe others in the future.