### PR TITLE
Reduce allocations and simplify CancellableTasksTracker

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -115,7 +115,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         if (this.features == DEFAULT_FEATURES) {
             return features(features);
         } else {
-            return features(ArrayUtils.concat(features(), features, Feature.class));
+            return features(ArrayUtils.concat(features(), features));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -35,7 +35,7 @@ public abstract class SecureSetting<T> extends Setting<T> {
     private static final Property[] FIXED_PROPERTIES = { Property.NodeScope };
 
     private SecureSetting(String key, Property... properties) {
-        super(key, (String) null, null, ArrayUtils.concat(properties, FIXED_PROPERTIES, Property.class));
+        super(key, (String) null, null, ArrayUtils.concat(properties, FIXED_PROPERTIES));
         assert assertAllowedProperties(properties);
         KeyStoreWrapper.validateSettingName(key);
     }

--- a/server/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
@@ -60,26 +60,24 @@ public class ArrayUtils {
     /**
      * Concatenates 2 arrays
      */
-    public static String[] concat(String[] one, String[] other) {
-        return concat(one, other, String.class);
-    }
-
-    /**
-     * Concatenates 2 arrays
-     */
-    public static <T> T[] concat(T[] one, T[] other, Class<T> clazz) {
+    public static <T> T[] concat(T[] one, T[] other) {
         @SuppressWarnings("unchecked")
-        T[] target = (T[]) Array.newInstance(clazz, one.length + other.length);
+        T[] target = (T[]) Array.newInstance(other.getClass().componentType(), one.length + other.length);
         System.arraycopy(one, 0, target, 0, one.length);
         System.arraycopy(other, 0, target, one.length, other.length);
         return target;
     }
 
     /**
-     * Concat a string to a string array.
+     * Copy the given array and the added element into a new array of size {@code array.length + 1}.
+     * @param array array to copy to the beginning of new returned array copy
+     * @param added last element in the newly created array
+     * @return copy that contains array and added element
+     * @param <T> type of the array elements
      */
-    public static String[] append(String[] array, String added) {
-        final String[] updated = new String[array.length + 1];
+    public static <T> T[] append(T[] array, T added) {
+        @SuppressWarnings("unchecked")
+        final T[] updated = (T[]) Array.newInstance(added.getClass(), array.length + 1);
         System.arraycopy(array, 0, updated, 0, array.length);
         updated[array.length] = added;
         return updated;

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -72,9 +72,7 @@ public class TaskManager implements ClusterStateApplier {
 
     private final Map<Long, Task> tasks = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
-    private final CancellableTasksTracker<CancellableTaskHolder> cancellableTasks = new CancellableTasksTracker<>(
-        new CancellableTaskHolder[0]
-    );
+    private final CancellableTasksTracker<CancellableTaskHolder> cancellableTasks = new CancellableTasksTracker<>();
 
     private final AtomicLong taskIdGenerator = new AtomicLong();
 

--- a/server/src/test/java/org/elasticsearch/tasks/CancellableTasksTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/CancellableTasksTrackerTests.java
@@ -146,7 +146,7 @@ public class CancellableTasksTrackerTests extends ESTestCase {
             () -> new TaskId(randomAlphaOfLength(5), randomNonNegativeLong())
         );
 
-        final CancellableTasksTracker<String> tracker = new CancellableTasksTracker<>(new String[0]);
+        final CancellableTasksTracker<String> tracker = new CancellableTasksTracker<>();
         final TestTask[] tasks = new TestTask[between(1, 100)];
 
         final Runnable awaitStart = new Runnable() {


### PR DESCRIPTION
Found this as an unexpectedly big contributor to transport thread allocations in some unrelated benchmarking. We can do without capturing the empty array in the two nested lambdas, saving some memory allocations. Solved this by using ArrayUtils instead and cleaning those up a little.
