### PR TITLE
Fixing data stream lifecycle documentation links that break clients

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1886,22 +1886,45 @@ ifeval::["{release-state}"=="unreleased"]
 [role="exclude",id="dlm-delete-lifecycle"]
 === Delete the lifecycle of a data stream
 
+ifeval::["{release-state}"=="unreleased"]
 Refer to <<data-streams-delete-lifecycle,Delete data stream lifecycle API>>.
+
+endif::[]
+ifeval::["{release-state}"=="unreleased"]
+This feature has not been released yet
+endif::[]
 
 [role="exclude",id="dlm-explain-lifecycle"]
 === Explain the lifecycle of a data stream
 
+ifeval::["{release-state}"=="unreleased"]
 Refer to <<data-streams-explain-lifecycle,Explain data stream lifecycle API>>.
+
+endif::[]
+ifeval::["{release-state}"=="unreleased"]
+This feature has not been released yet
+endif::[]
 
 [role="exclude",id="dlm-get-lifecycle"]
 === Get the lifecycle of a data stream
 
+ifeval::["{release-state}"=="unreleased"]
 Refer to <<data-streams-get-lifecycle,Get data stream lifecycle API>>.
+
+endif::[]
+ifeval::["{release-state}"=="unreleased"]
+This feature has not been released yet
+endif::[]
 
 [role="exclude",id="dlm-put-lifecycle"]
 === Update the lifecycle of a data stream
 
+ifeval::["{release-state}"=="unreleased"]
 Refer to <<data-streams-delete-lifecycle,Update data stream lifecycle API>>.
+
+endif::[]
+ifeval::["{release-state}"=="unreleased"]
+This feature has not been released yet
 endif::[]
 
 [role="exclude",id="get-synonyms"]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1882,7 +1882,6 @@ Refer to <<example-watches>> for other Watcher examples.
 
 Refer to <<fix-watermark-errors>>.
 
-ifeval::["{release-state}"=="unreleased"]
 [role="exclude",id="dlm-delete-lifecycle"]
 === Delete the lifecycle of a data stream
 


### PR DESCRIPTION
In #98334 we hid the data stream lifecycle docs when the documentation is released. This inadvertently also removed `dlm-delete-lifecycle`, `dlm-explain-lifecycle`, `dlm-get-lifecycle`, and `dlm-put-lifecycle` from the released docs because they were within the `ifeval` block in `redirects.asciidoc`. This did not cause a problem in the build for the `main` branch but did cause the backport to 8.9 to fail (#98353) due to a client compatibility check. This PR makes the same change to main that went into #98353.