### PR TITLE
Rename Synonyms API namespace

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete_synonym.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete_synonym.json
@@ -1,5 +1,5 @@
 {
-  "synonyms.delete": {
+  "synonyms.delete_synonym": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonyms-set.html",
       "description": "Deletes a synonym set"
@@ -14,14 +14,14 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms/{synonyms_set}",
+          "path": "/_synonyms/{id}",
           "methods": [
             "DELETE"
           ],
           "parts": {
-            "synonyms_set": {
+            "id": {
               "type": "string",
-              "description": "The name of the synonyms set to be deleted"
+              "description": "The id of the synonyms set to be deleted"
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete_synonym_rule.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete_synonym_rule.json
@@ -1,5 +1,5 @@
 {
-  "synonym_rule.delete": {
+  "synonyms.delete_synonym_rule": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonym-rule.html",
       "description": "Deletes a synonym rule in a synonym set"
@@ -17,16 +17,16 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms/{synonyms_set}/{synonym_rule}",
+          "path": "/_synonyms/{set_id}/{rule_id}",
           "methods": [
             "DELETE"
           ],
           "parts": {
-            "synonyms_set": {
+            "set_id": {
               "type": "string",
               "description": "The id of the synonym set to be updated"
             },
-            "synonym_rule": {
+            "rule_id": {
               "type": "string",
               "description": "The id of the synonym rule to be deleted"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get_synonym.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get_synonym.json
@@ -1,8 +1,8 @@
 {
-  "synonyms_sets.get": {
+  "synonyms.get_synonym": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-synonyms-sets.html",
-      "description": "Retrieves a summary of all defined synonym sets"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html",
+      "description": "Retrieves a synonym set"
     },
     "stability": "experimental",
     "visibility": "public",
@@ -14,10 +14,16 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms",
+          "path": "/_synonyms/{id}",
           "methods": [
             "GET"
-          ]
+          ],
+          "parts": {
+            "id": {
+              "type": "string",
+              "description": "The name of the synonyms set to be retrieved"
+            }
+          }
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get_synonym_rule.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get_synonym_rule.json
@@ -1,5 +1,5 @@
 {
-  "synonym_rule.get": {
+  "synonyms.get_synonym_rule": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonym-rule.html",
       "description": "Retrieves a synonym rule from a synonym set"
@@ -17,16 +17,16 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms/{synonyms_set}/{synonym_rule}",
+          "path": "/_synonyms/{set_id}/{rule_id}",
           "methods": [
             "GET"
           ],
           "parts": {
-            "synonyms_set": {
+            "set_id": {
               "type": "string",
               "description": "The id of the synonym set to retrieve the synonym rule from"
             },
-            "synonym_rule": {
+            "rule_id": {
               "type": "string",
               "description": "The id of the synonym rule to retrieve"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get_synonyms_sets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.get_synonyms_sets.json
@@ -1,8 +1,8 @@
 {
-  "synonyms.get": {
+  "synonyms.get_synonyms_sets": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-synonyms-set.html",
-      "description": "Retrieves a synonym set"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-synonyms-sets.html",
+      "description": "Retrieves a summary of all defined synonym sets"
     },
     "stability": "experimental",
     "visibility": "public",
@@ -14,16 +14,10 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms/{synonyms_set}",
+          "path": "/_synonyms",
           "methods": [
             "GET"
-          ],
-          "parts": {
-            "synonyms_set": {
-              "type": "string",
-              "description": "The name of the synonyms set to be retrieved"
-            }
-          }
+          ]
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.put_synonym.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.put_synonym.json
@@ -1,5 +1,5 @@
 {
-  "synonyms.put": {
+  "synonyms.put_synonym": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html",
       "description": "Creates or updates a synonyms set"
@@ -17,14 +17,14 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms/{synonyms_set}",
+          "path": "/_synonyms/{id}",
           "methods": [
             "PUT"
           ],
           "parts": {
-            "synonyms_set": {
+            "id": {
               "type": "string",
-              "description": "The name of the synonyms set to be created or updated"
+              "description": "The id of the synonyms set to be created or updated"
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.put_synonym_rule.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.put_synonym_rule.json
@@ -1,5 +1,5 @@
 {
-  "synonym_rule.put": {
+  "synonyms.put_synonym_rule": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonym-rule.html",
       "description": "Creates or updates a synonym rule in a synonym set"
@@ -17,16 +17,16 @@
     "url": {
       "paths": [
         {
-          "path": "/_synonyms/{synonyms_set}/{synonym_rule}",
+          "path": "/_synonyms/{set_id}/{rule_id}",
           "methods": [
             "PUT"
           ],
           "parts": {
-            "synonyms_set": {
+            "set_id": {
               "type": "string",
               "description": "The id of the synonym set to be updated with the synonym rule"
             },
-            "synonym_rule": {
+            "rule_id": {
               "type": "string",
               "description": "The id of the synonym rule to be updated or created"
             }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/100_synonyms_no_system_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/100_synonyms_no_system_index.yml
@@ -5,7 +5,7 @@ setup:
 ---
 "Get synonyms sets returns not found when no index exists":
   - do:
-      synonyms_sets.get: { }
+      synonyms.get_synonyms_sets: { }
 
   - match:
       count: 0
@@ -15,29 +15,29 @@ setup:
 "Get synonym set returns not found when no index exists":
   - do:
       catch: /synonyms set \[test\-synonyms\] not found/
-      synonyms.get:
-        synonyms_set: "test-synonyms"
+      synonyms.get_synonym:
+        id: "test-synonyms"
 
 
 ---
 "Delete synonym set returns not found when no index exists":
   - do:
       catch: /synonyms set \[test\-synonyms\] not found/
-      synonyms.delete:
-        synonyms_set: "test-synonyms"
+      synonyms.delete_synonym:
+        id: "test-synonyms"
 
 ---
 "Get synonym rule returns not found when no index exists":
   - do:
       catch: /synonyms set \[test\-synonyms\] not found/
-      synonym_rule.get:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id"
+      synonyms.get_synonym_rule:
+        set_id: "test-synonyms"
+        rule_id: "test-id"
 
 ---
 "Delete synonym rule returns not found when no index exists":
   - do:
       catch: /synonyms set \[test\-synonyms\] not found/
-      synonym_rule.delete:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id"
+      synonyms.delete_synonym_rule:
+        set_id: "test-synonyms"
+        rule_id: "test-id"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -6,8 +6,8 @@ setup:
 ---
 "Create synonyms with no ID creates ID automatically":
   - do:
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -16,8 +16,8 @@ setup:
   - match: { result: "created" }
 
   - do:
-      synonyms.get:
-        synonyms_set: test-update-synonyms
+      synonyms.get_synonym:
+        id: test-update-synonyms
 
   - is_true: synonyms_set.0.id
   - is_true: synonyms_set.1.id
@@ -25,8 +25,8 @@ setup:
 ---
 "Create and Update synonyms set":
   - do:
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -38,8 +38,8 @@ setup:
   - length: { reload_analyzers_details.reload_details: 0 }
 
   - do:
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: "other, another"
@@ -51,16 +51,16 @@ setup:
 ---
 "Create empty synonyms set":
   - do:
-      synonyms.put:
-        synonyms_set: test-empty-synonyms
+      synonyms.put_synonym:
+        id: test-empty-synonyms
         body:
           synonyms_set: []
 
   - match: { result: "created" }
 
   - do:
-      synonyms.get:
-        synonyms_set: test-empty-synonyms
+      synonyms.get_synonym:
+        id: test-empty-synonyms
 
   - match: { count: 0 }
   - match: { synonyms_set: [] }
@@ -69,40 +69,40 @@ setup:
 "Validation fails tests":
   - do:
       catch: /\[synonyms\] field can't be empty/
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: ""
 
   - do:
       catch: /More than one explicit mapping specified in the same synonyms rule/
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: "bye => => goodbye"
 
   - do:
       catch: /Incorrect syntax for \[synonyms\]/
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: " => goodbye"
 
   - do:
       catch: /Incorrect syntax for \[synonyms\]/
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: "bye => "
 
   - do:
       catch: /Incorrect syntax for \[synonyms\]/
-      synonyms.put:
-        synonyms_set: test-update-synonyms
+      synonyms.put_synonym:
+        id: test-update-synonyms
         body:
           synonyms_set:
             - synonyms: "bye, goodbye,  "

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
@@ -3,8 +3,8 @@ setup:
       version: " - 8.9.99"
       reason: Introduced in 8.10.0
   - do:
-      synonyms.put:
-        synonyms_set: test-get-synonyms
+      synonyms.put_synonym:
+        id: test-get-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -18,8 +18,8 @@ setup:
 ---
 "Get synonyms set":
   - do:
-      synonyms.get:
-        synonyms_set: test-get-synonyms
+      synonyms.get_synonym:
+        id: test-get-synonyms
 
   - match:
       count: 3
@@ -36,14 +36,14 @@ setup:
 "Get synonyms set - not found":
   - do:
       catch: missing
-      synonyms.get:
-        synonyms_set: unknown-synonym-set
+      synonyms.get_synonym:
+        id: unknown-synonym-set
 
 ---
 "Pagination - size":
   - do:
-      synonyms.get:
-        synonyms_set: test-get-synonyms
+      synonyms.get_synonym:
+        id: test-get-synonyms
         size: 2
 
   - match:
@@ -58,8 +58,8 @@ setup:
 ---
 "Pagination - from":
   - do:
-      synonyms.get:
-        synonyms_set: test-get-synonyms
+      synonyms.get_synonym:
+        id: test-get-synonyms
         from: 1
 
   - match:
@@ -75,8 +75,8 @@ setup:
 ---
 "Synonyms set with same IDs":
   - do:
-      synonyms.put:
-        synonyms_set: test-get-synonyms-same-ids
+      synonyms.put_synonym:
+        id: test-get-synonyms-same-ids
         body:
           synonyms_set:
             - synonyms: "another, different"
@@ -87,8 +87,8 @@ setup:
               id: "test-id-3"
 
   - do:
-      synonyms.get:
-        synonyms_set: test-get-synonyms
+      synonyms.get_synonym:
+        id: test-get-synonyms
 
   - match:
       count: 3
@@ -102,8 +102,8 @@ setup:
           id: "test-id-3"
 
   - do:
-      synonyms.get:
-        synonyms_set: test-get-synonyms-same-ids
+      synonyms.get_synonym:
+        id: test-get-synonyms-same-ids
 
   - match:
       count: 3

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -3,8 +3,8 @@ setup:
       version: " - 8.9.99"
       reason: Introduced in 8.10.0
   - do:
-      synonyms.put:
-        synonyms_set: test-get-synonyms
+      synonyms.put_synonym:
+        id: test-get-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -15,29 +15,29 @@ setup:
 ---
 "Delete synonyms set":
   - do:
-      synonyms.delete:
-        synonyms_set: test-get-synonyms
+      synonyms.delete_synonym:
+        id: test-get-synonyms
 
   - match:
       acknowledged: true
 
   - do:
       catch: missing
-      synonyms.get:
-        synonyms_set: test-get-synonyms
+      synonyms.get_synonym:
+        id: test-get-synonyms
 
 ---
 "Delete synonyms set - not found":
   - do:
       catch: missing
-      synonyms.delete:
-        synonyms_set: unknown-synonym-set
+      synonyms.delete_synonym:
+        id: unknown-synonym-set
 
 ---
 "Delete synonyms set - does not impact other synonym sets":
   - do:
-      synonyms.put:
-        synonyms_set: test-other-synonyms
+      synonyms.put_synonym:
+        id: test-other-synonyms
         body:
           synonyms_set:
             - synonyms: "hola, hi"
@@ -45,12 +45,12 @@ setup:
             - synonyms: "test => check"
               id: "test-other-2"
   - do:
-      synonyms.delete:
-        synonyms_set: test-get-synonyms
+      synonyms.delete_synonym:
+        id: test-get-synonyms
 
   - do:
-      synonyms.get:
-        synonyms_set: test-other-synonyms
+      synonyms.get_synonym:
+        id: test-other-synonyms
 
   - match:
       count: 2
@@ -91,12 +91,12 @@ setup:
 
   - do:
       catch: /synonyms set \[test-get-synonyms\] cannot be deleted as it is used in the following indices:\ my_index1/
-      synonyms.delete:
-        synonyms_set: test-get-synonyms
+      synonyms.delete_synonym:
+        id: test-get-synonyms
 
   - do:
-      synonyms.get:
-        synonyms_set: test-get-synonyms
+      synonyms.get_synonym:
+        id: test-get-synonyms
 
   - match:
       count: 2

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -3,23 +3,23 @@ setup:
       version: " - 8.9.99"
       reason: Introduced in 8.10.0
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-3
+      synonyms.put_synonym:
+        id: test-synonyms-3
         body:
           synonyms_set:
             - synonyms: "hello, hi"
             - synonyms: "goodbye, bye"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-1
+      synonyms.put_synonym:
+        id: test-synonyms-1
         body:
           synonyms_set:
             - synonyms: "test, check"
             - synonyms: "good, great"
             - synonyms: "bad, evil"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-2
+      synonyms.put_synonym:
+        id: test-synonyms-2
         body:
           synonyms_set:
             - synonyms: "pc, computer"
@@ -27,7 +27,7 @@ setup:
 ---
 "List synonyms set":
   - do:
-      synonyms_sets.get: { }
+      synonyms.get_synonyms_sets: { }
 
   - match:
       count: 3
@@ -44,7 +44,7 @@ setup:
 ---
 "Pagination - size":
   - do:
-      synonyms_sets.get:
+      synonyms.get_synonyms_sets:
         size: 2
 
   - match:
@@ -59,7 +59,7 @@ setup:
 ---
 "Pagination - from":
   - do:
-      synonyms_sets.get:
+      synonyms.get_synonyms_sets:
         from: 1
 
   - match:
@@ -75,19 +75,19 @@ setup:
 "No synonym sets":
 
   - do:
-      synonyms.delete:
-        synonyms_set: test-synonyms-1
+      synonyms.delete_synonym:
+        id: test-synonyms-1
 
   - do:
-      synonyms.delete:
-        synonyms_set: test-synonyms-2
+      synonyms.delete_synonym:
+        id: test-synonyms-2
 
   - do:
-      synonyms.delete:
-        synonyms_set: test-synonyms-3
+      synonyms.delete_synonym:
+        id: test-synonyms-3
 
   - do:
-      synonyms_sets.get: { }
+      synonyms.get_synonyms_sets: { }
 
   - match:
       count: 0
@@ -98,61 +98,61 @@ setup:
 "More than 10 synonym sets":
 
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-4
+      synonyms.put_synonym:
+        id: test-synonyms-4
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-5
+      synonyms.put_synonym:
+        id: test-synonyms-5
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-6
+      synonyms.put_synonym:
+        id: test-synonyms-6
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-7
+      synonyms.put_synonym:
+        id: test-synonyms-7
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-8
+      synonyms.put_synonym:
+        id: test-synonyms-8
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-9
+      synonyms.put_synonym:
+        id: test-synonyms-9
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-10
+      synonyms.put_synonym:
+        id: test-synonyms-10
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-11
+      synonyms.put_synonym:
+        id: test-synonyms-11
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms-12
+      synonyms.put_synonym:
+        id: test-synonyms-12
         body:
           synonyms_set:
             - synonyms: "test, check"
   - do:
-      synonyms_sets.get: { }
+      synonyms.get_synonyms_sets: { }
 
   - match:
       count: 12

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
@@ -3,8 +3,8 @@ setup:
       version: " - 8.9.99"
       reason: Introduced in 8.10.0
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms
+      synonyms.put_synonym:
+        id: test-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -18,9 +18,9 @@ setup:
 ---
 "Update a synonyms rule":
   - do:
-      synonym_rule.put:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-2"
+      synonyms.put_synonym_rule:
+        set_id: "test-synonyms"
+        rule_id: "test-id-2"
         body:
           synonyms: "bye, goodbye, seeya"
 
@@ -29,8 +29,8 @@ setup:
   - length: { reload_analyzers_details.reload_details: 0 }
 
   - do:
-      synonyms.get:
-        synonyms_set: test-synonyms
+      synonyms.get_synonym:
+        id: test-synonyms
 
   - match:
       synonyms_set:
@@ -45,9 +45,9 @@ setup:
 ---
 "Create a new synonym rule":
   - do:
-      synonym_rule.put:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-0"
+      synonyms.put_synonym_rule:
+        set_id: "test-synonyms"
+        rule_id: "test-id-0"
         body:
           synonyms: "i-phone, iphone"
 
@@ -56,8 +56,8 @@ setup:
   - length: { reload_analyzers_details.reload_details: 0 }
 
   - do:
-      synonyms.get:
-        synonyms_set: test-synonyms
+      synonyms.get_synonym:
+        id: test-synonyms
 
   - match:
       synonyms_set:
@@ -75,8 +75,8 @@ setup:
 
   - do:
       catch: missing
-      synonym_rule.put:
-        synonyms_set: "test-synonyms-non-existent"
-        synonym_rule: "test-id-0"
+      synonyms.put_synonym_rule:
+        set_id: "test-synonyms-non-existent"
+        rule_id: "test-id-0"
         body:
           synonyms: "i-phone, iphone"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
@@ -3,8 +3,8 @@ setup:
       version: " - 8.9.99"
       reason: Introduced in 8.10.0
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms
+      synonyms.put_synonym:
+        id: test-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -18,9 +18,9 @@ setup:
 ---
 "Get a synonym rule":
   - do:
-      synonym_rule.get:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-2"
+      synonyms.get_synonym_rule:
+        set_id: "test-synonyms"
+        rule_id: "test-id-2"
 
   - match: {id: "test-id-2"}
   - match: {synonyms: "bye => goodbye"}
@@ -29,13 +29,13 @@ setup:
 "Synonym set not found":
   - do:
       catch: missing
-      synonym_rule.get:
-        synonyms_set: "test-non-existing-synonyms"
-        synonym_rule: "test-id-2"
+      synonyms.get_synonym_rule:
+        set_id: "test-non-existing-synonyms"
+        rule_id: "test-id-2"
 ---
 "Synonym rule not found":
   - do:
       catch: missing
-      synonym_rule.get:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-non-existing-id"
+      synonyms.get_synonym_rule:
+        set_id: "test-synonyms"
+        rule_id: "test-non-existing-id"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -3,8 +3,8 @@ setup:
       version: " - 8.9.99"
       reason: Introduced in 8.10.0
   - do:
-      synonyms.put:
-        synonyms_set: test-synonyms
+      synonyms.put_synonym:
+        id: test-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -17,9 +17,9 @@ setup:
 ---
 "Delete synonym rule":
   - do:
-      synonym_rule.delete:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-2
+      synonyms.delete_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-id-2
 
   - match: { result: "deleted" }
   - match: { reload_analyzers_details._shards.total: 0 }
@@ -27,13 +27,13 @@ setup:
 
   - do:
       catch: missing
-      synonym_rule.get:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-2
+      synonyms.get_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-id-2
 
   - do:
-      synonyms.get:
-        synonyms_set: test-synonyms
+      synonyms.get_synonym:
+        id: test-synonyms
 
   - match:
       count: 2
@@ -48,23 +48,23 @@ setup:
 "Delete synonym rule - missing synonym set":
   - do:
       catch: missing
-      synonym_rule.delete:
-        synonyms_set: test-non-existing-synonyms
-        synonym_rule: test-id-2
+      synonyms.delete_synonym_rule:
+        set_id: test-non-existing-synonyms
+        rule_id: test-id-2
 
 ---
 "Delete synonym rule - missing synonym rule":
   - do:
       catch: missing
-      synonym_rule.delete:
-        synonyms_set: test-synonyms
-        synonym_rule: test-non-existing-id
+      synonyms.delete_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-non-existing-id
 
 ---
 "Delete synonym rule - does not impact other synonym sets":
   - do:
-      synonyms.put:
-        synonyms_set: test-other-synonyms
+      synonyms.put_synonym:
+        id: test-other-synonyms
         body:
           synonyms_set:
             - synonyms: "hola, hi"
@@ -72,13 +72,13 @@ setup:
             - synonyms: "test => check"
               id: "test-id-2"
   - do:
-      synonym_rule.delete:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-1
+      synonyms.delete_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-id-1
 
   - do:
-      synonyms.get:
-        synonyms_set: test-other-synonyms
+      synonyms.get_synonym:
+        id: test-other-synonyms
 
   - match:
       count: 2
@@ -92,23 +92,23 @@ setup:
 ---
 "Delete synonym rules - delete all synonym rules leave an empty synonym set":
   - do:
-      synonym_rule.delete:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-1
+      synonyms.delete_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-id-1
 
   - do:
-      synonym_rule.delete:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-2
+      synonyms.delete_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-id-2
 
   - do:
-      synonym_rule.delete:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-3
+      synonyms.delete_synonym_rule:
+        set_id: test-synonyms
+        rule_id: test-id-3
 
   - do:
-      synonyms.get:
-        synonyms_set: test-synonyms
+      synonyms.get_synonym:
+        id: test-synonyms
 
   - match: { count: 0 }
   - match: { synonyms_set: [] }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
@@ -5,8 +5,8 @@ setup:
 
   # Create a new synonyms set
   - do:
-      synonyms.put:
-        synonyms_set: set1
+      synonyms.put_synonym:
+        id: set1
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -74,8 +74,8 @@ setup:
 ---
 "Update the synonym set and auto-reload analyzer":
   - do:
-      synonyms.put:
-        synonyms_set: set1
+      synonyms.put_synonym:
+        id: set1
         body:
           synonyms_set:
             - synonyms: "hello, salute"
@@ -109,9 +109,9 @@ setup:
 ---
 "Update a single synonym rule and auto-reload analyzer":
   - do:
-      synonym_rule.put:
-        synonyms_set: set1
-        synonym_rule: "synonym-rule-1"
+      synonyms.put_synonym_rule:
+        set_id: set1
+        rule_id: "synonym-rule-1"
         body:
           synonyms: "hello, hola"
   - match: { result: "updated" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -6,8 +6,8 @@
 
   # Create synonyms_set1
   - do:
-      synonyms.put:
-        synonyms_set: synonyms_set1
+      synonyms.put_synonym:
+        id: synonyms_set1
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -17,8 +17,8 @@
 
   # Create synonyms synonyms_set2
   - do:
-      synonyms.put:
-        synonyms_set: synonyms_set2
+      synonyms.put_synonym:
+        id: synonyms_set2
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -98,8 +98,8 @@
 
   # An update of synonyms_set1 must trigger auto-reloading of analyzers only for synonyms_set1
   - do:
-      synonyms.put:
-        synonyms_set: synonyms_set1
+      synonyms.put_synonym:
+        id: synonyms_set1
         body:
           synonyms_set:
             - synonyms: "hello, salute"

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/10_synonyms_with_privileges.yml
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/10_synonyms_with_privileges.yml
@@ -33,7 +33,7 @@ teardown:
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
       synonyms.put_synonym:
-        synonyms_set: test-synonyms
+        id: test-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -44,7 +44,7 @@ teardown:
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
       synonyms.get_synonym:
-        synonyms_set: test-synonyms
+        id: test-synonyms
 
   - match:
       count: 1
@@ -59,8 +59,8 @@ teardown:
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
       synonyms.put_synonym_rule:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-0"
+        set_id: "test-synonyms"
+        rule_id: "test-id-0"
         body:
           synonyms: "i-phone, iphone"
 
@@ -69,21 +69,21 @@ teardown:
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
       synonyms.get_synonym_rule:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-0"
+        set_id: "test-synonyms"
+        rule_id: "test-id-0"
 
   - match: {id: "test-id-0"}
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
       synonyms.delete_synonym_rule:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-0
+        set_id: test-synonyms
+        rule_id: test-id-0
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
       synonyms.delete_synonym:
-        synonyms_set: test-synonyms
+        id: test-synonyms
 
   - match:
       acknowledged: true

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/10_synonyms_with_privileges.yml
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/10_synonyms_with_privileges.yml
@@ -32,7 +32,7 @@ teardown:
 "Check synonyms set operations - with manage_search_synonyms privilege":
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonyms.put:
+      synonyms.put_synonym:
         synonyms_set: test-synonyms
         body:
           synonyms_set:
@@ -43,7 +43,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonyms.get:
+      synonyms.get_synonym:
         synonyms_set: test-synonyms
 
   - match:
@@ -51,14 +51,14 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonyms_sets.get: { }
+      synonyms.get_synonyms_sets: { }
 
   - match:
       count: 1
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonym_rule.put:
+      synonyms.put_synonym_rule:
         synonyms_set: "test-synonyms"
         synonym_rule: "test-id-0"
         body:
@@ -68,7 +68,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonym_rule.get:
+      synonyms.get_synonym_rule:
         synonyms_set: "test-synonyms"
         synonym_rule: "test-id-0"
 
@@ -76,13 +76,13 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonym_rule.delete:
+      synonyms.delete_synonym_rule:
         synonyms_set: test-synonyms
         synonym_rule: test-id-0
 
   - do:
       headers: { Authorization: "Basic c3lub255bXMtdXNlcjpzeW5vbnltcy11c2VyLXBhc3N3b3Jk" }  # synonyms-user
-      synonyms.delete:
+      synonyms.delete_synonym:
         synonyms_set: test-synonyms
 
   - match:

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/20_synonyms_no_privileges.yml
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/20_synonyms_no_privileges.yml
@@ -35,7 +35,7 @@ teardown:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
       synonyms.put_synonym:
-        synonyms_set: test-synonyms
+        id: test-synonyms
         body:
           synonyms_set:
             - synonyms: "hello, hi"
@@ -47,7 +47,7 @@ teardown:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
       synonyms.get_synonym:
-        synonyms_set: test-synonyms
+        id: test-synonyms
 
 ---
 "Delete synonyms set - no manage_search_synonyms privilege":
@@ -55,7 +55,7 @@ teardown:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
       synonyms.delete_synonym:
-        synonyms_set: test-synonyms
+        id: test-synonyms
 ---
 "List synonyms sets - no manage_search_synonyms privilege":
   - do:
@@ -69,8 +69,8 @@ teardown:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
       synonyms.put_synonym_rule:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-2"
+        set_id: "test-synonyms"
+        rule_id: "test-id-2"
         body:
           synonyms: "bye, goodbye, seeya"
 
@@ -80,8 +80,8 @@ teardown:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
       synonyms.get_synonym_rule:
-        synonyms_set: "test-synonyms"
-        synonym_rule: "test-id-2"
+        set_id: "test-synonyms"
+        rule_id: "test-id-2"
 
 ---
 "Delete synonym rule - no manage_search_synonyms privilege":
@@ -89,5 +89,5 @@ teardown:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
       synonyms.delete_synonym_rule:
-        synonyms_set: test-synonyms
-        synonym_rule: test-id-2
+        set_id: test-synonyms
+        rule_id: test-id-2

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/20_synonyms_no_privileges.yml
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/synonyms_privileges/20_synonyms_no_privileges.yml
@@ -34,7 +34,7 @@ teardown:
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonyms.put:
+      synonyms.put_synonym:
         synonyms_set: test-synonyms
         body:
           synonyms_set:
@@ -46,7 +46,7 @@ teardown:
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonyms.get:
+      synonyms.get_synonym:
         synonyms_set: test-synonyms
 
 ---
@@ -54,21 +54,21 @@ teardown:
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonyms.delete:
+      synonyms.delete_synonym:
         synonyms_set: test-synonyms
 ---
 "List synonyms sets - no manage_search_synonyms privilege":
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonyms_sets.get: { }
+      synonyms.get_synonyms_sets: { }
 
 ---
 "Update a synonyms rule - no manage_search_synonyms privilege":
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonym_rule.put:
+      synonyms.put_synonym_rule:
         synonyms_set: "test-synonyms"
         synonym_rule: "test-id-2"
         body:
@@ -79,7 +79,7 @@ teardown:
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonym_rule.get:
+      synonyms.get_synonym_rule:
         synonyms_set: "test-synonyms"
         synonym_rule: "test-id-2"
 
@@ -88,6 +88,6 @@ teardown:
   - do:
       catch: "forbidden"
       headers: { Authorization: "Basic bm9uLXN5bm9ueW1zLXVzZXI6bm9uLXN5bm9ueW1zLXVzZXItcGFzc3dvcmQ=" }  # non-synonyms-user
-      synonym_rule.delete:
+      synonyms.delete_synonym_rule:
         synonyms_set: test-synonyms
         synonym_rule: test-id-2


### PR DESCRIPTION
Renames API namespace according to https://github.com/elastic/elasticsearch/issues/98364:

- `synonym_rule.{x} --> synonyms.{x)_synonym_rule`
- `synonyms.{x} --> synonyms.{x)_synonym`
- `synonyms_sets.{x} --> synonyms.{x}_synonyms_set`

Follow up PR for updating specifications: https://github.com/elastic/elasticsearch/pull/98383. Must be merged after this one.