### PR TITLE
[DOCS] ILM force merge action doesn't make index read-only

### DIFF
--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -6,7 +6,6 @@ Phases allowed: hot, warm.
 
 <<indices-forcemerge,Force merges>> the index into 
 the specified maximum number of <<indices-segments,segments>>.
-This action makes the index <<dynamic-index-settings,read-only>>.
 
 [NOTE]
 The `forcemerge` action is best effort. It might happen that some of the


### PR DESCRIPTION
A follow up on https://github.com/elastic/elasticsearch/pull/98357 that fixes another false mention of ILM force merge making the index read-only.