### PR TITLE
ESQL: Optimize some `MV_` functions on sorted

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.benchmark.compute.operator;
 
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.IntBlock;
@@ -19,6 +20,7 @@ import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateTrunc;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
+import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMin;
 import org.elasticsearch.xpack.esql.planner.EvalMapper;
 import org.elasticsearch.xpack.esql.planner.Layout;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -65,7 +67,7 @@ public class EvalBenchmark {
         }
     }
 
-    @Param({ "abs", "add", "date_trunc", "equal_to_const", "long_equal_to_long", "long_equal_to_int" })
+    @Param({ "abs", "add", "date_trunc", "equal_to_const", "long_equal_to_long", "long_equal_to_int", "mv_min", "mv_min_ascending" })
     public String operation;
 
     private static Operator operator(String operation) {
@@ -112,6 +114,10 @@ public class EvalBenchmark {
                 FieldAttribute lhs = longField();
                 FieldAttribute rhs = intField();
                 yield EvalMapper.toEvaluator(new Equals(Source.EMPTY, lhs, rhs), layout(lhs, rhs)).get();
+            }
+            case "mv_min", "mv_min_ascending" -> {
+                FieldAttribute longField = longField();
+                yield EvalMapper.toEvaluator(new MvMin(Source.EMPTY, longField), layout(longField)).get();
             }
             default -> throw new UnsupportedOperationException();
         };
@@ -178,6 +184,14 @@ public class EvalBenchmark {
                     }
                 }
             }
+            case "mv_min", "mv_min_ascending" -> {
+                LongVector v = actual.<LongBlock>getBlock(1).asVector();
+                for (int i = 0; i < BLOCK_LENGTH; i++) {
+                    if (v.getLong(i) != i) {
+                        throw new AssertionError("[" + operation + "] expected [" + i + "] but was [" + v.getLong(i) + "]");
+                    }
+                }
+            }
             default -> throw new UnsupportedOperationException();
         }
     }
@@ -208,6 +222,20 @@ public class EvalBenchmark {
                     rhs.appendInt(i * 100_000);
                 }
                 yield new Page(lhs.build(), rhs.build());
+            }
+            case "mv_min", "mv_min_ascending" -> {
+                var builder = LongBlock.newBlockBuilder(BLOCK_LENGTH);
+                if (operation.endsWith("ascending")) {
+                    builder.mvOrdering(Block.MvOrdering.ASCENDING);
+                }
+                for (int i = 0; i < BLOCK_LENGTH; i++) {
+                    builder.beginPositionEntry();
+                    builder.appendLong(i);
+                    builder.appendLong(i + 1);
+                    builder.appendLong(i + 2);
+                    builder.endPositionEntry();
+                }
+                yield new Page(builder.build());
             }
             default -> throw new UnsupportedOperationException();
         };

--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/MvEvaluator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/MvEvaluator.java
@@ -56,6 +56,12 @@ public @interface MvEvaluator {
     String single() default "";
 
     /**
+     * Optional method called to process blocks whose values are sorted
+     * in ascending order.
+     */
+    String ascending() default "";
+
+    /**
      * Exceptions thrown by the process method to catch and convert
      * into a warning and turn into a null value.
      */

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorProcessor.java
@@ -93,6 +93,7 @@ public class EvaluatorProcessor implements Processor {
                             mvEvaluatorAnn.extraName(),
                             mvEvaluatorAnn.finish(),
                             mvEvaluatorAnn.single(),
+                            mvEvaluatorAnn.ascending(),
                             warnExceptions(evaluatorMethod)
                         ).sourceFile(),
                         env

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -75,6 +75,9 @@ public final class BlockUtils {
             } else if (object instanceof List<?> listVal) {
                 BuilderWrapper wrapper = wrapperFor(listVal.get(0).getClass(), 1);
                 wrapper.append.accept(listVal);
+                if (isAscending(listVal)) {
+                    wrapper.builder.mvOrdering(Block.MvOrdering.ASCENDING);
+                }
                 blocks[i] = wrapper.builder.build();
             } else if (object == null) {
                 blocks[i] = constantNullBlock(blockSize);
@@ -83,6 +86,27 @@ public final class BlockUtils {
             }
         }
         return blocks;
+    }
+
+    /**
+     * Detect blocks with ascending fields. This is *mostly* useful for
+     * exercising the specialized ascending implementations.
+     */
+    private static boolean isAscending(List<?> values) {
+        Comparable<Object> prev = null;
+        for (Object o : values) {
+            @SuppressWarnings("unchecked")
+            Comparable<Object> val = (Comparable<Object>) o;
+            if (prev == null) {
+                prev = val;
+                continue;
+            }
+            if (prev.compareTo(val) > 0) {
+                return false;
+            }
+            prev = val;
+        }
+        return true;
     }
 
     public static Block[] fromList(List<List<Object>> list) {

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgDoubleEvaluator.java
@@ -27,6 +27,9 @@ public final class MvAvgDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return "MvAvg";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     DoubleBlock v = (DoubleBlock) fieldVal;
@@ -51,6 +54,9 @@ public final class MvAvgDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
     DoubleBlock v = (DoubleBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgIntEvaluator.java
@@ -28,6 +28,9 @@ public final class MvAvgIntEvaluator extends AbstractMultivalueFunction.Abstract
     return "MvAvg";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     IntBlock v = (IntBlock) fieldVal;
@@ -58,6 +61,9 @@ public final class MvAvgIntEvaluator extends AbstractMultivalueFunction.Abstract
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
     IntBlock v = (IntBlock) fieldVal;
@@ -84,6 +90,9 @@ public final class MvAvgIntEvaluator extends AbstractMultivalueFunction.Abstract
     return new DoubleArrayVector(values, positionCount);
   }
 
+  /**
+   * Evaluate blocks containing only single valued fields.
+   */
   @Override
   public Block evalSingleValuedNullable(Block fieldVal) {
     IntBlock v = (IntBlock) fieldVal;
@@ -105,6 +114,9 @@ public final class MvAvgIntEvaluator extends AbstractMultivalueFunction.Abstract
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing only single valued fields.
+   */
   @Override
   public Vector evalSingleValuedNotNullable(Block fieldVal) {
     IntBlock v = (IntBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgLongEvaluator.java
@@ -28,6 +28,9 @@ public final class MvAvgLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return "MvAvg";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;
@@ -58,6 +61,9 @@ public final class MvAvgLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;
@@ -84,6 +90,9 @@ public final class MvAvgLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return new DoubleArrayVector(values, positionCount);
   }
 
+  /**
+   * Evaluate blocks containing only single valued fields.
+   */
   @Override
   public Block evalSingleValuedNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;
@@ -105,6 +114,9 @@ public final class MvAvgLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing only single valued fields.
+   */
   @Override
   public Vector evalSingleValuedNotNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgUnsignedLongEvaluator.java
@@ -28,6 +28,9 @@ public final class MvAvgUnsignedLongEvaluator extends AbstractMultivalueFunction
     return "MvAvg";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;
@@ -58,6 +61,9 @@ public final class MvAvgUnsignedLongEvaluator extends AbstractMultivalueFunction
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;
@@ -84,6 +90,9 @@ public final class MvAvgUnsignedLongEvaluator extends AbstractMultivalueFunction
     return new DoubleArrayVector(values, positionCount);
   }
 
+  /**
+   * Evaluate blocks containing only single valued fields.
+   */
   @Override
   public Block evalSingleValuedNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;
@@ -105,6 +114,9 @@ public final class MvAvgUnsignedLongEvaluator extends AbstractMultivalueFunction
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing only single valued fields.
+   */
   @Override
   public Vector evalSingleValuedNotNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxBooleanEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMaxBooleanEvaluator extends AbstractMultivalueFunction.Abst
     return "MvMax";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     BooleanBlock v = (BooleanBlock) fieldVal;
     int positionCount = v.getPositionCount();
     BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMaxBooleanEvaluator extends AbstractMultivalueFunction.Abst
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     BooleanBlock v = (BooleanBlock) fieldVal;
     int positionCount = v.getPositionCount();
     boolean[] values = new boolean[positionCount];
@@ -65,6 +77,44 @@ public final class MvMaxBooleanEvaluator extends AbstractMultivalueFunction.Abst
         value = MvMax.process(value, next);
       }
       boolean result = value;
+      values[p] = result;
+    }
+    return new BooleanArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    BooleanBlock v = (BooleanBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(positionCount);
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMax.ascendingIndex(valueCount);
+      boolean result = v.getBoolean(first + idx);
+      builder.appendBoolean(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    BooleanBlock v = (BooleanBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    boolean[] values = new boolean[positionCount];
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMax.ascendingIndex(valueCount);
+      boolean result = v.getBoolean(first + idx);
       values[p] = result;
     }
     return new BooleanArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxBytesRefEvaluator.java
@@ -29,8 +29,14 @@ public final class MvMaxBytesRefEvaluator extends AbstractMultivalueFunction.Abs
     return "MvMax";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     BytesRefBlock v = (BytesRefBlock) fieldVal;
     int positionCount = v.getPositionCount();
     BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(positionCount);
@@ -55,8 +61,14 @@ public final class MvMaxBytesRefEvaluator extends AbstractMultivalueFunction.Abs
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     BytesRefBlock v = (BytesRefBlock) fieldVal;
     int positionCount = v.getPositionCount();
     BytesRefArray values = new BytesRefArray(positionCount, BigArrays.NON_RECYCLING_INSTANCE);
@@ -72,6 +84,48 @@ public final class MvMaxBytesRefEvaluator extends AbstractMultivalueFunction.Abs
         MvMax.process(value, next);
       }
       BytesRef result = value;
+      values.append(result);
+    }
+    return new BytesRefArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    BytesRefBlock v = (BytesRefBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(positionCount);
+    BytesRef firstScratch = new BytesRef();
+    BytesRef nextScratch = new BytesRef();
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMax.ascendingIndex(valueCount);
+      BytesRef result = v.getBytesRef(first + idx, firstScratch);
+      builder.appendBytesRef(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    BytesRefBlock v = (BytesRefBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    BytesRefArray values = new BytesRefArray(positionCount, BigArrays.NON_RECYCLING_INSTANCE);
+    BytesRef firstScratch = new BytesRef();
+    BytesRef nextScratch = new BytesRef();
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMax.ascendingIndex(valueCount);
+      BytesRef result = v.getBytesRef(first + idx, firstScratch);
       values.append(result);
     }
     return new BytesRefArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxDoubleEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMaxDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return "MvMax";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     DoubleBlock v = (DoubleBlock) fieldVal;
     int positionCount = v.getPositionCount();
     DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMaxDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     DoubleBlock v = (DoubleBlock) fieldVal;
     int positionCount = v.getPositionCount();
     double[] values = new double[positionCount];
@@ -65,6 +77,44 @@ public final class MvMaxDoubleEvaluator extends AbstractMultivalueFunction.Abstr
         value = MvMax.process(value, next);
       }
       double result = value;
+      values[p] = result;
+    }
+    return new DoubleArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    DoubleBlock v = (DoubleBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(positionCount);
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMax.ascendingIndex(valueCount);
+      double result = v.getDouble(first + idx);
+      builder.appendDouble(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    DoubleBlock v = (DoubleBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    double[] values = new double[positionCount];
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMax.ascendingIndex(valueCount);
+      double result = v.getDouble(first + idx);
       values[p] = result;
     }
     return new DoubleArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianDoubleEvaluator.java
@@ -26,6 +26,9 @@ public final class MvMedianDoubleEvaluator extends AbstractMultivalueFunction.Ab
     return "MvMedian";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     DoubleBlock v = (DoubleBlock) fieldVal;
@@ -50,6 +53,9 @@ public final class MvMedianDoubleEvaluator extends AbstractMultivalueFunction.Ab
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
     DoubleBlock v = (DoubleBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianIntEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMedianIntEvaluator extends AbstractMultivalueFunction.Abstr
     return "MvMedian";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     IntBlock v = (IntBlock) fieldVal;
     int positionCount = v.getPositionCount();
     IntBlock.Builder builder = IntBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMedianIntEvaluator extends AbstractMultivalueFunction.Abstr
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     IntBlock v = (IntBlock) fieldVal;
     int positionCount = v.getPositionCount();
     int[] values = new int[positionCount];
@@ -65,6 +77,44 @@ public final class MvMedianIntEvaluator extends AbstractMultivalueFunction.Abstr
         MvMedian.process(work, value);
       }
       int result = MvMedian.finish(work);
+      values[p] = result;
+    }
+    return new IntArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    IntBlock v = (IntBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    IntBlock.Builder builder = IntBlock.newBlockBuilder(positionCount);
+    MvMedian.Ints work = new MvMedian.Ints();
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int result = MvMedian.ascending(v, first, valueCount);
+      builder.appendInt(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    IntBlock v = (IntBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    int[] values = new int[positionCount];
+    MvMedian.Ints work = new MvMedian.Ints();
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int result = MvMedian.ascending(v, first, valueCount);
       values[p] = result;
     }
     return new IntArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianLongEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMedianLongEvaluator extends AbstractMultivalueFunction.Abst
     return "MvMedian";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     LongBlock v = (LongBlock) fieldVal;
     int positionCount = v.getPositionCount();
     LongBlock.Builder builder = LongBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMedianLongEvaluator extends AbstractMultivalueFunction.Abst
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     LongBlock v = (LongBlock) fieldVal;
     int positionCount = v.getPositionCount();
     long[] values = new long[positionCount];
@@ -65,6 +77,44 @@ public final class MvMedianLongEvaluator extends AbstractMultivalueFunction.Abst
         MvMedian.process(work, value);
       }
       long result = MvMedian.finish(work);
+      values[p] = result;
+    }
+    return new LongArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    LongBlock v = (LongBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    LongBlock.Builder builder = LongBlock.newBlockBuilder(positionCount);
+    MvMedian.Longs work = new MvMedian.Longs();
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      long result = MvMedian.ascending(v, first, valueCount);
+      builder.appendLong(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    LongBlock v = (LongBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    long[] values = new long[positionCount];
+    MvMedian.Longs work = new MvMedian.Longs();
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      long result = MvMedian.ascending(v, first, valueCount);
       values[p] = result;
     }
     return new LongArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinDoubleEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMinDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return "MvMin";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     DoubleBlock v = (DoubleBlock) fieldVal;
     int positionCount = v.getPositionCount();
     DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMinDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     DoubleBlock v = (DoubleBlock) fieldVal;
     int positionCount = v.getPositionCount();
     double[] values = new double[positionCount];
@@ -65,6 +77,44 @@ public final class MvMinDoubleEvaluator extends AbstractMultivalueFunction.Abstr
         value = MvMin.process(value, next);
       }
       double result = value;
+      values[p] = result;
+    }
+    return new DoubleArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    DoubleBlock v = (DoubleBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(positionCount);
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMin.ascendingIndex(valueCount);
+      double result = v.getDouble(first + idx);
+      builder.appendDouble(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    DoubleBlock v = (DoubleBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    double[] values = new double[positionCount];
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMin.ascendingIndex(valueCount);
+      double result = v.getDouble(first + idx);
       values[p] = result;
     }
     return new DoubleArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinIntEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMinIntEvaluator extends AbstractMultivalueFunction.Abstract
     return "MvMin";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     IntBlock v = (IntBlock) fieldVal;
     int positionCount = v.getPositionCount();
     IntBlock.Builder builder = IntBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMinIntEvaluator extends AbstractMultivalueFunction.Abstract
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     IntBlock v = (IntBlock) fieldVal;
     int positionCount = v.getPositionCount();
     int[] values = new int[positionCount];
@@ -65,6 +77,44 @@ public final class MvMinIntEvaluator extends AbstractMultivalueFunction.Abstract
         value = MvMin.process(value, next);
       }
       int result = value;
+      values[p] = result;
+    }
+    return new IntArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    IntBlock v = (IntBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    IntBlock.Builder builder = IntBlock.newBlockBuilder(positionCount);
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMin.ascendingIndex(valueCount);
+      int result = v.getInt(first + idx);
+      builder.appendInt(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    IntBlock v = (IntBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    int[] values = new int[positionCount];
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMin.ascendingIndex(valueCount);
+      int result = v.getInt(first + idx);
       values[p] = result;
     }
     return new IntArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinLongEvaluator.java
@@ -26,8 +26,14 @@ public final class MvMinLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return "MvMin";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNullable(fieldVal);
+    }
     LongBlock v = (LongBlock) fieldVal;
     int positionCount = v.getPositionCount();
     LongBlock.Builder builder = LongBlock.newBlockBuilder(positionCount);
@@ -50,8 +56,14 @@ public final class MvMinLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
+    if (fieldVal.mvOrdering() == Block.MvOrdering.ASCENDING) {
+      return evalAscendingNotNullable(fieldVal);
+    }
     LongBlock v = (LongBlock) fieldVal;
     int positionCount = v.getPositionCount();
     long[] values = new long[positionCount];
@@ -65,6 +77,44 @@ public final class MvMinLongEvaluator extends AbstractMultivalueFunction.Abstrac
         value = MvMin.process(value, next);
       }
       long result = value;
+      values[p] = result;
+    }
+    return new LongArrayVector(values, positionCount);
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Block evalAscendingNullable(Block fieldVal) {
+    LongBlock v = (LongBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    LongBlock.Builder builder = LongBlock.newBlockBuilder(positionCount);
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      if (valueCount == 0) {
+        builder.appendNull();
+        continue;
+      }
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMin.ascendingIndex(valueCount);
+      long result = v.getLong(first + idx);
+      builder.appendLong(result);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field and all multivalued fields are in ascending order.
+   */
+  private Vector evalAscendingNotNullable(Block fieldVal) {
+    LongBlock v = (LongBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    long[] values = new long[positionCount];
+    for (int p = 0; p < positionCount; p++) {
+      int valueCount = v.getValueCount(p);
+      int first = v.getFirstValueIndex(p);
+      int idx = MvMin.ascendingIndex(valueCount);
+      long result = v.getLong(first + idx);
       values[p] = result;
     }
     return new LongArrayVector(values, positionCount);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumDoubleEvaluator.java
@@ -27,6 +27,9 @@ public final class MvSumDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return "MvSum";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     DoubleBlock v = (DoubleBlock) fieldVal;
@@ -51,6 +54,9 @@ public final class MvSumDoubleEvaluator extends AbstractMultivalueFunction.Abstr
     return builder.build();
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Vector evalNotNullable(Block fieldVal) {
     DoubleBlock v = (DoubleBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumIntEvaluator.java
@@ -30,6 +30,9 @@ public final class MvSumIntEvaluator extends AbstractMultivalueFunction.Abstract
     return "MvSum";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     IntBlock v = (IntBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumLongEvaluator.java
@@ -30,6 +30,9 @@ public final class MvSumLongEvaluator extends AbstractMultivalueFunction.Abstrac
     return "MvSum";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumUnsignedLongEvaluator.java
@@ -30,6 +30,9 @@ public final class MvSumUnsignedLongEvaluator extends AbstractMultivalueFunction
     return "MvSum";
   }
 
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
   @Override
   public Block evalNullable(Block fieldVal) {
     LongBlock v = (LongBlock) fieldVal;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMax.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMax.java
@@ -57,12 +57,12 @@ public class MvMax extends AbstractMultivalueFunction {
         return NodeInfo.create(this, MvMax::new, field());
     }
 
-    @MvEvaluator(extraName = "Boolean")
+    @MvEvaluator(extraName = "Boolean", ascending = "ascendingIndex")
     static boolean process(boolean current, boolean v) {
         return current || v;
     }
 
-    @MvEvaluator(extraName = "BytesRef")
+    @MvEvaluator(extraName = "BytesRef", ascending = "ascendingIndex")
     static void process(BytesRef current, BytesRef v) {
         if (v.compareTo(current) > 0) {
             current.bytes = v.bytes;
@@ -71,18 +71,25 @@ public class MvMax extends AbstractMultivalueFunction {
         }
     }
 
-    @MvEvaluator(extraName = "Double")
+    @MvEvaluator(extraName = "Double", ascending = "ascendingIndex")
     static double process(double current, double v) {
         return Math.max(current, v);
     }
 
-    @MvEvaluator(extraName = "Int")
+    @MvEvaluator(extraName = "Int", ascending = "ascendingIndex")
     static int process(int current, int v) {
         return Math.max(current, v);
     }
 
-    @MvEvaluator(extraName = "Long")
+    @MvEvaluator(extraName = "Long", ascending = "ascendingIndex")
     static long process(long current, long v) {
         return Math.max(current, v);
+    }
+
+    /**
+     * If the values as ascending pick the final value.
+     */
+    static int ascendingIndex(int count) {
+        return count - 1;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMin.java
@@ -57,12 +57,12 @@ public class MvMin extends AbstractMultivalueFunction {
         return NodeInfo.create(this, MvMin::new, field());
     }
 
-    @MvEvaluator(extraName = "Boolean")
+    @MvEvaluator(extraName = "Boolean", ascending = "ascendingIndex")
     static boolean process(boolean current, boolean v) {
         return current && v;
     }
 
-    @MvEvaluator(extraName = "BytesRef")
+    @MvEvaluator(extraName = "BytesRef", ascending = "ascendingIndex")
     static void process(BytesRef current, BytesRef v) {
         if (v.compareTo(current) < 0) {
             current.bytes = v.bytes;
@@ -71,18 +71,25 @@ public class MvMin extends AbstractMultivalueFunction {
         }
     }
 
-    @MvEvaluator(extraName = "Double")
+    @MvEvaluator(extraName = "Double", ascending = "ascendingIndex")
     static double process(double current, double v) {
         return Math.min(current, v);
     }
 
-    @MvEvaluator(extraName = "Int")
+    @MvEvaluator(extraName = "Int", ascending = "ascendingIndex")
     static int process(int current, int v) {
         return Math.min(current, v);
     }
 
-    @MvEvaluator(extraName = "Long")
+    @MvEvaluator(extraName = "Long", ascending = "ascendingIndex")
     static long process(long current, long v) {
         return Math.min(current, v);
+    }
+
+    /**
+     * If the values are ascending pick the first value.
+     */
+    static int ascendingIndex(int count) {
+        return 0;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -229,6 +229,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     public final void testSimple() {
         Expression expression = buildFieldExpression(testCase);
         assertThat(expression.dataType(), equalTo(testCase.exptectedType));
+        // TODO should we convert unsigned_long into BigDecimal so it's easier to assert?
         Object result = toJavaObject(evaluator(expression).get().eval(row(testCase.getDataValues())), 0);
         assertThat(result, testCase.getMatcher());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
@@ -7,37 +7,385 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.ql.expression.Expression;
-import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.util.NumericUtils;
 import org.hamcrest.Matcher;
 
+import java.math.BigInteger;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarFunctionTestCase {
-    protected abstract Expression build(Source source, Expression field);
-
-    protected abstract Matcher<Object> resultMatcherForInput(List<?> input, DataType dataType);
-
-    protected abstract DataType[] supportedTypes();
+    /**
+     * Build a test case with {@code boolean} values.
+     */
+    protected static void booleans(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        BiFunction<Integer, Stream<Boolean>, Matcher<Object>> matcher
+    ) {
+        booleans(cases, name, evaluatorName, DataTypes.BOOLEAN, matcher);
+    }
 
     /**
-     * Matcher for single valued fields.
+     * Build a test case with {@code boolean} values.
      */
-    private Matcher<Object> singleValueMatcher(Object o, DataType dataType) {
-        return o == null ? nullValue() : resultMatcherForInput(List.of(o), dataType);
+    protected static void booleans(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        DataType expectedDataType,
+        BiFunction<Integer, Stream<Boolean>, Matcher<Object>> matcher
+    ) {
+        cases.add(
+            new TestCaseSupplier(
+                name + "(false)",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(false), DataTypes.BOOLEAN, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, Stream.of(false))
+                )
+            )
+        );
+        cases.add(
+            new TestCaseSupplier(
+                name + "(true)",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(true), DataTypes.BOOLEAN, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, Stream.of(true))
+                )
+            )
+        );
+        for (Block.MvOrdering ordering : Block.MvOrdering.values()) {
+            cases.add(new TestCaseSupplier(name + "(<booleans>) " + ordering, () -> {
+                List<Boolean> mvData = randomList(2, 100, ESTestCase::randomBoolean);
+                putInOrder(mvData, ordering);
+                return new TestCase(
+                    List.of(new TypedData(mvData, DataTypes.BOOLEAN, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(mvData.size(), mvData.stream())
+                );
+            }));
+        }
     }
+
+    /**
+     * Build a test case with {@link BytesRef} values.
+     */
+    protected static void bytesRefs(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        BiFunction<Integer, Stream<BytesRef>, Matcher<Object>> matcher
+    ) {
+        bytesRefs(cases, name, evaluatorName, DataTypes.KEYWORD, matcher);
+    }
+
+    /**
+     * Build a test case with {@link BytesRef} values.
+     */
+    protected static void bytesRefs(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        DataType expectedDataType,
+        BiFunction<Integer, Stream<BytesRef>, Matcher<Object>> matcher
+    ) {
+        cases.add(
+            new TestCaseSupplier(
+                name + "(\"\")",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(new BytesRef("")), DataTypes.KEYWORD, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, Stream.of(new BytesRef("")))
+                )
+            )
+        );
+        cases.add(new TestCaseSupplier(name + "(BytesRef)", () -> {
+            BytesRef data = new BytesRef(randomAlphaOfLength(10));
+            return new TestCase(
+                List.of(new TypedData(List.of(data), DataTypes.KEYWORD, "field")),
+                evaluatorName + "[field=Attribute[channel=0]]",
+                expectedDataType,
+                matcher.apply(1, Stream.of(data))
+            );
+        }));
+        for (Block.MvOrdering ordering : Block.MvOrdering.values()) {
+            cases.add(new TestCaseSupplier(name + "(<BytesRefs>) " + ordering, () -> {
+                List<BytesRef> mvData = randomList(1, 100, () -> new BytesRef(randomAlphaOfLength(10)));
+                putInOrder(mvData, ordering);
+                return new TestCase(
+                    List.of(new TypedData(mvData, DataTypes.KEYWORD, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(mvData.size(), mvData.stream())
+                );
+            }));
+        }
+    }
+
+    /**
+     * Build a test case with {@code double} values.
+     */
+    protected static void doubles(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        BiFunction<Integer, DoubleStream, Matcher<Object>> matcher
+    ) {
+        doubles(cases, name, evaluatorName, DataTypes.DOUBLE, matcher);
+    }
+
+    /**
+     * Build a test case with {@code double} values.
+     */
+    protected static void doubles(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        DataType expectedDataType,
+        BiFunction<Integer, DoubleStream, Matcher<Object>> matcher
+    ) {
+        cases.add(
+            new TestCaseSupplier(
+                name + "(0.0)",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(0.0), DataTypes.DOUBLE, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, DoubleStream.of(0.0))
+                )
+            )
+        );
+        cases.add(new TestCaseSupplier(name + "(double)", () -> {
+            double mvData = randomDouble();
+            return new TestCase(
+                List.of(new TypedData(List.of(mvData), DataTypes.DOUBLE, "field")),
+                evaluatorName + "[field=Attribute[channel=0]]",
+                expectedDataType,
+                matcher.apply(1, DoubleStream.of(mvData))
+            );
+        }));
+        for (Block.MvOrdering ordering : Block.MvOrdering.values()) {
+            cases.add(new TestCaseSupplier(name + "(<double>) " + ordering, () -> {
+                List<Double> mvData = randomList(1, 100, ESTestCase::randomDouble);
+                putInOrder(mvData, ordering);
+                return new TestCase(
+                    List.of(new TypedData(mvData, DataTypes.DOUBLE, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(mvData.size(), mvData.stream().mapToDouble(Double::doubleValue))
+                );
+            }));
+        }
+    }
+
+    /**
+     * Build a test case with {@code int} values.
+     */
+    protected static void ints(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        BiFunction<Integer, IntStream, Matcher<Object>> matcher
+    ) {
+        ints(cases, name, evaluatorName, DataTypes.INTEGER, matcher);
+    }
+
+    /**
+     * Build a test case with {@code int} values.
+     */
+    protected static void ints(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        DataType expectedDataType,
+        BiFunction<Integer, IntStream, Matcher<Object>> matcher
+    ) {
+        cases.add(
+            new TestCaseSupplier(
+                name + "(0)",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(0), DataTypes.INTEGER, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, IntStream.of(0))
+                )
+            )
+        );
+        cases.add(new TestCaseSupplier(name + "(int)", () -> {
+            int data = randomInt();
+            return new TestCase(
+                List.of(new TypedData(List.of(data), DataTypes.INTEGER, "field")),
+                evaluatorName + "[field=Attribute[channel=0]]",
+                expectedDataType,
+                matcher.apply(1, IntStream.of(data))
+            );
+        }));
+        for (Block.MvOrdering ordering : Block.MvOrdering.values()) {
+            cases.add(new TestCaseSupplier(name + "(<ints>) " + ordering, () -> {
+                List<Integer> mvData = randomList(1, 100, ESTestCase::randomInt);
+                putInOrder(mvData, ordering);
+                return new TestCase(
+                    List.of(new TypedData(mvData, DataTypes.INTEGER, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(mvData.size(), mvData.stream().mapToInt(Integer::intValue))
+                );
+            }));
+        }
+    }
+
+    /**
+     * Build a test case with {@code long} values.
+     */
+    protected static void longs(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        BiFunction<Integer, LongStream, Matcher<Object>> matcher
+    ) {
+        longs(cases, name, evaluatorName, DataTypes.LONG, matcher);
+    }
+
+    /**
+     * Build a test case with {@code long} values.
+     */
+    protected static void longs(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        DataType expectedDataType,
+        BiFunction<Integer, LongStream, Matcher<Object>> matcher
+    ) {
+        cases.add(
+            new TestCaseSupplier(
+                name + "(0L)",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(0L), DataTypes.LONG, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, LongStream.of(0L))
+                )
+            )
+        );
+        cases.add(new TestCaseSupplier(name + "(long)", () -> {
+            long data = randomLong();
+            return new TestCase(
+                List.of(new TypedData(List.of(data), DataTypes.LONG, "field")),
+                evaluatorName + "[field=Attribute[channel=0]]",
+                expectedDataType,
+                matcher.apply(1, LongStream.of(data))
+            );
+        }));
+        for (Block.MvOrdering ordering : Block.MvOrdering.values()) {
+            cases.add(new TestCaseSupplier(name + "(<longs>) " + ordering, () -> {
+                List<Long> mvData = randomList(1, 100, ESTestCase::randomLong);
+                putInOrder(mvData, ordering);
+                return new TestCase(
+                    List.of(new TypedData(mvData, DataTypes.LONG, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(mvData.size(), mvData.stream().mapToLong(Long::longValue))
+                );
+            }));
+        }
+    }
+
+    /**
+     * Build a test case with unsigned {@code long} values.
+     */
+    protected static void unsignedLongs(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        BiFunction<Integer, Stream<BigInteger>, Matcher<Object>> matcher
+    ) {
+        unsignedLongs(cases, name, evaluatorName, DataTypes.UNSIGNED_LONG, matcher);
+    }
+
+    /**
+     * Build a test case with unsigned {@code long} values.
+     */
+    protected static void unsignedLongs(
+        List<TestCaseSupplier> cases,
+        String name,
+        String evaluatorName,
+        DataType expectedDataType,
+        BiFunction<Integer, Stream<BigInteger>, Matcher<Object>> matcher
+    ) {
+        cases.add(
+            new TestCaseSupplier(
+                name + "(0UL)",
+                () -> new TestCase(
+                    List.of(new TypedData(List.of(NumericUtils.asLongUnsigned(BigInteger.ZERO)), DataTypes.UNSIGNED_LONG, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(1, Stream.of(BigInteger.ZERO))
+                )
+            )
+        );
+        cases.add(new TestCaseSupplier(name + "(unsigned long)", () -> {
+            long data = randomLong();
+            return new TestCase(
+                List.of(new TypedData(List.of(data), DataTypes.UNSIGNED_LONG, "field")),
+                evaluatorName + "[field=Attribute[channel=0]]",
+                expectedDataType,
+                matcher.apply(1, Stream.of(NumericUtils.unsignedLongAsBigInteger(data)))
+            );
+        }));
+        for (Block.MvOrdering ordering : Block.MvOrdering.values()) {
+            cases.add(new TestCaseSupplier(name + "(<unsigned longs>) " + ordering, () -> {
+                List<Long> mvData = randomList(1, 100, ESTestCase::randomLong);
+                putInOrder(mvData, ordering);
+                return new TestCase(
+                    List.of(new TypedData(mvData, DataTypes.UNSIGNED_LONG, "field")),
+                    evaluatorName + "[field=Attribute[channel=0]]",
+                    expectedDataType,
+                    matcher.apply(mvData.size(), mvData.stream().map(NumericUtils::unsignedLongAsBigInteger))
+                );
+            }));
+        }
+    }
+
+    private static <T extends Comparable<T>> void putInOrder(List<T> mvData, Block.MvOrdering ordering) {
+        switch (ordering) {
+            case UNORDERED -> {
+            }
+            case ASCENDING -> Collections.sort(mvData);
+            default -> throw new UnsupportedOperationException("unsupported ordering [" + ordering + "]");
+        }
+    }
+
+    protected abstract Expression build(Source source, Expression field);
+
+    protected abstract DataType[] supportedTypes();
 
     @Override
     protected final List<AbstractScalarFunctionTestCase.ArgumentSpec> argSpec() {
@@ -49,87 +397,56 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
         return argTypes.get(0);
     }
 
-    private Matcher<Object> resultsMatcher(List<TypedData> typedData) {
-        return resultMatcherForInput((List<?>) typedData.get(0).data(), typedData.get(0).type());
-    }
-
     @Override
     protected final Expression build(Source source, List<Expression> args) {
         return build(source, args.get(0));
     }
 
-    public final void testVector() {
-        for (DataType type : supportedTypes()) {
-            List<List<Object>> data = randomList(1, 200, () -> singletonList(randomLiteral(type).value()));
-            Expression expression = build(Source.EMPTY, field("f", type));
-            Block result = evaluator(expression).get().eval(new Page(BlockUtils.fromList(data)));
-            assertThat(result.asVector(), type == DataTypes.NULL ? nullValue() : notNullValue());
-            for (int p = 0; p < data.size(); p++) {
-                assertThat(toJavaObject(result, p), singleValueMatcher(data.get(p).get(0), type));
-            }
-        }
+    /**
+     * Tests a {@link Block} of values, all copied from the input pattern.
+     * <p>
+     *     Note that this'll sometimes be a {@link Vector} of values if the
+     *     input pattern contained only a single value.
+     * </p>
+     */
+    public final void testBlockWithoutNulls() {
+        testBlock(false);
     }
 
-    public final void testBlock() {
-        for (boolean insertNulls : new boolean[] { false, true }) {
-            for (DataType type : supportedTypes()) {
-                List<List<Object>> data = randomList(
-                    1,
-                    200,
-                    () -> type == DataTypes.NULL || (insertNulls && rarely()) ? singletonList(null) : List.of(dataForPosition(type))
-                );
-                Expression expression = build(Source.EMPTY, field("f", type));
-                Block result = evaluator(expression).get().eval(new Page(BlockUtils.fromList(data)));
-                boolean warningsAsserted = false;
-                for (int p = 0; p < data.size(); p++) {
-                    if (data.get(p).get(0) == null) {
-                        assertTrue(type.toString(), result.isNull(p));
-                    } else if (result.isNull(p) && type != DataTypes.NULL) {
-                        if (warningsAsserted == false) {
-                            assertEvalWarnings(expression, type);
-                            // only the 1st failure in a block registers a warning; the rest will simply be deduplicated
-                            warningsAsserted = true;
-                        }
-                    } else {
-                        assertThat(type.toString(), toJavaObject(result, p), resultMatcherForInput((List<?>) data.get(p).get(0), type));
-                    }
+    /**
+     * Tests a {@link Block} of values, all copied from the input pattern with
+     * some null values inserted between.
+     */
+    public final void testBlockWithNulls() {
+        testBlock(true);
+    }
+
+    private void testBlock(boolean insertNulls) {
+        int positions = between(1, 1024);
+        TypedData data = testCase.getData().get(0);
+        Block oneRowBlock = BlockUtils.fromListRow(testCase.getDataValues())[0];
+        ElementType elementType = LocalExecutionPlanner.toElementType(data.type());
+        Block.Builder builder = elementType.newBlockBuilder(positions);
+        for (int p = 0; p < positions; p++) {
+            if (insertNulls && randomBoolean()) {
+                int nulls = between(1, 5);
+                for (int n = 0; n < nulls; n++) {
+                    builder.appendNull();
                 }
             }
+            builder.copyFrom(oneRowBlock, 0, 1);
         }
-    }
+        Block input = builder.build();
+        Block result = evaluator(buildFieldExpression(testCase)).get().eval(new Page(input));
 
-    public final void testFoldSingleValue() {
-        for (DataType type : supportedTypes()) {
-            Literal lit = randomLiteral(type);
-            Expression expression = build(Source.EMPTY, lit);
-            assertTrue(expression.foldable());
-            assertThat(expression.fold(), singleValueMatcher(lit.value(), type));
-        }
-    }
-
-    public final void testFoldManyValues() {
-        for (DataType type : supportedTypes()) {
-            List<Object> data = type == DataTypes.NULL ? null : randomList(1, 100, () -> randomLiteral(type).value());
-            Expression expression = build(Source.EMPTY, new Literal(Source.EMPTY, data, type));
-            assertTrue(expression.foldable());
-            Object folded = expression.fold();
-            if (folded == null && type != DataTypes.NULL) {
-                assertEvalWarnings(expression, type);
-            } else {
-                assertThat(folded, resultMatcherForInput(data, type));
+        assertThat(result.getPositionCount(), equalTo(result.getPositionCount()));
+        for (int p = 0; p < input.getPositionCount(); p++) {
+            if (input.isNull(p)) {
+                assertThat(result.isNull(p), equalTo(true));
+                continue;
             }
+            assertThat(result.isNull(p), equalTo(false));
+            assertThat(toJavaObject(result, p), testCase.getMatcher());
         }
-    }
-
-    private List<Object> dataForPosition(DataType type) {
-        return randomList(1, 100, () -> randomLiteral(type).value());
-    }
-
-    private void assertEvalWarnings(Expression e, DataType dt) {
-        assertCriticalWarnings(
-            "Line -1:-1: evaluation of [" + e + "] failed, treating result as null. Only first 20 failures recorded.",
-            "java.lang.ArithmeticException: " + dt.typeName() + " overflow"
-        );
-
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvConcatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvConcatTests.java
@@ -16,12 +16,10 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.hamcrest.Matcher;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,17 +48,6 @@ public class MvConcatTests extends AbstractScalarFunctionTestCase {
     @Override
     protected Expression build(Source source, List<Expression> args) {
         return new MvConcat(source, args.get(0), args.get(1));
-    }
-
-    private Matcher<Object> resultsMatcher(List<TypedData> typedData) {
-        List<?> field = (List<?>) typedData.get(0).data();
-        BytesRef delim = (BytesRef) typedData.get(1).data();
-        if (field == null || delim == null) {
-            return nullValue();
-        }
-        return equalTo(
-            new BytesRef(field.stream().map(v -> ((BytesRef) v).utf8ToString()).collect(Collectors.joining(delim.utf8ToString())))
-        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
@@ -14,13 +14,12 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.hamcrest.Matcher;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class MvCountTests extends AbstractMultivalueFunctionTestCase {
     public MvCountTests(@Name("TestCase") Supplier<TestCase> testCaseSupplier) {
@@ -29,15 +28,14 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("mv_count(<double>)", () -> {
-            List<Double> mvData = randomList(1, 100, () -> randomDouble());
-            return new TestCase(
-                List.of(new TypedData(mvData, DataTypes.DOUBLE, "field")),
-                "MvCount[field=Attribute[channel=0]]",
-                DataTypes.INTEGER,
-                equalTo(mvData.size())
-            );
-        })));
+        List<TestCaseSupplier> cases = new ArrayList<>();
+        booleans(cases, "mv_count", "MvCount", DataTypes.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
+        bytesRefs(cases, "mv_count", "MvCount", DataTypes.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
+        doubles(cases, "mv_count", "MvCount", DataTypes.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
+        ints(cases, "mv_count", "MvCount", DataTypes.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
+        longs(cases, "mv_count", "MvCount", DataTypes.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
+        unsignedLongs(cases, "mv_count", "MvCount", DataTypes.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
+        return parameterSuppliersFromTypedData(cases);
     }
 
     @Override
@@ -54,10 +52,4 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
     protected DataType expectedType(List<DataType> argTypes) {
         return DataTypes.INTEGER;
     }
-
-    @Override
-    protected Matcher<Object> resultMatcherForInput(List<?> input, DataType dataType) {
-        return input == null ? nullValue() : equalTo(input.size());
-    }
-
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxTests.java
@@ -10,21 +10,18 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.hamcrest.Matcher;
+import org.elasticsearch.xpack.ql.util.NumericUtils;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class MvMaxTests extends AbstractMultivalueFunctionTestCase {
     public MvMaxTests(@Name("TestCase") Supplier<TestCase> testCaseSupplier) {
@@ -33,15 +30,19 @@ public class MvMaxTests extends AbstractMultivalueFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("mv_max(<double>)", () -> {
-            List<Double> mvData = randomList(1, 100, () -> randomDouble());
-            return new TestCase(
-                List.of(new TypedData(mvData, DataTypes.DOUBLE, "field")),
-                "MvMax[field=Attribute[channel=0]]",
-                DataTypes.DOUBLE,
-                equalTo(mvData.stream().mapToDouble(Double::doubleValue).summaryStatistics().getMax())
-            );
-        })));
+        List<TestCaseSupplier> cases = new ArrayList<>();
+        booleans(cases, "mv_max", "MvMax", (size, values) -> equalTo(values.max(Comparator.naturalOrder()).get()));
+        bytesRefs(cases, "mv_max", "MvMax", (size, values) -> equalTo(values.max(Comparator.naturalOrder()).get()));
+        doubles(cases, "mv_max", "MvMax", (size, values) -> equalTo(values.max().getAsDouble()));
+        ints(cases, "mv_max", "MvMax", (size, values) -> equalTo(values.max().getAsInt()));
+        longs(cases, "mv_max", "MvMax", (size, values) -> equalTo(values.max().getAsLong()));
+        unsignedLongs(
+            cases,
+            "mv_max",
+            "MvMax",
+            (size, values) -> equalTo(NumericUtils.asLongUnsigned(values.reduce(BigInteger::max).get()))
+        );
+        return parameterSuppliersFromTypedData(cases);
     }
 
     @Override
@@ -53,20 +54,4 @@ public class MvMaxTests extends AbstractMultivalueFunctionTestCase {
     protected DataType[] supportedTypes() {
         return representable();
     }
-
-    @Override
-    protected Matcher<Object> resultMatcherForInput(List<?> input, DataType dataType) {
-        if (input == null) {
-            return nullValue();
-        }
-        return switch (LocalExecutionPlanner.toElementType(EsqlDataTypes.fromJava(input.get(0)))) {
-            case BOOLEAN -> equalTo(input.stream().mapToInt(o -> (Boolean) o ? 1 : 0).max().getAsInt() == 1);
-            case BYTES_REF -> equalTo(input.stream().map(o -> (BytesRef) o).max(Comparator.naturalOrder()).get());
-            case DOUBLE -> equalTo(input.stream().mapToDouble(o -> (Double) o).max().getAsDouble());
-            case INT -> equalTo(input.stream().mapToInt(o -> (Integer) o).max().getAsInt());
-            case LONG -> equalTo(input.stream().mapToLong(o -> (Long) o).max().getAsLong());
-            default -> throw new UnsupportedOperationException("unsupported type " + input);
-        };
-    }
-
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinTests.java
@@ -10,21 +10,18 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.hamcrest.Matcher;
+import org.elasticsearch.xpack.ql.util.NumericUtils;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class MvMinTests extends AbstractMultivalueFunctionTestCase {
     public MvMinTests(@Name("TestCase") Supplier<TestCase> testCaseSupplier) {
@@ -33,15 +30,19 @@ public class MvMinTests extends AbstractMultivalueFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("mv_min(<double>)", () -> {
-            List<Double> mvData = randomList(1, 100, () -> randomDouble());
-            return new TestCase(
-                List.of(new TypedData(mvData, DataTypes.DOUBLE, "field")),
-                "MvMin[field=Attribute[channel=0]]",
-                DataTypes.DOUBLE,
-                equalTo(mvData.stream().mapToDouble(Double::doubleValue).summaryStatistics().getMin())
-            );
-        })));
+        List<TestCaseSupplier> cases = new ArrayList<>();
+        booleans(cases, "mv_min", "MvMin", (size, values) -> equalTo(values.min(Comparator.naturalOrder()).get()));
+        bytesRefs(cases, "mv_min", "MvMin", (size, values) -> equalTo(values.min(Comparator.naturalOrder()).get()));
+        doubles(cases, "mv_min", "MvMin", (size, values) -> equalTo(values.min().getAsDouble()));
+        ints(cases, "mv_min", "MvMin", (size, values) -> equalTo(values.min().getAsInt()));
+        longs(cases, "mv_min", "MvMin", (size, values) -> equalTo(values.min().getAsLong()));
+        unsignedLongs(
+            cases,
+            "mv_min",
+            "MvMin",
+            (size, values) -> equalTo(NumericUtils.asLongUnsigned(values.reduce(BigInteger::min).get()))
+        );
+        return parameterSuppliersFromTypedData(cases);
     }
 
     @Override
@@ -53,20 +54,4 @@ public class MvMinTests extends AbstractMultivalueFunctionTestCase {
     protected DataType[] supportedTypes() {
         return representable();
     }
-
-    @Override
-    protected Matcher<Object> resultMatcherForInput(List<?> input, DataType dataType) {
-        if (input == null) {
-            return nullValue();
-        }
-        return switch (LocalExecutionPlanner.toElementType(EsqlDataTypes.fromJava(input.get(0)))) {
-            case BOOLEAN -> equalTo(input.stream().mapToInt(o -> (Boolean) o ? 1 : 0).min().getAsInt() == 1);
-            case BYTES_REF -> equalTo(input.stream().map(o -> (BytesRef) o).min(Comparator.naturalOrder()).get());
-            case DOUBLE -> equalTo(input.stream().mapToDouble(o -> (Double) o).min().getAsDouble());
-            case INT -> equalTo(input.stream().mapToInt(o -> (Integer) o).min().getAsInt());
-            case LONG -> equalTo(input.stream().mapToLong(o -> (Long) o).min().getAsLong());
-            default -> throw new UnsupportedOperationException("unsupported type " + input);
-        };
-    }
-
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumTests.java
@@ -10,21 +10,15 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
-import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.hamcrest.Matcher;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.xpack.ql.util.NumericUtils.asLongUnsigned;
-import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAsBigInteger;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class MvSumTests extends AbstractMultivalueFunctionTestCase {
     public MvSumTests(@Name("TestCase") Supplier<TestCase> testCaseSupplier) {
@@ -33,15 +27,13 @@ public class MvSumTests extends AbstractMultivalueFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("mv_sum(<double>)", () -> {
-            List<Double> mvData = randomList(1, 100, () -> randomDouble());
-            return new TestCase(
-                List.of(new TypedData(mvData, DataTypes.DOUBLE, "field")),
-                "MvSum[field=Attribute[channel=0]]",
-                DataTypes.DOUBLE,
-                equalTo(mvData.stream().mapToDouble(Double::doubleValue).summaryStatistics().getSum())
-            );
-        })));
+        List<TestCaseSupplier> cases = new ArrayList<>();
+        doubles(cases, "mv_sum", "MvSum", (size, values) -> equalTo(values.sum()));
+        // TODO turn these on once we are summing without overflow
+        // ints(cases, "mv_sum", "MvSum", (size, values) -> equalTo(values.sum()));
+        // longs(cases, "mv_sum", "MvSum", (size, values) -> equalTo(values.sum()));
+        // unsignedLongAsBigInteger(cases, "mv_sum", "MvSum", (size, values) -> equalTo(values.sum()));
+        return parameterSuppliersFromTypedData(cases);
     }
 
     @Override
@@ -53,32 +45,4 @@ public class MvSumTests extends AbstractMultivalueFunctionTestCase {
     protected DataType[] supportedTypes() {
         return representableNumerics();
     }
-
-    @Override
-    protected Matcher<Object> resultMatcherForInput(List<?> input, DataType dataType) {
-        return switch (LocalExecutionPlanner.toElementType(dataType)) {
-            case DOUBLE -> {
-                CompensatedSum sum = new CompensatedSum();
-                for (Object i : input) {
-                    sum.add((Double) i);
-                }
-                yield equalTo(sum.value());
-            }
-            case INT -> equalTo(input.stream().mapToInt(o -> (Integer) o).sum());
-            case LONG -> {
-                if (dataType == DataTypes.UNSIGNED_LONG) {
-                    long sum = asLongUnsigned(0);
-                    for (Object i : input) {
-                        sum = asLongUnsigned(unsignedLongAsBigInteger(sum).add(unsignedLongAsBigInteger((long) i)).longValue());
-                        ;
-                    }
-                    yield equalTo(sum);
-                }
-                yield equalTo(input.stream().mapToLong(o -> (Long) o).sum());
-            }
-            case NULL -> nullValue();
-            default -> throw new UnsupportedOperationException("unsupported type " + input);
-        };
-    }
-
 }


### PR DESCRIPTION
When multivalued fields are loaded from lucene they are in sorted order but we weren't taking advantage of that fact. Now we are! It's much faster, even for fast operations like `mv_min`

```
     (operation)  Mode  Cnt  Score   Error  Units
          mv_min  avgt    7  3.820 ± 0.070  ns/op
mv_min_ascending  avgt    7  1.979 ± 0.130  ns/op
```

We still have code to run in non-sorted mode because conversion functions and a few other things don't load in sorted order.

I've also ported expanded the parameterized tests for the `MV_` functions because, well, I needed to expand them at least a little to test this change. And I just kept going and improved as many tests as I could.
