### PR TITLE
Avoid exceeded semaphore permits in ESQL tests

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -197,7 +197,7 @@ public class EsqlActionTaskIT extends AbstractEsqlIntegTestCase {
         CancelTasksRequest request = new CancelTasksRequest().setTargetTaskId(taskId).setReason("test cancel");
         request.setWaitForCompletion(false);
         client().admin().cluster().execute(CancelTasksAction.INSTANCE, request).actionGet();
-        scriptPermits.release(Integer.MAX_VALUE);
+        scriptPermits.release(Integer.MAX_VALUE / 2);
         request = new CancelTasksRequest().setTargetTaskId(taskId).setReason("test cancel");
         request.setWaitForCompletion(true);
         client().admin().cluster().execute(CancelTasksAction.INSTANCE, request).actionGet();


### PR DESCRIPTION
Closes #98603