### PR TITLE
Improve use of wildcard types in Iterators utils

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -25,7 +25,6 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -197,12 +196,12 @@ public class ListTasksResponse extends BaseTasksResponse {
                     task.toXContent(builder, params);
                     builder.endObject();
                     return builder;
-                }), Iterators.<ToXContent>single((builder, params) -> {
+                }), Iterators.single((builder, params) -> {
                     builder.endObject();
                     builder.endObject();
                     return builder;
                 }));
-            }), Iterators.<ToXContent>single((builder, params) -> {
+            }), Iterators.single((builder, params) -> {
                 builder.endObject();
                 builder.endObject();
                 return builder;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1434,7 +1434,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
             ? ChunkedToXContentHelper.wrapWithObject("indices", indices().values().iterator())
             : Collections.emptyIterator();
 
-        return Iterators.concat(start, Iterators.<ToXContent>single((builder, params) -> {
+        return Iterators.concat(start, Iterators.single((builder, params) -> {
             builder.field("cluster_uuid", clusterUUID);
             builder.field("cluster_uuid_committed", clusterUUIDCommitted);
             builder.startObject("cluster_coordination");

--- a/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -117,7 +117,7 @@ public class Iterators {
         }
     }
 
-    public static <T> Iterator<T> forRange(int lowerBoundInclusive, int upperBoundExclusive, IntFunction<T> fn) {
+    public static <T> Iterator<T> forRange(int lowerBoundInclusive, int upperBoundExclusive, IntFunction<? extends T> fn) {
         assert lowerBoundInclusive <= upperBoundExclusive : lowerBoundInclusive + " vs " + upperBoundExclusive;
         if (upperBoundExclusive <= lowerBoundInclusive) {
             return Collections.emptyIterator();
@@ -127,11 +127,11 @@ public class Iterators {
     }
 
     private static final class IntRangeIterator<T> implements Iterator<T> {
-        private final IntFunction<T> fn;
+        private final IntFunction<? extends T> fn;
         private final int upperBoundExclusive;
         private int index;
 
-        IntRangeIterator(int lowerBoundInclusive, int upperBoundExclusive, IntFunction<T> fn) {
+        IntRangeIterator(int lowerBoundInclusive, int upperBoundExclusive, IntFunction<? extends T> fn) {
             this.fn = fn;
             this.index = lowerBoundInclusive;
             this.upperBoundExclusive = upperBoundExclusive;
@@ -151,7 +151,7 @@ public class Iterators {
         }
     }
 
-    public static <T, U> Iterator<U> map(Iterator<? extends T> input, Function<T, U> fn) {
+    public static <T, U> Iterator<U> map(Iterator<? extends T> input, Function<T, ? extends U> fn) {
         if (input.hasNext()) {
             return new MapIterator<>(input, fn);
         } else {
@@ -161,9 +161,9 @@ public class Iterators {
 
     private static final class MapIterator<T, U> implements Iterator<U> {
         private final Iterator<? extends T> input;
-        private final Function<T, U> fn;
+        private final Function<T, ? extends U> fn;
 
-        MapIterator(Iterator<? extends T> input, Function<T, U> fn) {
+        MapIterator(Iterator<? extends T> input, Function<T, ? extends U> fn) {
             this.input = input;
             this.fn = fn;
         }
@@ -179,12 +179,7 @@ public class Iterators {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T> Iterator<T> flatten(Iterator<Iterator<T>> input) {
-        return (Iterator<T>) flatMap(input, i -> i);
-    }
-
-    public static <T, U> Iterator<? extends U> flatMap(Iterator<? extends T> input, Function<T, Iterator<? extends U>> fn) {
+    public static <T, U> Iterator<U> flatMap(Iterator<? extends T> input, Function<T, Iterator<? extends U>> fn) {
         while (input.hasNext()) {
             final var value = fn.apply(input.next());
             if (value.hasNext()) {

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -89,7 +89,7 @@ public record HttpStats(long serverOpen, long totalOpen, List<ClientStats> clien
                     .field(Fields.TOTAL_OPENED, totalOpen)
                     .startArray(Fields.CLIENTS)
             ),
-            Iterators.flatMap(clientStats.iterator(), Iterators::<ToXContent>single),
+            clientStats.iterator(),
             Iterators.single((builder, params) -> builder.endArray().endObject())
         );
     }

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -257,7 +257,7 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
                             ChunkedToXContentHelper.startArray(entry.getKey().getName()),
                             Iterators.flatMap(
                                 entry.getValue().iterator(),
-                                indexShardStats -> Iterators.<ToXContent>concat(
+                                indexShardStats -> Iterators.concat(
                                     Iterators.single(
                                         (b, p) -> b.startObject().startObject(String.valueOf(indexShardStats.getShardId().getId()))
                                     ),


### PR DESCRIPTION
We should not be returning iterators over wildcard types, because that
is not typesafe. However we can accept wildcards in more arguments than
we do today. This lets us clean up some casting and explicit type
annotations.