### PR TITLE
Mute testCCSCheckCompatibility

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -527,6 +527,7 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         updateClusterSettings(Settings.builder().put("search.max_async_search_response_size", (String) null));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98557")
     public void testCCSCheckCompatibility() throws Exception {
         SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(new SearchSourceBuilder().query(new DummyQueryBuilder() {
             @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TransportTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TransportTermsEnumActionTests.java
@@ -66,6 +66,7 @@ public class TransportTermsEnumActionTests extends ESSingleNodeTestCase {
     /**
      * Test that triggering the CCS compatibility check with a query that shouldn't go to the minor before Version.CURRENT works
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98557")
     public void testCCSCheckCompatibility() throws Exception {
         TermsEnumRequest request = new TermsEnumRequest().field("field").timeout(TimeValue.timeValueSeconds(5));
         request.indexFilter(new DummyQueryBuilder() {


### PR DESCRIPTION
These tests fail when `TransportVersion.current()` is equal to `TransportVersion.MINIMUM_CCS_VERSION`

Relates: #98557
