### PR TITLE
Reset GatewayService flags before reroute

### DIFF
--- a/docs/changelog/98653.yaml
+++ b/docs/changelog/98653.yaml
@@ -1,0 +1,6 @@
+pr: 98653
+summary: Reset `GatewayService` flags before reroute
+area: Cluster Coordination
+type: bug
+issues:
+ - 98606

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -228,7 +228,8 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
             logger.info("recovered [{}] indices into cluster_state", newState.metadata().indices().size());
             // reset flag even though state recovery completed, to ensure that if we subsequently become leader again based on a
             // not-recovered state, that we again do another state recovery.
-            rerouteService.reroute("state recovered", Priority.NORMAL, ActionListener.running(GatewayService.this::resetRecoveredFlags));
+            resetRecoveredFlags();
+            rerouteService.reroute("state recovered", Priority.NORMAL, ActionListener.noop());
         }
 
         @Override


### PR DESCRIPTION
It's possible (although very unlikely) that the `GatewayService`
recovers the state, then fails over to a new master with unrecovered
state, and then fails back to the original master, and only then
performs the reroute that resets the flags which would trigger another
state recovery attempt. This leaves the cluster in an unrecovered state
until the next cluster state update.

This commit resets the flags at the end of the recovery update rather
than waiting until after the reroute, allowing a subsequent election to
retry recovery again.

Closes #98606