### PR TITLE
Unmuting BootStrapTests.testMixedTriggeredWatchLoading()

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
@@ -203,7 +203,6 @@ public class BootStrapTests extends AbstractWatcherIntegrationTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82420")
     public void testMixedTriggeredWatchLoading() throws Exception {
         createIndex("output");
         client().prepareIndex()


### PR DESCRIPTION
Unmuting to see if it still fails after the bulk processor rewrite