### PR TITLE
[8.10] Change the downsample naming scheme to still match DS backing index naming (#98583)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/downsample/DonwsampleConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/action/downsample/DonwsampleConfigTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.downsample;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.action.downsample.DownsampleConfig.generateDownsampleIndexName;
+import static org.hamcrest.Matchers.is;
+
+public class DonwsampleConfigTests extends ESTestCase {
+
+    public void testGenerateDownsampleIndexName() {
+        {
+            String indexName = "test";
+            IndexMetadata indexMeta = IndexMetadata.builder(indexName).settings(indexSettings(IndexVersion.current(), 1, 0)).build();
+            assertThat(generateDownsampleIndexName("downsample-", indexMeta, new DateHistogramInterval("1h")), is("downsample-1h-test"));
+        }
+
+        {
+            String downsampledIndex = "downsample-1h-test";
+            IndexMetadata indexMeta = IndexMetadata.builder(downsampledIndex)
+                .settings(indexSettings(IndexVersion.current(), 1, 0).put(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_NAME_KEY, "test"))
+                .build();
+            assertThat(generateDownsampleIndexName("downsample-", indexMeta, new DateHistogramInterval("8h")), is("downsample-8h-test"));
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsamplePrepareLifeCycleStateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsamplePrepareLifeCycleStateStep.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 
+import static org.elasticsearch.action.downsample.DownsampleConfig.generateDownsampleIndexName;
 import static org.elasticsearch.xpack.core.ilm.DownsampleAction.DOWNSAMPLED_INDEX_PREFIX;
 
 /**
@@ -45,7 +46,7 @@ public class DownsamplePrepareLifeCycleStateStep extends ClusterStateActionStep 
         LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();
 
         LifecycleExecutionState.Builder newLifecycleState = LifecycleExecutionState.builder(lifecycleState);
-        final String downsampleIndexName = generateDownsampleIndexName(indexMetadata, fixedInterval);
+        final String downsampleIndexName = generateDownsampleIndexName(DOWNSAMPLED_INDEX_PREFIX, indexMetadata, fixedInterval);
         newLifecycleState.setDownsampleIndexName(downsampleIndexName);
 
         return LifecycleExecutionStateUtils.newClusterStateWithLifecycleState(
@@ -60,14 +61,4 @@ public class DownsamplePrepareLifeCycleStateStep extends ClusterStateActionStep 
         return true;
     }
 
-    static String generateDownsampleIndexName(IndexMetadata sourceIndexMetadata, DateHistogramInterval fixedInterval) {
-        String downsampleSourceName = sourceIndexMetadata.getSettings().get(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_NAME_KEY);
-        String sourceIndexName;
-        if (downsampleSourceName != null) {
-            sourceIndexName = downsampleSourceName;
-        } else {
-            sourceIndexName = sourceIndexMetadata.getIndex().getName();
-        }
-        return DOWNSAMPLED_INDEX_PREFIX + sourceIndexName + "-" + fixedInterval;
-    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.action.downsample.DownsampleConfig.generateDownsampleIndexName;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.newInstance;
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.common.IndexNameGenerator.generateValidIndexName;
@@ -96,7 +97,7 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
         lifecycleState.setAction(step.getKey().action());
         lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
-        lifecycleState.setDownsampleIndexName(DownsamplePrepareLifeCycleStateStep.generateDownsampleIndexName(im, step.getFixedInterval()));
+        lifecycleState.setDownsampleIndexName(generateDownsampleIndexName(DOWNSAMPLED_INDEX_PREFIX, im, step.getFixedInterval()));
         return IndexMetadata.builder(im).putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap()).build();
     }
 
@@ -105,7 +106,7 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
         assertThat(request.getSourceIndex(), equalTo(sourceIndex));
         assertThat(
             request.getTargetIndex(),
-            equalTo(DOWNSAMPLED_INDEX_PREFIX + sourceIndex + "-" + request.getDownsampleConfig().getFixedInterval())
+            equalTo(DOWNSAMPLED_INDEX_PREFIX + request.getDownsampleConfig().getFixedInterval() + "-" + sourceIndex)
         );
     }
 
@@ -185,10 +186,7 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        String downsampleIndex = DownsamplePrepareLifeCycleStateStep.generateDownsampleIndexName(
-            sourceIndexMetadata,
-            step.getFixedInterval()
-        );
+        String downsampleIndex = generateDownsampleIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexMetadata, step.getFixedInterval());
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(step.getKey().phase());
         lifecycleState.setAction(step.getKey().action());

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -191,7 +191,7 @@ public class ILMDownsampleDisruptionIT extends ESIntegTestCase {
                 }
             })).start();
 
-            final String targetIndex = "downsample-" + sourceIndex + "-1h";
+            final String targetIndex = "downsample-1h-" + sourceIndex;
             startDownsampleTaskViaIlm(sourceIndex, targetIndex, disruptionStart, disruptionEnd);
             waitUntil(() -> cluster.client().admin().cluster().preparePendingClusterTasks().get().pendingTasks().isEmpty());
             ensureStableCluster(cluster.numDataAndMasterNodes());


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Change the downsample naming scheme to still match DS backing index naming (#98583)