### PR TITLE
ESQL: Load `keyword` fields missing `doc_values`

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValueSources.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValueSources.java
@@ -29,6 +29,8 @@ import java.util.List;
 
 public final class ValueSources {
 
+    public static final String MATCH_ONLY_TEXT = "match_only_text";
+
     private ValueSources() {}
 
     public static List<ValueSourceInfo> sources(
@@ -52,7 +54,7 @@ public final class ValueSources {
                 // for the field type name to avoid adding a dependency to the module
                 if (fieldType instanceof KeywordFieldMapper.KeywordFieldType
                     || fieldType instanceof TextFieldMapper.TextFieldType
-                    || "match_only_text".equals(fieldType.typeName())) {
+                    || MATCH_ONLY_TEXT.equals(fieldType.typeName())) {
                     ValuesSource vs = textValueSource(ctx, fieldType);
                     sources.add(new ValueSourceInfo(CoreValuesSourceType.KEYWORD, vs, elementType, ctx.getIndexReader()));
                     continue;

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/30_types.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/30_types.yml
@@ -71,6 +71,35 @@ multivalued keyword:
   - match: {values.0.0: [diamonds, jack, of]}
 
 ---
+keyword no doc_values:
+  - do:
+      indices.create:
+        index:  test
+        body:
+          mappings:
+            properties:
+              card:
+                type: keyword
+                doc_values: false
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "card": ["jack", "of", "diamonds"] }
+
+  - do:
+      esql.query:
+        body:
+          query: 'from test'
+  - match: {columns.0.name: card}
+  - match: {columns.0.type: keyword}
+  - length: {values: 1}
+  - match: {values.0.0: [diamonds, jack, of]}
+
+---
 wildcard:
   - do:
       indices.create:


### PR DESCRIPTION
This PR adds support for loading `keyword` fields having `doc_values: false` in their mapping. 

The code follows the same code path as when loading `text` fields, loading field from the index (if `stored` is `true`) or  extracting from the `_source`. 