### PR TITLE
[TEST] Remove ExecutionException handling from AggregatorTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -159,7 +159,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -491,15 +490,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
             } catch (CircuitBreakingException e) {
                 // Circuit breaks from the cranky breaker are expected - it randomly fails, after all
                 assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
-            } catch (RuntimeException e) {
-                if (e.getCause() instanceof ExecutionException executionException) {
-                    if (executionException.getCause() instanceof CircuitBreakingException circuitBreakingException) {
-                        // Circuit breaks from the cranky breaker are expected - it randomly fails, after all
-                        assertThat(circuitBreakingException.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
-                        return;
-                    }
-                }
-                throw e;
             }
         }
     }


### PR DESCRIPTION
ExecutionException is no longer thrown by the searcher: runtime exceptions (like CircuitBreakingException) are re-thrown unchanged, so the catch needed for concurrent search is the same as the one for sequential search.