### PR TITLE
[8.10] Do not assign ignored shards (#98265)

### DIFF
--- a/docs/changelog/98265.yaml
+++ b/docs/changelog/98265.yaml
@@ -1,0 +1,5 @@
+pr: 98265
+summary: Do not assign ignored shards
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
@@ -24,10 +24,6 @@ public record ShardAssignment(Set<String> nodeIds, int total, int unassigned, in
         assert nodeIds.size() + unassigned == total : "Shard assignment should account for all shards";
     }
 
-    public boolean isIgnored(boolean primary) {
-        return primary ? total == ignored : ignored > 0;
-    }
-
     public int assigned() {
         return nodeIds.size();
     }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -189,7 +189,6 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91800")
     public void testPartialSearchableSnapshotDelaysAllocationUntilNodeCacheStatesKnown() throws Exception {
 
         updateClusterSettings(


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Do not assign ignored shards (#98265)