### PR TITLE
[8.9] [DOCS] ILM force merge action doesn't make index read-only (#98382)

### DIFF
--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -6,7 +6,6 @@ Phases allowed: hot, warm.
 
 <<indices-forcemerge,Force merges>> the index into 
 the specified maximum number of <<indices-segments,segments>>.
-This action makes the index <<dynamic-index-settings,read-only>>.
 
 [NOTE]
 The `forcemerge` action is best effort. It might happen that some of the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] ILM force merge action doesn't make index read-only (#98382)](https://github.com/elastic/elasticsearch/pull/98382)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)