### PR TITLE
Add unavailable EsqlFeatureSetUsage creation support

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/EsqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/EsqlFeatureSetUsage.java
@@ -27,8 +27,17 @@ public class EsqlFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     public EsqlFeatureSetUsage(Map<String, Object> stats) {
-        super(XPackField.ESQL, true, true);
+        this(true, true, stats);
+    }
+
+    private EsqlFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> stats) {
+        super(XPackField.ESQL, available, enabled);
         this.stats = stats;
+    }
+
+    /** Returns a feature set usage where the feature is not available or enabled, and has an empty stats. */
+    public static EsqlFeatureSetUsage unavailable() {
+        return new EsqlFeatureSetUsage(false, false, Map.of());
     }
 
     public Map<String, Object> stats() {


### PR DESCRIPTION
This commit adds a means to create an EsqlFeatureSetUsage that is unavailable and not enabled. This required to be able to mock out alternative / dummy implementations of usage / info transport actions where the ESQL module is not present, thus returns empty / unavailable feature usage stats, etc.

This is a similar to other not-present xpack features in stateless, e.g. ILM.