### PR TITLE
Fixing dense vectors bwc tests to reflect new default version

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/80_dense_vector_indexed_by_default.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/80_dense_vector_indexed_by_default.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: ' - 8.9.99'
-      reason: 'dense_vector indexed by default was added in 8.10'
+      version: ' - 8.10.99'
+      reason: 'dense_vector indexed by default was added in 8.11'
 
 ---
 "Indexed by default with cosine similarity":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -1124,7 +1124,7 @@ fetch geo_point:
 ---
 "Test with subobjects: false":
   - skip:
-      version: ' - 8.9.9'
+      version: ' - 8.9.99'
       reason: 'https://github.com/elastic/elasticsearch/issues/96700 fixed in 8.10.0'
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -1124,8 +1124,8 @@ fetch geo_point:
 ---
 "Test with subobjects: false":
   - skip:
-      version: ' - 8.9.1'
-      reason: 'https://github.com/elastic/elasticsearch/issues/96700 fixed after 8.9.0'
+      version: ' - 8.9.9'
+      reason: 'https://github.com/elastic/elasticsearch/issues/96700 fixed in 8.10.0'
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -69,7 +69,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
  */
 public class DenseVectorFieldMapper extends FieldMapper {
     public static final IndexVersion MAGNITUDE_STORED_INDEX_VERSION = IndexVersion.V_7_5_0;
-    public static final IndexVersion INDEXED_BY_DEFAULT_INDEX_VERSION = IndexVersion.V_8_10_0;
+    public static final IndexVersion INDEXED_BY_DEFAULT_INDEX_VERSION = IndexVersion.V_8_11_0;
     public static final IndexVersion LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION = IndexVersion.V_8_9_0;
 
     public static final String CONTENT_TYPE = "dense_vector";

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.when;
 
 public class DenseVectorFieldMapperTests extends MapperTestCase {
 
-    private static final IndexVersion INDEXED_BY_DEFAULT_PREVIOUS_INDEX_VERSION = IndexVersion.V_8_9_1;
+    private static final IndexVersion INDEXED_BY_DEFAULT_PREVIOUS_INDEX_VERSION = IndexVersion.V_8_10_0;
     private final ElementType elementType;
     private final boolean indexed;
     private final boolean indexOptionsSet;


### PR DESCRIPTION
New defaults were NOT added for 8.10. They were added for 8.11.

closes: https://github.com/elastic/elasticsearch/issues/98611

relates: https://github.com/elastic/elasticsearch/pull/98268