### PR TITLE
[lucene_snapshot] Fix schedules, set default branch, and pass branch to triggered builds

### DIFF
--- a/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
+++ b/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
@@ -17,4 +17,6 @@ steps:
       buildDirectory: /dev/shm/bk
   - wait
   - trigger: "elasticsearch-lucene-snapshot-tests"
+    build:
+      branch: "${BUILDKITE_BRANCH}"
     async: true

--- a/.buildkite/pipelines/lucene-snapshot/update-branch.yml
+++ b/.buildkite/pipelines/lucene-snapshot/update-branch.yml
@@ -4,4 +4,6 @@ steps:
     timeout_in_minutes: 15
   - wait
   - trigger: "elasticsearch-lucene-snapshot-tests"
+    build:
+      branch: "${BUILDKITE_BRANCH}"
     async: true

--- a/.buildkite/scripts/lucene-snapshot/update-es-snapshot.sh
+++ b/.buildkite/scripts/lucene-snapshot/update-es-snapshot.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot" ]]; then
+  echo "Error: This script should only be run on the lucene_snapshot branch"
+  exit 1
+fi
+
 echo --- Update Lucene snapshot in Elasticsearch
 
 LUCENE_SNAPSHOT_VERSION=${LUCENE_SNAPSHOT_VERSION:-}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -161,6 +161,7 @@ spec:
       repository: elastic/elasticsearch
       pipeline_file: .buildkite/pipelines/lucene-snapshot/build-snapshot.yml
       branch_configuration: lucene_snapshot
+      default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
         ml-core: {}
@@ -171,11 +172,11 @@ spec:
         build_pull_requests: false
         publish_commit_status: false
         trigger_mode: none
-  schedules:
-    Periodically on lucene_snapshot:
-      branch: lucene_snapshot
-      cronline: "0 2 * * America/New_York"
-      message: "Builds a new lucene snapshot 1x per day"
+      schedules:
+        Periodically on lucene_snapshot:
+          branch: lucene_snapshot
+          cronline: "0 2 * * America/New_York"
+          message: "Builds a new lucene snapshot 1x per day"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -200,6 +201,7 @@ spec:
       repository: elastic/elasticsearch
       pipeline_file: .buildkite/pipelines/lucene-snapshot/update-branch.yml
       branch_configuration: lucene_snapshot
+      default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
         ml-core: {}
@@ -210,11 +212,11 @@ spec:
         build_pull_requests: false
         publish_commit_status: false
         trigger_mode: none
-  schedules:
-    Periodically on lucene_snapshot:
-      branch: lucene_snapshot
-      cronline: "0 6 * * America/New_York"
-      message: "Merges main into lucene_snapshot branch 1x per day"
+      schedules:
+        Periodically on lucene_snapshot:
+          branch: lucene_snapshot
+          cronline: "0 6 * * America/New_York"
+          message: "Merges main into lucene_snapshot branch 1x per day"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -239,6 +241,7 @@ spec:
       repository: elastic/elasticsearch
       pipeline_file: .buildkite/pipelines/lucene-snapshot/run-tests.yml
       branch_configuration: lucene_snapshot
+      default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
         ml-core: {}
@@ -249,8 +252,8 @@ spec:
         build_pull_requests: false
         publish_commit_status: false
         trigger_mode: none
-  schedules:
-    Periodically on lucene_snapshot:
-      branch: lucene_snapshot
-      cronline: "0 9,12,15,18 * * America/New_York"
-      message: "Runs tests against lucene_snapshot branch several times per day"
+      schedules:
+        Periodically on lucene_snapshot:
+          branch: lucene_snapshot
+          cronline: "0 9,12,15,18 * * America/New_York"
+          message: "Runs tests against lucene_snapshot branch several times per day"


### PR DESCRIPTION
Fixes for a few things discovered after merging #98039

- Fix pipeline schedules not being set due to incorrect indentation
- Add default branch of `lucene_snapshot` so manual triggers don't accidentally default to `main`
- Pass correct branch to triggered test pipeline builds