### PR TITLE
Add some debug logs to IT test

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardPath;
@@ -270,6 +271,7 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
         Set<DiscoveryNode> nodesWithIndexData = Sets.difference(dataNodes, Collections.singleton(excludedDataNode));
         assertBusy(() -> {
             for (DiscoveryNode dataNode : nodesWithIndexData) {
+
                 CacheService cacheService = internalCluster().getInstance(CacheService.class, dataNode.getName());
                 cacheService.synchronizeCache();
                 assertThat(cacheService.getPersistentCache().getNumDocs(), greaterThan(0L));
@@ -286,6 +288,9 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
                 logger.warn("--> CacheFilesEventsQueueSize: {}", cacheService.getCacheFilesEventsQueueSize());
                 logger.warn("--> NumberOfCacheFilesEvents: {}", cacheService.getNumberOfCacheFilesEvents());
                 logger.warn("--> Pending shard evictions: {}", cacheService.pendingShardsEvictions().keySet());
+
+                NodeEnvironment nodeEnvironment = internalCluster().getInstance(NodeEnvironment.class, excludedDataNode.getName());
+                logger.warn("--> Node's index folders: {}", nodeEnvironment.availableIndexFolders());
             }
             assertThat(numberOfDocs, equalTo(0L));
         });


### PR DESCRIPTION
Test SearchableSnapshotsPersistentCacheIntegTests#testPersistentCacheCleanUpAfterRelocation [failed](https://github.com/elastic/elasticsearch/issues/98008) again. For past [2 years](https://ci-stats.elastic.co/s/jenkins/app/discover#/?_g=h@918ff80&_a=h@f47651e) this was the third failure.

Previous [failure](https://github.com/elastic/elasticsearch/issues/86060) and fix [attempt](https://github.com/elastic/elasticsearch/pull/88819)

Unfortunately I wasn't able to reproduce it locally. Ran many-many executions under simulated heavy CPU load (>90%)

Within this change I'd like to add more log statements around persistent cache state validation.
Most recent and previous test failures had same root cause. Attempt to increase asserting waiting time apparently didn't work. I'm removing 30 sec waiting time in this assert block, since we never saw problems with the same assert block (which runs on default timeout) few lines above.
https://github.com/elastic/elasticsearch/blob/26a9a080773817e080ad44083b3daffa75a4ebdc/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java#L231-L244

Key assumption I'm making is there is some leftover of lucene segment information (files) that we cannot fully control (which were not tracked by our cache and hence didn't receive self-erase signal)

Related #98008