### PR TITLE
Fix query rules yaml tests

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/200_query_ruleset_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/200_query_ruleset_put.yml
@@ -1,14 +1,11 @@
 
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
 
 ---
 'Create Query Ruleset':
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/98452"
   - do:
       query_ruleset.put:
         ruleset_id: test-ruleset
@@ -71,9 +68,6 @@ setup:
 
 ---
 'Create Query Ruleset - Resource already exists':
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/98452"
   - do:
       query_ruleset.put:
         ruleset_id: test-query-ruleset-recreating
@@ -114,8 +108,6 @@ setup:
 'Create Query Ruleset - Insufficient privilege':
   - skip:
       features: headers
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/98452"
 
   - do:
       catch: forbidden

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/250_query_ruleset_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/250_query_ruleset_delete.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.8.99"
-      reason: Introduced in 8.9.0
+      version: " - 8.9.99"
+      reason: Introduced in 8.10.0
   - do:
       query_ruleset.put:
         ruleset_id: test-query-ruleset-to-delete
@@ -21,9 +21,6 @@ setup:
 
 ---
 "Delete Query Ruleset":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/98452"
 
   - do:
       query_ruleset.delete:
@@ -38,9 +35,6 @@ setup:
 
 ---
 "Delete Query Ruleset - Ruleset does not exist":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/98452"
 
   - do:
       catch: "missing"


### PR DESCRIPTION
Query rules is launching in 8.10. Skip these tests for 8.9.

Fixes https://github.com/elastic/elasticsearch/issues/98452