### PR TITLE
Make YAML Test Case work with API protections

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -276,7 +276,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         assert nodeVersions != null;
     }
 
-    private static boolean has(ProductFeature feature) {
+    protected static boolean has(ProductFeature feature) {
         return availableFeatures.contains(feature);
     }
 


### PR DESCRIPTION
Modifies `ESClientYamlSuiteTestCase` to skip loading the global template if legacy templates are not supported.

Relates: #98250
