### PR TITLE
[Search Relevance] Delete extra space from exception message

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
@@ -48,7 +48,7 @@ public final class LicenseUtils {
             "Current license is non-compliant for "
                 + product.getName()
                 + ". Current license is {}. "
-                + " This feature requires an active trial, platinum or enterprise license.",
+                + "This feature requires an active trial, platinum or enterprise license.",
             RestStatus.FORBIDDEN,
             licenseStatus
         );


### PR DESCRIPTION
There exists an extra space before "This feature ..." in the exception message. In this PR, we removed the space.

<img width="1714" alt="Screenshot 2023-08-15 at 4 30 00 PM" src="https://github.com/elastic/elasticsearch/assets/132922331/908babce-5da8-4de6-9daf-87ad6d74aa8a">
