### PR TITLE
Simple grammar fix for MVT docs

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -70,8 +70,8 @@ have <<doc-values,doc values>> enabled. Cannot be a nested field.
 +
 NOTE: Vector tiles do not natively support geometry collections. For
 `geometrycollection` values in a `geo_shape` field, the API returns a `hits`
-layer feature for each element of the collection. This behavior may change may
-change in a future release.
+layer feature for each element of the collection.
+This behavior may change in a future release.
 
 `<zoom>`::
 (Required, integer) Zoom level for the vector tile to search. Accepts `0`-`29`.


### PR DESCRIPTION
While reviewing MVT docs for the SDH at https://github.com/elastic/sdh-elasticsearch/issues/7423, I noticed a small grammar mistake, the text `may change may change` should be `may change`.
