### PR TITLE
Unwrap IOException in ContextIndexSearcher concurrent code-path

### DIFF
--- a/docs/changelog/98459.yaml
+++ b/docs/changelog/98459.yaml
@@ -1,0 +1,5 @@
+pr: 98459
+summary: Unwrap IOException in `ContextIndexSearcher` concurrent code-path
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -455,6 +455,8 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
                         } else {
                             if (e.getCause() instanceof RuntimeException runtimeException) {
                                 exception = runtimeException;
+                            } else if (e.getCause() instanceof IOException ioException) {
+                                throw ioException;
                             } else {
                                 exception = new RuntimeException(e.getCause());
                             }

--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -624,18 +624,13 @@ public class ContextIndexSearcherTests extends ESTestCase {
                             return null;
                         }
                     };
-                    RuntimeException executionException = expectThrows(
-                        RuntimeException.class,
-                        () -> contextIndexSearcher.search(query, collectorManager)
-                    );
+                    expectThrows(IOException.class, () -> contextIndexSearcher.search(query, collectorManager));
                     assertBusy(() -> {
                         // active count is approximate, wait until it converges to the expected number
                         if (executor.getActiveCount() > numBusyThreads) {
                             throw new AssertionError("no search tasks should be left running");
                         }
                     });
-
-                    assertThat(executionException.getCause(), instanceOf(IOException.class));
                 }
                 // as many tasks as slices have been created
                 assertEquals(leafSlices.length, newCollectorsCalls[0]);


### PR DESCRIPTION
The search method that handles parallel collection across segment slices catches and unwrap execution exception that each slice may throw. It will rethrow the cause as-is if it's a runtime exception, otherwise wrap it into a new runtime exception before re-throwing. Given that the method itself throws IOException, we should refrain from wrapping IOExceptions with a new runtime exception.