### PR TITLE
Log file and full exception on changelog parse error

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ChangelogEntry.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ChangelogEntry.java
@@ -11,6 +11,9 @@ package org.elasticsearch.gradle.internal.release;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -28,6 +31,8 @@ import java.util.stream.Collectors;
  * </ul>
  */
 public class ChangelogEntry {
+    private static final Logger LOGGER = Logging.getLogger(GenerateReleaseNotesTask.class);
+
     private Integer pr;
     private List<Integer> issues;
     private String area;
@@ -48,6 +53,7 @@ public class ChangelogEntry {
         try {
             return yamlMapper.readValue(file, ChangelogEntry.class);
         } catch (IOException e) {
+            LOGGER.error("Failed to parse changelog from " + file.getAbsolutePath(), e);
             throw new UncheckedIOException(e);
         }
     }


### PR DESCRIPTION
This makes it possible to see which file is causing problems when release notes generation fails due to changelog validation issues.