### PR TITLE
Fix assertions in GeoIpDownloaderIT.testGeoIpDatabasesDownloadNoGeoipProcessors()

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -272,13 +272,11 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
         assertBusy(() -> {
             PersistentTasksCustomMetadata.PersistentTask<PersistentTaskParams> task = getTask();
             assertNotNull(task);
-            assertNull(task.getState());
-            putGeoIpPipeline(); // This is to work around the race condition described in #92888
+            assertNotNull(task.getState());
+            putGeoIpPipeline(pipelineId); // This is to work around the race condition described in #92888
         });
         putNonGeoipPipeline(pipelineId);
-        assertBusy(() -> { assertNull(getTask().getState()); });
-        putNonGeoipPipeline(pipelineId);
-        assertNull(getTask().getState());
+        assertNotNull(getTask().getState()); // removing all geoip processors should not result in the task being stopped
         putGeoIpPipeline();
         assertBusy(() -> {
             GeoIpTaskState state = getGeoIpTaskState();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
@@ -203,7 +203,6 @@ public class BootStrapTests extends AbstractWatcherIntegrationTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82420")
     public void testMixedTriggeredWatchLoading() throws Exception {
         createIndex("output");
         client().prepareIndex()


### PR DESCRIPTION
GeoIpDownloaderIT.testGeoIpDatabasesDownloadNoGeoipProcessors() is incorrectly asserting that we stop the geoip downloader if all pipelines with geoip processors are removed. That is not the case -- once the downloader has been started we leave it up.
Closes #97793