### PR TITLE
Fix shard-stores doc test

### DIFF
--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -192,8 +192,8 @@ The API returns the following response:
 // TESTRESPONSE[s/"attributes": \{[^}]*\}/"attributes": $body.$_path/]
 // TESTRESPONSE[s/"roles": \[[^]]*\]/"roles": $body.$_path/]
 // TESTRESPONSE[s/"8.10.0"/\$node_version/]
-// TESTRESPONSE[s/7000099/\d+/]
-// TESTRESPONSE[s/8100099/\d+/]
+// TESTRESPONSE[s/7000099/\{\d+\}/]
+// TESTRESPONSE[s/8100099/\{\d+\}/]
 
 
 

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -192,8 +192,8 @@ The API returns the following response:
 // TESTRESPONSE[s/"attributes": \{[^}]*\}/"attributes": $body.$_path/]
 // TESTRESPONSE[s/"roles": \[[^]]*\]/"roles": $body.$_path/]
 // TESTRESPONSE[s/"8.10.0"/\$node_version/]
-// TESTRESPONSE[s/7000099/\{\d+\}/]
-// TESTRESPONSE[s/8100099/\{\d+\}/]
+// TESTRESPONSE[s/7000099/"\d+"/]
+// TESTRESPONSE[s/8100099/"\d+"/]
 
 
 

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -192,8 +192,8 @@ The API returns the following response:
 // TESTRESPONSE[s/"attributes": \{[^}]*\}/"attributes": $body.$_path/]
 // TESTRESPONSE[s/"roles": \[[^]]*\]/"roles": $body.$_path/]
 // TESTRESPONSE[s/"8.10.0"/\$node_version/]
-// TESTRESPONSE[s/7000099/"\d+"/]
-// TESTRESPONSE[s/8100099/"\d+"/]
+// TESTRESPONSE[s/"min_index_version": 7000099/"min_index_version": $body.$_path/]
+// TESTRESPONSE[s/"max_index_version": 8100099/"max_index_version": $body.$_path/]
 
 
 

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -192,8 +192,8 @@ The API returns the following response:
 // TESTRESPONSE[s/"attributes": \{[^}]*\}/"attributes": $body.$_path/]
 // TESTRESPONSE[s/"roles": \[[^]]*\]/"roles": $body.$_path/]
 // TESTRESPONSE[s/"8.10.0"/\$node_version/]
-// TESTRESPONSE[s/"7000099"/"\d+"/]
-// TESTRESPONSE[s/"8100099"/"\d+"/]
+// TESTRESPONSE[s/7000099/\d+/]
+// TESTRESPONSE[s/8100099/\d+/]
 
 
 


### PR DESCRIPTION
Fix #98580.

The response was changed to use an int, but the search-and-replace wasn't updated, and this wasn't spotted until the response was actually different to the example