### PR TITLE
Documentation update that fixes a query rules code example

### DIFF
--- a/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
+++ b/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
@@ -148,7 +148,7 @@ PUT /_query_rules/my-ruleset
       "type": "pinned",
       "criteria": [
         {
-          "type": "fuzzy",
+          "type": "contains",
           "metadata": "query_string",
           "values": [ "beagles" ]
         }

--- a/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
+++ b/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
@@ -127,7 +127,7 @@ PUT /_query_rules/my-ruleset
       "criteria": [
         {
           "type": "fuzzy",
-          "metadata": "user.query",
+          "metadata": "query_string",
           "values": [ "puggles", "pugs" ]
         },
         {
@@ -149,7 +149,7 @@ PUT /_query_rules/my-ruleset
       "criteria": [
         {
           "type": "fuzzy",
-          "metadata": "user.query",
+          "metadata": "query_string",
           "values": [ "beagles" ]
         }
       ],


### PR DESCRIPTION
In the query rules guide, the query rule creation example refers to a metadata field `user.query` while the query example further down uses `query_string`. 

I chose to use `query_string` to keep consistent with examples in the other query rules doc pages.