### PR TITLE
Preserve PeerFinder state when deactivated

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -895,7 +895,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
         lastKnownLeader = Optional.of(getLocalNode());
         peerFinder.deactivate(getLocalNode());
-        peerFinder.closeInactivePeers();
+        peerFinder.closePeers();
         clusterFormationFailureHelper.stop();
         closePrevotingAndElectionScheduler();
         preVoteCollector.update(getPreVoteResponse(), getLocalNode());
@@ -964,7 +964,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         updateSingleNodeClusterChecker();
         lastKnownLeader = Optional.of(leaderNode);
         peerFinder.deactivate(leaderNode);
-        peerFinder.closeInactivePeers();
+        peerFinder.closePeers();
         clusterFormationFailureHelper.stop();
         closePrevotingAndElectionScheduler();
         cancelActivePublication("become follower: " + method);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -895,6 +895,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
         lastKnownLeader = Optional.of(getLocalNode());
         peerFinder.deactivate(getLocalNode());
+        peerFinder.closeInactivePeers();
         clusterFormationFailureHelper.stop();
         closePrevotingAndElectionScheduler();
         preVoteCollector.update(getPreVoteResponse(), getLocalNode());
@@ -963,6 +964,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         updateSingleNodeClusterChecker();
         lastKnownLeader = Optional.of(leaderNode);
         peerFinder.deactivate(leaderNode);
+        peerFinder.closeInactivePeers();
         clusterFormationFailureHelper.stop();
         closePrevotingAndElectionScheduler();
         cancelActivePublication("become follower: " + method);

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -149,7 +149,6 @@ public abstract class PeerFinder {
                     iterator.remove();
                 }
             }
-            handleWakeUp();
             this.leader = Optional.of(leader);
             assert assertInactiveWithNoUndiscoveredPeers();
         }

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -159,7 +159,7 @@ public abstract class PeerFinder {
         Releasables.close(connectionReferences);
     }
 
-    public void closeInactivePeers() {
+    public void closePeers() {
 
         // Discovery is over, we're joining a cluster, so we can release all the connections that were being used for discovery. We haven't
         // finished joining/forming the cluster yet, but if we're joining an existing master then the join will hold open the connection

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -122,34 +122,45 @@ public abstract class PeerFinder {
         logger.trace("activating with {}", lastAcceptedNodes);
 
         synchronized (mutex) {
-            assert assertInactiveWithNoKnownPeers();
+            assert assertInactiveWithNoUndiscoveredPeers();
             active = true;
             activatedAtMillis = transportService.getThreadPool().relativeTimeInMillis();
             this.lastAcceptedNodes = lastAcceptedNodes;
             leader = Optional.empty();
-            handleWakeUp(); // return value discarded: there are no known peers, so none can be disconnected
+            handleWakeUp();
         }
 
         onFoundPeersUpdated(); // trigger a check for a quorum already
     }
 
     public void deactivate(DiscoveryNode leader) {
-        final boolean peersRemoved;
+        final boolean hasInactivePeers;
         final Collection<Releasable> connectionReferences;
         synchronized (mutex) {
             logger.trace("deactivating and setting leader to {}", leader);
             active = false;
             connectionReferences = new ArrayList<>(peersByAddress.size());
-            for (Peer peer : peersByAddress.values()) {
-                connectionReferences.add(peer.getConnectionReference());
+            hasInactivePeers = peersByAddress.isEmpty() == false;
+            final var iterator = peersByAddress.values().iterator();
+            while (iterator.hasNext()) {
+                final var peer = iterator.next();
+                if (peer.getDiscoveryNode() == null) {
+                    connectionReferences.add(peer.getConnectionReference());
+                    iterator.remove();
+                }
             }
-            peersRemoved = handleWakeUp();
+            handleWakeUp();
             this.leader = Optional.of(leader);
-            assert assertInactiveWithNoKnownPeers();
+            assert assertInactiveWithNoUndiscoveredPeers();
         }
-        if (peersRemoved) {
+        if (hasInactivePeers) {
             onFoundPeersUpdated();
         }
+
+        Releasables.close(connectionReferences);
+    }
+
+    public void closeInactivePeers() {
 
         // Discovery is over, we're joining a cluster, so we can release all the connections that were being used for discovery. We haven't
         // finished joining/forming the cluster yet, but if we're joining an existing master then the join will hold open the connection
@@ -166,7 +177,16 @@ public abstract class PeerFinder {
         // Note also that the NodeConnectionsService is still maintaining connections to the nodes in the last-applied cluster state, so
         // this will only close connections to nodes that we didn't know about beforehand. In most cases that's because we only just started
         // and haven't applied any cluster states at all yet. This won't cause any connection disruption during a typical master failover.
-        assert peersRemoved || connectionReferences.isEmpty() : connectionReferences;
+
+        final Collection<Releasable> connectionReferences = new ArrayList<>(peersByAddress.size());
+        synchronized (mutex) {
+            assert active == false;
+            for (final var peer : peersByAddress.values()) {
+                connectionReferences.add(peer.getConnectionReference());
+            }
+            peersByAddress.clear();
+            logger.trace("closeInactivePeers: closing {}", connectionReferences);
+        }
         Releasables.close(connectionReferences);
     }
 
@@ -175,10 +195,10 @@ public abstract class PeerFinder {
         return Thread.holdsLock(mutex);
     }
 
-    private boolean assertInactiveWithNoKnownPeers() {
+    private boolean assertInactiveWithNoUndiscoveredPeers() {
         assert holdsLock() : "PeerFinder mutex not held";
         assert active == false;
-        assert peersByAddress.isEmpty() : peersByAddress.keySet();
+        assert peersByAddress.values().stream().allMatch(p -> p.getDiscoveryNode() != null);
         return true;
     }
 
@@ -254,6 +274,9 @@ public abstract class PeerFinder {
 
     private Collection<DiscoveryNode> getFoundPeersUnderLock() {
         assert holdsLock() : "PeerFinder mutex not held";
+        if (active == false) {
+            return Set.of();
+        }
         Set<DiscoveryNode> peers = Sets.newHashSetWithExpectedSize(peersByAddress.size());
         for (Peer peer : peersByAddress.values()) {
             DiscoveryNode discoveryNode = peer.getDiscoveryNode();
@@ -351,7 +374,8 @@ public abstract class PeerFinder {
             assert holdsLock() : "PeerFinder mutex not held";
 
             if (isActive() == false) {
-                return true;
+                logger.trace("Peer#handleWakeUp inactive: {}", Peer.this);
+                return false;
             }
 
             final DiscoveryNode discoveryNode = getDiscoveryNode();
@@ -391,6 +415,7 @@ public abstract class PeerFinder {
                     try {
                         synchronized (mutex) {
                             if (isActive() == false) {
+                                logger.trace("Peer#establishConnection inactive: {}", Peer.this);
                                 return;
                             }
 
@@ -472,11 +497,12 @@ public abstract class PeerFinder {
                 public void handleResponse(PeersResponse response) {
                     logger.trace("{} received {}", Peer.this, response);
                     synchronized (mutex) {
+                        peersRequestInFlight = false;
+
                         if (isActive() == false) {
+                            logger.trace("Peer#requestPeers inactive: {}", Peer.this);
                             return;
                         }
-
-                        peersRequestInFlight = false;
 
                         response.getMasterNode().ifPresent(node -> startProbe(node.getAddress()));
                         for (DiscoveryNode node : response.getKnownPeers()) {

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -250,7 +250,7 @@ public class PeerFinderTests extends ESTestCase {
     @After
     public void deactivateAndRunRemainingTasks() {
         peerFinder.deactivate(localNode);
-        peerFinder.closeInactivePeers();
+        peerFinder.closePeers();
         deterministicTaskQueue.runAllRunnableTasks();
         assertThat(connectedNodes, empty());
     }
@@ -379,7 +379,7 @@ public class PeerFinderTests extends ESTestCase {
         peerFinder.deactivate(localNode);
         assertFoundPeers();
         assertEquals(Set.of(otherNode), connectedNodes);
-        peerFinder.closeInactivePeers();
+        peerFinder.closePeers();
         assertThat(connectedNodes, empty());
 
         providedAddresses.clear();
@@ -402,7 +402,7 @@ public class PeerFinderTests extends ESTestCase {
         } while (deterministicTaskQueue.hasDeferredTasks());
         assertFoundPeers();
 
-        peerFinder.closeInactivePeers();
+        peerFinder.closePeers();
         assertThat(connectedNodes, empty());
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -370,12 +370,15 @@ public class PeerFinderTests extends ESTestCase {
         assertFoundPeers(otherNode);
 
         peerFinder.deactivate(localNode);
+        assertFoundPeers();
         assertEquals(Set.of(otherNode), connectedNodes);
 
         peerFinder.activate(DiscoveryNodes.EMPTY_NODES);
         assertFoundPeers(otherNode);
 
         peerFinder.deactivate(localNode);
+        assertFoundPeers();
+        assertEquals(Set.of(otherNode), connectedNodes);
         peerFinder.closeInactivePeers();
         assertThat(connectedNodes, empty());
 


### PR DESCRIPTION
Today the `PeerFinder` releases all its peers on deactivation, but to
complete #98354 we will need to delay the release until the cluster has
reached a more stable state, which happens some time later. This commit
separates the deactivate and release steps within the `PeerFinder` in
preparation for that change, although it still does both steps at once
in all production callers.