### PR TITLE
[8.9] Avoid lifecycle NPE in the data stream lifecycle usage API (#98260)

### DIFF
--- a/docs/changelog/98260.yaml
+++ b/docs/changelog/98260.yaml
@@ -1,0 +1,5 @@
+pr: 98260
+summary: Avoid lifecycle NPE in the data stream lifecycle usage API
+area: Data streams
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
@@ -89,7 +89,8 @@ public class RolloverConfiguration implements Writeable, ToXContentObject {
      * Evaluates the automatic conditions and converts the whole configuration to XContent.
      * For the automatic conditions is also adds the suffix [automatic]
      */
-    public XContentBuilder evaluateAndConvertToXContent(XContentBuilder builder, Params params, TimeValue retention) throws IOException {
+    public XContentBuilder evaluateAndConvertToXContent(XContentBuilder builder, Params params, @Nullable TimeValue retention)
+        throws IOException {
         builder.startObject();
         concreteConditions.toXContentFragment(builder, params);
         for (String automaticCondition : automaticConditions) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
@@ -184,16 +184,16 @@ public class DataLifecycle implements SimpleDiffable<DataLifecycle>, ToXContentO
     /**
      * This builder helps during the composition of the data lifecycle templates.
      */
-    static class Builder {
+    public static class Builder {
         @Nullable
         private Retention dataRetention = null;
 
-        Builder dataRetention(@Nullable Retention value) {
+        public Builder dataRetention(@Nullable Retention value) {
             dataRetention = value;
             return this;
         }
 
-        DataLifecycle build() {
+        public DataLifecycle build() {
             return new DataLifecycle(dataRetention);
         }
 

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportActionIT.java
@@ -86,19 +86,24 @@ public class DataLifecycleUsageTransportActionIT extends ESIntegTestCase {
             Map<String, DataStream> dataStreamMap = new HashMap<>();
             for (int dataStreamCount = 0; dataStreamCount < randomInt(200); dataStreamCount++) {
                 boolean hasLifecycle = randomBoolean();
-                long retentionMillis;
+                DataStreamLifecycle lifecycle;
                 if (hasLifecycle) {
-                    retentionMillis = randomLongBetween(1000, 100000);
-                    count.incrementAndGet();
-                    totalRetentionTimes.addAndGet(retentionMillis);
-                    if (retentionMillis < minRetention.get()) {
-                        minRetention.set(retentionMillis);
-                    }
-                    if (retentionMillis > maxRetention.get()) {
-                        maxRetention.set(retentionMillis);
+                    if (randomBoolean()) {
+                        lifecycle = new DataStreamLifecycle(null, null);
+                    } else {
+                        long retentionMillis = randomLongBetween(1000, 100000);
+                        count.incrementAndGet();
+                        totalRetentionTimes.addAndGet(retentionMillis);
+                        if (retentionMillis < minRetention.get()) {
+                            minRetention.set(retentionMillis);
+                        }
+                        if (retentionMillis > maxRetention.get()) {
+                            maxRetention.set(retentionMillis);
+                        }
+                        lifecycle = DataStreamLifecycle.newBuilder().dataRetention(retentionMillis).build();
                     }
                 } else {
-                    retentionMillis = 0;
+                    lifecycle = null;
                 }
                 List<Index> indices = new ArrayList<>();
                 for (int indicesCount = 0; indicesCount < randomIntBetween(1, 10); indicesCount++) {
@@ -116,7 +121,7 @@ public class DataLifecycleUsageTransportActionIT extends ESIntegTestCase {
                     systemDataStream,
                     randomBoolean(),
                     IndexMode.STANDARD,
-                    hasLifecycle ? new DataLifecycle(retentionMillis) : null
+                    lifecycle
                 );
                 dataStreamMap.put(dataStream.getName(), dataStream);
             }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportActionIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.DataLifecycle;
+import org.elasticsearch.cluster.metadata.DataLifecycle.Retention;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -20,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
@@ -86,10 +88,10 @@ public class DataLifecycleUsageTransportActionIT extends ESIntegTestCase {
             Map<String, DataStream> dataStreamMap = new HashMap<>();
             for (int dataStreamCount = 0; dataStreamCount < randomInt(200); dataStreamCount++) {
                 boolean hasLifecycle = randomBoolean();
-                DataStreamLifecycle lifecycle;
+                DataLifecycle lifecycle;
                 if (hasLifecycle) {
                     if (randomBoolean()) {
-                        lifecycle = new DataStreamLifecycle(null, null);
+                        lifecycle = new DataLifecycle((Retention) null);
                     } else {
                         long retentionMillis = randomLongBetween(1000, 100000);
                         count.incrementAndGet();
@@ -100,7 +102,8 @@ public class DataLifecycleUsageTransportActionIT extends ESIntegTestCase {
                         if (retentionMillis > maxRetention.get()) {
                             maxRetention.set(retentionMillis);
                         }
-                        lifecycle = DataStreamLifecycle.newBuilder().dataRetention(retentionMillis).build();
+                        lifecycle = new DataLifecycle.Builder().dataRetention(new Retention(TimeValue.timeValueMillis(retentionMillis)))
+                            .build();
                     }
                 } else {
                     lifecycle = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataLifecycleUsageTransportAction.java
@@ -61,6 +61,7 @@ public class DataLifecycleUsageTransportAction extends XPackUsageFeatureTranspor
         final Collection<DataStream> dataStreams = state.metadata().dataStreams().values();
         LongSummaryStatistics retentionStats = dataStreams.stream()
             .filter(ds -> ds.getLifecycle() != null)
+            .filter(ds -> ds.getLifecycle().getEffectiveDataRetention() != null)
             .collect(Collectors.summarizingLong(ds -> ds.getLifecycle().getEffectiveDataRetention().getMillis()));
         long dataStreamsWithLifecycles = retentionStats.getCount();
         long minRetention = dataStreamsWithLifecycles == 0 ? 0 : retentionStats.getMin();


### PR DESCRIPTION
(cherry picked from commit 07ae16962edefa857a75b2f663c6bddca9de17bd)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of https://github.com/elastic/elasticsearch/pull/98260
