### PR TITLE
Make sure the downsample step is not stuck

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleStep.java
@@ -85,10 +85,10 @@ public class DownsampleStep extends AsyncActionStep {
                     downsampleIndexName
                 );
                 listener.onResponse(null);
+                return;
             }
-        } else {
-            performDownsampleIndex(indexName, downsampleIndexName, ActionListener.wrap(listener::onResponse, listener::onFailure));
         }
+        performDownsampleIndex(indexName, downsampleIndexName, ActionListener.wrap(listener::onResponse, listener::onFailure));
     }
 
     void performDownsampleIndex(String indexName, String downsampleIndexName, ActionListener<Void> listener) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
@@ -219,8 +219,8 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
             @Override
             public void onFailure(Exception e) {
                 listenerIsCalled.set(true);
-                assertTrue(e instanceof IllegalStateException);
-                assertTrue(e.getMessage().contains("already exists with downsample status [started]"));
+                logger.error("-> " + e.getMessage(), e);
+                fail("repeatedly calling the downsampling API is expected, but got exception [" + e.getMessage() + "]");
             }
         });
         assertThat(listenerIsCalled.get(), is(true));


### PR DESCRIPTION
If the downsampling index exists but it's still downsampling we should invocate the downsample transport action again (and wire up the request listener such that the ILM listener gets notified of success or failure)

This modifies the test to assert the ILM listener is invoked and removes an invariant that doesn't hold anymore in ILM (i.e. previously before #97557 but now we can, and do)

Markin as non-issue as this hasn't been released yet.