### PR TITLE
Handle ES internal assertion errors in IT test

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -172,6 +172,8 @@ public class BulkIntegrationIT extends ESIntegTestCase {
                         logger.info("--> index id={} seq_no={}", response.getId(), response.getSeqNo());
                     } catch (ElasticsearchException ignore) {
                         logger.info("--> fail to index id={}", id);
+                    } catch (AssertionError ignore) {
+                        logger.info("--> fail to index id={} due to internal AssertionError", id);
                     }
                 }
             });


### PR DESCRIPTION
Indexing test thread throws `AssertionError` which is not handled, so it escapes to main **test thread**
```
aug 14, 2023 10:39:19 AM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException |  
-- | --
  | WARNING: Uncaught exception in thread: Thread[elasticsearch[node_s0][write][T#4],5,TGRP-BulkIntegrationIT] |  
  | java.lang.AssertionError: primary indexing unexpected in state [CLOSED] |  
  | at __randomizedtesting.SeedInfo.seed([8C8A69C029D945DF]:0) |  
  | at org.elasticsearch.index.shard.IndexShard.assertStartedForPrimaryIndexing(IndexShard.java:2204) |  
  | at org.elasticsearch.index.shard.IndexShard.ensureWriteAllowed(IndexShard.java:2184)
```
full test [log](https://gradle-enterprise.elastic.co/s/oraopkwtuyble/tests/task/:server:internalClusterTest/details/org.elasticsearch.action.bulk.BulkIntegrationIT/testDeleteIndexWhileIndexing?top-execution=1)

uncaught exception releases `thread.join` wait and **test thread** might be able to execute following `assertFalse` statement. Indexing thread might be technically alive by the time of `assertFalse` execution (e.g. due to jvm housekeeping so that thread status is not reported to OS in time thus **isAlive**  as native method still thinks that thread is ok)

```
            thread.join(ReplicationRequest.DEFAULT_TIMEOUT.millis() / 2);
            assertFalse(thread.isAlive());
```

Closes #98435