### PR TITLE
[8.10] [DOCS] Removing 'coming' admonition from 8.9.1 release notes (#98658)

### DIFF
--- a/docs/reference/release-notes/8.9.1.asciidoc
+++ b/docs/reference/release-notes/8.9.1.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.9.1]]
 == {es} version 8.9.1
 
-coming[8.9.1]
-
 Also see <<breaking-changes-8.9,Breaking changes in 8.9>>.
 
 [[bug-8.9.1]]


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOCS] Removing 'coming' admonition from 8.9.1 release notes (#98658)