### PR TITLE
Support cluster/details for CCS minimize_roundtrips=false

### DIFF
--- a/docs/changelog/98457.yaml
+++ b/docs/changelog/98457.yaml
@@ -1,0 +1,5 @@
+pr: 98457
+summary: Support cluster/details for CCS minimize_roundtrips=false
+area: Search
+type: enhancement
+issues: []

--- a/docs/reference/migration/migration.asciidoc
+++ b/docs/reference/migration/migration.asciidoc
@@ -11,3 +11,4 @@ include::apis/shared-migration-apis-tip.asciidoc[]
 
 include::apis/deprecation.asciidoc[]
 include::apis/feature-migration.asciidoc[]
+

--- a/docs/reference/migration/migration.asciidoc
+++ b/docs/reference/migration/migration.asciidoc
@@ -11,4 +11,3 @@ include::apis/shared-migration-apis-tip.asciidoc[]
 
 include::apis/deprecation.asciidoc[]
 include::apis/feature-migration.asciidoc[]
-

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -676,10 +676,10 @@ were searched across all clusters and that all were successful.
 
 Failures during a {ccs} can result in one of two conditions:
 
-1. partial results (2xx HTTP status code)
-2. a failed search (4xx or 5xx HTTP status code)
+. partial results (2xx HTTP status code)
+. a failed search (4xx or 5xx HTTP status code)
 
-The failures will be present in the search response in both cases.
+Failure details will be present in the search response in both cases.
 
 A search will be failed if a cluster marked with `skip_unavailable`=`false`
 is unavailable, disconnects during the search, or has search failures on
@@ -690,10 +690,10 @@ section and the `_clusters` section of the response.
 
 A failed search will have an additional top-level `errors` entry in the response.
 
-Here is an example of a cluster with partial results due to search failure
-a one shard. The query would be similar to ones shown previously. We
-use the `_async_search/status` endpoint here to show the completion status
-and not show the hits.
+Here is an example of a search with partial results due to a failure on one shard
+of one cluster. The search would be similar to ones shown previously. The
+`_async_search/status` endpoint is used here to show the completion status and
+not show the hits.
 
 [source,console]
 --------------------------------------------------
@@ -824,10 +824,12 @@ its status is `skipped` and since `cluster_two` is marked as `skip_unavailable`=
 its status is `failed`. Since there was a `failed` cluster, a top level `error`
 is also present and this returns an HTTP status of 500 (not shown).
 
+If you want the search to still return results even when a cluster is
+unavailable, set `skip_unavailable`=`true` for all the remote clusters.
 
 [source,console]
 --------------------------------------------------
-GET /_async_search/status/FjktRGJ1Y2w1U0phLTRhZnVyeUZ2MVEbWEJyeVBPQldTV3FGZGdIeUVabXBldzo5NzA4
+GET /_async_search/FjktRGJ1Y2w1U0phLTRhZnVyeUZ2MVEbWEJyeVBPQldTV3FGZGdIeUVabXBldzo5NzA4
 --------------------------------------------------
 // TEST[continued s/FjktRGJ1Y2w1U0phLTRhZnVyeUZ2MVEbWEJyeVBPQldTV3FGZGdIeUVabXBldzo5NzA4/\${body.id}/]
 
@@ -934,7 +936,7 @@ configuration as `skip_unavailable`=`false`.
 [[exclude-problematic-clusters]]
 === Excluding clusters or indices from a {ccs}
 
-If you use a wildcard to include large list of clusters and/or indices,
+If you use a wildcard to include a large list of clusters and/or indices,
 you can explicitly exclude one or more clusters or indices with a `-` minus
 sign in front of the cluster or index.
 
@@ -1001,8 +1003,8 @@ contacted and told to search any indexes matching `my-index-*` except for
 [[ccs-async-search-minimize-roundtrips-false]]
 === Using async search for {ccs} with ccs_minimize_roundtrips=false
 
-The `_shards` and `_clusters` section of the response behave slightly
-differently when `ccs_minimize_roundtrips` is `false` in asynchronous searches.
+The `_shards` and `_clusters` section of the response behave
+differently when `ccs_minimize_roundtrips` is `false`.
 
 Key differences are:
 
@@ -1016,7 +1018,7 @@ long-running search compared to when minimize roundtrips is used.
 . The `_cluster` section starts off listing all of its shard counts, since
 they are also obtained before the query phase begins.
 
-Example using the same set up as in the previous section (`ccs_minimize_roundtrips=true`):
+Example using the same setup as in the previous section (`ccs_minimize_roundtrips=true`):
 
 [source,console]
 --------------------------------------------------
@@ -1195,6 +1197,25 @@ network roundtrips, and sets the parameter `ccs_minimize_roundtrips` to `false`.
 
 [discrete]
 [[ccs-min-roundtrips]]
+==== Considerations for choosing whether to minimize roundtrips in a {ccs}
+
+For cross-cluster searches that query a large number of shards, the minimize roundtrips
+option typically provides much better performance. This is especially true if the clusters
+being searched have high network latency (e.g., distant geographic regions).
+
+However, not minimizing roundtrips allows you to get back incremental results of
+any aggregations in your query when using async-search while the search is still
+running.
+
+By default, synchronous searches minimize roundtrips, while asynchronous searches
+do not. You can override the default by using the `ccs_minimize_roundtrips` parameter,
+setting it to either `true` or `false`, as shown in several examples earlier in this
+document.
+
+
+[discrete]
+[[ccs-min-roundtrips-true]]
+
 ==== Minimize network roundtrips
 
 Here's how {ccs} works when you minimize network roundtrips.
@@ -1307,8 +1328,8 @@ on the same version of {es}. If you need to maintain clusters with different
 versions, you can:
 
 * Maintain a dedicated cluster for {ccs}. Keep this cluster on the earliest
-version needed to search the other clusters. For example, if you have 7.17 and 8.x clusters, you can maintain a dedicated 7.17 cluster to use
-as the local cluster for {ccs}.
+version needed to search the other clusters. For example, if you have 7.17 and 8.x clusters,
+you can maintain a dedicated 7.17 cluster to use as the local cluster for {ccs}.
 
 * Keep each cluster no more than one minor version apart. This lets you use any
 cluster as the local cluster when running a {ccs}.

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -76,17 +76,19 @@ PUT _cluster/settings
       "remote": {
         "cluster_one": {
           "seeds": [
-            "127.0.0.1:9300"
-          ]
+            "35.238.149.1:9300"
+          ],
+          "skip_unavailable": true
         },
         "cluster_two": {
           "seeds": [
-            "127.0.0.1:9301"
-          ]
+            "35.238.149.2:9300"
+          ],
+          "skip_unavailable": false
         },
-        "cluster_three": {
+        "cluster_three": {  <1>
           "seeds": [
-            "127.0.0.1:9302"
+            "35.238.149.3:9300"
           ]
         }
       }
@@ -95,7 +97,12 @@ PUT _cluster/settings
 }
 --------------------------------
 // TEST[setup:host]
-// TEST[s/127.0.0.1:930\d+/\${transport_host}/]
+// TEST[s/35.238.149.\d+:930\d+/\${transport_host}/]
+
+<1> Since `skip_unavailable` was not set on `cluster_three`, it uses
+the default of `false`. See the <<skip-unavailable-clusters>>
+section for details.
+
 
 [discrete]
 [[ccs-search-remote-cluster]]
@@ -111,6 +118,7 @@ The following <<search-search,search>> API request searches the
 --------------------------------------------------
 GET /cluster_one:my-index-000001/_search
 {
+  "size": 1,
   "query": {
     "match": {
       "user.id": "kimchy"
@@ -122,7 +130,9 @@ GET /cluster_one:my-index-000001/_search
 // TEST[continued]
 // TEST[setup:my_index]
 
-The API returns the following response:
+The API returns the following response. Note that when you
+search one or more remote clusters, a `_clusters` section is
+included to provide information about the search on each cluster.
 
 [source,console-result]
 --------------------------------------------------
@@ -130,8 +140,8 @@ The API returns the following response:
   "took": 150,
   "timed_out": false,
   "_shards": {
-    "total": 3,
-    "successful": 3,
+    "total": 12,
+    "successful": 12,
     "failed": 0,
     "skipped": 0
   },
@@ -141,13 +151,13 @@ The API returns the following response:
     "skipped": 0,
     "details": {
       "cluster_one": {  <1>
-        "status": "successful",
-        "indices": "my-index-000001",
-        "took": 148,
+        "status": "successful", <2>
+        "indices": "my-index-000001", <3>
+        "took": 148,  <4>
         "timed_out": false,
-        "_shards": {
-          "total": 3,
-          "successful": 3,
+        "_shards": {  <5>
+          "total": 12,
+          "successful": 12,
           "skipped": 0,
           "failed": 0
         }
@@ -162,7 +172,7 @@ The API returns the following response:
     "max_score": 1,
     "hits": [
       {
-        "_index": "cluster_one:my-index-000001", <2>
+        "_index": "cluster_one:my-index-000001", <6>
         "_id": "0",
         "_score": 1,
         "_source": {
@@ -185,14 +195,22 @@ The API returns the following response:
 // TESTRESPONSE[s/"took": 150/"took": "$body.took"/]
 // TESTRESPONSE[s/"max_score": 1/"max_score": "$body.hits.max_score"/]
 // TESTRESPONSE[s/"_score": 1/"_score": "$body.hits.hits.0._score"/]
-// TESTRESPONSE[s/"total": 3/"total": "$body._shards.total"/]
-// TESTRESPONSE[s/"successful": 3/"successful": "$body._shards.successful"/]
+// TESTRESPONSE[s/"total": 12/"total": "$body._shards.total"/]
+// TESTRESPONSE[s/"successful": 12/"successful": "$body._shards.successful"/]
 // TESTRESPONSE[s/"skipped": 0/"skipped": "$body._shards.skipped"/]
-// TESTRESPONSE[s/"failed": 3/"failed": "$body._shards.failed"/]
 // TESTRESPONSE[s/"took": 148/"took": "$body._clusters.details.cluster_one.took"/]
 
-<1> The details section shows information about the search on each cluster.
-<2> The search response body includes the name of the remote cluster in the
+<1> The `_clusters/details` section shows metadata about the search on each cluster.
+<2> The cluster status can be one of: *running*, *successful* (searches on all shards
+were successful), *partial* (searches on at least one shard of the cluster was successful
+and at least one failed), *skipped* (the search failed on a cluster marked with
+`skip_unavailable`=`true`) or *failed* (the search failed on a cluster marked with
+`skip_unavailable`=`false`).
+<3> The index expression supplied by the user. If you provide a wildcard such as `logs-*`,
+this section will show the value with the wildcard, not the concrete indices being searched.
+<4> How long (in milliseconds) the sub-search took on that cluster.
+<5> The shard details for the sub-search on that cluster.
+<6> The search response body includes the name of the remote cluster in the
 `_index` parameter.
 
 
@@ -204,8 +222,9 @@ The API returns the following response:
 The following <<search,search>> API request searches the `my-index-000001` index on
 three clusters:
 
-* Your local cluster
-* Two remote clusters, `cluster_one` and `cluster_two`
+* The local ("querying") cluster, with 10 shards
+* Two remote clusters, `cluster_one`, with 12 shards and `cluster_two`
+with 6 shards.
 
 [source,console]
 --------------------------------------------------
@@ -230,8 +249,8 @@ The API returns the following response:
   "timed_out": false,
   "num_reduce_phases": 4,
   "_shards": {
-    "total": 12,
-    "successful": 12,
+    "total": 28,
+    "successful": 28,
     "failed": 0,
     "skipped": 0
   },
@@ -246,8 +265,8 @@ The API returns the following response:
         "took": 21,
         "timed_out": false,
         "_shards": {
-          "total": 5,
-          "successful": 5,
+          "total": 10,
+          "successful": 10,
           "skipped": 0,
           "failed": 0
         }
@@ -258,8 +277,8 @@ The API returns the following response:
         "took": 48,
         "timed_out": false,
         "_shards": {
-          "total": 4,
-          "successful": 4,
+          "total": 12,
+          "successful": 12,
           "skipped": 0,
           "failed": 0
         }
@@ -270,8 +289,8 @@ The API returns the following response:
         "took": 141,
         "timed_out": false,
         "_shards": {
-          "total" : 3,
-          "successful" : 3,
+          "total" : 6,
+          "successful" : 6,
           "skipped": 0,
           "failed": 0
         }
@@ -344,16 +363,16 @@ The API returns the following response:
 // TESTRESPONSE[s/"max_score": 1/"max_score": "$body.hits.max_score"/]
 // TESTRESPONSE[s/"_score": 1/"_score": "$body.hits.hits.0._score"/]
 // TESTRESPONSE[s/"_score": 2/"_score": "$body.hits.hits.1._score"/]
-// TESTRESPONSE[s/"total": 12/"total": "$body._shards.total"/]
-// TESTRESPONSE[s/"successful": 12/"successful": "$body._shards.successful"/]
-// TESTRESPONSE[s/"total": 5/"total": "$body._clusters.details.(local)._shards.total"/]
-// TESTRESPONSE[s/"successful": 5/"successful": "$body._clusters.details.(local)._shards.successful"/]
+// TESTRESPONSE[s/"total": 28/"total": "$body._shards.total"/]
+// TESTRESPONSE[s/"successful": 28/"successful": "$body._shards.successful"/]
+// TESTRESPONSE[s/"total": 10/"total": "$body._clusters.details.(local)._shards.total"/]
+// TESTRESPONSE[s/"successful": 10/"successful": "$body._clusters.details.(local)._shards.successful"/]
 // TESTRESPONSE[s/"took": 21/"took": "$body._clusters.details.(local).took"/]
-// TESTRESPONSE[s/"total": 4/"total": "$body._clusters.details.cluster_one._shards.total"/]
-// TESTRESPONSE[s/"successful": 4/"successful": "$body._clusters.details.cluster_one._shards.successful"/]
+// TESTRESPONSE[s/"total": 12/"total": "$body._clusters.details.cluster_one._shards.total"/]
+// TESTRESPONSE[s/"successful": 12/"successful": "$body._clusters.details.cluster_one._shards.successful"/]
 // TESTRESPONSE[s/"took": 48/"took": "$body._clusters.details.cluster_one.took"/]
-// TESTRESPONSE[s/"total" : 3/"total": "$body._clusters.details.cluster_two._shards.total"/]
-// TESTRESPONSE[s/"successful" : 3/"successful": "$body._clusters.details.cluster_two._shards.successful"/]
+// TESTRESPONSE[s/"total" : 6/"total": "$body._clusters.details.cluster_two._shards.total"/]
+// TESTRESPONSE[s/"successful" : 6/"successful": "$body._clusters.details.cluster_two._shards.successful"/]
 // TESTRESPONSE[s/"took": 141/"took": "$body._clusters.details.cluster_two.took"/]
 
 <1> The local (querying) cluster is identified as "(local)".
@@ -368,14 +387,12 @@ means the document came from the local cluster.
 === Using async search for {ccs} with ccs_minimize_roundtrips=true
 
 Remote clusters can be queried asynchronously using the <<async-search,async search>> API.
-Async searches accept a <<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> parameter
-that defaults to `false`. See <<ccs-min-roundtrips>> to learn more about this option.
+A {ccs} accepts a <<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> parameter. For
+asynchronous searches it defaults to `false`. (Note: for synchronous searches it defaults to `true`.)
+See <<ccs-min-roundtrips>> to learn more about this option.
 
 The following request does an asynchronous search of the `my-index-000001` index using
-`ccs_minimize_roundtrips=true` against three clusters:
-
-* The local cluster, with 8 shards
-* Two remote clusters, `cluster_one` and `cluster_two`, with 10 shards each
+`ccs_minimize_roundtrips=true` against three clusters (same ones as the previous example).
 
 [source,console]
 --------------------------------------------------
@@ -408,7 +425,7 @@ The API returns the following response:
     "timed_out": false,
     "num_reduce_phases": 0,
     "_shards": {
-      "total": 8,     <2>
+      "total": 10,     <2>
       "successful": 0,
       "failed": 0,
       "skipped": 0
@@ -416,7 +433,24 @@ The API returns the following response:
     "_clusters": {    <3>
       "total" : 3,
       "successful" : 0,
-      "skipped": 0
+      "skipped": 0,
+      "details": {
+        "(local)": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false
+        },
+        "cluster_one": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false
+        },
+        "cluster_one": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false
+        }
+      }
     },
     "hits": {
       "total" : {
@@ -429,16 +463,17 @@ The API returns the following response:
   }
 }
 --------------------------------------------------
-// TEST[skip: terminated_early is absent from final results so is hard to reproduce here]
+// TEST[skip: hard to reproduce initial state]
 
 <1> The async search id.
 <2> When `ccs_minimize_roundtrips` = `true` and searches on the remote clusters
 are still running, this section indicates the number of shards in scope for the
 local cluster only. This will be updated to include the total number of shards
-across all clusters only when the search is completed.
+across all clusters only when the search is completed. When
+`ccs_minimize_roundtrips`= `false`, the total shard count is known up front and
+will be correct.
 <3> The `_clusters` section indicates that 3 clusters are in scope for the search
-and all are currently running (since `successful` and `skipped` both equal 0).
-
+and all are currently running.
 
 If you query the <<get-async-search,get async search>> endpoint while the query is
 still running, you will see an update in the `_clusters` and `_shards` section of
@@ -465,15 +500,39 @@ Response:
     "timed_out": false,
     "terminated_early": false,
     "_shards": {
-      "total": 8,
-      "successful": 8,  <1>
+      "total": 10,
+      "successful": 10,  <1>
       "skipped": 0,
       "failed": 0
     },
     "_clusters": {
       "total": 3,
       "successful": 1,  <2>
-      "skipped": 0
+      "skipped": 0,
+      "details": {
+        "(local)": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 2034,
+          "timed_out": false,
+          "_shards": {
+            "total": 10,
+            "successful": 10,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_one": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false
+        },
+        "cluster_two": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false
+        }
+      }
     },
     "hits": {
       "total": {
@@ -486,20 +545,21 @@ Response:
   }
 }
 --------------------------------------------------
-// TEST[skip: terminated_early is absent from final results so is hard to reproduce here]
+// TEST[skip: hard to reproduce intermediate results]
 
 
 <1> All the local cluster shards have completed.
 <2> The local cluster search has completed, so the "successful" clusters entry
-is set to 1. The `_clusters` response section will not be updated for the remote clusters
-until all remote searches have finished (either successfully or been skipped).
+is set to 1. The `_clusters` response metadata will be updated as each cluster
+finishes.
 <3> Number of hits from the local cluster search. Final hits are not
 shown until searches on all clusters have been completed and merged.
 
 
-After searches on all the clusters have completed, when you query the
-<<get-async-search,get async search>> endpoint, you will see the final
-status of the `_clusters` and `_shards` section as well as the hits.
+After searches on all the clusters have completed, querying the
+<<get-async-search,get async search>> endpoint will show the final
+status of the `_clusters` and `_shards` section as well as the hits
+and any aggregation results.
 
 [source,console]
 --------------------------------------------------
@@ -611,11 +671,338 @@ were searched across all clusters and that all were successful.
 
 
 [discrete]
+[[cross-cluster-search-failures]]
+=== {ccs-cap} failures
+
+Failures during a {ccs} can result in one of two conditions:
+
+1. partial results (2xx HTTP status code)
+2. a failed search (4xx or 5xx HTTP status code)
+
+The failures will be present in the search response in both cases.
+
+A search will be failed if a cluster marked with `skip_unavailable`=`false`
+is unavailable, disconnects during the search, or has search failures on
+all shards. In all other cases, failures will result in partial results.
+
+Search failures on individual shards will be present in both the `_shards`
+section and the `_clusters` section of the response.
+
+A failed search will have an additional top-level `errors` entry in the response.
+
+Here is an example of a cluster with partial results due to search failure
+a one shard. The query would be similar to ones shown previously. We
+use the `_async_search/status` endpoint here to show the completion status
+and not show the hits.
+
+[source,console]
+--------------------------------------------------
+GET /_async_search/status/FmpwbThueVB4UkRDeUxqb1l4akIza3cbWEJyeVBPQldTV3FGZGdIeUVabXBldzoyMDIw
+--------------------------------------------------
+// TEST[continued s/FmpwbThueVB4UkRDeUxqb1l4akIza3cbWEJyeVBPQldTV3FGZGdIeUVabXBldzoyMDIw/\${body.id}/]
+
+
+Response:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "id": "FmpwbThueVB4UkRDeUxqb1l4akIza3cbWEJyeVBPQldTV3FGZGdIeUVabXBldzoyMDIw",
+  "is_partial": true,  <1>
+  "is_running": false,
+  "start_time_in_millis": 1692106901478,
+  "expiration_time_in_millis": 1692538901478,
+  "completion_time_in_millis": 1692106903547,
+  "response": {
+    "took": 2069,
+    "timed_out": false,
+    "num_reduce_phases": 4,
+    "_shards": {
+      "total": 28,
+      "successful": 27,
+      "skipped": 0,
+      "failed": 1,
+      "failures": [   <2>
+        {
+          "shard": 1,
+          "index": "cluster_two:my-index-000001",
+          "node": "LMpUnAu0QEeCUMfg_56sAg",
+          "reason": {
+            "type": "query_shard_exception",
+            "reason": "failed to create query: [my-index-000001][1] exception message here",
+            "index_uuid": "4F2VWx8RQSeIhUE-nksvCQ",
+            "index": "cluster_two:my-index-000001",
+            "caused_by": {
+              "type": "runtime_exception",
+              "reason": "runtime_exception: [my-index-000001][1] exception message here"
+            }
+          }
+        }
+      ]
+    },
+    "_clusters": {
+      "total": 3,
+      "successful": 3,   <3>
+      "skipped": 0,
+      "details": {
+        "(local)": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 1753,
+          "timed_out": false,
+          "_shards": {
+            "total": 10,
+            "successful": 10,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_one": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 2054,
+          "timed_out": false,
+          "_shards": {
+            "total": 12,
+            "successful": 12,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_two": {
+          "status": "partial",   <4>
+          "indices": "my-index-000001",
+          "took": 2039,
+          "timed_out": false,
+          "_shards": {
+            "total": 6,
+            "successful": 5,
+            "skipped": 0,
+            "failed": 1   <5>
+          },
+          "failures": [  <6>
+            {
+              "shard": 1,
+              "index": "cluster_two:my-index-000001",
+              "node": "LMpUnAu0QEeCUMfg_56sAg",
+              "reason": {
+                "type": "query_shard_exception",
+                "reason": "failed to create query: [my-index-000001][1] exception message here",
+                "index_uuid": "4F2VWx8RQSeIhUE-nksvCQ",
+                "index": "cluster_two:my-index-000001",
+                "caused_by": {
+                  "type": "runtime_exception",
+                  "reason": "runtime_exception: [my-index-000001][1] exception message here"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "hits": {
+    }
+  }
+}
+--------------------------------------------------
+// TEST[skip: hard to reproduce failure results]
+
+
+<1> The search results are marked as partial, since at least one shard search failed.
+<2> The `_shards` section includes shard failure info.
+<3> Clusters that have partial results are still marked as successful. They are
+marked with status "skipped" (or "failed") only if no data was returned from the search.
+<4> The `partial` status has been applied to the cluster with partial results.
+<5> The failed shard count is shown.
+<6> The shard failures are listed under the cluster/details entry also.
+
+
+
+Here is an example where both `cluster_one` and `cluster_two` lost connectivity
+during a {ccs}. Since `cluster_one` is marked as `skip_unavailable`=`true`,
+its status is `skipped` and since `cluster_two` is marked as `skip_unavailable`=`false`,
+its status is `failed`. Since there was a `failed` cluster, a top level `error`
+is also present and this returns an HTTP status of 500 (not shown).
+
+
+[source,console]
+--------------------------------------------------
+GET /_async_search/status/FjktRGJ1Y2w1U0phLTRhZnVyeUZ2MVEbWEJyeVBPQldTV3FGZGdIeUVabXBldzo5NzA4
+--------------------------------------------------
+// TEST[continued s/FjktRGJ1Y2w1U0phLTRhZnVyeUZ2MVEbWEJyeVBPQldTV3FGZGdIeUVabXBldzo5NzA4/\${body.id}/]
+
+
+Response:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "id": "FjktRGJ1Y2w1U0phLTRhZnVyeUZ2MVEbWEJyeVBPQldTV3FGZGdIeUVabXBldzo5NzA4",
+  "is_partial": true,
+  "is_running": false,
+  "start_time_in_millis": 1692112102650,
+  "expiration_time_in_millis": 1692544102650,
+  "completion_time_in_millis": 1692112106177,
+  "response": {
+    "took": 3527,
+    "timed_out": false,
+    "terminated_early": false,
+    "_shards": {
+      "total": 10,   <1>
+      "successful": 10,
+      "skipped": 0,
+      "failed": 0
+    },
+    "_clusters": {
+      "total": 3,
+      "successful": 1,
+      "skipped": 2,   <2>
+      "details": {
+        "(local)": {
+          "status": "successful",
+          "indices": "my-index-000001",
+          "took": 1473,
+          "timed_out": false,
+          "_shards": {
+            "total": 10,
+            "successful": 10,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_one": {
+          "status": "skipped",   <3>
+          "indices": "my-index-000001",
+          "timed_out": false,
+          "failures": [
+            {
+              "shard": -1,
+              "index": null,
+              "reason": {
+                "type": "node_disconnected_exception",   <4>
+                "reason": "[myhostname1][35.238.149.1:9300][indices:data/read/search] disconnected"
+              }
+            }
+          ]
+        },
+        "cluster_two": {
+          "status": "failed",   <5>
+          "indices": "my-index-000001",
+          "timed_out": false,
+          "failures": [
+            {
+              "shard": -1,
+              "index": null,
+              "reason": {
+                "type": "node_disconnected_exception",
+                "reason": "[myhostname2][35.238.149.2:9300][indices:data/read/search] disconnected"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "hits": {
+    },
+  }
+  "error": {  <6>
+    "type": "status_exception",
+    "reason": "error while executing search",
+    "caused_by": {
+      "type": "node_disconnected_exception",
+      "reason": "[myhostname2][35.238.149.2:9300][indices:data/read/search] disconnected"
+    }
+  }
+}
+--------------------------------------------------
+// TEST[skip: hard to reproduce failure results]
+
+<1> The shard accounting will often be only partial when errors like this occur,
+since we need to be able to get shard info from remote clusters on each search.
+<2> The skipped counter is used for both "skipped" and "failed" clusters.
+<3> `cluster_one` disconnected during the search and it returned no results.
+Since it is marked in the remote cluster configuration as `skip_unavailable`=`true`,
+its status is "skipped", which will not fail the entire search.
+<4> The failures list shows that the remote cluster node disconnected from the
+querying cluster.
+<5> `cluster_two` status is "failed", since it is marked in the remote cluster
+configuration as `skip_unavailable`=`false`.
+<6> A top level `error` entry is included when there is a "failed" cluster.
+
+
+[discrete]
+[[exclude-problematic-clusters]]
+=== Excluding clusters or indices from a {ccs}
+
+If you use a wildcard to include large list of clusters and/or indices,
+you can explicitly exclude one or more clusters or indices with a `-` minus
+sign in front of the cluster or index.
+
+To exclude an entire cluster, you would put the minus sign in front of the
+cluster alias, such as: `-mycluster:*`. When excluding a cluster, you must
+use `*` in the index position or an error will be returned.
+
+To exclude a specific remote index, you would put the minus sign in front
+of the index, such as `mycluster:-myindex`.
+
+==== Exclude a remote cluster
+
+Here's how you would exclude `cluster_three` from a
+{ccs} that uses a wildcard to specify a list of clusters:
+
+[source,console]
+--------------------------------------------------
+POST /my-index-000001,cluster*:my-index-000001,-cluster_three:*/_async_search  <1>
+{
+  "query": {
+    "match": {
+      "user.id": "kimchy"
+    }
+  },
+  "_source": ["user.id", "message", "http.response.status_code"]
+}
+--------------------------------------------------
+// TEST[continued]
+// TEST[s/ccs_minimize_roundtrips=true/ccs_minimize_roundtrips=true&wait_for_completion_timeout=100ms&keep_on_completion=true/]
+
+<1> The `cluster*` notation would naturally include `cluster_one`, `cluster_two` and `cluster_three`.
+To exclude `cluster_three` use a `-` before the cluster name along with a simple wildcard `*` in
+the index position. This indicates that you do not want the search to make any contact with
+`cluster_three`.
+
+
+==== Exclude a remote index
+
+Suppose you want to search all indices matching `my-index-*` but you want to exclude
+`my-index-000001` on `cluster_three`. Here's how you could do that:
+
+[source,console]
+--------------------------------------------------
+POST /my-index-000001,cluster*:my-index-*,cluster_three:-my-index-000001/_async_search  <1>
+{
+  "query": {
+    "match": {
+      "user.id": "kimchy"
+    }
+  },
+  "_source": ["user.id", "message", "http.response.status_code"]
+}
+--------------------------------------------------
+// TEST[continued]
+// TEST[s/ccs_minimize_roundtrips=true/ccs_minimize_roundtrips=true&wait_for_completion_timeout=100ms&keep_on_completion=true/]
+
+<1> This will *not* exclude `cluster_three` from the search. It will still be
+contacted and told to search any indexes matching `my-index-*` except for
+`my-index-000001`.
+
+
+
+[discrete]
 [[ccs-async-search-minimize-roundtrips-false]]
 === Using async search for {ccs} with ccs_minimize_roundtrips=false
 
-The `_shards` and `_clusters` section of the response behave differently
-when `ccs_minimize_roundtrips` is `false` in asynchronous searches.
+The `_shards` and `_clusters` section of the response behave slightly
+differently when `ccs_minimize_roundtrips` is `false` in asynchronous searches.
 
 Key differences are:
 
@@ -626,9 +1013,8 @@ of shards is gathered from all clusters before the search starts.
 shards complete, so you will get a more accurate accounting of progress during a
 long-running search compared to when minimize roundtrips is used.
 
-. The `_cluster` section starts off in its final state, showing which clusters
-were successful or skipped based on gathering shard information before the actual
-search phase against each shard begins.
+. The `_cluster` section starts off listing all of its shard counts, since
+they are also obtained before the query phase begins.
 
 Example using the same set up as in the previous section (`ccs_minimize_roundtrips=true`):
 
@@ -670,8 +1056,43 @@ the `wait_for_completion_timeout` duration (see <<async-search>>).
     },
     "_clusters": {
       "total" : 3,
-      "successful": 3,  <2>
-      "skipped": 0
+      "successful": 0,
+      "skipped": 0,
+      "details": {    <2>
+        "(local)": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false,
+          "_shards": {
+            "total": 10,
+            "successful": 0,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_one": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false,
+          "_shards": {
+            "total": 12,
+            "successful": 0,
+            "skipped": 0,
+            "failed": 0
+          }
+        },
+        "cluster_two": {
+          "status": "running",
+          "indices": "my-index-000001",
+          "timed_out": false,
+          "_shards": {
+            "total": 6,
+            "successful": 0,
+            "skipped": 0,
+            "failed": 0
+          }
+        }
+      }
     },
     "hits": {
       "total" : {
@@ -684,34 +1105,31 @@ the `wait_for_completion_timeout` duration (see <<async-search>>).
   }
 }
 --------------------------------------------------
-// TESTRESPONSE[s/FklQYndoTDJ2VEFlMEVBTzFJMGhJVFEaLVlKYndBWWZSMUdicUc4WVlEaFl4ZzoxNTU=/$body.id/]
-// TESTRESPONSE[s/"is_partial": true/"is_partial": $body.is_partial/]
-// TESTRESPONSE[s/"is_running": true/"is_running": $body.is_running/]
-// TESTRESPONSE[s/1685563581380/$body.start_time_in_millis/]
-// TESTRESPONSE[s/1685995581380/$body.expiration_time_in_millis/]
-// TESTRESPONSE[s/"response"/"completion_time_in_millis": $body.completion_time_in_millis,\n  "response"/]
-// TESTRESPONSE[s/"max_score": null/"max_score": "$body.response.hits.max_score"/]
-// TESTRESPONSE[s/\d+/$body.$_path/]
-// TESTRESPONSE[s/"hits": \[\]/"hits": $body.response.hits.hits/]
+// TEST[skip: hard to reproduce intermediate results]
+
 
 <1> All shards from all clusters in scope for the search are listed here. Watch this
-section for updates to monitor search progress.
+section and/or the _clusters section for updates to monitor search progress.
 <2> The `_clusters` section shows that shard information was successfully
-gathered from all 3 clusters and that all will be searched (none are being skipped).
+gathered from all 3 clusters and the total shard count on each cluster is listed.
+
+
 
 
 [discrete]
 [[skip-unavailable-clusters]]
 === Optional remote clusters
 
-By default, a {ccs} fails if a remote cluster in the request returns an
-error or is unavailable. Use the `skip_unavailable` cluster
-setting to mark a specific remote cluster as optional for {ccs}.
+By default, a {ccs} fails if a remote cluster in the request is unavailable
+or returns an error where the search on all shards failed. Use the
+`skip_unavailable` cluster setting to mark a specific remote cluster as
+optional for {ccs}.
 
 If `skip_unavailable` is `true`, a {ccs}:
 
 * Skips the remote cluster if its nodes are unavailable during the search. The
-response's `_cluster.skipped` value contains a count of any skipped clusters.
+response's `_clusters.skipped` value contains a count of any skipped clusters
+and the `_clusters.details` section of the response will show a `skipped` status.
 
 * Ignores errors returned by the remote cluster, such as errors related to
 unavailable shards or indices. This can include errors related to search
@@ -724,7 +1142,7 @@ when searching the remote cluster. This means searches on the remote cluster may
 return partial results.
 
 The following <<cluster-update-settings,cluster update settings>>
-API request changes `cluster_two`'s `skip_unavailable` setting to `true`.
+API request changes `skip_unavailable` setting to `true` for `cluster_two`.
 
 [source,console]
 --------------------------------
@@ -738,7 +1156,10 @@ PUT _cluster/settings
 // TEST[continued]
 
 If `cluster_two` is disconnected or unavailable during a {ccs}, {es} won't
-include matching documents from that cluster in the final results.
+include matching documents from that cluster in the final results. If at
+least one shard provides results, those results will be used and the
+search will return partial data. (If doing {ccs} using async search,
+the `is_partial` field will be set to `true` to indicate partial results.)
 
 [discrete]
 [[ccs-network-delays]]

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -945,7 +945,7 @@ use `*` in the index position or an error will be returned.
 To exclude a specific remote index, you would put the minus sign in front
 of the index, such as `mycluster:-myindex`.
 
-==== Exclude a remote cluster
+*Exclude a remote cluster*
 
 Here's how you would exclude `cluster_three` from a
 {ccs} that uses a wildcard to specify a list of clusters:
@@ -971,7 +971,7 @@ the index position. This indicates that you do not want the search to make any c
 `cluster_three`.
 
 
-==== Exclude a remote index
+*Exclude a remote index*
 
 Suppose you want to search all indices matching `my-index-*` but you want to exclude
 `my-index-000001` on `cluster_three`. Here's how you could do that:

--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
@@ -199,21 +198,10 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
             }
 
             {
-                SearchRequest searchRequest = new SearchRequest("index", "remote1:index").scroll("1m");
-                searchRequest.setCcsMinimizeRoundtrips(false);
                 SearchResponse response = restHighLevelClient.search(
-                    searchRequest,
+                    new SearchRequest("index", "remote1:index").scroll("1m"),
                     RequestOptions.DEFAULT
                 );
-                System.err.println("PPP response.getClusters(): " + response.getClusters());
-                AtomicReference<SearchResponse.Cluster> local = response.getClusters().getCluster("");
-                AtomicReference<SearchResponse.Cluster> remote = response.getClusters().getCluster("remote1");
-                if (local != null) {
-                    System.err.println("PPP local cluster: " + local.get());
-                }
-                if (remote != null) {
-                    System.err.println("PPP remote cluster: " + remote.get());
-                }
                 assertEquals(2, response.getClusters().getTotal());
                 assertEquals(2, response.getClusters().getSuccessful());
                 assertEquals(0, response.getClusters().getSkipped());
@@ -375,7 +363,6 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                     {
                         for (Map.Entry<String, Object> entry : settings.entrySet()) {
                             builder.field(entry.getKey(), entry.getValue());
-                            System.err.println("PPP remote1 settings: key: " + entry.getKey() + "; value: " + entry.getValue());
                         }
                     }
                     builder.endObject();

--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
@@ -198,10 +199,21 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
             }
 
             {
+                SearchRequest searchRequest = new SearchRequest("index", "remote1:index").scroll("1m");
+                searchRequest.setCcsMinimizeRoundtrips(false);
                 SearchResponse response = restHighLevelClient.search(
-                    new SearchRequest("index", "remote1:index").scroll("1m"),
+                    searchRequest,
                     RequestOptions.DEFAULT
                 );
+                System.err.println("PPP response.getClusters(): " + response.getClusters());
+                AtomicReference<SearchResponse.Cluster> local = response.getClusters().getCluster("");
+                AtomicReference<SearchResponse.Cluster> remote = response.getClusters().getCluster("remote1");
+                if (local != null) {
+                    System.err.println("PPP local cluster: " + local.get());
+                }
+                if (remote != null) {
+                    System.err.println("PPP remote cluster: " + remote.get());
+                }
                 assertEquals(2, response.getClusters().getTotal());
                 assertEquals(2, response.getClusters().getSuccessful());
                 assertEquals(0, response.getClusters().getSkipped());
@@ -363,6 +375,7 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                     {
                         for (Map.Entry<String, Object> entry : settings.entrySet()) {
                             builder.field(entry.getKey(), entry.getValue());
+                            System.err.println("PPP remote1 settings: key: " + entry.getKey() + "; value: " + entry.getValue());
                         }
                     }
                     builder.endObject();

--- a/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
+++ b/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
@@ -1075,7 +1075,6 @@ public class CCSDuelIT extends ESRestTestCase {
             assertEquals(clustersMRT.getSuccessful(), clustersMRTFalse.getSuccessful());
             assertEquals(clustersMRT.getSkipped(), clustersMRTFalse.getSkipped());
 
-            boolean removeSkipped = searchRequest.source().collapse() != null;
             Map<String, Object> minimizeRoundtripsResponseMap = responseToMap(minimizeRoundtripsSearchResponse);
             if (clustersMRT.hasClusterObjects() && clustersMRTFalse.hasClusterObjects()) {
                 Map<String, Object> fanOutResponseMap = responseToMap(fanOutSearchResponse);
@@ -1148,7 +1147,6 @@ public class CCSDuelIT extends ESRestTestCase {
         assertEquals(clustersMRT.getSuccessful(), clustersMRTFalse.getSuccessful());
         assertEquals(clustersMRT.getSkipped(), clustersMRTFalse.getSkipped());
 
-        boolean removeSkipped = searchRequest.source().collapse() != null;
         Map<String, Object> minimizeRoundtripsResponseMap = responseToMap(minimizeRoundtripsSearchResponse);
         if (clustersMRT.hasClusterObjects() && clustersMRTFalse.hasClusterObjects()) {
             Map<String, Object> fanOutResponseMap = responseToMap(fanOutSearchResponse);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/CCSPointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/CCSPointInTimeIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
@@ -23,13 +24,10 @@ import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.transport.RemoteClusterAware;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -49,8 +47,7 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
-        List<Class<? extends Plugin>> plugs = Arrays.asList(CrossClusterSearchIT.TestQueryBuilderPlugin.class);
-        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+        return CollectionUtils.appendToCopy(super.nodePlugins(clusterAlias), CrossClusterSearchIT.TestQueryBuilderPlugin.class);
     }
 
     public static class TestQueryBuilderPlugin extends Plugin implements SearchPlugin {
@@ -117,7 +114,6 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
 
             if (includeLocalIndex) {
                 AtomicReference<SearchResponse.Cluster> localClusterRef = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                assertNotNull(localClusterRef);
                 assertNotNull(localClusterRef);
                 SearchResponse.Cluster localCluster = localClusterRef.get();
                 assertThat(localCluster.getTotalShards(), equalTo(1));
@@ -191,7 +187,6 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
 
             if (includeLocalIndex) {
                 AtomicReference<SearchResponse.Cluster> localClusterRef = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                assertNotNull(localClusterRef);
                 assertNotNull(localClusterRef);
                 SearchResponse.Cluster localCluster = localClusterRef.get();
                 assertThat(localCluster.getTotalShards(), equalTo(numShards));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/CCSPointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/CCSPointInTimeIT.java
@@ -8,25 +8,62 @@
 
 package org.elasticsearch.action.search;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.ccs.CrossClusterSearchIT;
+import org.elasticsearch.search.query.ThrowingQueryBuilder;
 import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
 
+    public static final String REMOTE_CLUSTER = "remote_cluster";
+
     @Override
     protected Collection<String> remoteClusterAlias() {
-        return List.of("remote_cluster");
+        return List.of(REMOTE_CLUSTER);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        List<Class<? extends Plugin>> plugs = Arrays.asList(CrossClusterSearchIT.TestQueryBuilderPlugin.class);
+        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+    }
+
+    public static class TestQueryBuilderPlugin extends Plugin implements SearchPlugin {
+        public TestQueryBuilderPlugin() {}
+
+        @Override
+        public List<QuerySpec<?>> getQueries() {
+            QuerySpec<ThrowingQueryBuilder> throwingSpec = new QuerySpec<>(ThrowingQueryBuilder.NAME, ThrowingQueryBuilder::new, p -> {
+                throw new IllegalStateException("not implemented");
+            });
+
+            return List.of(throwingSpec);
+        }
     }
 
     void indexDocs(Client client, String index, int numDocs) {
@@ -39,7 +76,7 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
 
     public void testBasic() {
         final Client localClient = client(LOCAL_CLUSTER);
-        final Client remoteClient = client("remote_cluster");
+        final Client remoteClient = client(REMOTE_CLUSTER);
         int localNumDocs = randomIntBetween(10, 50);
         assertAcked(localClient.admin().indices().prepareCreate("local_test"));
         indexDocs(localClient, "local_test", localNumDocs);
@@ -71,6 +108,114 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
                 .get();
             assertNoFailures(resp);
             assertHitCount(resp, (includeLocalIndex ? localNumDocs : 0) + remoteNumDocs);
+
+            SearchResponse.Clusters clusters = resp.getClusters();
+            int expectedNumClusters = 1 + (includeLocalIndex ? 1 : 0);
+            assertThat(clusters.getTotal(), equalTo(expectedNumClusters));
+            assertThat(clusters.getSuccessful(), equalTo(expectedNumClusters));
+            assertThat(clusters.getSkipped(), equalTo(0));
+
+            if (includeLocalIndex) {
+                AtomicReference<SearchResponse.Cluster> localClusterRef = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+                assertNotNull(localClusterRef);
+                assertNotNull(localClusterRef);
+                SearchResponse.Cluster localCluster = localClusterRef.get();
+                assertThat(localCluster.getTotalShards(), equalTo(1));
+                assertThat(localCluster.getSuccessfulShards(), equalTo(1));
+                assertThat(localCluster.getFailedShards(), equalTo(0));
+                assertThat(localCluster.getFailures().size(), equalTo(0));
+                assertThat(localCluster.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
+                assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+                assertFalse(localCluster.isTimedOut());
+            }
+
+            AtomicReference<SearchResponse.Cluster> remoteClusterRef = clusters.getCluster(REMOTE_CLUSTER);
+            assertNotNull(remoteClusterRef);
+            SearchResponse.Cluster remoteCluster = remoteClusterRef.get();
+            assertThat(remoteCluster.getTotalShards(), equalTo(1));
+            assertThat(remoteCluster.getSuccessfulShards(), equalTo(1));
+            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(0));
+            assertThat(remoteCluster.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
+            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+            assertFalse(remoteCluster.isTimedOut());
+
+        } finally {
+            closePointInTime(pitId);
+        }
+    }
+
+    public void testFailuresOnOneShardsWithPointInTime() throws ExecutionException, InterruptedException {
+        final Client localClient = client(LOCAL_CLUSTER);
+        final Client remoteClient = client(REMOTE_CLUSTER);
+        int localNumDocs = randomIntBetween(10, 50);
+        int numShards = randomIntBetween(2, 4);
+        Settings clusterSettings = indexSettings(numShards, randomIntBetween(0, 1)).build();
+        assertAcked(localClient.admin().indices().prepareCreate("local_test").setSettings(clusterSettings));
+        indexDocs(localClient, "local_test", localNumDocs);
+
+        int remoteNumDocs = randomIntBetween(10, 50);
+        assertAcked(remoteClient.admin().indices().prepareCreate("remote_test").setSettings(clusterSettings));
+        indexDocs(remoteClient, "remote_test", remoteNumDocs);
+        boolean includeLocalIndex = randomBoolean();
+        List<String> indices = new ArrayList<>();
+        if (includeLocalIndex) {
+            indices.add(randomFrom("*", "local_*", "local_test"));
+        }
+        indices.add(randomFrom("*:*", "remote_cluster:*", "remote_cluster:remote_test"));
+        String pitId = openPointInTime(indices.toArray(new String[0]), TimeValue.timeValueMinutes(2));
+        try {
+            if (randomBoolean()) {
+                localClient.prepareIndex("local_test").setId("local_new").setSource().get();
+                localClient.admin().indices().prepareRefresh().get();
+            }
+            if (randomBoolean()) {
+                remoteClient.prepareIndex("remote_test").setId("remote_new").setSource().get();
+                remoteClient.admin().indices().prepareRefresh().get();
+            }
+            PlainActionFuture<SearchResponse> queryFuture = new PlainActionFuture<>();
+
+            // shardId 0 means to throw the Exception only on shard 0; all others should work
+            ThrowingQueryBuilder queryBuilder = new ThrowingQueryBuilder(randomLong(), new IllegalStateException("index corrupted"), 0);
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10).pointInTimeBuilder(new PointInTimeBuilder(pitId)));
+            client(LOCAL_CLUSTER).search(searchRequest, queryFuture);
+
+            SearchResponse searchResponse = queryFuture.get();
+
+            SearchResponse.Clusters clusters = searchResponse.getClusters();
+            int expectedNumClusters = 1 + (includeLocalIndex ? 1 : 0);
+            assertThat(clusters.getTotal(), equalTo(expectedNumClusters));
+            assertThat(clusters.getSuccessful(), equalTo(expectedNumClusters));
+            assertThat(clusters.getSkipped(), equalTo(0));
+
+            if (includeLocalIndex) {
+                AtomicReference<SearchResponse.Cluster> localClusterRef = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+                assertNotNull(localClusterRef);
+                assertNotNull(localClusterRef);
+                SearchResponse.Cluster localCluster = localClusterRef.get();
+                assertThat(localCluster.getTotalShards(), equalTo(numShards));
+                assertThat(localCluster.getSuccessfulShards(), equalTo(numShards - 1));
+                assertThat(localCluster.getFailedShards(), equalTo(1));
+                assertThat(localCluster.getFailures().size(), equalTo(1));
+                assertThat(localCluster.getFailures().get(0).reason(), containsString("index corrupted"));
+                assertThat(localCluster.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
+                assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+                assertFalse(localCluster.isTimedOut());
+            }
+
+            AtomicReference<SearchResponse.Cluster> remoteClusterRef = clusters.getCluster(REMOTE_CLUSTER);
+            assertNotNull(remoteClusterRef);
+            SearchResponse.Cluster remoteCluster = remoteClusterRef.get();
+            assertThat(remoteCluster.getTotalShards(), equalTo(numShards));
+            assertThat(remoteCluster.getSuccessfulShards(), equalTo(numShards - 1));
+            assertThat(remoteCluster.getFailedShards(), equalTo(1));
+            assertThat(remoteCluster.getFailures().size(), equalTo(1));
+            assertThat(remoteCluster.getFailures().get(0).reason(), containsString("index corrupted"));
+            assertThat(remoteCluster.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
+            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+            assertFalse(remoteCluster.isTimedOut());
+
         } finally {
             closePointInTime(pitId);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchProgressActionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchProgressActionListenerIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.TaskId;
@@ -109,14 +110,15 @@ public class SearchProgressActionListenerIT extends ESSingleNodeTestCase {
                 List<SearchShard> searchShards,
                 List<SearchShard> skippedShards,
                 SearchResponse.Clusters clusters,
-                boolean fetchPhase
+                boolean fetchPhase,
+                TransportSearchAction.SearchTimeProvider timeProvider
             ) {
                 shardsListener.set(searchShards);
                 assertEquals(fetchPhase, hasFetchPhase);
             }
 
             @Override
-            public void onQueryResult(int shardIndex) {
+            public void onQueryResult(int shardIndex, QuerySearchResult result) {
                 assertThat(shardIndex, lessThan(shardsListener.get().size()));
                 numQueryResults.incrementAndGet();
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -400,8 +400,8 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         }
 
         TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
-        // query builder that will sleep for the specified amount of time in the query phase but only on the remote Index
-        SlowRunningQueryBuilder slowRunningQueryBuilder = new SlowRunningQueryBuilder(searchTimeout.millis() * 5, remoteIndex);
+        // query builder that will sleep for the specified amount of time in the query phase
+        SlowRunningQueryBuilder slowRunningQueryBuilder = new SlowRunningQueryBuilder(searchTimeout.millis() * 5);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(slowRunningQueryBuilder).timeout(searchTimeout);
         searchRequest.source(sourceBuilder);
         client(LOCAL_CLUSTER).search(searchRequest, queryFuture);
@@ -416,7 +416,7 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
         SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
         assertNotNull(localClusterSearchInfo);
-        assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.SUCCESSFUL));
+        assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));
         assertThat(localClusterSearchInfo.getIndexExpression(), equalTo(localIndex));
         assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
         assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(localNumShards));
@@ -424,7 +424,7 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         assertThat(localClusterSearchInfo.getFailedShards(), equalTo(0));
         assertThat(localClusterSearchInfo.getFailures().size(), equalTo(0));
         assertThat(localClusterSearchInfo.getTook().millis(), greaterThanOrEqualTo(0L));
-        assertFalse(localClusterSearchInfo.isTimedOut());
+        assertTrue(localClusterSearchInfo.isTimedOut());
 
         SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
         assertNotNull(remoteClusterSearchInfo);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -612,15 +611,11 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         int numShardsRemote = randomIntBetween(2, 10);
         final InternalTestCluster remoteCluster = cluster(REMOTE_CLUSTER);
         remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
-        final Settings.Builder remoteSettings = Settings.builder();
-        remoteSettings.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShardsRemote);
-        remoteSettings.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 1));
-
         assertAcked(
             client(REMOTE_CLUSTER).admin()
                 .indices()
                 .prepareCreate(remoteIndex)
-                .setSettings(Settings.builder().put(remoteSettings.build()))
+                .setSettings(indexSettings(numShardsRemote, randomIntBetween(0, 1)))
                 .setMapping("@timestamp", "type=date", "f", "type=text")
         );
         assertFalse(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -32,15 +33,12 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteTransportException;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
@@ -72,8 +70,7 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
-        List<Class<? extends Plugin>> plugs = Arrays.asList(TestQueryBuilderPlugin.class);
-        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+        return CollectionUtils.appendToCopy(super.nodePlugins(clusterAlias), CrossClusterSearchIT.TestQueryBuilderPlugin.class);
     }
 
     public static class TestQueryBuilderPlugin extends Plugin implements SearchPlugin {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -175,7 +175,6 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         if (dfs) {
             searchRequest.searchType(SearchType.DFS_QUERY_THEN_FETCH);
         }
-        System.err.println("dfs: " + dfs);
         if (randomBoolean()) {
             searchRequest.setPreFilterShardSize(1);
         }
@@ -186,11 +185,8 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         searchRequest.source(new SearchSourceBuilder().query(rangeQueryBuilder).size(10));
         client(LOCAL_CLUSTER).search(searchRequest, queryFuture);
 
-        System.err.println("minimizeRoundtrips: " + minimizeRoundtrips);
-
         SearchResponse searchResponse = queryFuture.get();
         assertNotNull(searchResponse);
-        System.err.println(searchResponse);
 
         SearchResponse.Clusters clusters = searchResponse.getClusters();
         assertFalse("search cluster results should NOT be marked as partial", clusters.hasPartialResults());
@@ -321,9 +317,6 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         );
         searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10));
         client(LOCAL_CLUSTER).search(searchRequest, queryFuture);
-
-        System.err.println("skipUnavailable: " + skipUnavailable);
-        System.err.println("minimize_roundtrips: " + minimizeRoundtrips);
 
         assertBusy(() -> assertTrue(queryFuture.isDone()));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -557,7 +557,6 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         }
     }
 
-    /// MP TODO use this
     private static void assertOneFailedShard(SearchResponse.Cluster cluster, int totalShards) {
         assertNotNull(cluster);
         assertThat(cluster.getStatus(), equalTo(SearchResponse.Cluster.Status.PARTIAL));

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -181,6 +181,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_065 = registerTransportVersion(8_500_065, "4e253c58-1b3d-11ee-be56-0242ac120002");
     public static final TransportVersion V_8_500_066 = registerTransportVersion(8_500_066, "F398ECC6-5D2A-4BD8-A9E8-1101F030DF85");
 
+    public static final TransportVersion V_8_500_067 = registerTransportVersion(8_500_067, "a7c86604-a917-4aff-9a1b-a4d44c3dbe02");
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _
@@ -203,7 +204,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
      */
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_066);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_067);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -177,7 +177,8 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
             SearchProgressListener.buildSearchShards(this.shardsIts),
             SearchProgressListener.buildSearchShards(toSkipShardsIts),
             clusters,
-            sourceBuilder == null || sourceBuilder.size() > 0
+            sourceBuilder == null || sourceBuilder.size() > 0,
+            timeProvider
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/CCSSingleCoordinatorSearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CCSSingleCoordinatorSearchProgressListener.java
@@ -9,13 +9,13 @@
 package org.elasticsearch.action.search;
 
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.transport.RemoteClusterAware;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -167,10 +167,8 @@ public class CCSSingleCoordinatorSearchProgressListener extends SearchProgressLi
                 took = new TimeValue(timeProvider.buildTookInMillis());
             }
 
-            List<ShardSearchFailure> failures = new ArrayList<>();
-            failures.addAll(curr.getFailures());
-            failures.add(new ShardSearchFailure(e, shardTarget));
-
+            // creates a new unmodifiable list
+            List<ShardSearchFailure> failures = CollectionUtils.appendToCopy(curr.getFailures(), new ShardSearchFailure(e, shardTarget));
             SearchResponse.Cluster updated = new SearchResponse.Cluster.Builder(curr).setStatus(status)
                 .setFailedShards(numFailedShards)
                 .setFailures(failures)

--- a/server/src/main/java/org/elasticsearch/action/search/CCSSingleCoordinatorSearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CCSSingleCoordinatorSearchProgressListener.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.search;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.transport.RemoteClusterAware;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Use this progress listener for cross-cluster searches where a single
+ * coordinator is used for all clusters (minimize_roundtrips=false).
+ * It updates state in the SearchResponse.Clusters object as the search
+ * progresses so that the metadata required for the _clusters/details
+ * section in the SearchResponse is accurate.
+ */
+public class CCSSingleCoordinatorSearchProgressListener extends SearchProgressListener {
+
+    private static final Logger logger = LogManager.getLogger(CCSSingleCoordinatorSearchProgressListener.class);
+    private SearchResponse.Clusters clusters;
+    private TransportSearchAction.SearchTimeProvider timeProvider;
+
+    /**
+     * Executed when shards are ready to be queried (after can-match)
+     *
+     * @param shards The list of shards to query.
+     * @param skipped The list of skipped shards.
+     * @param clusters The statistics for remote clusters included in the search.
+     * @param fetchPhase <code>true</code> if the search needs a fetch phase, <code>false</code> otherwise.
+     **/
+    @Override
+    public void onListShards(
+        List<SearchShard> shards,
+        List<SearchShard> skipped,
+        SearchResponse.Clusters clusters,
+        boolean fetchPhase,
+        TransportSearchAction.SearchTimeProvider timeProvider
+    ) {
+        logger.warn("XXX SSS CCSProgListener onListShards: shards size: {}; shards: {}", shards.size(), shards);
+        logger.warn("XXX SSS CCSProgListener onListShards: skipped size: {}; skipped: {}", skipped.size(), skipped);
+        logger.warn("XXX SSS CCSProgListener onListShards: clusters: {}", clusters);
+        logger.warn("XXX SSS CCSProgListener onListShards: fetchPhase: {}", fetchPhase);
+        assert clusters.isCcsMinimizeRoundtrips() == false : "minimize_roundtrips must be false to use this SearchListener";
+
+        this.clusters = clusters;
+        this.timeProvider = timeProvider;
+
+        // Partition by clusterAlias and get counts
+        Map<String, Integer> totalByClusterAlias = Stream.concat(shards.stream(), skipped.stream()).collect(Collectors.groupingBy(shard -> {
+            String clusterAlias = shard.clusterAlias();
+            return clusterAlias != null ? clusterAlias : RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        }, Collectors.reducing(0, e -> 1, Integer::sum)));
+        Map<String, Integer> skippedByClusterAlias = skipped.stream().collect(Collectors.groupingBy(shard -> {
+            String clusterAlias = shard.clusterAlias();
+            return clusterAlias != null ? clusterAlias : RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        }, Collectors.reducing(0, e -> 1, Integer::sum)));
+
+        for (Map.Entry<String, Integer> entry : totalByClusterAlias.entrySet()) {
+            String clusterAlias = entry.getKey();
+            AtomicReference<SearchResponse.Cluster> clusterRef = clusters.getCluster(clusterAlias);
+            assert clusterRef.get().getTotalShards() == null : "total shards should not be set on a Cluster before onListShards";
+
+            Integer totalCount = entry.getValue();
+            Integer skippedCount = skippedByClusterAlias.get(clusterAlias);
+            if (skippedCount == null) {
+                skippedCount = 0;
+            }
+            TimeValue took = null;
+
+            System.err.println("XXX SSS CCSProgListener onListShards totalCount for " + clusterAlias + " = " + totalCount);
+            System.err.println("XXX SSS CCSProgListener onListShards skippedCount for " + clusterAlias + " = " + skippedCount);
+
+            boolean swapped;
+            do {
+                SearchResponse.Cluster curr = clusterRef.get();
+                SearchResponse.Cluster.Status status = curr.getStatus();
+                assert status == SearchResponse.Cluster.Status.RUNNING : "should have RUNNING status during onListShards but has " + status;
+                if (skippedCount != null && skippedCount == totalCount) {
+                    took = new TimeValue(timeProvider.buildTookInMillis());
+                    status = SearchResponse.Cluster.Status.SUCCESSFUL;
+                }
+                SearchResponse.Cluster updated = new SearchResponse.Cluster(
+                    curr.getClusterAlias(),
+                    curr.getIndexExpression(),
+                    curr.isSkipUnavailable(),
+                    status,
+                    totalCount,
+                    skippedCount,
+                    skippedCount,
+                    0,
+                    curr.getFailures(),
+                    took,
+                    false
+                );
+                swapped = clusterRef.compareAndSet(curr, updated);
+                assert swapped : "compareAndSet in onListShards should never fail due to race condition";
+                logger.warn("XXX SSS CCSProgListener onListShards DEBUG 66 swapped: {} ;; new cluster: {}", swapped, updated);
+            } while (swapped == false);
+        }
+    }
+
+    /**
+     * Executed when a shard returns a query result.
+     *
+     * @param shardIndex  The index of the shard in the list provided by {@link SearchProgressListener#onListShards} )}.
+     * @param queryResult QuerySearchResult holding the result for a SearchShardTarget
+     */
+    @Override
+    public void onQueryResult(int shardIndex, QuerySearchResult queryResult) {
+        // logger.warn("XXX __Q__ CCSProgListener onQueryResult for : {}", queryResult.getSearchShardTarget());
+        if (queryResult.searchTimedOut() && clusters.hasClusterObjects()) {
+            logger.warn("XXX __Q__ CCSProgListener onQueryResult TIMED_OUT on target: {}", queryResult.getSearchShardTarget());
+            SearchShardTarget shardTarget = queryResult.getSearchShardTarget();
+            String clusterAlias = shardTarget.getClusterAlias();
+            if (clusterAlias == null) {
+                clusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            }
+            AtomicReference<SearchResponse.Cluster> clusterRef = clusters.getCluster(clusterAlias);
+            boolean swapped;
+            do {
+                SearchResponse.Cluster curr = clusterRef.get();
+                if (curr.isTimedOut()) {
+                    break; // already marked as timed out on some other shard
+                }
+                if (curr.getStatus() == SearchResponse.Cluster.Status.FAILED || curr.getStatus() == SearchResponse.Cluster.Status.SKIPPED) {
+                    break; // safety check to make sure it hasn't hit a terminal FAILED/SKIPPED state where timeouts don't matter
+                }
+                SearchResponse.Cluster updated = new SearchResponse.Cluster(
+                    curr.getClusterAlias(),
+                    curr.getIndexExpression(),
+                    curr.isSkipUnavailable(),
+                    curr.getStatus(),
+                    curr.getTotalShards(),
+                    curr.getSuccessfulShards(),
+                    curr.getSkippedShards(),
+                    curr.getFailedShards(),
+                    curr.getFailures(),
+                    curr.getTook(),
+                    true
+                );
+                swapped = clusterRef.compareAndSet(curr, updated);
+                logger.warn("XXX __Q__ onQueryResult swapped: {} ;; new cluster: {}", swapped, updated);
+            } while (swapped == false);
+        }
+    }
+
+    /**
+     * Executed when a shard reports a query failure.
+     *
+     * @param shardIndex The index of the shard in the list provided by {@link SearchProgressListener#onListShards})}.
+     * @param shardTarget The last shard target that thrown an exception.
+     * @param e The cause of the failure.
+     */
+    @Override
+    public void onQueryFailure(int shardIndex, SearchShardTarget shardTarget, Exception e) {
+        // logger.warn("XXX __L__ CCSProgListener onQueryFailure shardTarget: {}; exc: {}", shardTarget, e);
+
+        if (clusters.hasClusterObjects() == false) {
+            return;
+        }
+        String clusterAlias = shardTarget.getClusterAlias();
+        if (clusterAlias == null) {
+            clusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        }
+        AtomicReference<SearchResponse.Cluster> clusterRef = clusters.getCluster(clusterAlias);
+        boolean swapped;
+        do {
+            TimeValue took = null;
+            SearchResponse.Cluster curr = clusterRef.get();
+            SearchResponse.Cluster.Status status = SearchResponse.Cluster.Status.RUNNING;
+            int numFailedShards = curr.getFailedShards() == null ? 1 : curr.getFailedShards() + 1;
+
+            assert curr.getTotalShards() != null : "total shards should be set on the Cluster but not for " + clusterAlias;
+            if (curr.getTotalShards() == numFailedShards) {
+                if (curr.isSkipUnavailable()) {
+                    logger.warn("XXX __L__ onQueryFailure SETTING SKIPPED status bcs total=failed_shards; skipun=true !");
+                    status = SearchResponse.Cluster.Status.SKIPPED;
+                } else {
+                    logger.warn("XXX __L__ onQueryFailure SETTING FAILED status bcs total=failed_shards; skipun=false !");
+                    status = SearchResponse.Cluster.Status.FAILED;
+                    // TODO in the fail-fast ticket, should we throw an exception here to stop the search?
+                }
+            } else if (curr.getTotalShards() == numFailedShards + curr.getSuccessfulShards()) {
+                status = SearchResponse.Cluster.Status.PARTIAL;
+                took = new TimeValue(timeProvider.buildTookInMillis());
+            }
+
+            List<ShardSearchFailure> failures = new ArrayList<>();
+            curr.getFailures().forEach(failures::add);
+            failures.add(new ShardSearchFailure(e, shardTarget));
+            SearchResponse.Cluster updated = new SearchResponse.Cluster(
+                curr.getClusterAlias(),
+                curr.getIndexExpression(),
+                curr.isSkipUnavailable(),
+                status,
+                curr.getTotalShards(),
+                curr.getSuccessfulShards(),
+                curr.getSkippedShards(),
+                numFailedShards,
+                failures,
+                took,
+                curr.isTimedOut()
+            );
+            swapped = clusterRef.compareAndSet(curr, updated);
+            logger.warn("XXX __L__ onQueryFailure swapped: {} ;;;; new cluster: {}", swapped, updated);
+        } while (swapped == false);
+    }
+
+    /**
+     * Executed when a partial reduce is created. The number of partial reduce can be controlled via
+     * {@link SearchRequest#setBatchedReduceSize(int)}.
+     *
+     * @param shards The list of shards that are part of this reduce.
+     * @param totalHits The total number of hits in this reduce.
+     * @param aggs The partial result for aggregations.
+     * @param reducePhase The version number for this reduce.
+     */
+    @Override
+    public void onPartialReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggs, int reducePhase) {
+        // logger.warn(
+        // "XXX __P__ CCSProgListener onPartialReduce. shards {}, totalHits: {}; reducePhase: {}",
+        // shards,
+        // totalHits.value,
+        // reducePhase
+        // );
+
+        Map<String, Integer> totalByClusterAlias = shards.stream().collect(Collectors.groupingBy(shard -> {
+            String clusterAlias = shard.clusterAlias();
+            return clusterAlias != null ? clusterAlias : RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        }, Collectors.reducing(0, e -> 1, Integer::sum)));
+
+        System.err.println("XXX __P__ CCSProgListener onPartialReduce: " + totalByClusterAlias);
+        for (Map.Entry<String, Integer> entry : totalByClusterAlias.entrySet()) {
+            String clusterAlias = entry.getKey();
+            int successfulCount = entry.getValue().intValue();
+
+            AtomicReference<SearchResponse.Cluster> clusterRef = clusters.getCluster(clusterAlias);
+            boolean swapped;
+            do {
+                SearchResponse.Cluster curr = clusterRef.get();
+                SearchResponse.Cluster.Status status = curr.getStatus();
+                if (status != SearchResponse.Cluster.Status.RUNNING) {
+                    // don't swap in a new Cluster if the final state has already been set
+                    break;
+                }
+                TimeValue took = null;
+                int successfulShards = successfulCount + curr.getSkippedShards();
+                if (successfulShards == curr.getTotalShards()) {
+                    status = curr.isTimedOut() ? SearchResponse.Cluster.Status.PARTIAL : SearchResponse.Cluster.Status.SUCCESSFUL;
+                    took = new TimeValue(timeProvider.buildTookInMillis());
+                } else if (successfulShards + curr.getFailedShards() == curr.getTotalShards()) {
+                    status = SearchResponse.Cluster.Status.PARTIAL;
+                    took = new TimeValue(timeProvider.buildTookInMillis());
+                }
+                SearchResponse.Cluster updated = new SearchResponse.Cluster(
+                    curr.getClusterAlias(),
+                    curr.getIndexExpression(),
+                    curr.isSkipUnavailable(),
+                    status,
+                    curr.getTotalShards(),
+                    successfulShards,
+                    curr.getSkippedShards(),
+                    curr.getFailedShards(),
+                    curr.getFailures(),
+                    took,
+                    curr.isTimedOut()
+                );
+                swapped = clusterRef.compareAndSet(curr, updated);
+                logger.warn("XXX __P__ DEBUG 33 onPartialReduce swapped: {} ;; new cluster: {}", updated);
+            } while (swapped == false);
+        }
+    }
+
+    /**
+     * Executed once when the final reduce is created.
+     *
+     * @param shards The list of shards that are part of this reduce.
+     * @param totalHits The total number of hits in this reduce.
+     * @param aggs The final result for aggregations.
+     * @param reducePhase The version number for this reduce.
+     */
+    @Override
+    public void onFinalReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggs, int reducePhase) {
+        // logger.warn(
+        // "XXX __L__ CCSProgListener onFinalReduce. shards {}, totalHits: {}; reducePhase: {}",
+        // shards,
+        // totalHits.value,
+        // reducePhase
+        // );
+
+        if (clusters.hasClusterObjects() == false) {
+            return;
+        }
+
+        Map<String, Integer> totalByClusterAlias = shards.stream().collect(Collectors.groupingBy(shard -> {
+            String clusterAlias = shard.clusterAlias();
+            return clusterAlias != null ? clusterAlias : RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        }, Collectors.reducing(0, e -> 1, Integer::sum)));
+
+        System.err.println("XXX __L__ CCSProgListener onFinalReduce: " + totalByClusterAlias);
+        for (Map.Entry<String, Integer> entry : totalByClusterAlias.entrySet()) {
+            String clusterAlias = entry.getKey();
+            int successfulCount = entry.getValue().intValue();
+
+            AtomicReference<SearchResponse.Cluster> clusterRef = clusters.getCluster(clusterAlias);
+            boolean swapped;
+            do {
+                SearchResponse.Cluster curr = clusterRef.get();
+                SearchResponse.Cluster.Status status = curr.getStatus();
+                if (status != SearchResponse.Cluster.Status.RUNNING) {
+                    // don't swap in a new Cluster if the final state has already been set
+                    break;
+                }
+                TimeValue took = new TimeValue(timeProvider.buildTookInMillis());
+                int successfulShards = successfulCount + curr.getSkippedShards();
+                assert successfulShards + curr.getFailedShards() == curr.getTotalShards()
+                    : "successfulShards("
+                        + successfulShards
+                        + ") + failedShards("
+                        + curr.getFailedShards()
+                        + ") != totalShards ("
+                        + curr.getTotalShards()
+                        + ')';
+                if (curr.isTimedOut() || successfulShards < curr.getTotalShards()) {
+                    status = SearchResponse.Cluster.Status.PARTIAL;
+                } else {
+                    assert successfulShards == curr.getTotalShards()
+                        : "successful (" + successfulShards + ") should equal total(" + curr.getTotalShards() + ") if get here";
+                    status = SearchResponse.Cluster.Status.SUCCESSFUL;
+                }
+                SearchResponse.Cluster updated = new SearchResponse.Cluster(
+                    curr.getClusterAlias(),
+                    curr.getIndexExpression(),
+                    curr.isSkipUnavailable(),
+                    status,
+                    curr.getTotalShards(),
+                    successfulShards,
+                    curr.getSkippedShards(),
+                    curr.getFailedShards(),
+                    curr.getFailures(),
+                    took,
+                    curr.isTimedOut()
+                );
+                swapped = clusterRef.compareAndSet(curr, updated);
+                logger.warn("XXX __L__ DEBUG 44 onFinalReduce swapped: {} ;; new cluster: {}", updated);
+            } while (swapped == false);
+        }
+    }
+
+    /**
+     * Executed when a shard returns a fetch result.
+     *
+     * @param shardIndex The index of the shard in the list provided by {@link SearchProgressListener#onListShards})}.
+     */
+    @Override
+    public void onFetchResult(int shardIndex) {}
+
+    /**
+     * Executed when a shard reports a fetch failure.
+     *
+     * @param shardIndex The index of the shard in the list provided by {@link SearchProgressListener#onListShards})}.
+     * @param shardTarget The last shard target that thrown an exception.
+     * @param exc The cause of the failure.
+     */
+    @Override
+    public void onFetchFailure(int shardIndex, SearchShardTarget shardTarget, Exception exc) {}
+}

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -113,7 +113,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
     public void consumeResult(SearchPhaseResult result, Runnable next) {
         super.consumeResult(result, () -> {});
         QuerySearchResult querySearchResult = result.queryResult();
-        progressListener.notifyQueryResult(querySearchResult.getShardIndex());
+        progressListener.notifyQueryResult(querySearchResult.getShardIndex(), querySearchResult);
         pendingMerges.consume(querySearchResult, next);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -65,9 +65,7 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         );
         this.queryPhaseResultConsumer = queryPhaseResultConsumer;
         this.progressListener = task.getProgressListener();
-        if (progressListener != SearchProgressListener.NOOP) {
-            notifyListShards(progressListener, clusters, request.source());
-        }
+        notifyListShards(progressListener, clusters, request.source());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -65,7 +65,7 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         );
         this.queryPhaseResultConsumer = queryPhaseResultConsumer;
         this.progressListener = task.getProgressListener();
-        if (progressListener != SearchProgressListener.NOOP) {    /// MP TODO: remove this if check?
+        if (progressListener != SearchProgressListener.NOOP) {
             notifyListShards(progressListener, clusters, request.source());
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -65,7 +65,10 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         );
         this.queryPhaseResultConsumer = queryPhaseResultConsumer;
         this.progressListener = task.getProgressListener();
-        notifyListShards(progressListener, clusters, request.source());
+        // don't build the SearchShard list (can be expensive) if the SearchProgressListener won't use it
+        if (progressListener != SearchProgressListener.NOOP) {
+            notifyListShards(progressListener, clusters, request.source());
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -78,7 +78,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         // at the end of the search
         addReleasable(resultConsumer);
 
-        if (progressListener != SearchProgressListener.NOOP) {
+        if (progressListener != SearchProgressListener.NOOP) {  /// MP TODO: remove this if check?
             notifyListShards(progressListener, clusters, request.source());
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -77,10 +77,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         // register the release of the query consumer to free up the circuit breaker memory
         // at the end of the search
         addReleasable(resultConsumer);
-
-        if (progressListener != SearchProgressListener.NOOP) {
-            notifyListShards(progressListener, clusters, request.source());
-        }
+        notifyListShards(progressListener, clusters, request.source());
     }
 
     protected void executePhaseOnShard(

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -78,7 +78,7 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         // at the end of the search
         addReleasable(resultConsumer);
 
-        if (progressListener != SearchProgressListener.NOOP) {  /// MP TODO: remove this if check?
+        if (progressListener != SearchProgressListener.NOOP) {
             notifyListShards(progressListener, clusters, request.source());
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -77,7 +77,10 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         // register the release of the query consumer to free up the circuit breaker memory
         // at the end of the search
         addReleasable(resultConsumer);
-        notifyListShards(progressListener, clusters, request.source());
+        // don't build the SearchShard list (can be expensive) if the SearchProgressListener won't use it
+        if (progressListener != SearchProgressListener.NOOP) {
+            notifyListShards(progressListener, clusters, request.source());
+        }
     }
 
     protected void executePhaseOnShard(

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -514,7 +514,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         }
 
         /**
-         * Used for searches that are either not cross-cluster or CCS with minimize_roundtrips=false.
+         * Used for searches that are either not cross-cluster.
          * For CCS minimize_roundtrips=true use {@code Clusters(OriginalIndices, Map<String, OriginalIndices>, boolean)}
          * @param total total number of clusters in the search
          * @param successful number of successful clusters in the search

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -737,13 +737,18 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
 
         /**
          * @return true if any underlying Cluster objects have PARTIAL, SKIPPED, FAILED or RUNNING status.
+         *              or any Cluster is marked as timedOut.
          */
         public boolean hasPartialResults() {
-            for (AtomicReference<Cluster> cluster : clusterInfo.values()) {
-                switch (cluster.get().getStatus()) {
+            for (AtomicReference<Cluster> clusterRef : clusterInfo.values()) {
+                Cluster cluster = clusterRef.get();
+                switch (cluster.getStatus()) {
                     case PARTIAL, SKIPPED, FAILED, RUNNING -> {
                         return true;
                     }
+                }
+                if (cluster.isTimedOut()) {
+                    return true;
                 }
             }
             return false;
@@ -944,22 +949,22 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 return this;
             }
 
-            public Builder setTotalShards(Integer totalShards) {
+            public Builder setTotalShards(int totalShards) {
                 this.totalShards = totalShards;
                 return this;
             }
 
-            public Builder setSuccessfulShards(Integer successfulShards) {
+            public Builder setSuccessfulShards(int successfulShards) {
                 this.successfulShards = successfulShards;
                 return this;
             }
 
-            public Builder setSkippedShards(Integer skippedShards) {
+            public Builder setSkippedShards(int skippedShards) {
                 this.skippedShards = skippedShards;
                 return this;
             }
 
-            public Builder setFailedShards(Integer failedShards) {
+            public Builder setFailedShards(int failedShards) {
                 this.failedShards = failedShards;
                 return this;
             }
@@ -974,7 +979,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 return this;
             }
 
-            public Builder setTimedOut(Boolean timedOut) {
+            public Builder setTimedOut(boolean timedOut) {
                 this.timedOut = timedOut;
                 return this;
             }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -474,8 +474,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         // updates to the Cluster occur by CAS swapping in new Cluster objects into the AtomicReference in the map.
         private final Map<String, AtomicReference<Cluster>> clusterInfo;
 
-        // this field is not Writeable, as it is only needed on the initial "querying cluster" coordinator of a CCS search
-        private final transient boolean ccsMinimizeRoundtrips;
+        private final boolean ccsMinimizeRoundtrips;
 
         /**
          * For use with cross-cluster searches.
@@ -485,11 +484,14 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
          * @param localIndices The localIndices to be searched - null if no local indices are to be searched
          * @param remoteClusterIndices mapping of clusterAlias -> OriginalIndices for each remote cluster
          * @param ccsMinimizeRoundtrips whether minimizing roundtrips for the CCS
+         * @param skipUnavailablePredicate given a cluster alias, returns true if that cluster is skip_unavailable=true
+         *                                 and false otherwise
          */
         public Clusters(
             @Nullable OriginalIndices localIndices,
             Map<String, OriginalIndices> remoteClusterIndices,
-            boolean ccsMinimizeRoundtrips
+            boolean ccsMinimizeRoundtrips,
+            Predicate<String> skipUnavailablePredicate
         ) {
             this.total = remoteClusterIndices.size() + (localIndices == null ? 0 : 1);
             assert total >= 1 : "No local indices or remote clusters passed in";
@@ -499,12 +501,13 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             Map<String, AtomicReference<Cluster>> m = new HashMap<>();
             if (localIndices != null) {
                 String localKey = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
-                Cluster c = new Cluster(localKey, String.join(",", localIndices.indices()));
+                Cluster c = new Cluster(localKey, String.join(",", localIndices.indices()), false);
                 m.put(localKey, new AtomicReference<>(c));
             }
             for (Map.Entry<String, OriginalIndices> remote : remoteClusterIndices.entrySet()) {
                 String clusterAlias = remote.getKey();
-                Cluster c = new Cluster(clusterAlias, String.join(",", remote.getValue().indices()));
+                boolean skipUnavailable = skipUnavailablePredicate.test(clusterAlias);
+                Cluster c = new Cluster(clusterAlias, String.join(",", remote.getValue().indices()), skipUnavailable);
                 m.put(clusterAlias, new AtomicReference<>(c));
             }
             this.clusterInfo = Collections.unmodifiableMap(m);
@@ -518,6 +521,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
          * @param skipped number of skipped clusters (skipped can only happen for remote clusters with skip_unavailable=true)
          */
         public Clusters(int total, int successful, int skipped) {
+            /// MP TODO: change assert to total == 1 or total = 0
             assert total >= 0 && successful >= 0 && skipped >= 0 && successful <= total
                 : "total: " + total + " successful: " + successful + " skipped: " + skipped;
             assert skipped == total - successful : "total: " + total + " successful: " + successful + " skipped: " + skipped;
@@ -544,7 +548,11 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             } else {
                 this.clusterInfo = Collections.emptyMap();
             }
-            this.ccsMinimizeRoundtrips = false;
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_067)) {
+                this.ccsMinimizeRoundtrips = in.readBoolean();
+            } else {
+                this.ccsMinimizeRoundtrips = false;
+            }
             assert total >= 0 : "total is negative: " + total;
             assert total >= successful + skipped
                 : "successful + skipped is larger than total. total: " + total + " successful: " + successful + " skipped: " + skipped;
@@ -572,6 +580,9 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 } else {
                     out.writeCollection(Collections.emptyList());
                 }
+            }
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_067)) {
+                out.writeBoolean(ccsMinimizeRoundtrips);
             }
         }
 
@@ -746,6 +757,16 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             return clusterInfo.keySet().size() > 0;
         }
 
+        /**
+         * @return true if this Clusters object has been initialized with remote Cluster objects
+         *              This will be false for local-cluster (non-CCS) only searches.
+         */
+        public boolean hasRemoteClusters() {
+            if (clusterInfo.size() > 1) {
+                return true;
+            }
+            return clusterInfo.size() > 0 && clusterInfo.containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY) == false;
+        }
     }
 
     /**
@@ -763,6 +784,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
 
         private final String clusterAlias;
         private final String indexExpression; // original index expression from the user for this cluster
+        private final boolean skipUnavailable;
         private final Status status;
         private final Integer totalShards;
         private final Integer successfulShards;
@@ -794,9 +816,10 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
          * @param clusterAlias clusterAlias as defined in the remote cluster settings or RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
          *                     for the local cluster
          * @param indexExpression the original (not resolved/concrete) indices expression provided for this cluster.
+         * @param skipUnavailable whether this Cluster is marked as skip_unavailable in remote cluster settings
          */
-        public Cluster(String clusterAlias, String indexExpression) {
-            this(clusterAlias, indexExpression, Status.RUNNING, null, null, null, null, null, null, false);
+        public Cluster(String clusterAlias, String indexExpression, boolean skipUnavailable) {
+            this(clusterAlias, indexExpression, skipUnavailable, Status.RUNNING, null, null, null, null, null, null, false);
         }
 
         /**
@@ -806,16 +829,24 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
          * @param clusterAlias clusterAlias as defined in the remote cluster settings or RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
          *                     for the local cluster
          * @param indexExpression the original (not resolved/concrete) indices expression provided for this cluster.
+         * @param skipUnavailable whether cluster is marked as skip_unavailable in remote cluster settings
          * @param status current status of the search on this Cluster
          * @param failures list of failures that occurred during the search on this Cluster
          */
-        public Cluster(String clusterAlias, String indexExpression, Status status, List<ShardSearchFailure> failures) {
-            this(clusterAlias, indexExpression, status, null, null, null, null, failures, null, false);
+        public Cluster(
+            String clusterAlias,
+            String indexExpression,
+            boolean skipUnavailable,
+            Status status,
+            List<ShardSearchFailure> failures
+        ) {
+            this(clusterAlias, indexExpression, skipUnavailable, status, null, null, null, null, failures, null, false);
         }
 
         public Cluster(
             String clusterAlias,
             String indexExpression,
+            boolean skipUnavailable,
             Status status,
             Integer totalShards,
             Integer successfulShards,
@@ -830,6 +861,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             assert status != null : "status of Cluster cannot be null";
             this.clusterAlias = clusterAlias;
             this.indexExpression = indexExpression;
+            this.skipUnavailable = skipUnavailable;
             this.status = status;
             this.totalShards = totalShards;
             this.successfulShards = successfulShards;
@@ -856,6 +888,11 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             }
             this.timedOut = in.readBoolean();
             this.failures = Collections.unmodifiableList(in.readList(ShardSearchFailure::readShardSearchFailure));
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_067)) {
+                this.skipUnavailable = in.readBoolean();
+            } else {
+                this.skipUnavailable = false;
+            }
         }
 
         @Override
@@ -870,6 +907,9 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             out.writeOptionalLong(took == null ? null : took.millis());
             out.writeBoolean(timedOut);
             out.writeCollection(failures);
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_067)) {
+                out.writeBoolean(skipUnavailable);
+            }
         }
 
         @Override
@@ -985,10 +1025,12 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             Integer skippedShardsFinal = skippedShards == -1 ? null : skippedShards;
             Integer failedShardsFinal = failedShards == -1 ? null : failedShards;
             TimeValue tookTimeValue = took == -1L ? null : new TimeValue(took);
+            boolean skipUnavailable = false;  // skipUnavailable is not exposed to XContent, so just default to false here
 
             return new Cluster(
                 clusterName,
                 indexExpression,
+                skipUnavailable,
                 SearchResponse.Cluster.Status.valueOf(status.toUpperCase(Locale.ROOT)),
                 totalShardsFinal,
                 successfulShardsFinal,
@@ -1006,6 +1048,10 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
 
         public String getIndexExpression() {
             return indexExpression;
+        }
+
+        public boolean isSkipUnavailable() {
+            return skipUnavailable;
         }
 
         public Status getStatus() {
@@ -1043,13 +1089,11 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         @Override
         public String toString() {
             return "Cluster{"
-                + "clusterAlias='"
+                + "alias='"
                 + clusterAlias
                 + '\''
                 + ", status="
                 + status
-                + ", failures="
-                + failures
                 + ", totalShards="
                 + totalShards
                 + ", successfulShards="
@@ -1058,8 +1102,17 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 + skippedShards
                 + ", failedShards="
                 + failedShards
-                + ", searchLatencyMillis="
+                + ", failures(sz)="
+                + failures.size()
+                + ", took="
                 + took
+                + ", timedOut="
+                + timedOut
+                + ", indexExpression='"
+                + indexExpression
+                + '\''
+                + ", skipUnavailable="
+                + skipUnavailable
                 + '}';
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
@@ -109,4 +109,9 @@ public final class SearchShardsResponse extends ActionResponse {
         assert groups.stream().noneMatch(SearchShardsGroup::preFiltered) : "legacy responses must not have preFiltered set";
         return new SearchShardsResponse(groups, Arrays.asList(oldResp.getNodes()), aliasFilters);
     }
+
+    @Override
+    public String toString() {
+        return "SearchShardsResponse{" + "groups=" + groups + ", nodes=" + nodes + ", aliasFilters=" + aliasFilters + '}';
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -450,6 +450,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             return false;
         }
         if (searchRequest.scroll() != null) {
+            System.err.println("JJJ scroll in play - so shouldMinimizeRoundtrips=false");
             return false;
         }
         if (searchRequest.pointInTimeBuilder() != null) {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -447,7 +447,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         }
     }
 
-    static boolean shouldMinimizeRoundtrips(SearchRequest searchRequest) {
+    public static boolean shouldMinimizeRoundtrips(SearchRequest searchRequest) {
         if (searchRequest.isCcsMinimizeRoundtrips() == false) {
             return false;
         }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -708,6 +708,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             new ActionListenerResponseHandler<>(singleListener, SearchShardsResponse::new, responseExecutor)
                         );
                     } else {
+                        logger.warn("JJJ ClusterSearchShardsRequest");
                         // does not do a can-match
                         ClusterSearchShardsRequest searchShardsRequest = new ClusterSearchShardsRequest(indices).indicesOptions(
                             indicesOptions

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -709,7 +709,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             new ActionListenerResponseHandler<>(singleListener, SearchShardsResponse::new, responseExecutor)
                         );
                     } else {
-                        logger.warn("JJJ ClusterSearchShardsRequest");
                         // does not do a can-match
                         ClusterSearchShardsRequest searchShardsRequest = new ClusterSearchShardsRequest(indices).indicesOptions(
                             indicesOptions

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1264,8 +1264,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 );
             } else {
                 // for synchronous CCS minimize_roundtrips=false, use the CCSSingleCoordinatorSearchProgressListener
-                // (AsyncSearchTask will not return SearchProgressListener.NOOP, since it uses it's own progress listener
-                // which delegates to CCSSingleCoordinatorSearchProgressListener)
+                // (AsyncSearchTask will not return SearchProgressListener.NOOP, since it uses its own progress listener
+                // which delegates to CCSSingleCoordinatorSearchProgressListener when minimizing roundtrips)
                 if (clusters.isCcsMinimizeRoundtrips() == false
                     && clusters.hasRemoteClusters()
                     && task.getProgressListener() == SearchProgressListener.NOOP) {

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -92,10 +92,11 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
         for (int i = 0; i < 10; i++) {
             searchShards.add(new SearchShard(null, new ShardId("index", "uuid", i)));
         }
+        long timestamp = randomLongBetween(1000, Long.MAX_VALUE - 1000);
         TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
-            System.currentTimeMillis(),
-            System.nanoTime(),
-            System::nanoTime
+            timestamp,
+            timestamp,
+            () -> timestamp + 1000
         );
         searchProgressListener.notifyListShards(searchShards, Collections.emptyList(), SearchResponse.Clusters.EMPTY, false, timeProvider);
 

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -92,7 +92,12 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
         for (int i = 0; i < 10; i++) {
             searchShards.add(new SearchShard(null, new ShardId("index", "uuid", i)));
         }
-        searchProgressListener.notifyListShards(searchShards, Collections.emptyList(), SearchResponse.Clusters.EMPTY, false);
+        TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
+            System.currentTimeMillis(),
+            System.nanoTime(),
+            System::nanoTime
+        );
+        searchProgressListener.notifyListShards(searchShards, Collections.emptyList(), SearchResponse.Clusters.EMPTY, false, timeProvider);
 
         SearchRequest searchRequest = new SearchRequest("index");
         searchRequest.setBatchedReduceSize(2);
@@ -142,13 +147,14 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
             List<SearchShard> shards,
             List<SearchShard> skippedShards,
             SearchResponse.Clusters clusters,
-            boolean fetchPhase
+            boolean fetchPhase,
+            TransportSearchAction.SearchTimeProvider timeProvider
         ) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        protected void onQueryResult(int shardIndex) {
+        protected void onQueryResult(int shardIndex, QuerySearchResult queryResult) {
             onQueryResult.incrementAndGet();
             throw new UnsupportedOperationException();
         }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -1128,7 +1128,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
             AtomicReference<TotalHits> totalHitsListener = new AtomicReference<>();
             SearchProgressListener progressListener = new SearchProgressListener() {
                 @Override
-                public void onQueryResult(int shardIndex) {
+                public void onQueryResult(int shardIndex, QuerySearchResult queryResult) {
                     assertThat(shardIndex, lessThan(expectedNumResults));
                     numQueryResultListener.incrementAndGet();
                 }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -629,25 +629,42 @@ public class SearchResponseTests extends ESTestCase {
     }
 
     public void testClustersHasRemoteCluster() {
-        SearchResponse.Clusters c;
-        c = SearchResponse.Clusters.EMPTY;
-        assertFalse(c.hasRemoteClusters());
+        // local cluster search Clusters objects
+        assertFalse(SearchResponse.Clusters.EMPTY.hasRemoteClusters());
+        assertFalse(new SearchResponse.Clusters(1, 1, 0).hasRemoteClusters());
 
-        c = new SearchResponse.Clusters(1, 1, 0);
-        assertFalse(c.hasRemoteClusters());
+        // CCS search Cluster objects
 
-        Map<String, OriginalIndices> remoteClusterIndices = new HashMap<>();
-        remoteClusterIndices.put("remote1", new OriginalIndices(new String[] { "*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
-        c = new SearchResponse.Clusters(null, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
-        assertTrue(c.hasRemoteClusters());
+        // TODO: this variant of Clusters should not be allowed in a future ticket, but adding to test for now
+        assertTrue(new SearchResponse.Clusters(3, 2, 1).hasRemoteClusters());
+        {
+            Map<String, OriginalIndices> remoteClusterIndices = new HashMap<>();
+            remoteClusterIndices.put("remote1", new OriginalIndices(new String[] { "*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
 
-        OriginalIndices localIndices = new OriginalIndices(new String[] { "foo*" }, IndicesOptions.LENIENT_EXPAND_OPEN);
-        c = new SearchResponse.Clusters(localIndices, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
-        assertTrue(c.hasRemoteClusters());
+            var c = new SearchResponse.Clusters(null, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
+            assertTrue(c.hasRemoteClusters());
+        }
 
-        remoteClusterIndices.put("remote2", new OriginalIndices(new String[] { "a*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
-        remoteClusterIndices.put("remote3", new OriginalIndices(new String[] { "b*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
-        c = new SearchResponse.Clusters(localIndices, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
-        assertTrue(c.hasRemoteClusters());
+        {
+            OriginalIndices localIndices = new OriginalIndices(new String[] { "foo*" }, IndicesOptions.LENIENT_EXPAND_OPEN);
+
+            Map<String, OriginalIndices> remoteClusterIndices = new HashMap<>();
+            remoteClusterIndices.put("remote1", new OriginalIndices(new String[] { "*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+
+            var c = new SearchResponse.Clusters(localIndices, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
+            assertTrue(c.hasRemoteClusters());
+        }
+
+        {
+            OriginalIndices localIndices = new OriginalIndices(new String[] { "foo*" }, IndicesOptions.LENIENT_EXPAND_OPEN);
+
+            Map<String, OriginalIndices> remoteClusterIndices = new HashMap<>();
+            remoteClusterIndices.put("remote1", new OriginalIndices(new String[] { "*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+            remoteClusterIndices.put("remote2", new OriginalIndices(new String[] { "a*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+            remoteClusterIndices.put("remote3", new OriginalIndices(new String[] { "b*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+
+            var c = new SearchResponse.Clusters(localIndices, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
+            assertTrue(c.hasRemoteClusters());
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -200,7 +200,7 @@ public class SearchResponseTests extends ESTestCase {
             remoteClusterIndices.put("cluster_" + i, new OriginalIndices(new String[] { "foo", "bar*" }, IndicesOptions.lenientExpand()));
         }
 
-        SearchResponse.Clusters clusters = new SearchResponse.Clusters(localIndices, remoteClusterIndices, ccsMinimizeRoundtrips);
+        var clusters = new SearchResponse.Clusters(localIndices, remoteClusterIndices, ccsMinimizeRoundtrips, alias -> false);
 
         int successful = successfulClusters;
         int skipped = skippedClusters;
@@ -252,6 +252,7 @@ public class SearchResponseTests extends ESTestCase {
             SearchResponse.Cluster update = new SearchResponse.Cluster(
                 cluster.getClusterAlias(),
                 cluster.getIndexExpression(),
+                false,
                 status,
                 totalShards,
                 successfulShards,
@@ -625,5 +626,28 @@ public class SearchResponseTests extends ESTestCase {
         XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
         deserialized.getClusters().toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals(0, Strings.toString(builder).length());
+    }
+
+    public void testClustersHasRemoteCluster() {
+        SearchResponse.Clusters c;
+        c = SearchResponse.Clusters.EMPTY;
+        assertFalse(c.hasRemoteClusters());
+
+        c = new SearchResponse.Clusters(1, 1, 0);
+        assertFalse(c.hasRemoteClusters());
+
+        Map<String, OriginalIndices> remoteClusterIndices = new HashMap<>();
+        remoteClusterIndices.put("remote1", new OriginalIndices(new String[] { "*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+        c = new SearchResponse.Clusters(null, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
+        assertTrue(c.hasRemoteClusters());
+
+        OriginalIndices localIndices = new OriginalIndices(new String[] { "foo*" }, IndicesOptions.LENIENT_EXPAND_OPEN);
+        c = new SearchResponse.Clusters(localIndices, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
+        assertTrue(c.hasRemoteClusters());
+
+        remoteClusterIndices.put("remote2", new OriginalIndices(new String[] { "a*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+        remoteClusterIndices.put("remote3", new OriginalIndices(new String[] { "b*" }, IndicesOptions.LENIENT_EXPAND_OPEN));
+        c = new SearchResponse.Clusters(localIndices, remoteClusterIndices, randomBoolean(), alias -> randomBoolean());
+        assertTrue(c.hasRemoteClusters());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -523,14 +523,12 @@ public class TransportSearchActionTests extends ESTestCase {
                 ActionListener.wrap(r -> fail("no response expected"), failure::set),
                 latch
             );
-            SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
-
             TransportSearchAction.ccsRemoteReduce(
                 new TaskId("n", 1),
                 searchRequest,
                 localIndices,
                 remoteIndicesByCluster,
-                initClusters,
+                new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true, alias -> randomBoolean()),
                 timeProvider,
                 emptyReduceContextBuilder(),
                 remoteClusterService,
@@ -591,14 +589,12 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
-
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
-                    initClusters,
+                    new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true, alias -> randomBoolean()),
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -632,13 +628,12 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionListener.wrap(r -> fail("no response expected"), failure::set),
                     latch
                 );
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
-                    initClusters,
+                    new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true, alias -> randomBoolean()),
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -693,14 +688,12 @@ public class TransportSearchActionTests extends ESTestCase {
                     ActionListener.wrap(r -> fail("no response expected"), failure::set),
                     latch
                 );
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
-
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
-                    initClusters,
+                    new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true, alias -> randomBoolean()),
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -741,14 +734,12 @@ public class TransportSearchActionTests extends ESTestCase {
                 if (localIndices != null) {
                     clusterAliases.add("");
                 }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
-
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
-                    initClusters,
+                    new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true, alias -> randomBoolean()),
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -801,14 +792,12 @@ public class TransportSearchActionTests extends ESTestCase {
                 if (localIndices != null) {
                     clusterAliases.add("");
                 }
-                SearchResponse.Clusters initClusters = new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true);
-
                 TransportSearchAction.ccsRemoteReduce(
                     new TaskId("n", 1),
                     searchRequest,
                     localIndices,
                     remoteIndicesByCluster,
-                    initClusters,
+                    new SearchResponse.Clusters(localIndices, remoteIndicesByCluster, true, alias -> randomBoolean()),
                     timeProvider,
                     emptyReduceContextBuilder(),
                     remoteClusterService,
@@ -873,6 +862,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     skippedClusters,
                     remoteIndicesByCluster,
+                    new SearchResponse.Clusters(null, remoteIndicesByCluster, false, clusterAlias -> true),
                     service,
                     new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
@@ -901,6 +891,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     skippedClusters,
                     remoteIndicesByCluster,
+                    new SearchResponse.Clusters(null, remoteIndicesByCluster, false, clusterAlias -> true),
                     service,
                     new LatchedActionListener<>(ActionListener.wrap(r -> fail("no response expected"), failure::set), latch)
                 );
@@ -948,6 +939,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     skippedClusters,
                     remoteIndicesByCluster,
+                    new SearchResponse.Clusters(null, remoteIndicesByCluster, false, clusterAlias -> true),
                     service,
                     new LatchedActionListener<>(ActionListener.wrap(r -> fail("no response expected"), failure::set), latch)
                 );
@@ -977,6 +969,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     skippedClusters,
                     remoteIndicesByCluster,
+                    new SearchResponse.Clusters(null, remoteIndicesByCluster, false, clusterAlias -> true),
                     service,
                     new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
@@ -1022,6 +1015,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     skippedClusters,
                     remoteIndicesByCluster,
+                    new SearchResponse.Clusters(null, remoteIndicesByCluster, false, clusterAlias -> true),
                     service,
                     new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -847,6 +847,7 @@ public class TransportSearchActionTests extends ESTestCase {
             service.start();
             service.acceptIncomingRequests();
 
+            TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
             RemoteClusterService remoteClusterService = service.getRemoteClusterService();
             {
                 final CountDownLatch latch = new CountDownLatch(1);
@@ -861,6 +862,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     remoteIndicesByCluster,
                     clusters,
+                    timeProvider,
                     service,
                     new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
@@ -889,6 +891,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     remoteIndicesByCluster,
                     clusters,
+                    timeProvider,
                     service,
                     new LatchedActionListener<>(ActionListener.wrap(r -> fail("no response expected"), failure::set), latch)
                 );
@@ -936,6 +939,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     remoteIndicesByCluster,
                     clusters,
+                    timeProvider,
                     service,
                     new LatchedActionListener<>(ActionListener.wrap(r -> fail("no response expected"), failure::set), latch)
                 );
@@ -965,6 +969,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     remoteIndicesByCluster,
                     clusters,
+                    timeProvider,
                     service,
                     new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
@@ -1010,6 +1015,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     null,
                     remoteIndicesByCluster,
                     clusters,
+                    timeProvider,
                     service,
                     new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );

--- a/server/src/test/java/org/elasticsearch/search/query/SlowRunningQueryBuilder.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SlowRunningQueryBuilder.java
@@ -1,8 +1,9 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 package org.elasticsearch.search.query;

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -375,23 +375,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
-            if (clusters.isCcsMinimizeRoundtrips()) {
-                assertNull(localClusterSearchInfo.getTotalShards());
-                assertNull(localClusterSearchInfo.getSuccessfulShards());
-                assertNull(localClusterSearchInfo.getSkippedShards());
-                assertNull(localClusterSearchInfo.getFailedShards());
-                assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            } else {
-                assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
-                assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(0));
-                assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
-                assertThat(localClusterSearchInfo.getFailedShards(), equalTo(localNumShards));
-                assertThat(localClusterSearchInfo.getFailures().size(), equalTo(localNumShards));
-            }
-            assertNull(localClusterSearchInfo.getTook());
-            assertFalse(localClusterSearchInfo.isTimedOut());
-            ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
+            assertAllShardsFailed(clusters.isCcsMinimizeRoundtrips(), localClusterSearchInfo, localNumShards);
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
@@ -399,23 +383,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            if (clusters.isCcsMinimizeRoundtrips()) {
-                assertNull(remoteClusterSearchInfo.getTotalShards());
-                assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-                assertNull(remoteClusterSearchInfo.getSkippedShards());
-                assertNull(remoteClusterSearchInfo.getFailedShards());
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            } else {
-                assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(remoteNumShards));
-            }
-            assertNull(remoteClusterSearchInfo.getTook());
-            assertFalse(remoteClusterSearchInfo.isTimedOut());
-            ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertAllShardsFailed(clusters.isCcsMinimizeRoundtrips(), remoteClusterSearchInfo, remoteNumShards);
         }
         // check that the async_search/status response includes the same cluster details
         {
@@ -428,23 +396,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).get();
             assertNotNull(localClusterSearchInfo);
             assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
-            if (clusters.isCcsMinimizeRoundtrips()) {
-                assertNull(localClusterSearchInfo.getTotalShards());
-                assertNull(localClusterSearchInfo.getSuccessfulShards());
-                assertNull(localClusterSearchInfo.getSkippedShards());
-                assertNull(localClusterSearchInfo.getFailedShards());
-                assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
-            } else {
-                assertThat(localClusterSearchInfo.getTotalShards(), equalTo(localNumShards));
-                assertThat(localClusterSearchInfo.getSuccessfulShards(), equalTo(0));
-                assertThat(localClusterSearchInfo.getSkippedShards(), equalTo(0));
-                assertThat(localClusterSearchInfo.getFailedShards(), equalTo(localNumShards));
-                assertThat(localClusterSearchInfo.getFailures().size(), equalTo(localNumShards));
-            }
-            assertNull(localClusterSearchInfo.getTook());
-            assertFalse(localClusterSearchInfo.isTimedOut());
-            ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
+            assertAllShardsFailed(clusters.isCcsMinimizeRoundtrips(), localClusterSearchInfo, localNumShards);
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER).get();
             assertNotNull(remoteClusterSearchInfo);
@@ -452,23 +404,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            if (clusters.isCcsMinimizeRoundtrips()) {
-                assertNull(remoteClusterSearchInfo.getTotalShards());
-                assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-                assertNull(remoteClusterSearchInfo.getSkippedShards());
-                assertNull(remoteClusterSearchInfo.getFailedShards());
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            } else {
-                assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(remoteNumShards));
-            }
-            assertNull(remoteClusterSearchInfo.getTook());
-            assertFalse(remoteClusterSearchInfo.isTimedOut());
-            ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertAllShardsFailed(clusters.isCcsMinimizeRoundtrips(), remoteClusterSearchInfo, remoteNumShards);
         }
     }
 
@@ -1013,23 +949,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            if (clusters.isCcsMinimizeRoundtrips()) {
-                assertNull(remoteClusterSearchInfo.getTotalShards());
-                assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-                assertNull(remoteClusterSearchInfo.getSkippedShards());
-                assertNull(remoteClusterSearchInfo.getFailedShards());
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            } else {
-                assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(remoteNumShards));
-            }
-            assertNull(remoteClusterSearchInfo.getTook());
-            assertFalse(remoteClusterSearchInfo.isTimedOut());
-            ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertAllShardsFailed(clusters.isCcsMinimizeRoundtrips(), remoteClusterSearchInfo, remoteNumShards);
         }
         // check that the async_search/status response includes the same cluster details
         {
@@ -1047,23 +967,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 ? SearchResponse.Cluster.Status.SKIPPED
                 : SearchResponse.Cluster.Status.FAILED;
             assertThat(remoteClusterSearchInfo.getStatus(), equalTo(expectedStatus));
-            if (clusters.isCcsMinimizeRoundtrips()) {
-                assertNull(remoteClusterSearchInfo.getTotalShards());
-                assertNull(remoteClusterSearchInfo.getSuccessfulShards());
-                assertNull(remoteClusterSearchInfo.getSkippedShards());
-                assertNull(remoteClusterSearchInfo.getFailedShards());
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
-            } else {
-                assertThat(remoteClusterSearchInfo.getTotalShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getSuccessfulShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getSkippedShards(), equalTo(0));
-                assertThat(remoteClusterSearchInfo.getFailedShards(), equalTo(remoteNumShards));
-                assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(remoteNumShards));
-            }
-            assertNull(remoteClusterSearchInfo.getTook());
-            assertFalse(remoteClusterSearchInfo.isTimedOut());
-            ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertAllShardsFailed(clusters.isCcsMinimizeRoundtrips(), remoteClusterSearchInfo, remoteNumShards);
         }
     }
 
@@ -1408,6 +1312,26 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
             }
         });
+    }
+
+    private static void assertAllShardsFailed(boolean minimizeRoundtrips, SearchResponse.Cluster cluster, int numShards) {
+        if (minimizeRoundtrips) {
+            assertNull(cluster.getTotalShards());
+            assertNull(cluster.getSuccessfulShards());
+            assertNull(cluster.getSkippedShards());
+            assertNull(cluster.getFailedShards());
+            assertThat(cluster.getFailures().size(), equalTo(1));
+        } else {
+            assertThat(cluster.getTotalShards(), equalTo(numShards));
+            assertThat(cluster.getSuccessfulShards(), equalTo(0));
+            assertThat(cluster.getSkippedShards(), equalTo(0));
+            assertThat(cluster.getFailedShards(), equalTo(numShards));
+            assertThat(cluster.getFailures().size(), equalTo(numShards));
+        }
+        assertNull(cluster.getTook());
+        assertFalse(cluster.isTimedOut());
+        ShardSearchFailure shardSearchFailure = cluster.getFailures().get(0);
+        assertTrue("should have 'index corrupted' in reason", shardSearchFailure.reason().contains("index corrupted"));
     }
 
     protected AsyncSearchResponse submitAsyncSearch(SubmitAsyncSearchRequest request) throws ExecutionException, InterruptedException {

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -75,11 +75,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 
 public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
@@ -1190,7 +1190,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             ChunkedToXContent.wrapAsToXContent(searchResponseAfterCompletion)
                 .toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
         );
-        assertThat(json, containsString("task cancelled [by user request]"));
+        assertThat(json, matchesRegex(".*task (was)?\s*cancelled.*"));
     }
 
     public void testCancelViaAsyncSearchDelete() throws Exception {

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -62,7 +62,6 @@ import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -179,12 +178,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         SearchListenerPlugin.waitSearchStarted();
         SearchListenerPlugin.allowQueryPhase();
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
-
+        waitForSearchTasksToFinish();
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
 
@@ -294,12 +288,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         SearchListenerPlugin.waitSearchStarted();
         SearchListenerPlugin.allowQueryPhase();
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
-
+        waitForSearchTasksToFinish();
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
             assertNotNull(finishedResponse);
@@ -373,12 +362,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertNotNull(response.getSearchResponse());
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
-        Thread.sleep(255);
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -533,11 +517,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         SearchListenerPlugin.waitSearchStarted();
         SearchListenerPlugin.allowQueryPhase();
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -654,12 +634,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         SearchListenerPlugin.waitSearchStarted();
         SearchListenerPlugin.allowQueryPhase();
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
-        Thread.sleep(255);
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -772,12 +747,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertNotNull(response.getSearchResponse());
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
-        Thread.sleep(255);
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -873,11 +843,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertNotNull(response.getSearchResponse());
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -952,11 +918,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertNotNull(response.getSearchResponse());
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -1033,11 +995,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertNotNull(response.getSearchResponse());
 
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
-            assertFalse(statusResponse.isRunning());
-            assertNotNull(statusResponse.getCompletionStatus());
-        });
+        waitForSearchTasksToFinish();
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
@@ -1208,18 +1166,8 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         }
 
         assertBusy(() -> assertTrue(cancelFuture.isDone()));
-        assertBusy(() -> {
-            final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
-            for (TransportService transportService : transportServices) {
-                assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
-            }
-        });
 
-        // wait until search status endpoint reports it as completed
-        assertBusy(() -> {
-            AsyncStatusResponse statusResponseAfterCompletion = getAsyncStatus(response.getId());
-            assertNotNull(statusResponseAfterCompletion.getCompletionStatus());
-        });
+        waitForSearchTasksToFinish();
 
         AsyncStatusResponse statusResponseAfterCompletion = getAsyncStatus(response.getId());
         assertTrue(statusResponseAfterCompletion.isPartial());
@@ -1338,13 +1286,9 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             SearchListenerPlugin.allowQueryPhase();
         }
 
+        waitForSearchTasksToFinish();
+
         assertBusy(() -> expectThrows(ExecutionException.class, () -> getAsyncStatus(response.getId())));
-        assertBusy(() -> {
-            final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
-            for (TransportService transportService : transportServices) {
-                assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
-            }
-        });
     }
 
     public void testCancellationViaTimeoutWithAllowPartialResultsSetToFalse() throws Exception {
@@ -1411,32 +1355,52 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         // query phase has begun, so wait for query failure (due to timeout)
         SearchListenerPlugin.waitQueryFailure();
 
-        // wait for the async_search task to be cancelled or unregistered
+        // wait for search tasks to complete and be unregistered
         assertBusy(() -> {
-            ListTasksResponse taskResponses = client().admin().cluster().prepareListTasks().setDetailed(true).get();
-            List<TaskInfo> asyncSearchTaskInfos = new ArrayList<>();
-            for (TaskInfo task : taskResponses.getTasks()) {
-                if (task.action().contains("search")) {
-                    if (task.description().contains("async_search{indices[")) {
-                        asyncSearchTaskInfos.add(task);
-                    }
-                }
-            }
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(0));
 
-            if (asyncSearchTaskInfos.size() > 0) {
-                // if still present, and it is cancelled, then we can proceed with the test
-                assertTrue(asyncSearchTaskInfos.get(0).cancelled());
-            }
-            // if not present, then it has been unregistered and the async search should no longer be running, so can proceed
-        }, 30, TimeUnit.SECONDS);
-
-        assertBusy(() -> { assertFalse(getAsyncStatus(response.getId()).isRunning()); });
+            ListTasksResponse remoteTasksResponse = client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> remoteTasks = remoteTasksResponse.getTasks();
+            assertThat(remoteTasks.size(), equalTo(0));
+        });
 
         AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
         assertFalse(statusResponse.isRunning());
         assertEquals(0, statusResponse.getSuccessfulShards());
         assertEquals(0, statusResponse.getSkippedShards());
         assertThat(statusResponse.getFailedShards(), greaterThanOrEqualTo(1));
+
+        waitForSearchTasksToFinish();
+    }
+
+    private void waitForSearchTasksToFinish() throws Exception {
+        assertBusy(() -> {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(0));
+
+            ListTasksResponse remoteTasksResponse = client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> remoteTasks = remoteTasksResponse.getTasks();
+            assertThat(remoteTasks.size(), equalTo(0));
+        });
 
         assertBusy(() -> {
             final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -187,10 +187,8 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
-            System.err.println(Strings.toString(finishedResponse.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)));
 
             SearchResponse.Clusters clusters = finishedResponse.getSearchResponse().getClusters();
-
             assertFalse("search cluster results should NOT be marked as partial", clusters.hasPartialResults());
             assertThat(clusters.getTotal(), equalTo(2));
             assertThat(clusters.getSuccessful(), equalTo(2));
@@ -305,7 +303,6 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
             assertNotNull(finishedResponse);
-            System.err.println(Strings.toString(finishedResponse.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)));
 
             SearchResponse.Clusters clusters = finishedResponse.getSearchResponse().getClusters();
             assertFalse("search cluster results should NOT be marked as partial", clusters.hasPartialResults());
@@ -385,8 +382,6 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
-            System.err.println(skipUnavailable);
-            System.err.println(Strings.toString(finishedResponse.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)));
 
             SearchResponse.Clusters clusters = finishedResponse.getSearchResponse().getClusters();
             assertThat(clusters.getTotal(), equalTo(2));
@@ -546,9 +541,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
         {
             AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
-            System.err.println(Strings.toString(finishedResponse.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)));
             SearchResponse.Clusters clusters = finishedResponse.getSearchResponse().getClusters();
-            System.err.println(clusters);
             assertThat(clusters.getTotal(), equalTo(2));
             assertThat(clusters.getSuccessful(), equalTo(2));
             assertThat(clusters.getSkipped(), equalTo(0));

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -85,8 +85,8 @@ import static org.hamcrest.Matchers.not;
 public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
     private static final String REMOTE_CLUSTER = "cluster_a";
-    private static long EARLIEST_TIMESTAMP = 1691348810000L;
-    private static long LATEST_TIMESTAMP = 1691348820000L;
+    private static final long EARLIEST_TIMESTAMP = 1691348810000L;
+    private static final long LATEST_TIMESTAMP = 1691348820000L;
 
     @Override
     protected Collection<String> remoteClusterAlias() {

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -431,6 +431,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         ) {
             // best effort to cancel expired tasks
             checkCancellation();
+            assert clusters.isCcsMinimizeRoundtrips() != null : "CCS minimize_roundtrips value must be set in this context";
             ccsMinimizeRoundtrips = clusters.isCcsMinimizeRoundtrips();
             if (ccsMinimizeRoundtrips == false && clusters.hasClusterObjects()) {
                 delegate = new CCSSingleCoordinatorSearchProgressListener();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -416,6 +416,11 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             // in which case the final response already includes results as well as shard fetch failures)
         }
 
+        /**
+         * onListShards is guaranteed to be the first SearchProgressListener method called and
+         * the search will not progress until this returns, so this is a safe place to initialize state
+         * that is needed for handling subsequent callbacks.
+         */
         @Override
         protected void onListShards(
             List<SearchShard> shards,

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
+import org.elasticsearch.action.search.CCSSingleCoordinatorSearchProgressListener;
 import org.elasticsearch.action.search.SearchProgressActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -20,11 +21,13 @@ import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.SearchShard;
 import org.elasticsearch.action.search.SearchTask;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.threadpool.Scheduler.Cancellable;
@@ -367,20 +370,32 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
 
     class Listener extends SearchProgressActionListener {
 
+        // needed when there's a single coordinator for all CCS search phases (minimize_roundtrips=false)
+        private CCSSingleCoordinatorSearchProgressListener delegate;
+
         @Override
-        protected void onQueryResult(int shardIndex) {
+        protected void onQueryResult(int shardIndex, QuerySearchResult queryResult) {
             checkCancellation();
+            if (delegate != null) {
+                delegate.onQueryResult(shardIndex, queryResult);
+            }
         }
 
         @Override
         protected void onFetchResult(int shardIndex) {
             checkCancellation();
+            if (delegate != null) {
+                delegate.onFetchResult(shardIndex);
+            }
         }
 
         @Override
         protected void onQueryFailure(int shardIndex, SearchShardTarget shardTarget, Exception exc) {
             // best effort to cancel expired tasks
             checkCancellation();
+            if (delegate != null) {
+                delegate.onQueryFailure(shardIndex, shardTarget, exc);
+            }
             searchResponse.get()
                 .addQueryFailure(
                     shardIndex,
@@ -402,10 +417,20 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         }
 
         @Override
-        protected void onListShards(List<SearchShard> shards, List<SearchShard> skipped, Clusters clusters, boolean fetchPhase) {
+        protected void onListShards(
+            List<SearchShard> shards,
+            List<SearchShard> skipped,
+            Clusters clusters,
+            boolean fetchPhase,
+            TransportSearchAction.SearchTimeProvider timeProvider
+        ) {
             // best effort to cancel expired tasks
             checkCancellation();
             ccsMinimizeRoundtrips = clusters.isCcsMinimizeRoundtrips();
+            if (ccsMinimizeRoundtrips == false && clusters.hasClusterObjects()) {
+                delegate = new CCSSingleCoordinatorSearchProgressListener();
+                delegate.onListShards(shards, skipped, clusters, fetchPhase, timeProvider);
+            }
             searchResponse.compareAndSet(
                 null,
                 new MutableSearchResponse(shards.size() + skipped.size(), skipped.size(), clusters, threadPool.getThreadContext())
@@ -417,6 +442,9 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         public void onPartialReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggregations, int reducePhase) {
             // best effort to cancel expired tasks
             checkCancellation();
+            if (delegate != null) {
+                delegate.onPartialReduce(shards, totalHits, aggregations, reducePhase);
+            }
             // The way that the MutableSearchResponse will build the aggs.
             Supplier<InternalAggregations> reducedAggs;
             if (aggregations == null) {
@@ -444,6 +472,9 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         public void onFinalReduce(List<SearchShard> shards, TotalHits totalHits, InternalAggregations aggregations, int reducePhase) {
             // best effort to cancel expired tasks
             checkCancellation();
+            if (delegate != null) {
+                delegate.onFinalReduce(shards, totalHits, aggregations, reducePhase);
+            }
             searchResponse.get().updatePartialResponse(shards.size(), totalHits, () -> aggregations, reducePhase);
         }
 

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -465,6 +465,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         SearchResponse.Cluster updated = new SearchResponse.Cluster(
             localCluster.getClusterAlias(),
             localCluster.getIndexExpression(),
+            false,
             SearchResponse.Cluster.Status.SUCCESSFUL,
             10,
             10,
@@ -482,6 +483,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         updated = new SearchResponse.Cluster(
             cluster0.getClusterAlias(),
             cluster0.getIndexExpression(),
+            false,
             SearchResponse.Cluster.Status.SUCCESSFUL,
             8,
             8,
@@ -507,6 +509,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         updated = new SearchResponse.Cluster(
             cluster1.getClusterAlias(),
             cluster1.getIndexExpression(),
+            false,
             SearchResponse.Cluster.Status.SKIPPED,
             2,
             0,
@@ -524,6 +527,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         updated = new SearchResponse.Cluster(
             cluster2.getClusterAlias(),
             cluster2.getIndexExpression(),
+            false,
             SearchResponse.Cluster.Status.PARTIAL,
             8,
             8,
@@ -764,7 +768,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
             remoteClusterIndices.put("cluster_" + i, new OriginalIndices(new String[] { "foo", "bar*" }, IndicesOptions.lenientExpand()));
         }
 
-        return new SearchResponse.Clusters(localIndices, remoteClusterIndices, ccsMinimizeRoundtrips);
+        return new SearchResponse.Clusters(localIndices, remoteClusterIndices, ccsMinimizeRoundtrips, alias -> false);
     }
 
     static SearchResponse.Clusters createCCSClusterObjects(
@@ -794,6 +798,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 updated = new SearchResponse.Cluster(
                     localAlias,
                     localRef.get().getIndexExpression(),
+                    false,
                     SearchResponse.Cluster.Status.SUCCESSFUL,
                     5,
                     5,
@@ -808,6 +813,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 updated = new SearchResponse.Cluster(
                     localAlias,
                     localRef.get().getIndexExpression(),
+                    false,
                     SearchResponse.Cluster.Status.SKIPPED,
                     5,
                     0,
@@ -822,6 +828,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 updated = new SearchResponse.Cluster(
                     localAlias,
                     localRef.get().getIndexExpression(),
+                    false,
                     SearchResponse.Cluster.Status.PARTIAL,
                     5,
                     2,
@@ -848,6 +855,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 updated = new SearchResponse.Cluster(
                     clusterAlias,
                     clusterRef.get().getIndexExpression(),
+                    false,
                     SearchResponse.Cluster.Status.SUCCESSFUL,
                     5,
                     5,
@@ -862,6 +870,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 updated = new SearchResponse.Cluster(
                     clusterAlias,
                     clusterRef.get().getIndexExpression(),
+                    false,
                     SearchResponse.Cluster.Status.SKIPPED,
                     5,
                     0,
@@ -876,6 +885,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
                 updated = new SearchResponse.Cluster(
                     clusterAlias,
                     clusterRef.get().getIndexExpression(),
+                    false,
                     SearchResponse.Cluster.Status.PARTIAL,
                     5,
                     2,


### PR DESCRIPTION
This commit tracks progress for each shard search by cluster alias
using a new SearchProgressListener (CCSSingleCoordinatorSearchProgressListener).
Both sync and async CCS searches use this new progress listener when
minimize_roundtrips=false.

Two of the SearchProgressListener methods had to be extended to allow tracking
per-cluster 'took' values (TransportSearchAction.SearchTimeProvider) and
whether searches timed out (by passing in QuerySearchResult to the onQueryResult
listener method).

This commit brings parity between minimize_roundtrips=true and false to have
the same _cluster/details sections in CCS search responses.

Note that there are still a few differences in behavior between minimize_roundtrips=true 
and false:

1. The per-cluster 'took' value for minimize_roundtrips=true is accurate, but the
   for 'false' it is only measured at the granularity of each partial reduce,
   so the per cluster 'took' time is overestimated in basically all cases.
2. For minimize_roundtrips=true, a skip_unavailable=false cluster that disconnects
   during the search or has all searches on all shards fail, will cause the entire
   search to fail. This is (still) not true for minimize_roundtrips=false. The search
   is only failed if the skip_unavailable=false cluster cannot be connected to at the
   start of the search. (This will likely be changed in a follow up ticket that implements
   fail-fast logic for in-progress searches that should fail due to a skip_unavailable=true
   cluster failing.)
3. The shard accounting for minimize_roundtrips=false is always accurate (total shard counts
   are known at the start of the search). For minimize_roundtrips=true, the shard accounting
   is only accurate per cluster, unless all clusters have successful (or partially successful)
   searches. For clusters that have failures we do not have shard count info.
