### PR TITLE
Fix NPE in StableMasterHealthIndicatorService

### DIFF
--- a/docs/changelog/98635.yaml
+++ b/docs/changelog/98635.yaml
@@ -1,0 +1,5 @@
+pr: 98635
+summary: Fix NPE in `StableMasterHealthIndicatorService`
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -23,7 +23,6 @@ import org.elasticsearch.health.node.HealthInfo;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * This indicator reports the health of master stability.
@@ -206,8 +205,7 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
         if (node == null) {
             return null;
         } else {
-            String nodeName = node.getName();
-            return Objects.requireNonNullElse(nodeName, null);
+            return node.getName();
         }
     }
 


### PR DESCRIPTION
`Objects.requireNonNullElse(nodeName, null);` will throw an NPE if
`nodeName` is null, but there's no need to fail like that when we can
just return `null`.