### PR TITLE
[8.10] Update docs for v8.9.1 release (#98416)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,7 +6,11 @@
 
 This section summarizes the changes in each release.
 
+<<<<<<< HEAD
 * <<release-notes-8.10.0>>
+=======
+* <<release-notes-8.9.1>>
+>>>>>>> 7985f8ef0f7 (Update docs for v8.9.1 release (#98416))
 * <<release-notes-8.9.0>>
 * <<release-notes-8.8.2>>
 * <<release-notes-8.8.1>>
@@ -47,6 +51,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.10.0.asciidoc[]
+include::release-notes/8.9.1.asciidoc[]
 include::release-notes/8.9.0.asciidoc[]
 include::release-notes/8.8.2.asciidoc[]
 include::release-notes/8.8.1.asciidoc[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,11 +6,8 @@
 
 This section summarizes the changes in each release.
 
-<<<<<<< HEAD
 * <<release-notes-8.10.0>>
-=======
 * <<release-notes-8.9.1>>
->>>>>>> 7985f8ef0f7 (Update docs for v8.9.1 release (#98416))
 * <<release-notes-8.9.0>>
 * <<release-notes-8.8.2>>
 * <<release-notes-8.8.1>>

--- a/docs/reference/release-notes/8.9.1.asciidoc
+++ b/docs/reference/release-notes/8.9.1.asciidoc
@@ -1,0 +1,53 @@
+[[release-notes-8.9.1]]
+== {es} version 8.9.1
+
+coming[8.9.1]
+
+Also see <<breaking-changes-8.9,Breaking changes in 8.9>>.
+
+[[bug-8.9.1]]
+[float]
+=== Bug fixes
+
+Aggregations::
+* `GlobalAggregator` should call rewrite() before `createWeight()` {es-pull}98091[#98091] (issue: {es-issue}98076[#98076])
+
+Cluster Coordination::
+* Improve exception handling in Coordinator#publish {es-pull}97840[#97840] (issue: {es-issue}97798[#97798])
+
+EQL::
+* Backport fix for async missing events and re-enable the feature {es-pull}98130[#98130]
+
+ILM+SLM::
+* Ignore the `total_shards_per_node` setting on searchable snapshots in frozen {es-pull}97979[#97979]
+* Migrate to data tiers routing configures correct default for mounted indices {es-pull}97936[#97936] (issue: {es-issue}97898[#97898])
+
+Infra/Core::
+* Fix APM trace start time {es-pull}98113[#98113]
+
+Infra/Logging::
+* Add Configuration to `PatternLayout` {es-pull}97679[#97679]
+
+Machine Learning::
+* Fix failure processing Question Answering model output where the input has been spanned over multiple sequences {es-pull}98167[#98167] (issue: {es-issue}97917[#97917])
+
+Search::
+* `UnmappedFieldFetcher` should ignore nested fields {es-pull}97987[#97987] (issue: {es-issue}97684[#97684])
+
+[[enhancement-8.9.1]]
+[float]
+=== Enhancements
+
+Authentication::
+* Upgrade xmlsec to 2.1.8 {es-pull}97741[#97741]
+
+Infra/Core::
+* Enhance regex performance with duplicate wildcards {es-pull}98176[#98176]
+
+Machine Learning::
+* Add setting to scale the processor count used in the model assignment planner {es-pull}98296[#98296]
+
+Search::
+* Refactor nested field handling in `FieldFetcher` {es-pull}97683[#97683]
+
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.9` to `8.10`:
 - [Update docs for v8.9.1 release (#98416)](https://github.com/elastic/elasticsearch/pull/98416)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)