### PR TITLE
Add desired node marker to allocation explain api

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -178,6 +178,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_062 = registerTransportVersion(8_500_062, "09CD9C9B-3207-4B40-8756-B7A12001A885");
     public static final TransportVersion V_8_500_063 = registerTransportVersion(8_500_063, "31dedced-0055-4f34-b952-2f6919be7488");
     public static final TransportVersion V_8_500_064 = registerTransportVersion(8_500_064, "3a795175-5e6f-40ff-90fe-5571ea8ab04e");
+    public static final TransportVersion V_8_500_065 = registerTransportVersion(8_500_065, "0cc763ca-49d5-4b47-9eba-0dd5de1bed79");
 
     /*
      * STOP! READ THIS FIRST! No, really,
@@ -201,7 +202,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
      */
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_064);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_065);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
@@ -46,6 +46,7 @@ public final class ClusterAllocationExplanation implements ToXContentObject, Wri
     private final boolean specificShard;
     private final ShardRouting shardRouting;
     private final DiscoveryNode currentNode;
+    // TODO current node is desired?
     private final DiscoveryNode relocationTargetNode;
     private final ClusterInfo clusterInfo;
     private final ShardAllocationDecision shardAllocationDecision;
@@ -172,7 +173,7 @@ public final class ClusterAllocationExplanation implements ToXContentObject, Wri
             if (currentNode != null) {
                 builder.startObject("current_node");
                 {
-                    discoveryNodeToXContent(currentNode, true, builder);
+                    discoveryNodeToXContent(currentNode, null, true, builder);
                     if (shardAllocationDecision.getMoveDecision().isDecisionTaken()
                         && shardAllocationDecision.getMoveDecision().getCurrentNodeRanking() > 0) {
                         builder.field("weight_ranking", shardAllocationDecision.getMoveDecision().getCurrentNodeRanking());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecision.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardAssignment;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -297,7 +298,7 @@ public class AllocateUnassignedDecision extends AbstractAllocationDecision {
         builder.field("allocate_explanation", getExplanation());
         if (targetNode != null) {
             builder.startObject("target_node");
-            discoveryNodeToXContent(targetNode, true, builder);
+            discoveryNodeToXContent(targetNode, targetNodeIsDesired, true, builder);
             builder.endObject();
         }
         if (allocationId != null) {
@@ -352,4 +353,15 @@ public class AllocateUnassignedDecision extends AbstractAllocationDecision {
         );
     }
 
+    public AllocateUnassignedDecision withNodeAssignment(ShardAssignment assignment) {
+        return new AllocateUnassignedDecision(
+            allocationStatus,
+            targetNode,
+            allocationId,
+            nodeDecisionsWithNodeAssignment(nodeDecisions, assignment.nodeIds()),
+            reuseStore,
+            remainingDelayInMillis,
+            configuredDelayInMillis
+        );
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardAssignment;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -286,7 +287,7 @@ public final class MoveDecision extends AbstractAllocationDecision {
         checkDecisionState();
         if (targetNode != null) {
             builder.startObject("target_node");
-            discoveryNodeToXContent(targetNode, true, builder);
+            discoveryNodeToXContent(targetNode, targetNodeIsDesired, true, builder);
             builder.endObject();
         }
         builder.field("can_remain_on_current_node", canRemain() ? "yes" : "no");
@@ -335,4 +336,14 @@ public final class MoveDecision extends AbstractAllocationDecision {
         return 31 * super.hashCode() + Objects.hash(allocationDecision, canRemainDecision, clusterRebalanceDecision, currentNodeRanking);
     }
 
+    public MoveDecision withNodeAssignment(ShardAssignment assignment) {
+        return new MoveDecision(
+            canRemainDecision,
+            clusterRebalanceDecision,
+            allocationDecision,
+            targetNode,
+            nodeDecisionsWithNodeAssignment(nodeDecisions, assignment.nodeIds()),
+            currentNodeRanking
+        );
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardAllocationDecision.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardAssignment;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -92,4 +93,7 @@ public final class ShardAllocationDecision implements ToXContentFragment, Writea
         return builder;
     }
 
+    public ShardAllocationDecision withNodeAssignment(ShardAssignment assignment) {
+        return new ShardAllocationDecision(allocateDecision.withNodeAssignment(assignment), moveDecision.withNodeAssignment(assignment));
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -159,7 +159,9 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
 
     @Override
     public ShardAllocationDecision decideShardAllocation(ShardRouting shard, RoutingAllocation allocation) {
-        return delegateAllocator.decideShardAllocation(shard, allocation);
+        var decision = delegateAllocator.decideShardAllocation(shard, allocation);
+        var assignment = currentDesiredBalance.getAssignment(shard.shardId());
+        return assignment != null ? decision.withNodeAssignment(assignment) : decision;
     }
 
     @Override


### PR DESCRIPTION
This change adds `"desired": true` marker next to desired nodes to make it easier to understand if node is going to be used.
Marker is skipped if balanced shard allocator is used.

(this is a draft for now)
