### PR TITLE
[Fleet] Update ilm settings for more uniform rollover/deletion for Fleet files datastreams

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-meta-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-meta-ilm-policy.json
@@ -5,12 +5,12 @@
       "actions": {
         "rollover": {
           "max_size": "10gb",
-          "max_age": "30d"
+          "max_age": "7d"
         }
       }
     },
     "delete": {
-      "min_age": "90d",
+      "min_age": "7d",
       "actions": {
         "delete": {
           "delete_searchable_snapshot": true

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-data-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-data-ilm-policy.json
@@ -5,12 +5,12 @@
       "actions": {
         "rollover": {
           "max_size": "10gb",
-          "max_age": "14d"
+          "max_age": "7d"
         }
       }
     },
     "delete": {
-      "min_age": "24d",
+      "min_age": "7d",
       "actions": {
         "delete": {
           "delete_searchable_snapshot": true

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-meta-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-meta-ilm-policy.json
@@ -5,12 +5,12 @@
       "actions": {
         "rollover": {
           "max_size": "10gb",
-          "max_age": "30d"
+          "max_age": "7d"
         }
       }
     },
     "delete": {
-      "min_age": "90d",
+      "min_age": "7d",
       "actions": {
         "delete": {
           "delete_searchable_snapshot": true


### PR DESCRIPTION
Update ILM settings for the Fleet files datastreams to have uniform rollover/deletion policies.

Before, the settings were different values ranging from `7d` to `90d`.  This sets them to a uniform deletion of `7d`
