### PR TITLE
Simple ESQL pow() docs fixes after re-reviewing

### DIFF
--- a/docs/reference/esql/functions/pow.asciidoc
+++ b/docs/reference/esql/functions/pow.asciidoc
@@ -18,8 +18,8 @@ The type of the returned value is determined by the types of the base and expone
 The following rules are applied to determine the result type:
 
 * If either of the base or exponent are of a floating point type, the result will be a double
-* Otherwise, if either the base of the exponent are 64-bit (long or unsigned long), the result will be a long
-* Otherwise, the result will be a 32-bit integer (all other numeric types, including int, short and byte)
+* Otherwise, if either the base or the exponent are 64-bit (long or unsigned long), the result will be a long
+* Otherwise, the result will be a 32-bit integer (this covers all other numeric types, including int, short and byte)
 
 For example, using simple integers as arguments will lead to an integer result:
 
@@ -32,13 +32,14 @@ include::{esql-specs}/math.csv-spec[tag=powII]
 include::{esql-specs}/math.csv-spec[tag=powII-result]
 |===
 
-Note: The actual power function is performed using double precision values for all cases.
-This means that for very large non-floating point values the operation can lead to very slightly different answers.
+NOTE: The actual power function is performed using double precision values for all cases.
+This means that for very large non-floating point values there is a small chance that the
+operation can lead to slightly different answers than expected.
 However, a more likely outcome of very large non-floating point values is numerical overflow.
 
 ==== Arithmetic errors
 
-Arithmetic errors and numeric overflow do not result in an error, instead the result will be `null`
+Arithmetic errors and numeric overflow do not result in an error. Instead, the result will be `null`
 and a warning for the `ArithmeticException` added.
 For example:
 
@@ -55,7 +56,7 @@ include::{esql-specs}/math.csv-spec[tag=powULOverrun-warning]
 include::{esql-specs}/math.csv-spec[tag=powULOverrun-result]
 |===
 
-If it is desired to protect against numerical overruns, use `to_double` on any one of the arguments:
+If it is desired to protect against numerical overruns, use `to_double` on either of the arguments:
 
 [source.merge.styled,esql]
 ----


### PR DESCRIPTION
After the big merge of ESQL into main, I wanted to review the rendered version of the pow() function docs I wrote earlier, and found a few improvements (and one grammar fix too).