### PR TITLE
Fix erroneous linear scaling when resampling.

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -395,6 +395,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                 this.sampleRate = sampleRate;
                 this.p = 1.0d;
             }
+	    this.sampleRate *= this.p;
         }
 
         public int adjustSampleCount(int originalCount) {
@@ -412,7 +413,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
 		    // Note: In the future, this upsampling needs to take the sample rate into
 		    // account, too, so that *all* scaling of results is done in the ES
 		    // plugin, and no longer in Kibana.
-                    return (int) Math.floor(newCount / p);
+                    return (int) Math.floor(newCount / sampleRate);
                 } else {
                     return 0;
                 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -409,7 +409,10 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     // Adjust the sample counts from down-sampled to fully sampled.
                     // Be aware that downsampling drops entries from stackTraceEvents, so that
                     // the sum of the upscaled count values is less that totalCount.
-                    return (int) Math.floor(newCount / (sampleRate * p));
+		    // Note: In the future, this upsampling needs to take the sample rate into
+		    // account, too, so that *all* scaling of results is done in the ES
+		    // plugin, and no longer in Kibana.
+                    return (int) Math.floor(newCount / p);
                 } else {
                     return 0;
                 }


### PR DESCRIPTION
The ES profiling plugin does two different sorts of sampling: 1) The sampling rate that is derived from choosing a particular index.
2) An additional sampling rate that is applied if the particular index granularity leads to too many events -- e.g. if the number of events is more than 10% higher than requested, the events are subsampled further.

The client expects the results to *not* be scaled according to the sample rate, but the current API assumes the client will do the scaling for #1. The server, however, does the scaling for #2.

The "proper" and cleanest way would be to push scaling for both #1 and #2 into the server, and this will be done in a follow-up PR that touches both ES and Kibana. In the meantime, this PR will make sure the UI reports correct data, in case the follow-up PR encounters problems.
