### PR TITLE
Make GET /_nodes/shutdown internal on serverless

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestGetShutdownStatusAction.java
@@ -11,10 +11,13 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.util.List;
 
+@ServerlessScope(Scope.INTERNAL)
 public class RestGetShutdownStatusAction extends BaseRestHandler {
 
     @Override


### PR DESCRIPTION
On serverless we don't use Rest APIs to create shutdown events, but we do want to check the status of an event
