### PR TITLE
Introduce Iterators#forRange

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -136,7 +136,7 @@ public class ClusterStateTests extends ESTestCase {
             clusterState,
             builder,
             new ToXContent.MapParams(singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API)),
-            37
+            41
         );
         builder.endObject();
 
@@ -393,7 +393,7 @@ public class ClusterStateTests extends ESTestCase {
 
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        writeChunks(clusterState, builder, new ToXContent.MapParams(mapParams), 37);
+        writeChunks(clusterState, builder, new ToXContent.MapParams(mapParams), 41);
         builder.endObject();
 
         assertEquals(
@@ -644,7 +644,7 @@ public class ClusterStateTests extends ESTestCase {
 
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        writeChunks(clusterState, builder, new ToXContent.MapParams(mapParams), 37);
+        writeChunks(clusterState, builder, new ToXContent.MapParams(mapParams), 41);
         builder.endObject();
 
         assertEquals(

--- a/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
@@ -154,6 +154,21 @@ public class IteratorsTests extends ESTestCase {
         expectThrows(NullPointerException.class, "Unable to iterate over a null array", () -> Iterators.forArray(null));
     }
 
+    public void testForRange() {
+        String[] array = generateRandomStringArray(20, 20, false, true);
+        Iterator<String> iterator = Iterators.forRange(0, array.length, i -> array[i]);
+
+        int i = 0;
+        while (iterator.hasNext()) {
+            assertEquals(array[i++], iterator.next());
+        }
+        assertEquals(array.length, i);
+    }
+
+    public void testForRangeOnNull() {
+        expectThrows(NullPointerException.class, () -> Iterators.forRange(0, 1, null));
+    }
+
     public void testFlatMap() {
         final var array = randomIntegerArray();
         assertEmptyIterator(Iterators.flatMap(Iterators.forArray(array), i -> Iterators.concat()));


### PR DESCRIPTION
It's useful to be able to iterate over a range of integers, mapping each
one to some object, but today we must do this with an `IntStream` and
all the extra complexity that this brings. This commit introduces
`Iterators.forRange` and uses it to implement finer-grained chunking of
cluster state responses.