### PR TITLE
Remove temporary workaround for doc root

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -1,9 +1,6 @@
 [[elasticsearch-reference]]
 = Elasticsearch Guide
 
-// Temporary workaround until we merge into the primary Elasticsearch branch.
-:elasticsearch-root: {elasticsearch-internal-root}
-
 :include-xpack:         true
 :es-test-dir:           {elasticsearch-root}/docs/src/test
 :plugins-examples-dir:  {elasticsearch-root}/plugins/examples


### PR DESCRIPTION
This commit removes a temporary workaround that was added for the doc root.