### PR TITLE
[8.10] RCS 2.0 - expose cross cluster credentials authentication (#98682)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -543,6 +543,7 @@ public class Security extends Plugin
     private final SetOnce<ThreadContext> threadContext = new SetOnce<>();
     private final SetOnce<TokenService> tokenService = new SetOnce<>();
     private final SetOnce<SecurityActionFilter> securityActionFilter = new SetOnce<>();
+    private final SetOnce<CrossClusterAccessAuthenticationService> crossClusterAccessAuthcService = new SetOnce<>();
 
     private final SetOnce<SharedGroupFactory> sharedGroupFactory = new SetOnce<>();
     private final SetOnce<DocumentSubsetBitsetCache> dlsBitsetCache = new SetOnce<>();
@@ -993,12 +994,8 @@ public class Security extends Plugin
         final RemoteClusterCredentialsResolver remoteClusterCredentialsResolver = new RemoteClusterCredentialsResolver(settings);
 
         DestructiveOperations destructiveOperations = new DestructiveOperations(settings, clusterService.getClusterSettings());
-        final CrossClusterAccessAuthenticationService crossClusterAccessAuthcService = new CrossClusterAccessAuthenticationService(
-            clusterService,
-            apiKeyService,
-            authcService.get()
-        );
-        components.add(crossClusterAccessAuthcService);
+        crossClusterAccessAuthcService.set(new CrossClusterAccessAuthenticationService(clusterService, apiKeyService, authcService.get()));
+        components.add(crossClusterAccessAuthcService.get());
         securityInterceptor.set(
             new SecurityServerTransportInterceptor(
                 settings,
@@ -1008,7 +1005,7 @@ public class Security extends Plugin
                 getSslService(),
                 securityContext.get(),
                 destructiveOperations,
-                crossClusterAccessAuthcService,
+                crossClusterAccessAuthcService.get(),
                 remoteClusterCredentialsResolver,
                 getLicenseState()
             )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessAuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessAuthenticationService.java
@@ -19,10 +19,14 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.security.action.apikey.ApiKey;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.CrossClusterAccessSubjectInfo;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.core.Strings.format;
@@ -106,6 +110,59 @@ public class CrossClusterAccessAuthenticationService {
                 }, listener::onFailure))
             );
         }
+    }
+
+    public void tryAuthenticate(ApiKeyService.ApiKeyCredentials credentials, ActionListener<Void> listener) {
+        Objects.requireNonNull(credentials);
+        apiKeyService.tryAuthenticate(clusterService.threadPool().getThreadContext(), credentials, ActionListener.wrap(authResult -> {
+            if (authResult.isAuthenticated()) {
+                logger.trace("Cross cluster credentials authentication successful for [{}]", credentials.principal());
+                listener.onResponse(null);
+                return;
+            }
+
+            if (authResult.getStatus() == AuthenticationResult.Status.TERMINATE) {
+                Exception e = (authResult.getException() != null)
+                    ? authResult.getException()
+                    : Exceptions.authenticationError(authResult.getMessage());
+                logger.debug(() -> "API key service terminated authentication", e);
+                listener.onFailure(e);
+            } else {
+                if (authResult.getMessage() != null) {
+                    if (authResult.getException() != null) {
+                        logger.warn(
+                            () -> format("Authentication using apikey failed - %s", authResult.getMessage()),
+                            authResult.getException()
+                        );
+                    } else {
+                        logger.warn("Authentication using apikey failed - {}", authResult.getMessage());
+                    }
+                }
+                listener.onFailure(Exceptions.authenticationError(authResult.getMessage(), authResult.getException()));
+            }
+        }, e -> listener.onFailure(Exceptions.authenticationError("failed to authenticate cross cluster credentials", e))));
+    }
+
+    public ApiKeyService.ApiKeyCredentials extractApiKeyCredentialsFromHeaders(Map<String, String> headers) {
+        try {
+            apiKeyService.ensureEnabled();
+            final String credentials = headers.get(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY);
+            if (credentials == null) {
+                throw requiredHeaderMissingException(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY);
+            }
+            return CrossClusterAccessHeaders.parseCredentialsHeader(credentials);
+        } catch (Exception ex) {
+            throw Exceptions.authenticationError("failed to extract credentials from headers", ex);
+        }
+    }
+
+    public static IllegalArgumentException requiredHeaderMissingException(String headerKey) {
+        return new IllegalArgumentException(
+            "Cross cluster requests through the dedicated remote cluster server port require transport header ["
+                + headerKey
+                + "] but none found. "
+                + "Please ensure you have configured remote cluster credentials on the cluster originating the request."
+        );
     }
 
     public AuthenticationService getAuthenticationService() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeaders.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeaders.java
@@ -48,7 +48,7 @@ public final class CrossClusterAccessHeaders {
         return parseCredentialsHeader(credentialsHeader);
     }
 
-    private static ApiKeyService.ApiKeyCredentials parseCredentialsHeader(final String header) {
+    static ApiKeyService.ApiKeyCredentials parseCredentialsHeader(final String header) {
         try {
             return Objects.requireNonNull(ApiKeyService.getCredentialsFromHeader(header, ApiKey.Type.CROSS_CLUSTER));
         } catch (Exception ex) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/CrossClusterAccessServerTransportFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/CrossClusterAccessServerTransportFilter.java
@@ -110,12 +110,7 @@ final class CrossClusterAccessServerTransportFilter extends ServerTransportFilte
 
     private void ensureRequiredHeaderInContext(ThreadContext threadContext, String requiredHeader) {
         if (threadContext.getHeader(requiredHeader) == null) {
-            throw new IllegalArgumentException(
-                "Cross cluster requests through the dedicated remote cluster server port require transport header ["
-                    + requiredHeader
-                    + "] but none found. "
-                    + "Please ensure you have configured remote cluster credentials on the cluster originating the request."
-            );
+            throw CrossClusterAccessAuthenticationService.requiredHeaderMissingException(requiredHeader);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeadersTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeadersTests.java
@@ -105,7 +105,7 @@ public class CrossClusterAccessHeadersTests extends ESTestCase {
     }
 
     // TODO centralize common usage of this across all tests
-    static String randomEncodedApiKeyHeader() {
+    public static String randomEncodedApiKeyHeader() {
         return encodedApiKeyWithPrefix(UUIDs.randomBase64UUID(), UUIDs.randomBase64UUID());
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessAuthenticationServiceIntegTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessAuthenticationServiceIntegTests.java
@@ -12,24 +12,35 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSource;
 import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.apikey.ApiKey;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authc.CrossClusterAccessSubjectInfo;
+import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptorsIntersection;
 import org.elasticsearch.xpack.core.security.user.InternalUsers;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
 import org.elasticsearch.xpack.security.authc.CrossClusterAccessAuthenticationService;
 import org.elasticsearch.xpack.security.authc.CrossClusterAccessHeaders;
+import org.elasticsearch.xpack.security.authc.CrossClusterAccessHeadersTests;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
@@ -135,15 +146,215 @@ public class CrossClusterAccessAuthenticationServiceIntegTests extends SecurityI
         }
     }
 
+    public void testTryAuthenticateSuccess() throws IOException {
+        final String encodedCrossClusterAccessApiKey = getEncodedCrossClusterAccessApiKey();
+        final String nodeName = internalCluster().getRandomNodeName();
+        final ThreadContext threadContext = internalCluster().getInstance(SecurityContext.class, nodeName).getThreadContext();
+        final CrossClusterAccessAuthenticationService service = internalCluster().getInstance(
+            CrossClusterAccessAuthenticationService.class,
+            nodeName
+        );
+
+        try (var ignored = threadContext.stashContext()) {
+            addRandomizedHeaders(threadContext, encodedCrossClusterAccessApiKey);
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            Map<String, String> headers = withRandomizedAdditionalSecurityHeaders(
+                Map.of(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY, encodedCrossClusterAccessApiKey)
+            );
+            final ApiKeyService.ApiKeyCredentials credentials = service.extractApiKeyCredentialsFromHeaders(headers);
+            service.tryAuthenticate(credentials, future);
+            future.actionGet();
+        }
+    }
+
+    public void testGetApiKeyCredentialsFromHeaders() {
+        final String nodeName = internalCluster().getRandomNodeName();
+        final CrossClusterAccessAuthenticationService service = internalCluster().getInstance(
+            CrossClusterAccessAuthenticationService.class,
+            nodeName
+        );
+
+        {
+            ElasticsearchSecurityException ex = expectThrows(
+                ElasticsearchSecurityException.class,
+                () -> service.extractApiKeyCredentialsFromHeaders(withRandomizedAdditionalSecurityHeaders(Map.of()))
+            );
+            assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(
+                ex.getCause().getMessage(),
+                containsString(
+                    "Cross cluster requests through the dedicated remote cluster server port require transport header ["
+                        + CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY
+                        + "] but none found. "
+                        + "Please ensure you have configured remote cluster credentials on the cluster originating the request."
+                )
+            );
+        }
+
+        {
+            ElasticsearchSecurityException ex = expectThrows(
+                ElasticsearchSecurityException.class,
+                () -> service.extractApiKeyCredentialsFromHeaders(
+                    withRandomizedAdditionalSecurityHeaders(
+                        Map.of(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY, ApiKeyService.withApiKeyPrefix("abc"))
+                    )
+                )
+            );
+            assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(
+                ex.getCause().getMessage(),
+                containsString(
+                    "cross cluster access header ["
+                        + CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY
+                        + "] value must be a valid API key credential"
+                )
+            );
+        }
+
+    }
+
+    public void testTryAuthenticateFailure() throws IOException {
+        final EncodedKeyWithId encodedCrossClusterAccessApiKeyWithId = getEncodedCrossClusterAccessApiKeyWithId();
+        final EncodedKeyWithId encodedRestApiKeyWithId = getEncodedRestApiKeyWithId();
+        final String nodeName = internalCluster().getRandomNodeName();
+        final ThreadContext threadContext = internalCluster().getInstance(SecurityContext.class, nodeName).getThreadContext();
+        final CrossClusterAccessAuthenticationService service = internalCluster().getInstance(
+            CrossClusterAccessAuthenticationService.class,
+            nodeName
+        );
+
+        try (var ignored = threadContext.stashContext()) {
+            addRandomizedHeaders(threadContext, encodedCrossClusterAccessApiKeyWithId.encoded);
+            final Map<String, String> headers = withRandomizedAdditionalSecurityHeaders(
+                Map.of(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY, encodedRestApiKeyWithId.encoded)
+            );
+            final ApiKeyService.ApiKeyCredentials credentials = service.extractApiKeyCredentialsFromHeaders(headers);
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            service.tryAuthenticate(credentials, future);
+            final ExecutionException actualException = expectThrows(ExecutionException.class, future::get);
+            assertThat(actualException.getCause(), instanceOf(ElasticsearchSecurityException.class));
+            assertThat(
+                actualException.getCause().getMessage(),
+                containsString("authentication expected API key type of [" + ApiKey.Type.CROSS_CLUSTER.value() + "]")
+            );
+        }
+
+        try (var ignored = threadContext.stashContext()) {
+            addRandomizedHeaders(threadContext, encodedCrossClusterAccessApiKeyWithId.encoded);
+            final String wrongApiKeyWithCorrectId = ApiKeyService.withApiKeyPrefix(
+                Base64.getEncoder()
+                    .encodeToString(
+                        (encodedCrossClusterAccessApiKeyWithId.id + ":" + UUIDs.randomBase64UUIDSecureString()).getBytes(
+                            StandardCharsets.UTF_8
+                        )
+                    )
+            );
+            final Map<String, String> headers = withRandomizedAdditionalSecurityHeaders(
+                Map.of(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY, wrongApiKeyWithCorrectId)
+            );
+            final ApiKeyService.ApiKeyCredentials credentials = service.extractApiKeyCredentialsFromHeaders(headers);
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            service.tryAuthenticate(credentials, future);
+            final ExecutionException actualException = expectThrows(ExecutionException.class, future::get);
+            assertThat(actualException.getCause(), instanceOf(ElasticsearchSecurityException.class));
+            assertThat(actualException.getCause().getMessage(), containsString("invalid credentials for API key"));
+        }
+
+        try (var ignored = threadContext.stashContext()) {
+            addRandomizedHeaders(threadContext, encodedCrossClusterAccessApiKeyWithId.encoded);
+            final String wrongApiKey = ApiKeyService.withApiKeyPrefix(
+                Base64.getEncoder()
+                    .encodeToString((UUIDs.base64UUID() + ":" + UUIDs.randomBase64UUIDSecureString()).getBytes(StandardCharsets.UTF_8))
+            );
+            final Map<String, String> headers = withRandomizedAdditionalSecurityHeaders(
+                Map.of(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY, wrongApiKey)
+            );
+            final ApiKeyService.ApiKeyCredentials credentials = service.extractApiKeyCredentialsFromHeaders(headers);
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            service.tryAuthenticate(credentials, future);
+            final ExecutionException actualException = expectThrows(ExecutionException.class, future::get);
+            assertThat(actualException.getCause(), instanceOf(ElasticsearchSecurityException.class));
+            assertThat(actualException.getCause().getMessage(), containsString("unable to find apikey with id"));
+        }
+    }
+
+    private Map<String, String> withRandomizedAdditionalSecurityHeaders(Map<String, String> headers) throws IOException {
+        var map = new HashMap<>(headers);
+        if (randomBoolean()) {
+            map.put(
+                "Authorization",
+                randomFrom(
+                    CrossClusterAccessHeadersTests.randomEncodedApiKeyHeader(),
+                    UsernamePasswordToken.basicAuthHeaderValue(
+                        SecuritySettingsSource.TEST_USER_NAME,
+                        new SecureString(SecuritySettingsSource.TEST_USER_NAME.toCharArray())
+                    ),
+                    UsernamePasswordToken.basicAuthHeaderValue("user", new SecureString(randomAlphaOfLength(20).toCharArray()))
+                )
+            );
+        }
+        if (randomBoolean()) {
+            map.put(AuthenticationField.AUTHENTICATION_KEY, AuthenticationTestHelper.builder().build().encode());
+        }
+        return Map.copyOf(map);
+    }
+
+    private void addRandomizedHeaders(ThreadContext threadContext, String validEncodedApiKey) throws IOException {
+        // Headers in thread context should have no impact on tryAuthenticate
+        if (randomBoolean()) {
+            new CrossClusterAccessHeaders(
+                validEncodedApiKey,
+                randomFrom(
+                    new CrossClusterAccessSubjectInfo(AuthenticationTestHelper.builder().build(), RoleDescriptorsIntersection.EMPTY),
+                    new CrossClusterAccessSubjectInfo(
+                        AuthenticationTestHelper.builder().crossClusterAccess().build(),
+                        RoleDescriptorsIntersection.EMPTY
+                    )
+                )
+            ).writeToContext(threadContext);
+        } else {
+            if (randomBoolean()) {
+                threadContext.putHeader(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY, validEncodedApiKey);
+            }
+        }
+        if (randomBoolean()) {
+            new AuthenticationContextSerializer().writeToContext(AuthenticationTestHelper.builder().build(), threadContext);
+        }
+        if (randomBoolean()) {
+            threadContext.putHeader("Authorization", CrossClusterAccessHeadersTests.randomEncodedApiKeyHeader());
+        }
+    }
+
     private String getEncodedCrossClusterAccessApiKey() throws IOException {
+        return getEncodedCrossClusterAccessApiKeyWithId().encoded;
+    }
+
+    private EncodedKeyWithId getEncodedCrossClusterAccessApiKeyWithId() throws IOException {
         final CreateCrossClusterApiKeyRequest request = CreateCrossClusterApiKeyRequest.withNameAndAccess("cross_cluster_access_key", """
             {"search": [{"names": ["*"]}]}""");
         request.setRefreshPolicy(randomFrom(NONE, IMMEDIATE, WAIT_UNTIL));
         final CreateApiKeyResponse response = client().execute(CreateCrossClusterApiKeyAction.INSTANCE, request).actionGet();
-        return ApiKeyService.withApiKeyPrefix(
-            Base64.getEncoder().encodeToString((response.getId() + ":" + response.getKey()).getBytes(StandardCharsets.UTF_8))
+        return new EncodedKeyWithId(
+            response.getId(),
+            ApiKeyService.withApiKeyPrefix(
+                Base64.getEncoder().encodeToString((response.getId() + ":" + response.getKey()).getBytes(StandardCharsets.UTF_8))
+            )
         );
     }
+
+    private EncodedKeyWithId getEncodedRestApiKeyWithId() {
+        final CreateApiKeyRequest request = new CreateApiKeyRequest(randomAlphaOfLength(10), null, null, null);
+        request.setRefreshPolicy(randomFrom(NONE, IMMEDIATE, WAIT_UNTIL));
+        final CreateApiKeyResponse response = client().execute(CreateApiKeyAction.INSTANCE, request).actionGet();
+        return new EncodedKeyWithId(
+            response.getId(),
+            ApiKeyService.withApiKeyPrefix(
+                Base64.getEncoder().encodeToString((response.getId() + ":" + response.getKey()).getBytes(StandardCharsets.UTF_8))
+            )
+        );
+    }
+
+    record EncodedKeyWithId(String id, String encoded) {}
 
     private void authenticateAndAssertExpectedErrorMessage(
         CrossClusterAccessAuthenticationService service,
@@ -156,4 +367,5 @@ public class CrossClusterAccessAuthenticationServiceIntegTests extends SecurityI
         assertThat(actualException.getCause().getCause(), instanceOf(IllegalArgumentException.class));
         errorMessageAssertion.accept(actualException.getCause().getCause().getMessage());
     }
+
 }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - RCS 2.0 - expose cross cluster credentials authentication (#98682)