### PR TITLE
AsyncSearchTask completion listeners must finish for async search isRunning=false

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.search;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
@@ -83,7 +82,6 @@ import static org.hamcrest.Matchers.not;
  * This IT test copies the setup and general approach that the {@code CrossClusterSearchIT} test
  * used for testing synchronous CCS.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98272")
 public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
     private static final String REMOTE_CLUSTER = "cluster_a";
@@ -1039,7 +1037,6 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97286")
     public void testCancellationViaTimeoutWithAllowPartialResultsSetToFalse() throws Exception {
         Map<String, Object> testClusterInfo = setupTwoClusters();
         String localIndex = (String) testClusterInfo.get("local.index");

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -300,6 +300,10 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             hasCompleted = true;
             completionsListenersCopy = new HashMap<>(this.completionListeners);
             this.completionListeners.clear();
+            MutableSearchResponse mutableSearchResponse = searchResponse.get();
+            if (mutableSearchResponse != null) {
+                mutableSearchResponse.notifySearchTaskCompleted();
+            }
         }
         // we don't need to restore the response headers, they should be included in the current
         // context since we are called by the search action listener.
@@ -366,7 +370,6 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
     }
 
     class Listener extends SearchProgressActionListener {
-
         @Override
         protected void onQueryResult(int shardIndex) {
             checkCancellation();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -297,12 +297,15 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             if (hasCompleted) {
                 return;
             }
-            hasCompleted = true;
-            completionsListenersCopy = new HashMap<>(this.completionListeners);
-            this.completionListeners.clear();
-            MutableSearchResponse mutableSearchResponse = searchResponse.get();
-            if (mutableSearchResponse != null) {
-                mutableSearchResponse.notifySearchTaskCompleted();
+            try {
+                hasCompleted = true;
+                completionsListenersCopy = new HashMap<>(this.completionListeners);
+                this.completionListeners.clear();
+            } finally {
+                if (searchResponse != null && searchResponse.get() != null) {
+                    MutableSearchResponse mutableSearchResponse = searchResponse.get();
+                    mutableSearchResponse.notifySearchTaskCompleted();
+                }
             }
         }
         // we don't need to restore the response headers, they should be included in the current

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -63,6 +63,7 @@ class MutableSearchResponse {
     private Map<String, List<String>> responseHeaders;
 
     private boolean frozen;
+    private boolean searchTaskCompleted;
 
     /**
      * Creates a new mutable search response.
@@ -121,6 +122,10 @@ class MutableSearchResponse {
         this.finalResponse = response;
         this.isPartial = isPartialResponse(response);
         this.frozen = true;
+    }
+
+    public synchronized void notifySearchTaskCompleted() {
+        this.searchTaskCompleted = true;
     }
 
     private boolean isPartialResponse(SearchResponse response) {
@@ -212,7 +217,7 @@ class MutableSearchResponse {
             searchResponse,
             failure,
             isPartial,
-            frozen == false,
+            searchTaskCompleted == false,
             task.getStartTime(),
             expirationTime
         );
@@ -235,7 +240,7 @@ class MutableSearchResponse {
         if (finalResponse != null) {
             return new AsyncStatusResponse(
                 asyncExecutionId,
-                false,
+                searchTaskCompleted == false,
                 false,
                 startTime,
                 expirationTime,
@@ -251,7 +256,7 @@ class MutableSearchResponse {
         if (failure != null) {
             return new AsyncStatusResponse(
                 asyncExecutionId,
-                false,
+                searchTaskCompleted == false,
                 true,
                 startTime,
                 expirationTime,
@@ -266,7 +271,7 @@ class MutableSearchResponse {
         }
         return new AsyncStatusResponse(
             asyncExecutionId,
-            true,
+            searchTaskCompleted == false,
             true,
             startTime,
             expirationTime,
@@ -293,7 +298,7 @@ class MutableSearchResponse {
             buildResponse(task.getStartTimeNanos(), null),
             reduceException,
             isPartial,
-            frozen == false,
+            searchTaskCompleted == false,
             task.getStartTime(),
             expirationTime
         );

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -124,7 +124,7 @@ class MutableSearchResponse {
         this.frozen = true;
     }
 
-    public synchronized void notifySearchTaskCompleted() {
+    synchronized void notifySearchTaskCompleted() {
         this.searchTaskCompleted = true;
     }
 


### PR DESCRIPTION
Currently, the async search 'isRunning' status is based on upon receiving a "final" SearchResponse. 
However, the AsyncSearchTask can still have completion listeners running in parallel 
to this final response or even after. This can result in race conditions in IT tests that cause 
them to fail, as the test completes before the AsyncSearchTask is completely finished and 
when the completion listeners try to modify state that is deleted (such as writing to the
.async-search index), it fails, causing the IT test to fail.
