### PR TITLE
Work around adaptive offloading of knn rewrite tasks

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -1982,8 +1982,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.DFS, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
-                assertSame(executor, searcher.getExecutor());
-                int maxNumSlices = ((ThreadPoolExecutor) searcher.getExecutor()).getMaximumPoolSize();
+                int maxNumSlices = executor.getMaximumPoolSize();
                 int numSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxNumSlices, 1).length;
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
                 assertBusy(() -> assertEquals(numSlices, executor.getCompletedTaskCount()));
@@ -1993,7 +1992,6 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
-                assertSame(executor, searcher.getExecutor());
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
                 int expectedTaskCount = ++taskCount;
                 assertBusy(() -> assertEquals(expectedTaskCount, executor.getCompletedTaskCount()));
@@ -2002,7 +2000,6 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.FETCH, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
-                assertSame(executor, searcher.getExecutor());
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
                 int expectedTaskCount = ++taskCount;
                 assertBusy(() -> assertEquals(expectedTaskCount, executor.getCompletedTaskCount()));
@@ -2011,7 +2008,6 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.NONE, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
-                assertSame(executor, searcher.getExecutor());
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
                 int expectedTaskCount = ++taskCount;
                 assertBusy(() -> assertEquals(expectedTaskCount, executor.getCompletedTaskCount()));

--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -212,63 +212,61 @@ public class ContextIndexSearcherTests extends ESTestCase {
      * Check that knn queries rewrite parallelizes on the number of segments
      */
     public void testConcurrentRewrite() throws Exception {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(randomIntBetween(2, 5));
         try (Directory directory = newDirectory()) {
             indexDocs(directory);
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
-                AtomicInteger executeCalls = new AtomicInteger(0);
                 ContextIndexSearcher searcher = new ContextIndexSearcher(
                     directoryReader,
                     IndexSearcher.getDefaultSimilarity(),
                     IndexSearcher.getDefaultQueryCache(),
                     IndexSearcher.getDefaultQueryCachingPolicy(),
                     randomBoolean(),
-                    command -> {
-                        executeCalls.incrementAndGet();
-                        command.run();
-                    },
-                    randomIntBetween(1, Integer.MAX_VALUE),
-                    randomIntBetween(1, Integer.MAX_VALUE)
+                    executor,
+                    // create as many slices as possible
+                    Integer.MAX_VALUE,
+                    1
                 );
-                // check that we create one slice per segment
                 int numSegments = directoryReader.getContext().leaves().size();
                 assertEquals(numSegments, searcher.slices(directoryReader.getContext().leaves()).length);
                 KnnFloatVectorQuery vectorQuery = new KnnFloatVectorQuery("float_vector", new float[] { 0, 0, 0 }, 10, null);
                 vectorQuery.rewrite(searcher);
-                // Note: we expect one execute calls less than segments since the last is executed on the caller thread.
-                // For details see QueueSizeBasedExecutor#processTask
-                assertEquals(numSegments - 1, executeCalls.get());
+                // Note: we expect one execute call less than segments since the last is executed on the caller thread, but no additional
+                // exceptions to the offloading of operations. For details see QueueSizeBasedExecutor#processTask.
+                assertBusy(() -> assertEquals(numSegments - 1, executor.getCompletedTaskCount()));
             }
+        } finally {
+            terminate(executor);
         }
     }
 
     /**
      * Test that collection starts one task per slice, all offloaded to the separate executor, none executed in the caller thread
      */
-    public void testConcurrentCollection() throws IOException {
+    public void testConcurrentCollection() throws Exception {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(randomIntBetween(2, 5));
         try (Directory directory = newDirectory()) {
             int numDocs = indexDocs(directory);
-            int maxNumSlices = randomIntBetween(1, 100);
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
-                AtomicInteger executeCalls = new AtomicInteger(0);
                 ContextIndexSearcher searcher = new ContextIndexSearcher(
                     directoryReader,
                     IndexSearcher.getDefaultSimilarity(),
                     IndexSearcher.getDefaultQueryCache(),
                     IndexSearcher.getDefaultQueryCachingPolicy(),
                     randomBoolean(),
-                    command -> {
-                        executeCalls.incrementAndGet();
-                        command.run();
-                    },
-                    maxNumSlices,
+                    executor,
+                    // create as many slices as possible
+                    Integer.MAX_VALUE,
                     1
                 );
                 Integer totalHits = searcher.search(new MatchAllDocsQuery(), new TotalHitCountCollectorManager());
                 assertEquals(numDocs, totalHits.intValue());
-                int numExpectedTasks = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxNumSlices, 1).length;
+                int numExpectedTasks = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), Integer.MAX_VALUE, 1).length;
                 // check that each slice goes to the executor, no matter the queue size or the number of slices
-                assertEquals(numExpectedTasks, executeCalls.get());
+                assertBusy(() -> assertEquals(numExpectedTasks, executor.getCompletedTaskCount()));
             }
+        } finally {
+            terminate(executor);
         }
     }
 


### PR DESCRIPTION
Lucene has a non configurable QueueSizeBasedExecutor that inspects the executor, and uses the queue size compared to the max pool size to decide whether to executor some of the parallelizable tasks on the caller thread or on the executor. We'd rather want every I/O or CPU bound task executed on the recently introduced search worker thread pool.

We have already worked around this in our ContextIndexSearcher customizations when it comes to the collection part of the search. The rewrite part is more difficult to customize, but we can temporarily wrap the executor to make it not an instanceof ThreadPoolExecutor, to disable such adaptive mechanism that we don't wish to leverage.