### PR TITLE
[CI] Backport test skip fix from #98621

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -1124,8 +1124,8 @@ fetch geo_point:
 ---
 "Test with subobjects: false":
   - skip:
-      version: ' - 8.9.1'
-      reason: 'https://github.com/elastic/elasticsearch/issues/96700 fixed after 8.9.0'
+      version: ' - 8.9.99'
+      reason: 'https://github.com/elastic/elasticsearch/issues/96700 fixed in 8.10.0'
 
   - do:
       indices.create:


### PR DESCRIPTION
This is PR backports only the test skip changes for 330_fetch_fields from #98621. It does *not* backport anything else from the same PR.

Relates: #98621
Resolves: #98673
