### PR TITLE
[main] [DOCS] Force merge doesn't mark index as read-only (#98357)

### DIFF
--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -11,7 +11,6 @@ Permanently remove the index.
 
 <<ilm-forcemerge,Force merge>>::
 Reduce the number of index segments and purge deleted documents.
-Makes the index read-only.
 
 <<ilm-migrate,Migrate>>::
 Move the index shards to the <<data-tiers, data tier>> that corresponds


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.9` to `main`:
 - [[DOCS] Force merge doesn't mark index as read-only (#98357)](https://github.com/elastic/elasticsearch/pull/98357)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)