### PR TITLE
[8.8] [DOCS] Remove 'coming' notice from 8.8.2 release notes (#98659)

### DIFF
--- a/docs/reference/release-notes/8.8.2.asciidoc
+++ b/docs/reference/release-notes/8.8.2.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.8.2]]
 == {es} version 8.8.2
 
-coming[8.8.2]
-
 Also see <<breaking-changes-8.8,Breaking changes in 8.8>>.
 
 [[bug-8.8.2]]


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Remove 'coming' notice from 8.8.2 release notes (#98659)