### PR TITLE
Update allowed inferred versions to include 8.10.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/VersionInformation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/VersionInformation.java
@@ -32,7 +32,7 @@ public record VersionInformation(Version nodeVersion, IndexVersion minIndexVersi
             return null;
         } else if (nodeVersion.equals(Version.CURRENT)) {
             return CURRENT;
-        } else if (nodeVersion.before(Version.V_8_10_0)) {
+        } else if (nodeVersion.onOrBefore(Version.V_8_10_0)) {
             return new VersionInformation(
                 nodeVersion,
                 IndexVersion.fromId(nodeVersion.minimumIndexCompatibilityVersion().id),

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
@@ -40,6 +41,7 @@ import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -107,7 +109,11 @@ public class TransportBulkActionTests extends ESTestCase {
         super.setUp();
         threadPool = new TestThreadPool(getClass().getName());
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("node")
-            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .version(
+                VersionUtils.randomCompatibleVersion(random(), Version.CURRENT),
+                IndexVersion.MINIMUM_COMPATIBLE,
+                IndexVersionUtils.randomCompatibleVersion(random())
+            )
             .build();
         clusterService = createClusterService(threadPool, discoveryNode);
         CapturingTransport capturingTransport = new CapturingTransport();

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -29,11 +29,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -77,7 +79,11 @@ public class TransportBulkActionTookTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("node")
-            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .version(
+                VersionUtils.randomCompatibleVersion(random(), Version.CURRENT),
+                IndexVersion.MINIMUM_COMPATIBLE,
+                IndexVersionUtils.randomCompatibleVersion(random())
+            )
             .build();
         clusterService = createClusterService(threadPool, discoveryNode);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -36,11 +36,13 @@ import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -224,7 +226,11 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             final List<DiscoveryNode> allNodes = new ArrayList<>();
             while (allNodes.size() < 10) {
                 var node = DiscoveryNodeUtils.builder("node-" + allNodes.size())
-                    .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+                    .version(
+                        VersionUtils.randomCompatibleVersion(random(), Version.CURRENT),
+                        IndexVersion.MINIMUM_COMPATIBLE,
+                        IndexVersionUtils.randomCompatibleVersion(random())
+                    )
                     .build();
                 allNodes.add(node);
                 nodeTransports.put(
@@ -355,7 +361,11 @@ public class PublicationTransportHandlerTests extends ESTestCase {
 
         final var localNode = DiscoveryNodeUtils.create("localNode");
         final var otherNode = DiscoveryNodeUtils.builder("otherNode")
-            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .version(
+                VersionUtils.randomCompatibleVersion(random(), Version.CURRENT),
+                IndexVersion.MINIMUM_COMPATIBLE,
+                IndexVersionUtils.randomCompatibleVersion(random())
+            )
             .build();
         for (final var discoveryNode : List.of(localNode, otherNode)) {
             final var transport = new MockTransport() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -713,9 +713,9 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(newNode("node-0", Version.V_8_10_0))
-                    .add(newNode("node-1", Version.V_8_9_0))
-                    .add(newNode("node-2", Version.V_8_9_0))
+                    .add(newNode("node-0", Version.V_8_10_0, IndexVersion.V_8_10_0))
+                    .add(newNode("node-1", Version.V_8_9_0, IndexVersion.V_8_9_0))
+                    .add(newNode("node-2", Version.V_8_9_0, IndexVersion.V_8_9_0))
             )
             .metadata(Metadata.builder().put(indexMetadata, false))
             .routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(shardId.getIndex()).addShard(primary).addShard(replica)))

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.cluster.ClusterStateChanges;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -224,7 +225,11 @@ public class FailedNodeRoutingTests extends ESAllocationTestCase {
         return DiscoveryNodeUtils.builder(id)
             .name(id)
             .roles(roles)
-            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .version(
+                VersionUtils.randomCompatibleVersion(random(), Version.CURRENT),
+                IndexVersion.MINIMUM_COMPATIBLE,
+                IndexVersionUtils.randomCompatibleVersion(random())
+            )
             .build();
     }
 


### PR DESCRIPTION
8.10 actually wasn't released with separated index versions, so update the version check for inferred versions to include 8.10.

Also update tests that could pass CURRENT to infer versions from to specify explicit versions