### PR TITLE
[DOCS] Set up temporary redirects for new remote clusters docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1918,3 +1918,13 @@ See <<delete-synonyms-set>>
 === Create or delete synonyms sets API
 
 See <<put-synonyms-set>>
+
+[role="exclude",id="remote-clusters-api-key"]
+=== Add remote clusters using API key authentication
+
+coming::[8.10]
+
+[role="exclude",id="remote-clusters-cert"]
+=== Add remote clusters using TLS certificate authentication
+
+coming::[8.10]


### PR DESCRIPTION
Sets up temporary redirects for the new pages that will be published in https://github.com/elastic/elasticsearch/pull/98330.

This is necessary to unlock https://github.com/elastic/kibana/pull/161836 which needs to be merged before feature freeze.