### PR TITLE
Mute MultiVersionRepositoryAccessIT tests

### DIFF
--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.upgrades;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.client.Request;
@@ -46,7 +45,7 @@ import static org.hamcrest.Matchers.is;
  * </ul>
  */
 @SuppressWarnings("removal")
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94459")
+//@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94459")
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.upgrades;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.client.Request;
@@ -45,7 +46,7 @@ import static org.hamcrest.Matchers.is;
  * </ul>
  */
 @SuppressWarnings("removal")
-//@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94459")
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98454")
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {


### PR DESCRIPTION
This is a followup of https://github.com/elastic/elasticsearch/pull/94580 to update the AwaitsFix notation to reflect the current tracking issue.

While checking if https://github.com/elastic/elasticsearch/issues/94459 is still an open issue, we realized the failure pointed out there it is not valid anymore: the bug in the tests shutdown was there only for versions prior to v7.13 API and now the minimum BwC version is v7.16.

However, re-enabling the IT uncovered a new bug (https://github.com/elastic/elasticsearch/issues/98454); I am updating the `bugUrl` to keep traceability.

