### PR TITLE
Test fix: test slicing behaviour for parallel collection

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -2092,7 +2092,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
                 assertBusy(
                     () -> assertEquals(
-                        "The number of slices should be 1 as FETCH is does not support parallel collection.",
+                        "The number of slices should be 1 as FETCH does not support parallel collection.",
                         1,
                         executor.getCompletedTaskCount() - priorExecutorTaskCount
                     )
@@ -2106,7 +2106,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
                 assertBusy(
                     () -> assertEquals(
-                        "The number of slices should be 1 as NONE is does not support parallel collection.",
+                        "The number of slices should be 1 as NONE does not support parallel collection.",
                         1,
                         executor.getCompletedTaskCount() - priorExecutorTaskCount
                     )

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -2051,14 +2051,24 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 assertNotNull(searcher.getExecutor());
 
                 final int maxPoolSize = executor.getMaximumPoolSize();
-                assertEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", configuredMaxPoolSize, maxPoolSize);
+                assertEquals(
+                    "Sanity check to ensure this isn't the default of 1 when pool size is unset",
+                    configuredMaxPoolSize,
+                    maxPoolSize
+                );
 
                 final int expectedSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxPoolSize, 1).length;
                 assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
 
                 final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(() -> assertEquals("DFS supports parallel collection, so the number of slices should be > 1.", expectedSlices, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                assertBusy(
+                    () -> assertEquals(
+                        "DFS supports parallel collection, so the number of slices should be > 1.",
+                        expectedSlices,
+                        executor.getCompletedTaskCount() - priorExecutorTaskCount
+                    )
+                );
             }
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
@@ -2066,7 +2076,13 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 assertNotNull(searcher.getExecutor());
                 final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(() -> assertEquals("The number of slices should be 1 as QUERY parallel collection is disabled by default.",1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                assertBusy(
+                    () -> assertEquals(
+                        "The number of slices should be 1 as QUERY parallel collection is disabled by default.",
+                        1,
+                        executor.getCompletedTaskCount() - priorExecutorTaskCount
+                    )
+                );
             }
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.FETCH, true);
@@ -2074,7 +2090,13 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 assertNotNull(searcher.getExecutor());
                 final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(() -> assertEquals("The number of slices should be 1 as FETCH is does not support parallel collection.", 1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                assertBusy(
+                    () -> assertEquals(
+                        "The number of slices should be 1 as FETCH is does not support parallel collection.",
+                        1,
+                        executor.getCompletedTaskCount() - priorExecutorTaskCount
+                    )
+                );
             }
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.NONE, true);
@@ -2082,15 +2104,21 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 assertNotNull(searcher.getExecutor());
                 final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(() -> assertEquals("The number of slices should be 1 as NONE is does not support parallel collection.", 1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                assertBusy(
+                    () -> assertEquals(
+                        "The number of slices should be 1 as NONE is does not support parallel collection.",
+                        1,
+                        executor.getCompletedTaskCount() - priorExecutorTaskCount
+                    )
+                );
             }
 
             try {
                 ClusterUpdateSettingsResponse response = client().admin()
-                        .cluster()
-                        .prepareUpdateSettings()
-                        .setPersistentSettings(Settings.builder().put(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey(), true).build())
-                        .get();
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setPersistentSettings(Settings.builder().put(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey(), true).build())
+                    .get();
                 assertTrue(response.isAcknowledged());
                 {
                     SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
@@ -2098,29 +2126,49 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     assertNotNull(searcher.getExecutor());
 
                     final int maxPoolSize = executor.getMaximumPoolSize();
-                    assertEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", configuredMaxPoolSize, maxPoolSize);
+                    assertEquals(
+                        "Sanity check to ensure this isn't the default of 1 when pool size is unset",
+                        configuredMaxPoolSize,
+                        maxPoolSize
+                    );
 
-                    final int expectedSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxPoolSize, 1).length;
+                    final int expectedSlices = ContextIndexSearcher.computeSlices(
+                        searcher.getIndexReader().leaves(),
+                        maxPoolSize,
+                        1
+                    ).length;
                     assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
 
                     final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                     searcher.search(termQuery, new TotalHitCountCollectorManager());
-                    assertBusy(() -> assertEquals("QUERY supports parallel collection when enabled, so the number of slices should be > 1.", expectedSlices, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                    assertBusy(
+                        () -> assertEquals(
+                            "QUERY supports parallel collection when enabled, so the number of slices should be > 1.",
+                            expectedSlices,
+                            executor.getCompletedTaskCount() - priorExecutorTaskCount
+                        )
+                    );
                 }
             } finally {
                 // Reset to the original default setting.
                 client().admin()
-                        .cluster()
-                        .prepareUpdateSettings()
-                        .setPersistentSettings(Settings.builder().putNull(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey()).build())
-                        .get();
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setPersistentSettings(Settings.builder().putNull(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey()).build())
+                    .get();
                 {
                     SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
                     ContextIndexSearcher searcher = searchContext.searcher();
                     assertNotNull(searcher.getExecutor());
                     final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                     searcher.search(termQuery, new TotalHitCountCollectorManager());
-                    assertBusy(() -> assertEquals("The number of slices should be 1 for Query when QUERY_PHASE_PARALLEL_COLLECTION_ENABLED is disabled.",1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                    assertBusy(
+                        () -> assertEquals(
+                            "The number of slices should be 1 for Query when QUERY_PHASE_PARALLEL_COLLECTION_ENABLED is disabled.",
+                            1,
+                            executor.getCompletedTaskCount() - priorExecutorTaskCount
+                        )
+                    );
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -2013,11 +2013,14 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
 
     /**
      * Verify that a single slice is created for requests that don't support parallel collection, while computation
-     * is still offloaded to the worker threads.
+     * is still offloaded to the worker threads. Also ensure multiple slices are created for requests that do support
+     * parallel collection.
      */
-    public void testSupportsParallelCollectionAffectsSlicing() throws Exception {
+    public void testSlicingBehaviourForParallelCollection() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY);
         ThreadPoolExecutor executor = (ThreadPoolExecutor) indexService.getThreadPool().executor(ThreadPool.Names.SEARCH_WORKER);
+        final int configuredMaxPoolSize = 10;
+        executor.setMaximumPoolSize(configuredMaxPoolSize); // We set this explicitly to be independent of CPU cores.
         int numDocs = randomIntBetween(50, 100);
         for (int i = 0; i < numDocs; i++) {
             client().prepareIndex("index").setId(String.valueOf(i)).setSource("field", "value").get();
@@ -2040,42 +2043,85 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         SearchService service = getInstanceFromNode(SearchService.class);
         NonCountingTermQuery termQuery = new NonCountingTermQuery(new Term("field", "value"));
         assertEquals(0, executor.getCompletedTaskCount());
-        int taskCount = 0;
         try (ReaderContext readerContext = createReaderContext(indexService, indexShard)) {
             SearchShardTask task = new SearchShardTask(0, "type", "action", "description", null, emptyMap());
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.DFS, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
-                int maxNumSlices = executor.getMaximumPoolSize();
-                int numSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxNumSlices, 1).length;
+
+                final int maxPoolSize = executor.getMaximumPoolSize();
+                assertEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", configuredMaxPoolSize, maxPoolSize);
+
+                final int expectedSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxPoolSize, 1).length;
+                assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
+
+                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(() -> assertEquals(numSlices, executor.getCompletedTaskCount()));
-                taskCount += numSlices;
+                assertBusy(() -> assertEquals("DFS supports parallel collection, so the number of slices should be > 1.", expectedSlices, executor.getCompletedTaskCount() - priorExecutorTaskCount));
             }
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
+                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                int expectedTaskCount = ++taskCount;
-                assertBusy(() -> assertEquals(expectedTaskCount, executor.getCompletedTaskCount()));
+                assertBusy(() -> assertEquals("The number of slices should be 1 as QUERY parallel collection is disabled by default.",1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
             }
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.FETCH, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
+                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                int expectedTaskCount = ++taskCount;
-                assertBusy(() -> assertEquals(expectedTaskCount, executor.getCompletedTaskCount()));
+                assertBusy(() -> assertEquals("The number of slices should be 1 as FETCH is does not support parallel collection.", 1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
             }
             {
                 SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.NONE, true);
                 ContextIndexSearcher searcher = searchContext.searcher();
                 assertNotNull(searcher.getExecutor());
+                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                 searcher.search(termQuery, new TotalHitCountCollectorManager());
-                int expectedTaskCount = ++taskCount;
-                assertBusy(() -> assertEquals(expectedTaskCount, executor.getCompletedTaskCount()));
+                assertBusy(() -> assertEquals("The number of slices should be 1 as NONE is does not support parallel collection.", 1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+            }
+
+            try {
+                ClusterUpdateSettingsResponse response = client().admin()
+                        .cluster()
+                        .prepareUpdateSettings()
+                        .setPersistentSettings(Settings.builder().put(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey(), true).build())
+                        .get();
+                assertTrue(response.isAcknowledged());
+                {
+                    SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
+                    ContextIndexSearcher searcher = searchContext.searcher();
+                    assertNotNull(searcher.getExecutor());
+
+                    final int maxPoolSize = executor.getMaximumPoolSize();
+                    assertEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", configuredMaxPoolSize, maxPoolSize);
+
+                    final int expectedSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxPoolSize, 1).length;
+                    assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
+
+                    final long priorExecutorTaskCount = executor.getCompletedTaskCount();
+                    searcher.search(termQuery, new TotalHitCountCollectorManager());
+                    assertBusy(() -> assertEquals("QUERY supports parallel collection when enabled, so the number of slices should be > 1.", expectedSlices, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                }
+            } finally {
+                // Reset to the original default setting.
+                client().admin()
+                        .cluster()
+                        .prepareUpdateSettings()
+                        .setPersistentSettings(Settings.builder().putNull(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey()).build())
+                        .get();
+                {
+                    SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
+                    ContextIndexSearcher searcher = searchContext.searcher();
+                    assertNotNull(searcher.getExecutor());
+                    final long priorExecutorTaskCount = executor.getCompletedTaskCount();
+                    searcher.search(termQuery, new TotalHitCountCollectorManager());
+                    assertBusy(() -> assertEquals("The number of slices should be 1 for Query when QUERY_PHASE_PARALLEL_COLLECTION_ENABLED is disabled.",1, executor.getCompletedTaskCount() - priorExecutorTaskCount));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes testSupportsParallelCollectionAffectsSlicing so that it tests slicing behaviour.