### PR TITLE
ESQL: Verify the constant types assigned in a row

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
+import org.elasticsearch.xpack.esql.plan.logical.Row;
 import org.elasticsearch.xpack.esql.stats.FeatureMetric;
 import org.elasticsearch.xpack.esql.stats.Metrics;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -148,8 +149,7 @@ public class Verifier {
                         );
                     }
                 });
-            }
-            if (p instanceof RegexExtract re) {
+            } else if (p instanceof RegexExtract re) {
                 Expression expr = re.input();
                 DataType type = expr.dataType();
                 if (EsqlDataTypes.isString(type) == false) {
@@ -163,7 +163,10 @@ public class Verifier {
                         )
                     );
                 }
+            } else if (p instanceof Row row) {
+                failures.addAll(validateRow(row));
             }
+
             p.forEachExpression(BinaryOperator.class, bo -> {
                 Failure f = validateUnsignedLongOperator(bo);
                 if (f != null) {
@@ -208,6 +211,16 @@ public class Verifier {
         for (int i = b.nextSetBit(0); i >= 0; i = b.nextSetBit(i + 1)) {
             metrics.inc(FeatureMetric.values()[i]);
         }
+    }
+
+    public static Collection<Failure> validateRow(Row row) {
+        List<Failure> failures = new ArrayList<>(row.fields().size());
+        row.fields().forEach(o -> {
+            if (EsqlDataTypes.isRepresentable(o.dataType()) == false && o instanceof Alias a) {
+                failures.add(fail(o, "cannot use [{}] directly in a row assignment", a.child().sourceText()));
+            }
+        });
+        return failures;
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -237,6 +237,12 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testPeriodAndDurationInRowAssignment() {
+        for (var unit : List.of("millisecond", "second", "minute", "hour", "day", "week", "month", "year")) {
+            assertEquals("1:5: cannot use [1 " + unit + "] directly in a row assignment", error("row a = 1 " + unit));
+        }
+    }
+
     private String error(String query) {
         return error(query, defaultAnalyzer);
 


### PR DESCRIPTION
This adds a verification for the constant types assigned directly into a ROW source command.
Types like Duration and Period cannot be used, as they are not representable in a block.
