### PR TITLE
Not checking index.time_series.end_time because it changes

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -114,7 +114,8 @@ created the data stream:
   - match: { $body.$backing_index.data_stream: 'k8s' }
   - match: { $body.$backing_index.settings.index.mode: 'time_series' }
   - match: { $body.$backing_index.settings.index.time_series.start_time: '2021-04-28T00:00:00Z' }
-  - match: { $body.$backing_index.settings.index.time_series.end_time: '2021-04-29T00:00:00Z' }
+# We can't match on index.time_series.end_time in this test because UpdateTimeSeriesRangeService updates it every 5 minutes, so every
+# once in a while it is not what we expect it to be. See #93068.
 
   - do:
       cat.indices:


### PR DESCRIPTION
In the `created the data stream` test in 150_tsdb.yml, we assert that the `index.time_series.end_time` setting is what it was when we created the data stream. But [UpdateTimeSeriesRangeService](https://github.com/elastic/elasticsearch/blob/main/modules/data-streams/src/main/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeService.java) updates the value of this setting every 5 minutes. This means that every once in a while the test fails if UpdateTimeSeriesRangeService happens to have run during the test. This PR gets rid of this check, with the assumption that the mechanics for `index.time_series.start_time` are otherwise identical, so we still have good coverage.
Closes #93068