### PR TITLE
Fixed scaling bug.

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -409,8 +409,8 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     // Adjust the sample counts from down-sampled to fully sampled.
                     // Be aware that downsampling drops entries from stackTraceEvents, so that
                     // the sum of the upscaled count values is less that totalCount.
-		    // This code needs to be refactored to move all scaling into the server
-		    // side, not just the resampling-scaling.
+                    // This code needs to be refactored to move all scaling into the server
+                    // side, not just the resampling-scaling.
                     return (int) Math.floor(newCount / (p));
                 } else {
                     return 0;

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -409,7 +409,9 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     // Adjust the sample counts from down-sampled to fully sampled.
                     // Be aware that downsampling drops entries from stackTraceEvents, so that
                     // the sum of the upscaled count values is less that totalCount.
-                    return (int) Math.floor(newCount / (sampleRate * p));
+		    // This code needs to be refactored to move all scaling into the server
+		    // side, not just the resampling-scaling.
+                    return (int) Math.floor(newCount / (p));
                 } else {
                     return 0;
                 }


### PR DESCRIPTION
The ES profiling plugin does two different sorts of sampling: 1) The sampling rate that is derived from choosing a particular index.
2) An additional sampling rate that is applied if the particular index granularity leads to too many events -- e.g. if the number of events is more than 10% higher than requested, the events are subsampled further.

The client expects the results to *not* be scaled according to the sample rate, but the current API assumes the client will do the scaling for #1. The server, however, does the scaling for #2.

The "proper" and cleanest way would be to push scaling for both #1 and #2 into the server, and this will be done in a follow-up PR that touches both ES and Kibana. In the meantime, this PR will make sure the UI reports correct data, in case the follow-up PR encounters problems.

See also: https://github.com/elastic/prodfiler/issues/3115