### PR TITLE
[8.9] Add deprecated note for `balanced` allocator (#98610)

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -115,6 +115,7 @@ runs a background task which computes the desired balance of shards in the
 cluster. Once this background task completes, {es} moves shards to their
 desired locations.
 
+deprecated:[8.8,The `balanced` allocator type is deprecated and no longer recommended]
 May also be set to `balanced` to select the legacy _balanced allocator_. This
 allocator was the default allocator in versions of {es} before 8.6.0. It runs
 in the foreground, preventing the master from doing other work in parallel. It


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Add deprecated note for `balanced` allocator (#98610)](https://github.com/elastic/elasticsearch/pull/98610)

<!--- Backport version: 8.9.9 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)