### PR TITLE
Remove dead exception handling code in InboundHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -221,41 +221,19 @@ public class InboundHandler {
                 channel.close();
             }
         } else {
-            final TransportChannel transportChannel;
-            final RequestHandlerRegistry<T> reg;
-            try {
-                reg = requestHandlers.getHandler(action);
-                assert message.isShortCircuit() || reg != null : action;
-                transportChannel = new TcpTransportChannel(
-                    outboundHandler,
-                    channel,
-                    action,
-                    requestId,
-                    version,
-                    header.getCompressionScheme(),
-                    reg == null ? ResponseStatsConsumer.NONE : reg,
-                    header.isHandshake(),
-                    message.takeBreakerReleaseControl()
-                );
-            } catch (Exception e) {
-                assert false : e;
-                sendErrorResponse(
-                    action,
-                    new TcpTransportChannel(
-                        outboundHandler,
-                        channel,
-                        action,
-                        requestId,
-                        version,
-                        header.getCompressionScheme(),
-                        ResponseStatsConsumer.NONE,
-                        header.isHandshake(),
-                        message.takeBreakerReleaseControl()
-                    ),
-                    e
-                );
-                return;
-            }
+            final RequestHandlerRegistry<T> reg = requestHandlers.getHandler(action);
+            assert message.isShortCircuit() || reg != null : action;
+            final TransportChannel transportChannel = new TcpTransportChannel(
+                outboundHandler,
+                channel,
+                action,
+                requestId,
+                version,
+                header.getCompressionScheme(),
+                reg == null ? ResponseStatsConsumer.NONE : reg,
+                header.isHandshake(),
+                message.takeBreakerReleaseControl()
+            );
 
             try {
                 messageListener.onRequestReceived(requestId, action);


### PR DESCRIPTION
The code inside the try never throws and there's no point in asserting that much, the code obviously does not throw and we have exception handling that prevents leaks further up the stack anyway in case of a bug.
