### PR TITLE
Check allowed states before the primary mode check

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2174,6 +2174,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 );
             }
         } else {
+            if (writeAllowedStates.contains(state) == false) {
+                throw new IllegalIndexShardStateException(
+                    shardId,
+                    state,
+                    "operation only allowed when shard state is one of " + writeAllowedStates + ", origin [" + origin + "]"
+                );
+            }
             if (origin == Engine.Operation.Origin.PRIMARY) {
                 assert assertPrimaryMode();
                 // We only do indexing into primaries that are started since:
@@ -2188,13 +2195,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 assert origin == Engine.Operation.Origin.LOCAL_RESET;
                 assert getActiveOperationsCount() == OPERATIONS_BLOCKED
                     : "locally resetting without blocking operations, active operations [" + getActiveOperationsCount() + "]";
-            }
-            if (writeAllowedStates.contains(state) == false) {
-                throw new IllegalIndexShardStateException(
-                    shardId,
-                    state,
-                    "operation only allowed when shard state is one of " + writeAllowedStates + ", origin [" + origin + "]"
-                );
             }
         }
     }


### PR DESCRIPTION
If the current state is `CLOSED`, we want to bail out with an exception that can be gracefully handled, not an assertion that takes down the whole node.

Resolves #97889
Resolves #98255