### PR TITLE
Support unsigned long in sqrt and log10 for ESQL 

### DIFF
--- a/docs/changelog/98711.yaml
+++ b/docs/changelog/98711.yaml
@@ -1,0 +1,5 @@
+pr: 98711
+summary: Support unsigned long in sqrt and log10 for ESQL
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -301,10 +301,17 @@ Infinity | true
 ;
 
 log10ofLong
-row d = 10 | eval l = log10(10);
+row l = to_long(1000000000000) | eval s = log10(l);
 
-d:i | l:double
-10  | 1
+l:long         | s:double
+1000000000000  | 12
+;
+
+log10ofUnsignedLong
+row l = to_ul(1000000000000000000) | eval s = log10(l);
+
+l:ul                  | s:double
+1000000000000000000   | 18
 ;
 
 powDoubleDouble
@@ -952,6 +959,20 @@ row i = 81 | eval s = sqrt(i);
 
 i:integer | s:double
 81        | 9
+;
+
+sqrtOfLong
+row l = to_long(1000000000000) | eval s = sqrt(l);
+
+l:long            | s:double
+1000000000000     | 1000000
+;
+
+sqrtOfUnsignedLong
+row l = to_ul(1000000000000000000) | eval s = sqrt(l);
+
+l:ul                  | s:double
+1000000000000000000   | 1000000000
 ;
 
 sqrtOfNegative

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10UnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10UnsignedLongEvaluator.java
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.EvalOperator;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Log10}.
+ * This class is generated. Do not edit it.
+ */
+public final class Log10UnsignedLongEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final EvalOperator.ExpressionEvaluator val;
+
+  public Log10UnsignedLongEvaluator(EvalOperator.ExpressionEvaluator val) {
+    this.val = val;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    Block valUncastBlock = val.eval(page);
+    if (valUncastBlock.areAllValuesNull()) {
+      return Block.constantNullBlock(page.getPositionCount());
+    }
+    LongBlock valBlock = (LongBlock) valUncastBlock;
+    LongVector valVector = valBlock.asVector();
+    if (valVector == null) {
+      return eval(page.getPositionCount(), valBlock);
+    }
+    return eval(page.getPositionCount(), valVector).asBlock();
+  }
+
+  public DoubleBlock eval(int positionCount, LongBlock valBlock) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      if (valBlock.isNull(p) || valBlock.getValueCount(p) != 1) {
+        result.appendNull();
+        continue position;
+      }
+      result.appendDouble(Log10.processUnsignedLong(valBlock.getLong(valBlock.getFirstValueIndex(p))));
+    }
+    return result.build();
+  }
+
+  public DoubleVector eval(int positionCount, LongVector valVector) {
+    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      result.appendDouble(Log10.processUnsignedLong(valVector.getLong(p)));
+    }
+    return result.build();
+  }
+
+  @Override
+  public String toString() {
+    return "Log10UnsignedLongEvaluator[" + "val=" + val + "]";
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtUnsignedLongEvaluator.java
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.EvalOperator;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Sqrt}.
+ * This class is generated. Do not edit it.
+ */
+public final class SqrtUnsignedLongEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final EvalOperator.ExpressionEvaluator val;
+
+  public SqrtUnsignedLongEvaluator(EvalOperator.ExpressionEvaluator val) {
+    this.val = val;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    Block valUncastBlock = val.eval(page);
+    if (valUncastBlock.areAllValuesNull()) {
+      return Block.constantNullBlock(page.getPositionCount());
+    }
+    LongBlock valBlock = (LongBlock) valUncastBlock;
+    LongVector valVector = valBlock.asVector();
+    if (valVector == null) {
+      return eval(page.getPositionCount(), valBlock);
+    }
+    return eval(page.getPositionCount(), valVector).asBlock();
+  }
+
+  public DoubleBlock eval(int positionCount, LongBlock valBlock) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      if (valBlock.isNull(p) || valBlock.getValueCount(p) != 1) {
+        result.appendNull();
+        continue position;
+      }
+      result.appendDouble(Sqrt.processUnsignedLong(valBlock.getLong(valBlock.getFirstValueIndex(p))));
+    }
+    return result.build();
+  }
+
+  public DoubleVector eval(int positionCount, LongVector valVector) {
+    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      result.appendDouble(Sqrt.processUnsignedLong(valVector.getLong(p)));
+    }
+    return result.build();
+  }
+
+  @Override
+  public String toString() {
+    return "SqrtUnsignedLongEvaluator[" + "val=" + val + "]";
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10.java
@@ -66,8 +66,7 @@ public class Log10 extends UnaryScalarFunction implements EvaluatorMapper {
 
     @Evaluator(extraName = "UnsignedLong")
     static double processUnsignedLong(long val) {
-        Number ul = NumericUtils.unsignedLongAsNumber(val);
-        return Math.log10(ul.doubleValue());
+        return Math.log10(NumericUtils.unsignedLongToDouble(val));
     }
 
     @Evaluator(extraName = "Int")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log10.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.util.NumericUtils;
 
 import java.util.List;
 import java.util.function.Function;
@@ -46,6 +47,9 @@ public class Log10 extends UnaryScalarFunction implements EvaluatorMapper {
         if (fieldType == DataTypes.LONG) {
             return () -> new Log10LongEvaluator(eval);
         }
+        if (fieldType == DataTypes.UNSIGNED_LONG) {
+            return () -> new Log10UnsignedLongEvaluator(eval);
+        }
 
         throw new UnsupportedOperationException("Unsupported type " + fieldType);
     }
@@ -58,6 +62,12 @@ public class Log10 extends UnaryScalarFunction implements EvaluatorMapper {
     @Evaluator(extraName = "Long")
     static double process(long val) {
         return Math.log10(val);
+    }
+
+    @Evaluator(extraName = "UnsignedLong")
+    static double processUnsignedLong(long val) {
+        Number ul = NumericUtils.unsignedLongAsNumber(val);
+        return Math.log10(ul.doubleValue());
     }
 
     @Evaluator(extraName = "Int")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sqrt.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sqrt.java
@@ -66,8 +66,7 @@ public class Sqrt extends UnaryScalarFunction implements EvaluatorMapper {
 
     @Evaluator(extraName = "UnsignedLong")
     static double processUnsignedLong(long val) {
-        Number ul = NumericUtils.unsignedLongAsNumber(val);
-        return Math.sqrt(ul.doubleValue());
+        return Math.sqrt(NumericUtils.unsignedLongToDouble(val));
     }
 
     @Evaluator(extraName = "Int")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sqrt.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sqrt.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.util.NumericUtils;
 
 import java.util.List;
 import java.util.function.Function;
@@ -46,6 +47,9 @@ public class Sqrt extends UnaryScalarFunction implements EvaluatorMapper {
         if (fieldType == DataTypes.LONG) {
             return () -> new SqrtLongEvaluator(eval);
         }
+        if (fieldType == DataTypes.UNSIGNED_LONG) {
+            return () -> new SqrtUnsignedLongEvaluator(eval);
+        }
 
         throw new UnsupportedOperationException("Unsupported type " + fieldType);
     }
@@ -58,6 +62,12 @@ public class Sqrt extends UnaryScalarFunction implements EvaluatorMapper {
     @Evaluator(extraName = "Long")
     static double process(long val) {
         return Math.sqrt(val);
+    }
+
+    @Evaluator(extraName = "UnsignedLong")
+    static double processUnsignedLong(long val) {
+        Number ul = NumericUtils.unsignedLongAsNumber(val);
+        return Math.sqrt(ul.doubleValue());
     }
 
     @Evaluator(extraName = "Int")


### PR DESCRIPTION
Add support for unsigned long fields in these functions. The underlying Java functions consume doubles as input, so the unsigned long values are converted to double.

Related to #98544
