### PR TITLE
Remove write pool constraints from RejectionActionIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/RejectionActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/RejectionActionIT.java
@@ -36,9 +36,6 @@ public class RejectionActionIT extends ESIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put("thread_pool.search.size", 1)
             .put("thread_pool.search.queue_size", 1)
-            .put("thread_pool.write.size", 1)
-            // Needs to be 2 since we have concurrent indexing and global checkpoint syncs
-            .put("thread_pool.write.queue_size", 2)
             .put("thread_pool.get.size", 1)
             .put("thread_pool.get.queue_size", 1)
             .build();


### PR DESCRIPTION
These tests are not trying to trigger rejections from the write
threadpool, so it would be best to have the default config here.

Closes #97291