### PR TITLE
Add deprecated note for `balanced` allocator

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -115,6 +115,7 @@ runs a background task which computes the desired balance of shards in the
 cluster. Once this background task completes, {es} moves shards to their
 desired locations.
 
+deprecated:[8.8,The `balanced` allocator type is deprecated and no longer recommended]
 May also be set to `balanced` to select the legacy _balanced allocator_. This
 allocator was the default allocator in versions of {es} before 8.6.0. It runs
 in the foreground, preventing the master from doing other work in parallel. It
@@ -123,9 +124,6 @@ the balance of the cluster, and when those shard movements complete it runs
 again and selects another few shards to move. Since this allocator makes its
 decisions based only on the current state of the cluster, it will sometimes
 move a shard several times while balancing the cluster.
-
-NOTE: the legacy `balanced` allocator is deprecated as of `8.8.0` ({es-pull}94066[#94066]) and is no longer recommended.  
-
 --
 
 [[shards-rebalancing-heuristics]]

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -123,6 +123,9 @@ the balance of the cluster, and when those shard movements complete it runs
 again and selects another few shards to move. Since this allocator makes its
 decisions based only on the current state of the cluster, it will sometimes
 move a shard several times while balancing the cluster.
+
+NOTE: the legacy `balanced` allocator is deprecated as of `8.8.0` ({es-pull}94066[#94066]) and is no longer recommended.  
+
 --
 
 [[shards-rebalancing-heuristics]]


### PR DESCRIPTION
Added note to shard allocation doc explicitly indicating the `balanced` allocator was deprecated in `8.8.0`