### PR TITLE
Improve `toString()` for some listener utils

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
@@ -66,6 +66,6 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
 
     @Override
     public String toString() {
-        return super.toString() + "/" + listener;
+        return getClass().getSimpleName() + '[' + listener + ']';
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -456,7 +456,7 @@ public abstract class TransportBroadcastByNodeAction<
 
             @Override
             public String toString() {
-                return actionName;
+                return transportNodeBroadcastAction;
             }
         }.run(task, shards.iterator(), listener);
     }
@@ -534,6 +534,11 @@ public abstract class TransportBroadcastByNodeAction<
         @Override
         public boolean hasReferences() {
             return indicesLevelRequest.hasReferences();
+        }
+
+        @Override
+        public String toString() {
+            return "[" + transportNodeBroadcastAction + "][" + nodeId + "][" + indicesLevelRequest + "]";
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -317,6 +317,11 @@ public abstract class TransportTasksAction<
         public boolean hasReferences() {
             return tasksRequest.hasReferences();
         }
+
+        @Override
+        public String toString() {
+            return "[" + transportNodeAction + "][" + tasksRequest + "]";
+        }
     }
 
     private class NodeTasksResponse extends TransportResponse {

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1432,7 +1432,7 @@ public class TransportService extends AbstractLifecycleComponent
 
         @Override
         public String toString() {
-            return getClass().getName() + "/" + delegate.toString();
+            return getClass().getSimpleName() + "[" + delegate.toString() + "]";
         }
 
         void setTimeoutHandler(TimeoutHandler timeoutHandler) {

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -90,6 +90,7 @@ import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.elasticsearch.test.ClusterServiceUtils.setState;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.object.HasToString.hasToString;
@@ -135,6 +136,11 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         @Override
         public boolean hasReferences() {
             return refCounted.hasReferences();
+        }
+
+        @Override
+        public String toString() {
+            return "testrequest" + Arrays.toString(indices);
         }
     }
 
@@ -397,6 +403,14 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         for (Map.Entry<String, List<CapturingTransport.CapturedRequest>> entry : capturedRequests.entrySet()) {
             // check one request was sent to each node
             assertEquals(1, entry.getValue().size());
+            assertThat(
+                entry.getValue().iterator().next().request().toString(),
+                allOf(
+                    containsString('[' + action.transportNodeBroadcastAction + ']'),
+                    containsString('[' + entry.getKey() + ']'),
+                    containsString("[testrequest[" + TEST_INDEX + "]]")
+                )
+            );
         }
 
         assertFalse(request.hasReferences());


### PR DESCRIPTION
The `toString()` output for these listener utilities appear in log
messages sometimes, so this commit makes them a little more useful.