### PR TITLE
Modify version check for upgrade tests to include 8.10

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.OLD;
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.UPGRADED;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @TestCaseOrdering(FullClusterRestartTestOrdering.class)
 public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTestCase {
@@ -85,7 +85,11 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
         if (version.equals(org.elasticsearch.Version.CURRENT)) {
             return IndexVersion.current();
         } else {
-            assertThat("Index version needs to be added to restart test parameters", version, lessThan(org.elasticsearch.Version.V_8_10_0));
+            assertThat(
+                "Index version needs to be added to restart test parameters",
+                version,
+                lessThanOrEqualTo(org.elasticsearch.Version.V_8_10_0)
+            );
             return IndexVersion.fromId(version.id);
         }
     }


### PR DESCRIPTION
#97200 hasn't been resolved yet, but IndexVersion hasn't yet been separated from Version. So it's ok to bump this check to include 8.10 so the 8.10 release can go ahead.

#97200 will need to be resolved for 8.11 instead.