### PR TITLE
Specify correct current IndexVersion after 8.10 release

### DIFF
--- a/docs/changelog/98574.yaml
+++ b/docs/changelog/98574.yaml
@@ -1,0 +1,6 @@
+pr: 98574
+summary: Specify correct current `IndexVersion` after 8.10 release
+area: Infra/Core
+type: bug
+issues:
+ - 98555

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -386,7 +386,6 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         return numDocs;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98555")
     public void testClusterState() throws Exception {
         if (isRunningAgainstOldCluster()) {
             XContentBuilder mappingsAndSettings = jsonBuilder();

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -185,7 +185,7 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
      * Detached index versions added below here.
      */
     private static class CurrentHolder {
-        private static final IndexVersion CURRENT = findCurrent(V_8_10_0);
+        private static final IndexVersion CURRENT = findCurrent(V_8_11_0);
 
         // finds the pluggable current version, or uses the given fallback
         private static IndexVersion findCurrent(IndexVersion fallback) {


### PR DESCRIPTION
The current IndexVersion wasn't bumped by the release automation. This fixes it.

This will not be an issue in 8.11, as we're expecting IndexVersion to be separated from node version by then. It will need to be fixed (or bumped manually again) if we release any 8.10.x patches.

This fixes #98555 (and others)