### PR TITLE
ESQL: Replace AssertionError in mappers

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.versionfield.Version;
@@ -237,7 +238,7 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
             case "boolean" -> ((BooleanBlock) block).getBoolean(offset);
             case "version" -> new Version(((BytesRefBlock) block).getBytesRef(offset, scratch)).toString();
             case "unsupported" -> UnsupportedValueSource.UNSUPPORTED_OUTPUT;
-            default -> throw new UnsupportedOperationException("unsupported data type [" + dataType + "]");
+            default -> throw new EsqlIllegalArgumentException("unsupported data type [" + dataType + "]");
         };
     }
 
@@ -270,7 +271,7 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
                     case "boolean" -> ((BooleanBlock.Builder) builder).appendBoolean(((Boolean) value));
                     case "null" -> builder.appendNull();
                     case "version" -> ((BytesRefBlock.Builder) builder).appendBytesRef(new Version(value.toString()).toBytesRef());
-                    default -> throw new UnsupportedOperationException("unsupported data type [" + dataTypes.get(c) + "]");
+                    default -> throw new EsqlIllegalArgumentException("unsupported data type [" + dataTypes.get(c) + "]");
                 }
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -181,7 +181,7 @@ public class EnrichLookupService {
                     QueryList queryList = QueryList.termQueryList(fieldType, searchExecutionContext, inputBlock);
                     yield new EnrichQuerySourceOperator(queryList, searchExecutionContext.getIndexReader());
                 }
-                default -> throw new UnsupportedOperationException("unsupported match type " + matchType);
+                default -> throw new EsqlIllegalArgumentException("unsupported match type " + matchType);
             };
             List<Operator> intermediateOperators = new ArrayList<>(extractFields.size() + 2);
             final ElementType[] mergingTypes = new ElementType[extractFields.size()];

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,8 +97,8 @@ abstract class QueryList {
                 yield longBlock::getLong;
             }
             case NULL -> offset -> null;
-            case DOC -> throw new UnsupportedOperationException("can't read values from doc block");
-            case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
+            case DOC -> throw new EsqlIllegalArgumentException("can't read values from [doc] block");
+            case UNKNOWN -> throw new EsqlIllegalArgumentException("can't read values from [" + block + "]");
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.aggregation.CountDistinctBytesRefAggregatorFunc
 import org.elasticsearch.compute.aggregation.CountDistinctDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctLongAggregatorFunctionSupplier;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
@@ -86,6 +87,6 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
         if (type == DataTypes.KEYWORD || type == DataTypes.IP) {
             return new CountDistinctBytesRefAggregatorFunctionSupplier(bigArrays, inputChannels, precision);
         }
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("unsupported type [" + type.typeName() + "]");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/NumericAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/NumericAggregate.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.TypeResolutions;
@@ -70,7 +71,7 @@ public abstract class NumericAggregate extends AggregateFunction implements ToAg
         if (type == DataTypes.DOUBLE) {
             return doubleSupplier(bigArrays, inputChannels);
         }
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("unsupported type [" + type.typeName() + "]");
     }
 
     protected abstract AggregatorFunctionSupplier longSupplier(BigArrays bigArrays, List<Integer> inputChannels);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/UnaryScalarFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/UnaryScalarFunction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar;
 
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.TypeResolutions;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
@@ -66,6 +67,6 @@ public abstract class UnaryScalarFunction extends ScalarFunction {
 
     @Override
     public final ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -110,7 +111,7 @@ public class Case extends ScalarFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("case does not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.expression.function.Warnings;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.esql.planner.Mappable;
@@ -43,7 +44,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction implem
         DataType sourceType = field().dataType();
         var evaluator = evaluators().get(sourceType);
         if (evaluator == null) {
-            throw new UnsupportedOperationException("unsupported type [" + sourceType + "]");
+            throw new EsqlIllegalArgumentException("unsupported type [" + sourceType + "]");
         }
         return () -> evaluator.apply(fieldEval.get(), source());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
@@ -43,7 +43,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction implem
         DataType sourceType = field().dataType();
         var evaluator = evaluators().get(sourceType);
         if (evaluator == null) {
-            throw new AssertionError("unsupported type [" + sourceType + "]");
+            throw new UnsupportedOperationException("unsupported type [" + sourceType + "]");
         }
         return () -> evaluator.apply(fieldEval.get(), source());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/BinaryDateTimeFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/BinaryDateTimeFunction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.date;
 
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
@@ -44,7 +45,7 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("binary datetime functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
@@ -103,7 +103,7 @@ public class DateExtract extends ConfigurationFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("date_extract does not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateFormat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateFormat.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -128,6 +129,6 @@ public class DateFormat extends ConfigurationFunction implements OptionalArgumen
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("date_format does not support scripting");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -134,6 +134,6 @@ public class DateParse extends ScalarFunction implements OptionalArgument, Mappa
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("date_parse does not support scripting");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/Now.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/Now.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.date;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ConfigurationFunction;
@@ -81,6 +82,6 @@ public class Now extends ConfigurationFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("now does not support scripting");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.CIDRUtils;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
@@ -105,7 +106,7 @@ public class CIDRMatch extends ScalarFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Abs.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Abs.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -62,7 +63,7 @@ public class Abs extends UnaryScalarFunction implements Mappable {
         if (dataType() == DataTypes.INTEGER) {
             return () -> new AbsIntEvaluator(field.get());
         }
-        throw new UnsupportedOperationException("unsupported data type [" + dataType() + "]");
+        throw new EsqlIllegalArgumentException("unsupported data type [" + dataType() + "]");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
@@ -93,7 +94,7 @@ public class Atan2 extends ScalarFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     public Expression y() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AutoBucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AutoBucket.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateTrunc;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -121,7 +122,7 @@ public class AutoBucket extends ScalarFunction implements Mappable {
             Mul mul = new Mul(source(), floor, rounding);
             return toEvaluator.apply(mul);
         }
-        throw new UnsupportedOperationException("unsupported type [" + field.dataType() + "]");
+        throw new EsqlIllegalArgumentException("unsupported type [" + field.dataType() + "]");
     }
 
     private record DateRoundingPicker(int buckets, long from, long to) {
@@ -213,7 +214,7 @@ public class AutoBucket extends ScalarFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cast.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cast.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
@@ -62,8 +63,8 @@ public class Cast {
         throw cantCast(current, required);
     }
 
-    private static UnsupportedOperationException cantCast(DataType current, DataType required) {
-        return new UnsupportedOperationException("can't process [" + current.typeName() + " -> " + required.typeName() + "]");
+    private static EsqlIllegalArgumentException cantCast(DataType current, DataType required) {
+        return new EsqlIllegalArgumentException("can't process [" + current.typeName() + " -> " + required.typeName() + "]");
     }
 
     @Evaluator(extraName = "IntToLong")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/DoubleConstantFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/DoubleConstantFunction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
@@ -35,7 +36,7 @@ public abstract class DoubleConstantFunction extends ScalarFunction {
 
     @Override
     public final ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -47,7 +48,7 @@ public class Log10 extends UnaryScalarFunction implements Mappable {
             return () -> new Log10LongEvaluator(eval);
         }
 
-        throw new UnsupportedOperationException("Unsupported type " + fieldType);
+        throw new EsqlIllegalArgumentException("unsupported type [" + fieldType.typeName() + "]");
     }
 
     @Evaluator(extraName = "Double")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Pow.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Pow.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
@@ -160,7 +161,7 @@ public class Pow extends ScalarFunction implements OptionalArgument, Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
@@ -136,7 +137,7 @@ public class Round extends ScalarFunction implements OptionalArgument, Mappable 
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override
@@ -156,7 +157,7 @@ public class Round extends ScalarFunction implements OptionalArgument, Mappable 
         if (fieldType == DataTypes.UNSIGNED_LONG) {
             return toEvaluator(toEvaluator, Function.identity(), RoundUnsignedLongEvaluator::new);
         }
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("unsupported type [" + fieldType.typeName() + "]");
     }
 
     private Supplier<EvalOperator.ExpressionEvaluator> toEvaluator(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvg.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvg.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import org.elasticsearch.compute.ann.MvEvaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -51,7 +52,7 @@ public class MvAvg extends AbstractMultivalueFunction {
                 ? () -> new MvAvgUnsignedLongEvaluator(fieldEval.get())
                 : () -> new MvAvgLongEvaluator(fieldEval.get());
             case NULL -> () -> EvalOperator.CONSTANT_NULL;
-            default -> throw new UnsupportedOperationException("unsupported type [" + field().dataType() + "]");
+            default -> throw new EsqlIllegalArgumentException("unsupported type [" + field().dataType().typeName() + "]");
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMax.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMax.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.ann.MvEvaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -43,7 +44,7 @@ public class MvMax extends AbstractMultivalueFunction {
             case INT -> () -> new MvMaxIntEvaluator(fieldEval.get());
             case LONG -> () -> new MvMaxLongEvaluator(fieldEval.get());
             case NULL -> () -> EvalOperator.CONSTANT_NULL;
-            default -> throw new UnsupportedOperationException("unsupported type [" + field().dataType() + "]");
+            default -> throw new EsqlIllegalArgumentException("unsupported type [" + field().dataType().typeName() + "]");
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedian.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedian.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -50,7 +51,7 @@ public class MvMedian extends AbstractMultivalueFunction {
             case LONG -> field().dataType() == DataTypes.UNSIGNED_LONG
                 ? () -> new MvMedianUnsignedLongEvaluator(fieldEval.get())
                 : () -> new MvMedianLongEvaluator(fieldEval.get());
-            default -> throw new UnsupportedOperationException("unsupported type [" + field().dataType() + "]");
+            default -> throw new EsqlIllegalArgumentException("unsupported type [" + field().dataType().typeName() + "]");
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMin.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.ann.MvEvaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -43,7 +44,7 @@ public class MvMin extends AbstractMultivalueFunction {
             case INT -> () -> new MvMinIntEvaluator(fieldEval.get());
             case LONG -> () -> new MvMinLongEvaluator(fieldEval.get());
             case NULL -> () -> EvalOperator.CONSTANT_NULL;
-            default -> throw new UnsupportedOperationException("unsupported type [" + field().dataType() + "]");
+            default -> throw new EsqlIllegalArgumentException("unsupported type [" + field().dataType().typeName() + "]");
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSum.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSum.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import org.elasticsearch.compute.ann.MvEvaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -45,7 +46,7 @@ public class MvSum extends AbstractMultivalueFunction {
                 ? () -> new MvSumUnsignedLongEvaluator(source(), fieldEval.get())
                 : () -> new MvSumLongEvaluator(source(), fieldEval.get());
             case NULL -> () -> EvalOperator.CONSTANT_NULL;
-            default -> throw new UnsupportedOperationException("unsupported type [" + field().dataType() + "]");
+            default -> throw new EsqlIllegalArgumentException("unsupported type [" + field().dataType().typeName() + "]");
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Concat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Concat.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
@@ -103,6 +104,6 @@ public class Concat extends ScalarFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
@@ -87,7 +88,7 @@ public class StartsWith extends ScalarFunction implements Mappable {
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Substring.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.Mappable;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
@@ -128,7 +129,7 @@ public class Substring extends ScalarFunction implements OptionalArgument, Mappa
 
     @Override
     public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormat.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.formatter;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.xcontent.MediaType;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.ql.util.StringUtils;
@@ -48,12 +49,12 @@ public enum TextFormat implements MediaType {
 
         @Override
         protected Character delimiter() {
-            throw new UnsupportedOperationException();
+            throw new EsqlIllegalArgumentException("plain text does not specify a delimiter character");
         }
 
         @Override
         protected String eol() {
-            throw new UnsupportedOperationException();
+            throw new EsqlIllegalArgumentException("plain text does not specify an end of line character");
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNameRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNameRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.io.stream;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,7 +74,7 @@ public class PlanNameRegistry {
         V read(PlanStreamInput in, String name) throws IOException;
 
         default V read(PlanStreamInput in) throws IOException {
-            throw new UnsupportedOperationException("should not reach here");
+            throw new EsqlIllegalArgumentException("should not reach here");
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -662,7 +662,7 @@ public class LogicalPlanOptimizer extends RuleExecutor<LogicalPlan> {
 
             return project.replaceChild(expressionsWithResolvedAliases.replaceChild(project.child()));
         } else {
-            throw new UnsupportedOperationException("Expected child to be instance of Project");
+            throw new EsqlIllegalArgumentException("Expected child to be instance of Project");
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.plan.physical;
 
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.type.DataType;
@@ -111,12 +112,12 @@ public interface EstimatesRowSize {
                 }
                 yield 50; // wild estimate for the size of a string.
             }
-            case DOC -> throw new UnsupportedOperationException("can't load a doc with field extraction");
+            case DOC -> throw new EsqlIllegalArgumentException("can't load a doc with field extraction");
             case DOUBLE -> Double.BYTES;
             case INT -> Integer.BYTES;
             case LONG -> Long.BYTES;
             case NULL -> 0;
-            case UNKNOWN -> throw new UnsupportedOperationException("unknown can't be the result of field extraction");
+            case UNKNOWN -> throw new EsqlIllegalArgumentException("unknown can't be the result of field extraction");
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LeafExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LeafExec.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.tree.Source;
 
 import java.util.Collections;
@@ -20,6 +21,6 @@ public abstract class LeafExec extends PhysicalPlan {
 
     @Override
     public final LeafExec replaceChildren(List<PhysicalPlan> newChildren) {
-        throw new UnsupportedOperationException("this type of node doesn't have any children to replace");
+        throw new EsqlIllegalArgumentException("this type of node doesn't have any children to replace");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -162,7 +162,7 @@ abstract class AbstractPhysicalOperationProviders implements PhysicalOperationPr
         if (operatorFactory != null) {
             return source.with(operatorFactory, layout.build());
         }
-        throw new UnsupportedOperationException();
+        throw new EsqlIllegalArgumentException("no operator factory");
     }
 
     /***
@@ -244,7 +244,7 @@ abstract class AbstractPhysicalOperationProviders implements PhysicalOperationPr
                             sourceAttr = aggregateMapper.mapNonGrouping(aggregateFunction);
                         }
                     } else {
-                        throw new UnsupportedOperationException();
+                        throw new EsqlIllegalArgumentException("illegal aggregation mode");
                     }
                     var aggParams = aggregateFunction.parameters();
                     Object[] params = new Object[aggParams.size()];
@@ -257,7 +257,7 @@ abstract class AbstractPhysicalOperationProviders implements PhysicalOperationPr
                     if (aggregateFunction instanceof ToAggregator agg) {
                         consumer.accept(new AggFunctionSupplierContext(agg.supplier(bigArrays, inputChannels), aggMode));
                     } else {
-                        throw new UnsupportedOperationException("aggregate functions must extend ToAggregator");
+                        throw new EsqlIllegalArgumentException("aggregate functions must extend ToAggregator");
                     }
                 }
             }
@@ -267,7 +267,7 @@ abstract class AbstractPhysicalOperationProviders implements PhysicalOperationPr
     private record GroupSpec(Integer channel, Attribute attribute) {
         HashAggregationOperator.GroupSpec toHashGroupSpec() {
             if (channel == null) {
-                throw new UnsupportedOperationException("planned to use ordinals but tried to use the hash instead");
+                throw new EsqlIllegalArgumentException("planned to use ordinals but tried to use the hash instead");
             }
             return new HashAggregationOperator.GroupSpec(channel, elementType());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.planner;
 import org.elasticsearch.compute.aggregation.IntermediateStateDesc;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
@@ -118,7 +119,7 @@ public class AggregateMapper {
     private List<IntermediateStateDesc> getNonNull(AggDef aggDef) {
         var l = mapper.get(aggDef);
         if (l == null) {
-            throw new UnsupportedOperationException("Cannot find intermediate state for: " + aggDef);
+            throw new EsqlIllegalArgumentException("Cannot find intermediate state for: " + aggDef);
         }
         return l;
     }
@@ -157,7 +158,7 @@ public class AggregateMapper {
             return (List<IntermediateStateDesc>) lookup(aggDef.aggClazz(), aggDef.type(), aggDef.grouping()).invokeExact();
         } catch (Throwable t) {
             // invokeExact forces us to handle any Throwable thrown by lookup.
-            throw new UnsupportedOperationException(t);
+            throw new EsqlIllegalArgumentException(t);
         }
     }
 
@@ -171,7 +172,7 @@ public class AggregateMapper {
                     MethodType.methodType(List.class)
                 );
         } catch (IllegalAccessException | NoSuchMethodException | ClassNotFoundException e) {
-            throw new UnsupportedOperationException(e);
+            throw new EsqlIllegalArgumentException(e);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -118,7 +118,7 @@ public class AggregateMapper {
     private List<IntermediateStateDesc> getNonNull(AggDef aggDef) {
         var l = mapper.get(aggDef);
         if (l == null) {
-            throw new AssertionError("Cannot find intermediate state for: " + aggDef);
+            throw new UnsupportedOperationException("Cannot find intermediate state for: " + aggDef);
         }
         return l;
     }
@@ -156,7 +156,8 @@ public class AggregateMapper {
         try {
             return (List<IntermediateStateDesc>) lookup(aggDef.aggClazz(), aggDef.type(), aggDef.grouping()).invokeExact();
         } catch (Throwable t) {
-            throw new AssertionError(t);
+            // invokeExact forces us to handle any Throwable thrown by lookup.
+            throw new UnsupportedOperationException(t);
         }
     }
 
@@ -170,7 +171,7 @@ public class AggregateMapper {
                     MethodType.methodType(List.class)
                 );
         } catch (IllegalAccessException | NoSuchMethodException | ClassNotFoundException e) {
-            throw new AssertionError(e);
+            throw new UnsupportedOperationException(e);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -111,7 +111,7 @@ public class AggregateMapper {
             // This condition is a little pedantic, but do we expected other expressions here? if so, then add them
             return List.of();
         } else {
-            throw new UnsupportedOperationException("unknown: " + aggregate.getClass() + ": " + aggregate);
+            throw new EsqlIllegalArgumentException("unknown: " + aggregate.getClass() + ": " + aggregate);
         }
     }
 
@@ -201,7 +201,7 @@ public class AggregateMapper {
             case INT -> DataTypes.INTEGER;
             case LONG -> DataTypes.LONG;
             case DOUBLE -> DataTypes.DOUBLE;
-            default -> throw new UnsupportedOperationException("unsupported agg type: " + elementType);
+            default -> throw new EsqlIllegalArgumentException("unsupported agg type: " + elementType);
         };
     }
 
@@ -221,7 +221,7 @@ public class AggregateMapper {
         } else if (type.equals(DataTypes.KEYWORD) || type.equals(DataTypes.IP)) {
             return "BytesRef";
         } else {
-            throw new UnsupportedOperationException("unsupported agg type: " + type);
+            throw new EsqlIllegalArgumentException("unsupported agg type: " + type);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ArithmeticMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ArithmeticMapper.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.planner;
 
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeRegistry;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.ArithmeticOperation;
@@ -117,6 +118,6 @@ abstract class ArithmeticMapper<T extends ArithmeticOperation> extends EvalMappe
                 return castToEvaluator(op, layout, DataTypes.DOUBLE, doubles);
             }
         }
-        throw new UnsupportedOperationException("resolved type for [" + op + "] but didn't implement mapping");
+        throw new EsqlIllegalArgumentException("resolved type for [" + op + "] but didn't implement mapping");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ArithmeticMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ArithmeticMapper.java
@@ -117,6 +117,6 @@ abstract class ArithmeticMapper<T extends ArithmeticOperation> extends EvalMappe
                 return castToEvaluator(op, layout, DataTypes.DOUBLE, doubles);
             }
         }
-        throw new AssertionError("resolved type for [" + op + "] but didn't implement mapping");
+        throw new UnsupportedOperationException("resolved type for [" + op + "] but didn't implement mapping");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ComparisonMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ComparisonMapper.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.planner;
 
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Cast;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeRegistry;
 import org.elasticsearch.xpack.ql.expression.predicate.BinaryOperator;
@@ -107,7 +108,7 @@ abstract class ComparisonMapper<T extends BinaryComparison> extends EvalMapper.E
         this.longs = longs;
         this.doubles = doubles;
         this.keywords = keywords;
-        this.bools = (lhs, rhs) -> { throw new UnsupportedOperationException("bool unsupported"); };
+        this.bools = (lhs, rhs) -> { throw new EsqlIllegalArgumentException("bool unsupported"); };
     }
 
     @Override
@@ -140,7 +141,7 @@ abstract class ComparisonMapper<T extends BinaryComparison> extends EvalMapper.E
         if (leftType == DataTypes.DATETIME) {
             return () -> longs.apply(leftEval.get(), rightEval.get());
         }
-        throw new UnsupportedOperationException("resolved type for [" + bc + "] but didn't implement mapping");
+        throw new EsqlIllegalArgumentException("resolved type for [" + bc + "] but didn't implement mapping");
     }
 
     static Supplier<EvalOperator.ExpressionEvaluator> castToEvaluator(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ComparisonMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ComparisonMapper.java
@@ -107,7 +107,7 @@ abstract class ComparisonMapper<T extends BinaryComparison> extends EvalMapper.E
         this.longs = longs;
         this.doubles = doubles;
         this.keywords = keywords;
-        this.bools = (lhs, rhs) -> { throw new AssertionError("bool unsupported"); };
+        this.bools = (lhs, rhs) -> { throw new UnsupportedOperationException("bool unsupported"); };
     }
 
     @Override
@@ -140,7 +140,7 @@ abstract class ComparisonMapper<T extends BinaryComparison> extends EvalMapper.E
         if (leftType == DataTypes.DATETIME) {
             return () -> longs.apply(leftEval.get(), rightEval.get());
         }
-        throw new AssertionError("resolved type for [" + bc + "] but didn't implement mapping");
+        throw new UnsupportedOperationException("resolved type for [" + bc + "] but didn't implement mapping");
     }
 
     static Supplier<EvalOperator.ExpressionEvaluator> castToEvaluator(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EvalMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EvalMapper.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -227,7 +228,7 @@ public final class EvalMapper {
                     yield positions -> LongBlock.newConstantBlockWith(v, positions);
                 }
                 case NULL -> Block::constantNullBlock;
-                case DOC, UNKNOWN -> throw new UnsupportedOperationException("can't eval to doc or unknown");
+                case DOC, UNKNOWN -> throw new EsqlIllegalArgumentException("can't eval to doc or unknown");
             };
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -199,7 +199,7 @@ public class LocalExecutionPlanner {
             return planExchangeSink(exchangeSink, context);
         }
 
-        throw new UnsupportedOperationException(node.nodeName());
+        throw new EsqlIllegalArgumentException("unknown physical plan node [" + node.nodeName() + "]");
     }
 
     private PhysicalOperation planAggregation(AggregateExec aggregate, LocalExecutionPlannerContext context) {
@@ -253,7 +253,7 @@ public class LocalExecutionPlanner {
         if (dataType == DataTypes.BOOLEAN) {
             return ElementType.BOOLEAN;
         }
-        throw new UnsupportedOperationException("unsupported data type [" + dataType + "]");
+        throw new EsqlIllegalArgumentException("unsupported data type [" + dataType + "]");
     }
 
     private PhysicalOperation planOutput(OutputExec outputExec, LocalExecutionPlannerContext context) {
@@ -329,7 +329,7 @@ public class LocalExecutionPlanner {
             if (order.child() instanceof Attribute a) {
                 sortByChannel = source.layout.getChannel(a.id());
             } else {
-                throw new UnsupportedOperationException();
+                throw new EsqlIllegalArgumentException("order by expression must be an attribute");
             }
 
             return new TopNOperator.SortOrder(
@@ -343,7 +343,7 @@ public class LocalExecutionPlanner {
         if (topNExec.limit() instanceof Literal literal) {
             limit = Integer.parseInt(literal.value().toString());
         } else {
-            throw new UnsupportedOperationException();
+            throw new EsqlIllegalArgumentException("limit only supported with literal values");
         }
 
         // TODO Replace page size with passing estimatedRowSize down
@@ -366,7 +366,7 @@ public class LocalExecutionPlanner {
             if (namedExpression instanceof Alias alias) {
                 evaluatorSupplier = EvalMapper.toEvaluator(alias.child(), source.layout);
             } else {
-                throw new UnsupportedOperationException();
+                throw new EsqlIllegalArgumentException("source fields for eval nodes have to be aliases");
             }
             Layout.Builder layout = source.layout.builder();
             layout.appendChannel(namedExpression.toAttribute().id());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.planner;
 
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
@@ -106,7 +107,7 @@ public class Mapper {
             return plan;
         }
 
-        throw new UnsupportedOperationException(p.nodeName());
+        throw new EsqlIllegalArgumentException("unsupported logical plan node [" + p.nodeName() + "]");
     }
 
     private static boolean isPipelineBreaker(LogicalPlan p) {
@@ -172,7 +173,7 @@ public class Mapper {
             return map(aggregate, child);
         }
 
-        throw new UnsupportedOperationException(p.nodeName());
+        throw new EsqlIllegalArgumentException("unsupported unary logical plan node [" + p.nodeName() + "]");
     }
 
     private PhysicalPlan map(Aggregate aggregate, PhysicalPlan child) {


### PR DESCRIPTION
We want to avoid throwing errors; AssertionErrors are thrown in mappers whenever an operation is not supported for whatever reason. Throw UnsupportedOperationException instead.