### PR TITLE
Fix refcounting in action base classes

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -81,7 +81,8 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
     }
 
     /**
-     * Like {#wrap} except with a {@link Releasable} which is released after executing the consumer, or if the action is rejected.
+     * Like {#wrap} except with a {@link Releasable} which is released after executing the consumer, or if the action is rejected. This is
+     * particularly useful for submitting actions holding resources to a threadpool which might have a bounded queue.
      */
     public static <T> ActionRunnable<T> wrapReleasing(
         ActionListener<T> listener,
@@ -90,16 +91,16 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
     ) {
         return new ActionRunnable<>(listener) {
             @Override
-            protected void doRun() throws Exception {
+            protected void doRun() {
                 try (releasable) {
-                    consumer.accept(listener);
+                    ActionListener.run(listener, consumer);
                 }
             }
 
             @Override
-            public void onRejection(Exception e) {
+            public void onFailure(Exception e) {
                 try (releasable) {
-                    super.onRejection(e);
+                    super.onFailure(e);
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -34,6 +34,7 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        assert hasReferences();
         out.writeTimeValue(masterNodeTimeout);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -169,7 +169,8 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
         if (task != null) {
             request.setParentTask(clusterService.localNode().getId(), task.getId());
         }
-        new AsyncSingleAction(task, request, listener).doStart(state);
+        request.incRef();
+        new AsyncSingleAction(task, request, ActionListener.runBefore(listener, request::decRef)).doStart(state);
     }
 
     class AsyncSingleAction {

--- a/server/src/test/java/org/elasticsearch/action/ActionRunnableTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionRunnableTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matchers;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ActionRunnableTests extends ESTestCase {
+    public void testWrapReleasingNotRejected() throws Exception {
+        final var executor = EsExecutors.newScaling(
+            "test",
+            1,
+            1,
+            60,
+            TimeUnit.SECONDS,
+            true,
+            Thread::new,
+            new ThreadContext(Settings.EMPTY)
+        );
+        try {
+            final var resultListener = new PlainActionFuture<Void>();
+            final var releaseListener = new PlainActionFuture<Void>();
+            final var barrier = new CyclicBarrier(2);
+
+            executor.execute(() -> safeAwait(barrier)); // block the thread before running the ActionRunnable
+
+            executor.execute(ActionRunnable.wrapReleasing(resultListener.delegateResponse((l, e) -> {
+                assertThat(e, Matchers.instanceOf(ElasticsearchException.class));
+                assertEquals("simulated", e.getMessage());
+                l.onResponse(null);
+            }), () -> releaseListener.onResponse(null), l -> executor.execute(() -> ActionListener.completeWith(l, () -> {
+                if (randomBoolean()) {
+                    throw new ElasticsearchException("simulated");
+                } else {
+                    return null;
+                }
+            }))));
+
+            executor.execute(() -> safeAwait(barrier)); // block the thread after running the ActionRunnable but before completing listener
+
+            assertFalse(releaseListener.isDone());
+            assertFalse(resultListener.isDone());
+
+            safeAwait(barrier); // execute the ActionRunnable
+
+            assertNull(releaseListener.get(10, TimeUnit.SECONDS));
+            assertFalse(resultListener.isDone());
+
+            safeAwait(barrier); // complete the listener
+
+            assertNull(resultListener.get(10, TimeUnit.SECONDS));
+        } finally {
+            ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testWrapReleasingRejected() throws Exception {
+        final var executor = EsExecutors.newFixed(
+            "test",
+            1,
+            0,
+            Thread::new,
+            new ThreadContext(Settings.EMPTY),
+            EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
+        );
+        try {
+            final var listener = new PlainActionFuture<Void>();
+            final var isReleased = new AtomicBoolean();
+
+            final var barrier = new CyclicBarrier(2);
+            executor.execute(() -> safeAwait(barrier));
+
+            executor.execute(ActionRunnable.wrapReleasing(new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void unused) {
+                    fail("should not execute");
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    assertThat(e, Matchers.instanceOf(EsRejectedExecutionException.class));
+                    assertFalse(isReleased.get());
+                    listener.onResponse(null);
+                }
+            }, () -> assertTrue(isReleased.compareAndSet(false, true)), l -> fail("should not execute")));
+
+            assertTrue(listener.isDone());
+            assertTrue(isReleased.get());
+            assertNull(listener.get(10, TimeUnit.SECONDS));
+            safeAwait(barrier);
+        } finally {
+            ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
+        }
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskGroup;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
@@ -35,6 +36,8 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelledException;
@@ -174,16 +177,44 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
     }
 
     static class TestTasksRequest extends BaseTasksRequest<TestTasksRequest> {
+        private final RefCounted refCounted;
 
         TestTasksRequest(StreamInput in) throws IOException {
             super(in);
+            refCounted = AbstractRefCounted.of(() -> {});
         }
 
-        TestTasksRequest() {}
+        TestTasksRequest() {
+            this(() -> {});
+        }
+
+        TestTasksRequest(Runnable onClose) {
+            refCounted = AbstractRefCounted.of(onClose);
+        }
 
         @Override
         public CancellableTask createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
             return new CancellableTask(id, type, action, "testTasksRequest", parentTaskId, headers);
+        }
+
+        @Override
+        public void incRef() {
+            refCounted.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return refCounted.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return refCounted.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return refCounted.hasReferences();
         }
     }
 
@@ -938,5 +969,66 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         builder.flush();
         logger.info(Strings.toString(builder));
         return XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+    }
+
+    public void testRefCounting() throws Exception {
+        setupTestNodes(Settings.EMPTY);
+        connectNodes(testNodes);
+
+        CountDownLatch checkLatch = new CountDownLatch(1);
+        ActionFuture<NodesResponse> future = startBlockingTestNodesAction(checkLatch);
+
+        final var firstNodeListeners = new SubscribableListener<TestTaskResponse>();
+        final var otherNodeListeners = new SubscribableListener<TestTaskResponse>();
+        TestTasksAction[] tasksActions = new TestTasksAction[nodesCount];
+        for (int nodeId = 0; nodeId < nodesCount; nodeId++) {
+            final var listeners = nodeId == 0 ? firstNodeListeners : otherNodeListeners;
+            tasksActions[nodeId] = new TestTasksAction(
+                "internal:testTasksAction",
+                testNodes[nodeId].clusterService,
+                testNodes[nodeId].transportService
+            ) {
+                @Override
+                protected void taskOperation(
+                    CancellableTask actionTask,
+                    TestTasksRequest request,
+                    Task task,
+                    ActionListener<TestTaskResponse> listener
+                ) {
+                    request.incRef();
+                    listeners.addListener(ActionListener.runBefore(listener, request::decRef));
+                }
+            };
+        }
+
+        final var requestReleaseFuture = new PlainActionFuture<Void>();
+        TestTasksRequest testTasksRequest = new TestTasksRequest(() -> requestReleaseFuture.onResponse(null));
+        testTasksRequest.setActions("internal:testAction[n]"); // pick all test actions
+        testTasksRequest.setNodes(testNodes[0].getNodeId(), testNodes[1].getNodeId()); // only first two nodes
+        final var taskFuture = new PlainActionFuture<TestTasksResponse>();
+        testNodes[0].transportService.getTaskManager()
+            .registerAndExecute(
+                "direct",
+                tasksActions[0],
+                testTasksRequest,
+                testNodes[0].transportService.getLocalNodeConnection(),
+                taskFuture
+            );
+        testTasksRequest.decRef();
+
+        assertTrue(testTasksRequest.hasReferences());
+        firstNodeListeners.onResponse(new TestTaskResponse("done"));
+        assertNull(requestReleaseFuture.get(10, TimeUnit.SECONDS));
+
+        assertFalse(testTasksRequest.hasReferences());
+        assertFalse(taskFuture.isDone());
+
+        otherNodeListeners.onResponse(new TestTaskResponse("done"));
+        taskFuture.get(10, TimeUnit.SECONDS);
+
+        // Release all node tasks and wait for response
+        checkLatch.countDown();
+        NodesResponse responses = future.get();
+        assertEquals(0, responses.failureCount());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -42,6 +42,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.index.IndexVersion;
@@ -143,6 +145,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
     public static class Request extends MasterNodeRequest<Request> implements IndicesRequest.Replaceable {
         private String[] indices = Strings.EMPTY_ARRAY;
+        private final RefCounted refCounted = AbstractRefCounted.of(() -> {});
 
         Request() {}
 
@@ -174,6 +177,26 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         public IndicesRequest indices(String... indices) {
             this.indices = indices;
             return this;
+        }
+
+        @Override
+        public void incRef() {
+            refCounted.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return refCounted.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return refCounted.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return refCounted.hasReferences();
         }
     }
 
@@ -380,6 +403,9 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         } else {
             assertListenerThrows("ClusterBlockException should be thrown", listener, ClusterBlockException.class);
         }
+
+        request.decRef();
+        assertFalse(request.hasReferences());
     }
 
     public void testCheckBlockThrowsException() throws InterruptedException {
@@ -443,6 +469,8 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
         assertTrue(listener.isDone());
         assertListenerThrows("MasterNotDiscoveredException should be thrown", listener, MasterNotDiscoveredException.class);
+        request.decRef();
+        assertFalse(request.hasReferences());
     }
 
     public void testMasterBecomesAvailable() throws ExecutionException, InterruptedException {
@@ -451,8 +479,11 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
         ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
         assertFalse(listener.isDone());
+        request.decRef();
+        assertTrue(request.hasReferences());
         setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, allNodes));
         assertTrue(listener.isDone());
+        assertFalse(request.hasReferences());
         listener.get();
     }
 
@@ -462,6 +493,8 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
         ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
+        request.decRef();
+        assertTrue(request.hasReferences());
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
@@ -473,6 +506,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         transport.handleResponse(capturedRequest.requestId(), response);
         assertTrue(listener.isDone());
         assertThat(listener.get(), equalTo(response));
+        assertFalse(request.hasReferences());
     }
 
     public void testDelegateToFailingMaster() throws ExecutionException, InterruptedException {

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -24,6 +24,8 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelHelper;
@@ -44,6 +46,7 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,6 +77,7 @@ public class TransportNodesActionTests extends ESTestCase {
         int numNodes = clusterService.state().getNodes().getSize();
         // check a request was sent to the right number of nodes
         assertEquals(numNodes, capturedRequests.size());
+        assertTrue(capturedRequests.values().stream().flatMap(Collection::stream).noneMatch(cr -> cr.request().hasReferences()));
     }
 
     public void testNodesSelectors() {
@@ -390,10 +394,32 @@ public class TransportNodesActionTests extends ESTestCase {
     }
 
     private static class TestNodeRequest extends TransportRequest {
+        private final RefCounted refCounted = AbstractRefCounted.of(() -> {});
+
         TestNodeRequest() {}
 
         TestNodeRequest(StreamInput in) throws IOException {
             super(in);
+        }
+
+        @Override
+        public void incRef() {
+            refCounted.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return refCounted.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return refCounted.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return refCounted.hasReferences();
         }
     }
 


### PR DESCRIPTION
Transport requests may hold nontrivial resources, and support
ref-counting to ensure prompt release of those resources. The base
classes that implement various delegating action patterns create new
requests, or retain references to requests after returning to the
caller, and must therefore integrate properly with the ref-counting
mechanism on those requests. The following classes do not do so today,
and this commit fixes that:

- `TransportBroadcastByNodeAction`
- `TransportMasterNodeAction`
- `TransportNodesAction`
- `TransportTasksAction`