### PR TITLE
Fix tests that break when minimum ccs compatibility == current transport version

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveIndexActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -48,11 +49,12 @@ public class TransportResolveIndexActionTests extends ESTestCase {
             .build();
         ActionFilters actionFilters = mock(ActionFilters.class);
         when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        TransportVersion transportVersion = TransportVersionUtils.getNextVersion(TransportVersion.MINIMUM_CCS_VERSION, true);
         try {
             TransportService transportService = MockTransportService.createNewService(
                 Settings.EMPTY,
                 VersionInformation.CURRENT,
-                TransportVersion.current(),
+                transportVersion,
                 threadPool
             );
 
@@ -60,9 +62,9 @@ public class TransportResolveIndexActionTests extends ESTestCase {
                 @Override
                 public void writeTo(StreamOutput out) throws IOException {
                     super.writeTo(out);
-                    if (out.getTransportVersion().before(TransportVersion.current())) {
+                    if (out.getTransportVersion().before(transportVersion)) {
                         throw new IllegalArgumentException(
-                            "This request isn't serializable before transport version " + TransportVersion.current()
+                            "This request isn't serializable before transport version " + transportVersion
                         );
                     }
                 }
@@ -90,7 +92,7 @@ public class TransportResolveIndexActionTests extends ESTestCase {
             assertThat(ex.getMessage(), containsString("not compatible with version"));
             assertThat(ex.getMessage(), containsString("and the 'search.check_ccs_compatibility' setting is enabled."));
             assertEquals(
-                "This request isn't serializable before transport version " + TransportVersion.current(),
+                "This request isn't serializable before transport version " + transportVersion,
                 ex.getCause().getMessage()
             );
         } finally {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.search.DummyQueryBuilder;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -50,11 +51,12 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
             .build();
         ActionFilters actionFilters = mock(ActionFilters.class);
         when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        TransportVersion transportVersion = TransportVersionUtils.getNextVersion(TransportVersion.MINIMUM_CCS_VERSION, true);
         try {
             TransportService transportService = MockTransportService.createNewService(
                 Settings.EMPTY,
                 VersionInformation.CURRENT,
-                TransportVersion.current(),
+                transportVersion,
                 threadPool
             );
 
@@ -62,10 +64,8 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
             fieldCapsRequest.indexFilter(new DummyQueryBuilder() {
                 @Override
                 protected void doWriteTo(StreamOutput out) throws IOException {
-                    if (out.getTransportVersion().before(TransportVersion.current())) {
-                        throw new IllegalArgumentException(
-                            "This query isn't serializable before transport version " + TransportVersion.current()
-                        );
+                    if (out.getTransportVersion().before(transportVersion)) {
+                        throw new IllegalArgumentException("This query isn't serializable before transport version " + transportVersion);
                     }
                 }
             });
@@ -100,10 +100,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
                 containsString("[class org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest] is not compatible with version")
             );
             assertThat(ex.getMessage(), containsString("and the 'search.check_ccs_compatibility' setting is enabled."));
-            assertEquals(
-                "This query isn't serializable before transport version " + TransportVersion.current(),
-                ex.getCause().getMessage()
-            );
+            assertEquals("This query isn't serializable before transport version " + transportVersion, ex.getCause().getMessage());
         } finally {
             assertTrue(ESTestCase.terminate(threadPool));
         }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -13,7 +13,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.OriginalIndices;
@@ -78,6 +77,7 @@ import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -1500,12 +1500,13 @@ public class TransportSearchActionTests extends ESTestCase {
             .build();
         ActionFilters actionFilters = mock(ActionFilters.class);
         when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        TransportVersion transportVersion = TransportVersionUtils.getNextVersion(TransportVersion.MINIMUM_CCS_VERSION, true);
         ThreadPool threadPool = new ThreadPool(settings);
         try {
             TransportService transportService = MockTransportService.createNewService(
                 Settings.EMPTY,
                 VersionInformation.CURRENT,
-                TransportVersion.current(),
+                transportVersion,
                 threadPool
             );
 
@@ -1513,7 +1514,7 @@ public class TransportSearchActionTests extends ESTestCase {
             searchRequest.source(new SearchSourceBuilder().query(new DummyQueryBuilder() {
                 @Override
                 protected void doWriteTo(StreamOutput out) throws IOException {
-                    throw new IllegalArgumentException("Not serializable to " + Version.CURRENT);
+                    throw new IllegalArgumentException("Not serializable to " + transportVersion);
                 }
             }));
             NodeClient client = new NodeClient(settings, threadPool);
@@ -1556,7 +1557,7 @@ public class TransportSearchActionTests extends ESTestCase {
                         containsString("[class org.elasticsearch.action.search.SearchRequest] is not compatible with version")
                     );
                     assertThat(ex.getMessage(), containsString("and the 'search.check_ccs_compatibility' setting is enabled."));
-                    assertEquals("Not serializable to " + Version.CURRENT, ex.getCause().getMessage());
+                    assertEquals("Not serializable to " + transportVersion, ex.getCause().getMessage());
                     latch.countDown();
                 }
             });

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -94,6 +94,10 @@ public class TransportVersionUtils {
     }
 
     public static TransportVersion getNextVersion(TransportVersion version) {
+        return getNextVersion(version, false);
+    }
+
+    public static TransportVersion getNextVersion(TransportVersion version, boolean createIfNecessary) {
         int place = Collections.binarySearch(ALL_VERSIONS, version);
         if (place < 0) {
             // version does not exist - need the item at the index this version should be inserted
@@ -104,7 +108,12 @@ public class TransportVersionUtils {
         }
 
         if (place < 0 || place >= ALL_VERSIONS.size()) {
-            throw new IllegalArgumentException("couldn't find any released versions after [" + version + "]");
+            if (createIfNecessary) {
+                // create a new transport version one greater than specified
+                return new TransportVersion(version.id() + 1);
+            } else {
+                throw new IllegalArgumentException("couldn't find any released versions after [" + version + "]");
+            }
         }
         return ALL_VERSIONS.get(place);
     }

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.search.aggregations.metrics.Min;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.query.ThrowingQueryBuilder;
 import org.elasticsearch.test.ESIntegTestCase.SuiteScopeTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
 import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
@@ -527,12 +528,11 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         updateClusterSettings(Settings.builder().put("search.max_async_search_response_size", (String) null));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98557")
     public void testCCSCheckCompatibility() throws Exception {
         SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(new SearchSourceBuilder().query(new DummyQueryBuilder() {
             @Override
             public TransportVersion getMinimalSupportedVersion() {
-                return TransportVersion.current();
+                return TransportVersionUtils.getNextVersion(TransportVersion.MINIMUM_CCS_VERSION, true);
             }
         }), indexName);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TransportTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TransportTermsEnumActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.DummyQueryBuilder;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumAction;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumRequest;
@@ -66,13 +67,13 @@ public class TransportTermsEnumActionTests extends ESSingleNodeTestCase {
     /**
      * Test that triggering the CCS compatibility check with a query that shouldn't go to the minor before Version.CURRENT works
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98557")
     public void testCCSCheckCompatibility() throws Exception {
         TermsEnumRequest request = new TermsEnumRequest().field("field").timeout(TimeValue.timeValueSeconds(5));
+        TransportVersion version = TransportVersionUtils.getNextVersion(TransportVersion.MINIMUM_CCS_VERSION, true);
         request.indexFilter(new DummyQueryBuilder() {
             @Override
             public TransportVersion getMinimalSupportedVersion() {
-                return TransportVersion.current();
+                return version;
             }
         });
         ExecutionException ex = expectThrows(ExecutionException.class, () -> client().execute(TermsEnumAction.INSTANCE, request).get());
@@ -82,7 +83,7 @@ public class TransportTermsEnumActionTests extends ESSingleNodeTestCase {
             ex.getCause().getCause().getMessage(),
             containsString(
                 "was released first in version "
-                    + TransportVersion.current()
+                    + version
                     + ", failed compatibility check trying to send it to node with version"
             )
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TransportTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TransportTermsEnumActionTests.java
@@ -82,9 +82,7 @@ public class TransportTermsEnumActionTests extends ESSingleNodeTestCase {
         assertThat(
             ex.getCause().getCause().getMessage(),
             containsString(
-                "was released first in version "
-                    + version
-                    + ", failed compatibility check trying to send it to node with version"
+                "was released first in version " + version + ", failed compatibility check trying to send it to node with version"
             )
         );
     }


### PR DESCRIPTION
Add a function to get a higher transport version, even if one hasn't been defined yet.

This fixes #98557