### PR TITLE
Fix response for IS NULL

### DIFF
--- a/docs/reference/esql/esql-syntax.asciidoc
+++ b/docs/reference/esql/esql-syntax.asciidoc
@@ -126,7 +126,7 @@ include::{esql-specs}/null.csv-spec[tag=is-null]
 ----
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
-include::{esql-specs}/null.csv-spec[tag=is-not-null-result]
+include::{esql-specs}/null.csv-spec[tag=is-null-result]
 |===
 
 [source.merge.styled,esql]


### PR DESCRIPTION
The response shown for `IS NULL` [here](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-syntax.html#esql-predicates) is actually the response for the `IS NOT NULL` snippet. This PR fixes that.
