### PR TITLE
QL: Add expressions and references accessor to query plan

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -661,7 +661,7 @@ public class LogicalPlanOptimizer extends RuleExecutor<LogicalPlan> {
                     }
                 } while (recheck);
 
-                var inUse = usedSet.combine(references(p));
+                var inUse = usedSet.combine(p.references());
                 used.set(inUse);
 
                 // preserve the state before going to the next node
@@ -689,16 +689,6 @@ public class LogicalPlanOptimizer extends RuleExecutor<LogicalPlan> {
                 }
             }
             return clone.size() != named.size() ? clone : null;
-        }
-
-        private static List<Expression> expressions(LogicalPlan plan) {
-            List<Expression> exp = new ArrayList<>();
-            plan.forEachExpression(exp::add);
-            return exp;
-        }
-
-        private static AttributeSet references(LogicalPlan plan) {
-            return Expressions.references(expressions(plan));
         }
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/QueryPlan.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/QueryPlan.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ql.plan;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.AttributeSet;
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.tree.Node;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -25,6 +26,8 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
 
     private AttributeSet lazyOutputSet;
     private AttributeSet lazyInputSet;
+    private List<Expression> lazyExpressions;
+    private AttributeSet lazyReferences;
 
     public QueryPlan(Source source, List<PlanType> children) {
         super(source, children);
@@ -48,6 +51,28 @@ public abstract class QueryPlan<PlanType extends QueryPlan<PlanType>> extends No
             lazyInputSet = new AttributeSet(attrs);
         }
         return lazyInputSet;
+    }
+
+    /**
+     * Returns the top-level expressions for this query plan node.
+     * In other words the node properties.
+     */
+    public List<Expression> expressions() {
+        if (lazyExpressions == null) {
+            lazyExpressions = new ArrayList<>();
+            forEachPropertyOnly(Object.class, e -> doForEachExpression(e, lazyExpressions::add));
+        }
+        return lazyExpressions;
+    }
+
+    /**
+     * Returns the expressions referenced on this query plan node.
+     */
+    public AttributeSet references() {
+        if (lazyReferences == null) {
+            lazyReferences = Expressions.references(expressions());
+        }
+        return lazyReferences;
     }
 
     //

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/plan/QueryPlanTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/plan/QueryPlanTests.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.ql.plan;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.expression.Alias;
+import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.ql.plan.logical.Filter;
 import org.elasticsearch.xpack.ql.plan.logical.Limit;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.plan.logical.OrderBy;
@@ -23,11 +26,13 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.ql.TestUtils.equalsOf;
 import static org.elasticsearch.xpack.ql.TestUtils.fieldAttribute;
 import static org.elasticsearch.xpack.ql.TestUtils.of;
 import static org.elasticsearch.xpack.ql.TestUtils.relation;
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.ql.type.DataTypes.INTEGER;
+import static org.hamcrest.Matchers.contains;
 
 public class QueryPlanTests extends ESTestCase {
 
@@ -132,4 +137,21 @@ public class QueryPlanTests extends ESTestCase {
         assertEquals(singletonList(one.child().fold()), list);
     }
 
+    public void testPlanExpressions() {
+        Alias one = new Alias(EMPTY, "one", of(42));
+        FieldAttribute two = fieldAttribute();
+        Project project = new Project(EMPTY, relation(), asList(one, two));
+
+        assertThat(Expressions.names(project.expressions()), contains("one", two.name()));
+    }
+
+    public void testPlanReferences() {
+        var one = fieldAttribute("one", INTEGER);
+        var two = fieldAttribute("two", INTEGER);
+        var add = new Add(EMPTY, one, two);
+        var field = fieldAttribute("field", INTEGER);
+
+        var filter = new Filter(EMPTY, relation(), equalsOf(field, add));
+        assertThat(Expressions.names(filter.references()), contains("field", "one", "two"));
+    }
 }


### PR DESCRIPTION
Add utility methods expressions() and references() method to QueryPlan

Fix #98509