### PR TITLE
[Search Relevance]  Refine the license compliance error message to be specific for features

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandler.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandler.java
@@ -18,9 +18,11 @@ import java.io.IOException;
 
 public abstract class EnterpriseSearchBaseRestHandler extends BaseRestHandler {
     protected final XPackLicenseState licenseState;
+    protected final EnterpriseSearchFeature.Feature feature;
 
-    protected EnterpriseSearchBaseRestHandler(XPackLicenseState licenseState) {
+    protected EnterpriseSearchBaseRestHandler(XPackLicenseState licenseState, EnterpriseSearchFeature.Feature feature) {
         this.licenseState = licenseState;
+        this.feature = feature;
     }
 
     protected final BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
@@ -31,7 +33,9 @@ public abstract class EnterpriseSearchBaseRestHandler extends BaseRestHandler {
             // and return a license error.
             request.params().keySet().forEach(key -> request.param(key, ""));
             request.content();
-            return channel -> channel.sendResponse(new RestResponse(channel, LicenseUtils.newComplianceException(this.licenseState)));
+            return channel -> channel.sendResponse(
+                new RestResponse(channel, LicenseUtils.newComplianceException(this.licenseState, this.feature))
+            );
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeature.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeature.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application;
+
+public class EnterpriseSearchFeature {
+    // Enum of features
+    public enum Feature {
+        SEARCH_APPLICATION("Search Application"),
+        BEHAVIORAL_ANALYTICS("Behavioral Analytics"),
+        QUERY_RULE("Query Rule");
+
+        private final String name;
+
+        // Constructor to initialize the feature name
+        Feature(String name) {
+            this.name = name;
+        }
+
+        // Getter method to retrieve the feature name
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeature.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeature.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.application;
 
 public class EnterpriseSearchFeature {
-    // Enum of features
     public enum Feature {
         SEARCH_APPLICATION("Search Application"),
         BEHAVIORAL_ANALYTICS("Behavioral Analytics"),
@@ -16,12 +15,10 @@ public class EnterpriseSearchFeature {
 
         private final String name;
 
-        // Constructor to initialize the feature name
         Feature(String name) {
             this.name = name;
         }
-
-        // Getter method to retrieve the feature name
+        
         public String getName() {
             return name;
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeature.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeature.java
@@ -11,14 +11,14 @@ public class EnterpriseSearchFeature {
     public enum Feature {
         SEARCH_APPLICATION("Search Application"),
         BEHAVIORAL_ANALYTICS("Behavioral Analytics"),
-        QUERY_RULE("Query Rule");
+        QUERY_RULES("Query Rules");
 
         private final String name;
 
         Feature(String name) {
             this.name = name;
         }
-        
+
         public String getName() {
             return name;
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestDeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestDeleteAnalyticsCollectionAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 @ServerlessScope(Scope.PUBLIC)
 public class RestDeleteAnalyticsCollectionAction extends EnterpriseSearchBaseRestHandler {
     public RestDeleteAnalyticsCollectionAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestGetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestGetAnalyticsCollectionAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.List;
 
@@ -24,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetAnalyticsCollectionAction extends EnterpriseSearchBaseRestHandler {
     public RestGetAnalyticsCollectionAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.net.InetAddress;
 import java.util.List;
@@ -29,7 +30,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 @ServerlessScope(Scope.PUBLIC)
 public class RestPostAnalyticsEventAction extends EnterpriseSearchBaseRestHandler {
     public RestPostAnalyticsEventAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS);
     }
 
     public static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPutAnalyticsCollectionAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.List;
 
@@ -24,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 @ServerlessScope(Scope.PUBLIC)
 public class RestPutAnalyticsCollectionAction extends EnterpriseSearchBaseRestHandler {
     public RestPutAnalyticsCollectionAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 @ServerlessScope(Scope.PUBLIC)
 public class RestDeleteQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     public RestDeleteQueryRulesetAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetAction.java
@@ -24,7 +24,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 @ServerlessScope(Scope.PUBLIC)
 public class RestDeleteQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     public RestDeleteQueryRulesetAction(XPackLicenseState licenseState) {
-        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULES);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetAction.java
@@ -25,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     public RestGetQueryRulesetAction(XPackLicenseState licenseState) {
-        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULES);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     public RestGetQueryRulesetAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsAction.java
@@ -25,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestListQueryRulesetsAction extends EnterpriseSearchBaseRestHandler {
     public RestListQueryRulesetsAction(XPackLicenseState licenseState) {
-        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULES);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 import java.util.List;
@@ -24,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestListQueryRulesetsAction extends EnterpriseSearchBaseRestHandler {
     public RestListQueryRulesetsAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetAction.java
@@ -26,7 +26,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 @ServerlessScope(Scope.PUBLIC)
 public class RestPutQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     public RestPutQueryRulesetAction(XPackLicenseState licenseState) {
-        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULES);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.io.IOException;
 import java.util.List;
@@ -25,7 +26,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 @ServerlessScope(Scope.PUBLIC)
 public class RestPutQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     public RestPutQueryRulesetAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.QUERY_RULE);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestDeleteSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestDeleteSearchApplicationAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 @ServerlessScope(Scope.PUBLIC)
 public class RestDeleteSearchApplicationAction extends EnterpriseSearchBaseRestHandler {
     public RestDeleteSearchApplicationAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestGetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestGetSearchApplicationAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetSearchApplicationAction extends EnterpriseSearchBaseRestHandler {
     public RestGetSearchApplicationAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestListSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestListSearchApplicationAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 import java.util.List;
@@ -24,7 +25,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestListSearchApplicationAction extends EnterpriseSearchBaseRestHandler {
     public RestListSearchApplicationAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestPutSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestPutSearchApplicationAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.io.IOException;
 import java.util.List;
@@ -25,7 +26,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 @ServerlessScope(Scope.PUBLIC)
 public class RestPutSearchApplicationAction extends EnterpriseSearchBaseRestHandler {
     public RestPutSearchApplicationAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,7 +27,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 @ServerlessScope(Scope.PUBLIC)
 public class RestQuerySearchApplicationAction extends EnterpriseSearchBaseRestHandler {
     public RestQuerySearchApplicationAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     public static final String ENDPOINT_PATH = "/" + EnterpriseSearch.SEARCH_APPLICATION_API_ENDPOINT + "/{name}" + "/_search";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestRenderSearchApplicationQueryAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestRenderSearchApplicationQueryAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,7 +22,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestRenderSearchApplicationQueryAction extends EnterpriseSearchBaseRestHandler {
     public RestRenderSearchApplicationQueryAction(XPackLicenseState licenseState) {
-        super(licenseState);
+        super(licenseState, EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     public static final String ENDPOINT_PATH = "/" + EnterpriseSearch.SEARCH_APPLICATION_API_ENDPOINT + "/{name}" + "/_render_query";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
@@ -12,6 +12,7 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 import org.elasticsearch.xpack.core.XPackField;
 
 public final class LicenseUtils {
@@ -25,12 +26,18 @@ public final class LicenseUtils {
         return LICENSED_ENT_SEARCH_FEATURE.check(licenseState);
     }
 
-    public static ElasticsearchSecurityException newComplianceException(XPackLicenseState licenseState) {
+    public static ElasticsearchSecurityException newComplianceException(
+        XPackLicenseState licenseState,
+        EnterpriseSearchFeature.Feature feature
+    ) {
         String licenseStatus = licenseState.statusDescription();
 
         ElasticsearchSecurityException e = new ElasticsearchSecurityException(
-            "Current license is non-compliant for search application and behavioral analytics. Current license is {}. "
-                + "Search Applications and behavioral analytics require an active trial, platinum or enterprise license.",
+            "Current license is non-compliant for "
+                + feature.getName()
+                + ". Current license is {}. "
+                + feature.getName()
+                + " requires an active trial, platinum or enterprise license.",
             RestStatus.FORBIDDEN,
             licenseStatus
         );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/AbstractRestEnterpriseSearchActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/AbstractRestEnterpriseSearchActionTests.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 
 public abstract class AbstractRestEnterpriseSearchActionTests extends ESTestCase {
-    protected void checkLicenseForRequest(FakeRestRequest request) throws Exception {
+    protected void checkLicenseForRequest(FakeRestRequest request, EnterpriseSearchFeature.Feature feature) throws Exception {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         final EnterpriseSearchBaseRestHandler action = getRestAction(licenseState);
 
@@ -33,6 +33,7 @@ public abstract class AbstractRestEnterpriseSearchActionTests extends ESTestCase
         assertThat(channel.capturedResponse(), notNullValue());
         assertThat(channel.capturedResponse().status(), equalTo(RestStatus.FORBIDDEN));
         assertThat(channel.capturedResponse().content().utf8ToString(), containsString("Current license is non-compliant"));
+        assertThat(channel.capturedResponse().content().utf8ToString(), containsString(feature.getName()));
     }
 
     protected abstract EnterpriseSearchBaseRestHandler getRestAction(XPackLicenseState licenseState);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandlerTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandlerTests.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 public class EnterpriseSearchBaseRestHandlerTests extends ESTestCase {
     public void testLicenseEnforcement() throws Exception {
         MockLicenseState licenseState = MockLicenseState.createMock();
-        final EnterpriseSearchFeature.Feature feature = EnterpriseSearchFeature.Feature.QUERY_RULE;
+        final EnterpriseSearchFeature.Feature feature = EnterpriseSearchFeature.Feature.QUERY_RULES;
         final boolean licensedFeature = randomBoolean();
 
         when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(licensedFeature);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandlerTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandlerTests.java
@@ -27,13 +27,14 @@ import static org.mockito.Mockito.when;
 public class EnterpriseSearchBaseRestHandlerTests extends ESTestCase {
     public void testLicenseEnforcement() throws Exception {
         MockLicenseState licenseState = MockLicenseState.createMock();
+        final EnterpriseSearchFeature.Feature feature = EnterpriseSearchFeature.Feature.QUERY_RULE;
         final boolean licensedFeature = randomBoolean();
 
         when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(licensedFeature);
         when(licenseState.isActive()).thenReturn(licensedFeature);
 
         final AtomicBoolean consumerCalled = new AtomicBoolean(false);
-        EnterpriseSearchBaseRestHandler handler = new EnterpriseSearchBaseRestHandler(licenseState) {
+        EnterpriseSearchBaseRestHandler handler = new EnterpriseSearchBaseRestHandler(licenseState, feature) {
 
             @Override
             protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestDeleteAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestDeleteAnalyticsCollectionActionTests.java
@@ -11,10 +11,11 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 public class RestDeleteAnalyticsCollectionActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
-        checkLicenseForRequest(new FakeRestRequest());
+        checkLicenseForRequest(new FakeRestRequest(), EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestGetAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestGetAnalyticsCollectionActionTests.java
@@ -11,10 +11,11 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 public class RestGetAnalyticsCollectionActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
-        checkLicenseForRequest(new FakeRestRequest());
+        checkLicenseForRequest(new FakeRestRequest(), EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -26,7 +27,8 @@ public class RestPostAnalyticsEventActionTests extends AbstractRestEnterpriseSea
                 .withParams(Map.of("collection_name", "my-collection"))
                 .withContent(new BytesArray("{}"), XContentType.JSON)
                 .withRemoteAddress(new InetSocketAddress(randomIp(randomBoolean()), randomIntBetween(1, 65535)))
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestPutAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/RestPutAnalyticsCollectionActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
@@ -21,7 +22,8 @@ public class RestPutAnalyticsCollectionActionTests extends AbstractRestEnterpris
         checkLicenseForRequest(
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.PUT)
                 .withParams(Map.of("collection_name", "my-collection"))
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.BEHAVIORAL_ANALYTICS
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
@@ -21,7 +22,8 @@ public class RestDeleteQueryRulesetActionTests extends AbstractRestEnterpriseSea
         checkLicenseForRequest(
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.DELETE)
                 .withParams(Map.of("ruleset_id", "ruleset-id"))
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.QUERY_RULE
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestDeleteQueryRulesetActionTests.java
@@ -23,7 +23,7 @@ public class RestDeleteQueryRulesetActionTests extends AbstractRestEnterpriseSea
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.DELETE)
                 .withParams(Map.of("ruleset_id", "ruleset-id"))
                 .build(),
-            EnterpriseSearchFeature.Feature.QUERY_RULE
+            EnterpriseSearchFeature.Feature.QUERY_RULES
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetActionTests.java
@@ -23,7 +23,7 @@ public class RestGetQueryRulesetActionTests extends AbstractRestEnterpriseSearch
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.GET)
                 .withParams(Map.of("ruleset_id", "ruleset-id"))
                 .build(),
-            EnterpriseSearchFeature.Feature.QUERY_RULE
+            EnterpriseSearchFeature.Feature.QUERY_RULES
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestGetQueryRulesetActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
@@ -21,7 +22,8 @@ public class RestGetQueryRulesetActionTests extends AbstractRestEnterpriseSearch
         checkLicenseForRequest(
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.GET)
                 .withParams(Map.of("ruleset_id", "ruleset-id"))
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.QUERY_RULE
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsActionTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 public class RestListQueryRulesetsActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
-        checkLicenseForRequest(new FakeRestRequest(), EnterpriseSearchFeature.Feature.QUERY_RULE);
+        checkLicenseForRequest(new FakeRestRequest(), EnterpriseSearchFeature.Feature.QUERY_RULES);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestListQueryRulesetsActionTests.java
@@ -11,10 +11,11 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 public class RestListQueryRulesetsActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
-        checkLicenseForRequest(new FakeRestRequest());
+        checkLicenseForRequest(new FakeRestRequest(), EnterpriseSearchFeature.Feature.QUERY_RULE);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
@@ -48,7 +49,8 @@ public class RestPutQueryRulesetActionTests extends AbstractRestEnterpriseSearch
                       ]
                     }
                     """), XContentType.JSON)
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.QUERY_RULE
         );
     }
 
@@ -57,7 +59,8 @@ public class RestPutQueryRulesetActionTests extends AbstractRestEnterpriseSearch
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.PUT)
                 .withParams(Map.of("invalid_param_name", "invalid_value"))
                 .withContent(new BytesArray("{}"), XContentType.JSON)
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.QUERY_RULE
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetActionTests.java
@@ -50,7 +50,7 @@ public class RestPutQueryRulesetActionTests extends AbstractRestEnterpriseSearch
                     }
                     """), XContentType.JSON)
                 .build(),
-            EnterpriseSearchFeature.Feature.QUERY_RULE
+            EnterpriseSearchFeature.Feature.QUERY_RULES
         );
     }
 
@@ -60,7 +60,7 @@ public class RestPutQueryRulesetActionTests extends AbstractRestEnterpriseSearch
                 .withParams(Map.of("invalid_param_name", "invalid_value"))
                 .withContent(new BytesArray("{}"), XContentType.JSON)
                 .build(),
-            EnterpriseSearchFeature.Feature.QUERY_RULE
+            EnterpriseSearchFeature.Feature.QUERY_RULES
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestDeleteSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestDeleteSearchApplicationActionTests.java
@@ -12,13 +12,15 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
 public class RestDeleteSearchApplicationActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
         checkLicenseForRequest(
-            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build()
+            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build(),
+            EnterpriseSearchFeature.Feature.SEARCH_APPLICATION
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestGetSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestGetSearchApplicationActionTests.java
@@ -12,13 +12,15 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
 public class RestGetSearchApplicationActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
         checkLicenseForRequest(
-            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build()
+            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build(),
+            EnterpriseSearchFeature.Feature.SEARCH_APPLICATION
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestListSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestListSearchApplicationActionTests.java
@@ -11,10 +11,11 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 public class RestListSearchApplicationActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
-        checkLicenseForRequest(new FakeRestRequest());
+        checkLicenseForRequest(new FakeRestRequest(), EnterpriseSearchFeature.Feature.SEARCH_APPLICATION);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestPutSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestPutSearchApplicationActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
@@ -24,7 +25,8 @@ public class RestPutSearchApplicationActionTests extends AbstractRestEnterpriseS
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.PUT)
                 .withParams(Map.of("name", "my-app"))
                 .withContent(new BytesArray("{\"indices\": [\"my-index\"]}"), XContentType.JSON)
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.SEARCH_APPLICATION
         );
     }
 
@@ -33,7 +35,8 @@ public class RestPutSearchApplicationActionTests extends AbstractRestEnterpriseS
             new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.PUT)
                 .withParams(Map.of("invalid_param_name", "invalid_value"))
                 .withContent(new BytesArray("{}"), XContentType.JSON)
-                .build()
+                .build(),
+            EnterpriseSearchFeature.Feature.SEARCH_APPLICATION
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationActionTests.java
@@ -12,13 +12,15 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
 public class RestQuerySearchApplicationActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
         checkLicenseForRequest(
-            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build()
+            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build(),
+            EnterpriseSearchFeature.Feature.SEARCH_APPLICATION
         );
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestRenderSearchApplicationQueryActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/RestRenderSearchApplicationQueryActionTests.java
@@ -12,13 +12,15 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.AbstractRestEnterpriseSearchActionTests;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
+import org.elasticsearch.xpack.application.EnterpriseSearchFeature;
 
 import java.util.Map;
 
 public class RestRenderSearchApplicationQueryActionTests extends AbstractRestEnterpriseSearchActionTests {
     public void testWithNonCompliantLicense() throws Exception {
         checkLicenseForRequest(
-            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build()
+            new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(Map.of("name", "my-search-application")).build(),
+            EnterpriseSearchFeature.Feature.SEARCH_APPLICATION
         );
     }
 


### PR DESCRIPTION
Error message for features included in the Enterprise Search plugin is generic. In this PR, we modify this error message to include specific name of feature. Following is an example of updated error message.

# Before
> Current license is non-compliant for search application and behavioral analytics. Current license is active basic license. Search Applications and behavioral analytics require an active trial, platinum or enterprise license.

# After 
> Current license is non-compliant for Behavioral Analytics. Current license is null. Behavioral Analytics requires an active trial, platinum or enterprise license.
