### PR TITLE
Use efficient ActionListener.delegateFailureAndWrap in QL code

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlUsageTransportAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlUsageTransportAction.java
@@ -58,7 +58,7 @@ public class EqlUsageTransportAction extends XPackUsageFeatureTransportAction {
         EqlStatsRequest eqlRequest = new EqlStatsRequest();
         eqlRequest.includeStats(true);
         eqlRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(EqlStatsAction.INSTANCE, eqlRequest, ActionListener.wrap(r -> {
+        client.execute(EqlStatsAction.INSTANCE, eqlRequest, listener.delegateFailureAndWrap((delegate, r) -> {
             List<Counters> countersPerNode = r.getNodes()
                 .stream()
                 .map(EqlStatsResponse.NodeStatsResponse::getStats)
@@ -66,7 +66,7 @@ public class EqlUsageTransportAction extends XPackUsageFeatureTransportAction {
                 .collect(Collectors.toList());
             Counters mergedCounters = Counters.merge(countersPerNode);
             EqlFeatureSetUsage usage = new EqlFeatureSetUsage(mergedCounters.toNestedMap());
-            listener.onResponse(new XPackUsageFeatureResponse(usage));
-        }, listener::onFailure));
+            delegate.onResponse(new XPackUsageFeatureResponse(usage));
+        }));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sample/SampleIterator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sample/SampleIterator.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Stack;
 
 import static org.elasticsearch.action.ActionListener.runAfter;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.common.Strings.EMPTY_ARRAY;
 import static org.elasticsearch.xpack.eql.execution.assembler.SampleQueryRequest.COMPOSITE_AGG_NAME;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.prepareRequest;
@@ -147,7 +146,7 @@ public class SampleIterator implements Executable {
     }
 
     private void queryForCompositeAggPage(ActionListener<Payload> listener, final SampleQueryRequest request) {
-        client.query(request, wrap(r -> {
+        client.query(request, listener.delegateFailureAndWrap((delegate, r) -> {
             Aggregation a = r.getAggregations().get(COMPOSITE_AGG_NAME);
             if (a instanceof InternalComposite == false) {
                 throw new EqlIllegalArgumentException("Unexpected aggregation result type returned [{}]", a.getClass());
@@ -158,15 +157,15 @@ public class SampleIterator implements Executable {
             Page nextPage = new Page(composite, request);
             if (nextPage.size > 0) {
                 pushToStack(nextPage);
-                advance(listener);
+                advance(delegate);
             } else {
                 if (stack.size() > 0) {
-                    nextPage(listener, stack.pop());
+                    nextPage(delegate, stack.pop());
                 } else {
-                    payload(listener);
+                    payload(delegate);
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     protected void pushToStack(Page nextPage) {
@@ -210,7 +209,7 @@ public class SampleIterator implements Executable {
         }
 
         int initialSize = samples.size();
-        client.multiQuery(searches, ActionListener.wrap(r -> {
+        client.multiQuery(searches, listener.delegateFailureAndWrap((delegate, r) -> {
             List<List<SearchHit>> sample = new ArrayList<>(maxCriteria);
             MultiSearchResponse.Item[] response = r.getResponses();
             int docGroupsCounter = 1;
@@ -228,7 +227,7 @@ public class SampleIterator implements Executable {
                             samples.add(new Sample(sampleKeys.get(responseIndex / maxCriteria), match));
                         }
                         if (samples.size() == limit.limit()) {
-                            payload(listener);
+                            payload(delegate);
                             return;
                         }
                     }
@@ -244,8 +243,8 @@ public class SampleIterator implements Executable {
             // or it's just not the last page and we should advance
             var next = page.size == fetchSize ? page : stack.pop();
             log.trace("Final step... getting next page of the " + (next == page ? "current" : "previous") + " page");
-            nextPage(listener, next);
-        }, listener::onFailure));
+            nextPage(delegate, next);
+        }));
     }
 
     private void updateMemoryUsage() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
@@ -151,11 +151,11 @@ public class BasicQueryClient implements QueryClient {
             multiSearchBuilder.add(search);
         }
 
-        search(multiSearchBuilder.request(), ActionListener.wrap(r -> {
+        search(multiSearchBuilder.request(), listener.delegateFailureAndWrap((delegate, r) -> {
             for (MultiSearchResponse.Item item : r.getResponses()) {
                 // check for failures
                 if (item.isFailure()) {
-                    listener.onFailure(item.getFailure());
+                    delegate.onFailure(item.getFailure());
                     return;
                 }
                 // otherwise proceed
@@ -176,8 +176,8 @@ public class BasicQueryClient implements QueryClient {
                     });
                 }
             }
-            listener.onResponse(seq);
-        }, listener::onFailure));
+            delegate.onResponse(seq);
+        }));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -131,10 +131,10 @@ public class PITAwareQueryClient extends BasicQueryClient {
     private <Response> void openPIT(ActionListener<Response> listener, Runnable runnable) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).indicesOptions(IndexResolver.FIELD_CAPS_INDICES_OPTIONS)
             .keepAlive(keepAlive);
-        client.execute(OpenPointInTimeAction.INSTANCE, request, wrap(r -> {
+        client.execute(OpenPointInTimeAction.INSTANCE, request, listener.delegateFailureAndWrap((l, r) -> {
             pitId = r.getPointInTimeId();
             runnable.run();
-        }, listener::onFailure));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -56,21 +56,21 @@ public final class RuntimeUtils {
     private RuntimeUtils() {}
 
     public static ActionListener<SearchResponse> searchLogListener(ActionListener<SearchResponse> listener, Logger log) {
-        return ActionListener.wrap(response -> {
+        return listener.delegateFailureAndWrap((delegate, response) -> {
             ShardSearchFailure[] failures = response.getShardFailures();
             if (CollectionUtils.isEmpty(failures) == false) {
-                listener.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
+                delegate.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
                 return;
             }
             if (log.isTraceEnabled()) {
                 logSearchResponse(response, log);
             }
-            listener.onResponse(response);
-        }, listener::onFailure);
+            delegate.onResponse(response);
+        });
     }
 
     public static ActionListener<MultiSearchResponse> multiSearchLogListener(ActionListener<MultiSearchResponse> listener, Logger log) {
-        return ActionListener.wrap(items -> {
+        return listener.delegateFailureAndWrap((delegate, items) -> {
             for (MultiSearchResponse.Item item : items) {
                 Exception failure = item.getFailure();
                 SearchResponse response = item.getResponse();
@@ -82,15 +82,15 @@ public final class RuntimeUtils {
                     }
                 }
                 if (failure != null) {
-                    listener.onFailure(failure);
+                    delegate.onFailure(failure);
                     return;
                 }
                 if (log.isTraceEnabled()) {
                     logSearchResponse(response, log);
                 }
             }
-            listener.onResponse(items);
-        }, listener::onFailure);
+            delegate.onResponse(items);
+        });
     }
 
     private static void logSearchResponse(SearchResponse response, Logger logger) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -47,7 +47,6 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.ActionListener.runAfter;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.eql.execution.ExecutionUtils.copySource;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.addFilter;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.searchHits;
@@ -218,7 +217,7 @@ public class TumblingWindow implements Executable {
             }
 
             List<SearchRequest> queries = prepareQueryForMissingEvents(batchToCheck);
-            client.multiQuery(queries, wrap(p -> doCheckMissingEvents(batchToCheck, p, listener, next), listener::onFailure));
+            client.multiQuery(queries, listener.delegateFailureAndWrap((l, p) -> doCheckMissingEvents(batchToCheck, p, l, next)));
         }
     }
 
@@ -354,7 +353,7 @@ public class TumblingWindow implements Executable {
         log.trace("{}", matcher);
         log.trace("Querying base stage [{}] {}", stage, base.queryRequest());
 
-        client.query(base.queryRequest(), wrap(p -> baseCriterion(stage, p, listener), listener::onFailure));
+        client.query(base.queryRequest(), listener.delegateFailureAndWrap((l, p) -> baseCriterion(stage, p, l)));
     }
 
     /**
@@ -527,7 +526,7 @@ public class TumblingWindow implements Executable {
 
         log.trace("Querying until stage {}", request);
 
-        client.query(request, wrap(r -> {
+        client.query(request, listener.delegateFailureAndWrap((delegate, r) -> {
             List<SearchHit> hits = searchHits(r);
 
             log.trace("Found [{}] hits", hits.size());
@@ -540,15 +539,14 @@ public class TumblingWindow implements Executable {
 
             // keep running the query runs out of the results (essentially returns less than what we want)
             if (hits.size() == windowSize && request.after().before(window.end)) {
-                untilCriterion(window, listener, next);
+                untilCriterion(window, delegate, next);
             }
             // looks like this stage is done, move on
             else {
                 // to the next query
                 next.run();
             }
-
-        }, listener::onFailure));
+        }));
     }
 
     private void secondaryCriterion(WindowInfo window, int currentStage, ActionListener<Payload> listener) {
@@ -559,7 +557,7 @@ public class TumblingWindow implements Executable {
 
         log.trace("Querying (secondary) stage [{}] {}", criterion.stage(), request);
 
-        client.query(request, wrap(r -> {
+        client.query(request, listener.delegateFailureAndWrap((delegate, r) -> {
             List<SearchHit> hits = searchHits(r);
 
             // filter hits that are escaping the window (same timestamp but different tiebreaker)
@@ -593,7 +591,7 @@ public class TumblingWindow implements Executable {
 
                 // if the limit has been reached, return what's available
                 if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
-                    payload(listener);
+                    payload(delegate);
                     return;
                 }
 
@@ -611,19 +609,19 @@ public class TumblingWindow implements Executable {
             // keep running the query runs out of the results (essentially returns less than what we want)
             // however check if the window has been fully consumed
             if (hits.size() == windowSize && request.after().before(window.end)) {
-                secondaryCriterion(window, currentStage, listener);
+                secondaryCriterion(window, currentStage, delegate);
             }
             // looks like this stage is done, move on
             else {
                 // but first check is there are still candidates within the current window
                 if (nextPositiveStage > 0 && matcher.hasFollowingCandidates(criterion.stage())) {
-                    secondaryCriterion(window, nextPositiveStage, listener);
+                    secondaryCriterion(window, nextPositiveStage, delegate);
                 } else {
                     // otherwise, advance it
-                    tumbleWindow(window.baseStage, listener);
+                    tumbleWindow(window.baseStage, delegate);
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     /**

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 
 public class EqlSession {
@@ -83,7 +82,7 @@ public class EqlSession {
     }
 
     public void eql(String eql, ParserParams params, ActionListener<Results> listener) {
-        eqlExecutable(eql, params, wrap(e -> e.execute(this, map(listener, Results::fromPayload)), listener::onFailure));
+        eqlExecutable(eql, params, listener.delegateFailureAndWrap((l, e) -> e.execute(this, map(l, Results::fromPayload))));
     }
 
     public void eqlExecutable(String eql, ParserParams params, ActionListener<PhysicalPlan> listener) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/EsqlUsageTransportAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/EsqlUsageTransportAction.java
@@ -65,7 +65,7 @@ public class EsqlUsageTransportAction extends XPackUsageFeatureTransportAction {
         EsqlStatsRequest esqlRequest = new EsqlStatsRequest();
         esqlRequest.includeStats(true);
         esqlRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(EsqlStatsAction.INSTANCE, esqlRequest, ActionListener.wrap(r -> {
+        client.execute(EsqlStatsAction.INSTANCE, esqlRequest, listener.delegateFailureAndWrap((l, r) -> {
             List<Counters> countersPerNode = r.getNodes()
                 .stream()
                 .map(EsqlStatsResponse.NodeStatsResponse::getStats)
@@ -73,7 +73,7 @@ public class EsqlUsageTransportAction extends XPackUsageFeatureTransportAction {
                 .collect(Collectors.toList());
             Counters mergedCounters = Counters.merge(countersPerNode);
             EsqlFeatureSetUsage usage = new EsqlFeatureSetUsage(mergedCounters.toNestedMap());
-            listener.onResponse(new XPackUsageFeatureResponse(usage));
-        }, listener::onFailure));
+            l.onResponse(new XPackUsageFeatureResponse(usage));
+        }));
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -272,7 +272,7 @@ public class IndexResolver {
                     indexRequest.indicesOptions(FROZEN_INDICES_OPTIONS);
                 }
 
-                client.admin().indices().getIndex(indexRequest, wrap(indices -> {
+                client.admin().indices().getIndex(indexRequest, listener.delegateFailureAndWrap((delegate, indices) -> {
                     if (indices != null) {
                         for (String indexName : indices.getIndices()) {
                             boolean isFrozen = retrieveFrozenIndices
@@ -282,8 +282,8 @@ public class IndexResolver {
                             );
                         }
                     }
-                    resolveRemoteIndices(clusterWildcard, indexWildcards, javaRegex, retrieveFrozenIndices, indexInfos, listener);
-                }, listener::onFailure));
+                    resolveRemoteIndices(clusterWildcard, indexWildcards, javaRegex, retrieveFrozenIndices, indexInfos, delegate);
+                }));
             } else {
                 resolveRemoteIndices(clusterWildcard, indexWildcards, javaRegex, retrieveFrozenIndices, indexInfos, listener);
             }
@@ -363,7 +363,7 @@ public class IndexResolver {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, indicesOptions, runtimeMappings);
         client.fieldCaps(
             fieldRequest,
-            ActionListener.wrap(response -> listener.onResponse(mergedMappings(typeRegistry, indexWildcard, response)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response)))
         );
     }
 
@@ -379,7 +379,7 @@ public class IndexResolver {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, includeFrozen, runtimeMappings);
         client.fieldCaps(
             fieldRequest,
-            ActionListener.wrap(response -> listener.onResponse(mergedMappings(typeRegistry, indexWildcard, response)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response)))
         );
     }
 
@@ -591,17 +591,17 @@ public class IndexResolver {
         ActionListener<List<EsIndex>> listener
     ) {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, includeFrozen, runtimeMappings);
-        client.fieldCaps(fieldRequest, wrap(response -> {
+        client.fieldCaps(fieldRequest, listener.delegateFailureAndWrap((delegate, response) -> {
             client.admin().indices().getAliases(createGetAliasesRequest(response, includeFrozen), wrap(aliases -> {
-                listener.onResponse(separateMappings(typeRegistry, javaRegex, response, aliases.getAliases()));
+                delegate.onResponse(separateMappings(typeRegistry, javaRegex, response, aliases.getAliases()));
             }, ex -> {
                 if (ex instanceof IndexNotFoundException || ex instanceof ElasticsearchSecurityException) {
-                    listener.onResponse(separateMappings(typeRegistry, javaRegex, response, null));
+                    delegate.onResponse(separateMappings(typeRegistry, javaRegex, response, null));
                 } else {
-                    listener.onFailure(ex);
+                    delegate.onFailure(ex);
                 }
             }));
-        }, listener::onFailure));
+        }));
 
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
@@ -96,13 +96,13 @@ public abstract class AbstractTransportQlAsyncGetResultsAction<Response extends 
     protected void doExecute(Task task, GetAsyncResultRequest request, ActionListener<Response> listener) {
         DiscoveryNode node = resultsService.getNode(request.getId());
         if (node == null || resultsService.isLocalNode(node)) {
-            resultsService.retrieveResult(request, ActionListener.wrap(r -> {
+            resultsService.retrieveResult(request, listener.delegateFailureAndWrap((l, r) -> {
                 if (r.getException() != null) {
-                    listener.onFailure(r.getException());
+                    l.onFailure(r.getException());
                 } else {
-                    listener.onResponse(r.getResponse());
+                    l.onResponse(r.getResponse());
                 }
-            }, listener::onFailure));
+            }));
         } else {
             transportService.sendRequest(
                 node,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ActionListeners.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ActionListeners.java
@@ -21,6 +21,6 @@ public class ActionListeners {
      * Combination of {@link ActionListener#wrap(CheckedConsumer, Consumer)} and {@link ActionListener#map}
      */
     public static <T, Response> ActionListener<Response> map(ActionListener<T> delegate, CheckedFunction<Response, T, Exception> fn) {
-        return ActionListener.wrap(r -> delegate.onResponse(fn.apply(r)), delegate::onFailure);
+        return delegate.delegateFailureAndWrap((l, r) -> l.onResponse(fn.apply(r)));
     }
 }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
@@ -231,7 +231,7 @@ public abstract class AbstractSqlBlockingIntegTestCase extends ESIntegTestCase {
                             task,
                             action,
                             request,
-                            ActionListener.wrap(resp -> executorService.execute(() -> actionWrapper.accept(resp)), listener::onFailure)
+                            listener.delegateFailureAndWrap((l, resp) -> executorService.execute(() -> actionWrapper.accept(resp)))
                         );
                     } else {
                         chain.proceed(task, action, request, listener);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
@@ -75,9 +75,9 @@ public class PlanExecutor {
     ) {
         metrics.translate();
 
-        newSession(cfg).sqlExecutable(sql, params, wrap(exec -> {
+        newSession(cfg).sqlExecutable(sql, params, listener.delegateFailureAndWrap((delegate, exec) -> {
             if (exec instanceof EsQueryExec e) {
-                listener.onResponse(SourceGenerator.sourceBuilder(e.queryContainer(), cfg.filter(), cfg.pageSize()));
+                delegate.onResponse(SourceGenerator.sourceBuilder(e.queryContainer(), cfg.filter(), cfg.pageSize()));
             }
             // try to provide a better resolution of what failed
             else {
@@ -90,9 +90,9 @@ public class PlanExecutor {
                 } else {
                     message = "Cannot generate a query DSL";
                 }
-                listener.onFailure(new PlanningException(message + ", sql statement: [{}]", sql));
+                delegate.onFailure(new PlanningException(message + ", sql statement: [{}]", sql));
             }
-        }, listener::onFailure));
+        }));
     }
 
     public void sql(SqlConfiguration cfg, String sql, List<SqlTypedParamValue> params, ActionListener<Page> listener) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -156,19 +156,23 @@ public class Querier {
         final OpenPointInTimeRequest openPitRequest = new OpenPointInTimeRequest(search.indices()).indicesOptions(search.indicesOptions())
             .keepAlive(cfg.pageTimeout());
 
-        client.execute(OpenPointInTimeAction.INSTANCE, openPitRequest, wrap(openPointInTimeResponse -> {
-            String pitId = openPointInTimeResponse.getPointInTimeId();
-            search.indices(Strings.EMPTY_ARRAY);
-            search.source().pointInTimeBuilder(new PointInTimeBuilder(pitId));
-            ActionListener<SearchResponse> closePitOnErrorListener = wrap(searchResponse -> {
-                try {
-                    listener.onResponse(searchResponse);
-                } catch (Exception e) {
-                    closePointInTimeAfterError(client, pitId, e, listener);
-                }
-            }, searchError -> closePointInTimeAfterError(client, pitId, searchError, listener));
-            client.search(search, closePitOnErrorListener);
-        }, listener::onFailure));
+        client.execute(
+            OpenPointInTimeAction.INSTANCE,
+            openPitRequest,
+            listener.delegateFailureAndWrap((delegate, openPointInTimeResponse) -> {
+                String pitId = openPointInTimeResponse.getPointInTimeId();
+                search.indices(Strings.EMPTY_ARRAY);
+                search.source().pointInTimeBuilder(new PointInTimeBuilder(pitId));
+                ActionListener<SearchResponse> closePitOnErrorListener = wrap(searchResponse -> {
+                    try {
+                        delegate.onResponse(searchResponse);
+                    } catch (Exception e) {
+                        closePointInTimeAfterError(client, pitId, e, delegate);
+                    }
+                }, searchError -> closePointInTimeAfterError(client, pitId, searchError, delegate));
+                client.search(search, closePitOnErrorListener);
+            })
+        );
     }
 
     private static void closePointInTimeAfterError(Client client, String pointInTimeId, Exception e, ActionListener<?> listener) {
@@ -186,7 +190,7 @@ public class Querier {
             client.execute(
                 ClosePointInTimeAction.INSTANCE,
                 new ClosePointInTimeRequest(pointInTimeId),
-                wrap(clearPointInTimeResponse -> listener.onResponse(clearPointInTimeResponse.isSucceeded()), listener::onFailure)
+                listener.delegateFailureAndWrap((l, clearPointInTimeResponse) -> l.onResponse(clearPointInTimeResponse.isSucceeded()))
             );
         } else {
             listener.onResponse(true);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
@@ -124,17 +124,16 @@ public class SearchHitCursor implements Cursor {
 
         client.search(
             request,
-            ActionListener.wrap(
-                (SearchResponse response) -> handle(
+            listener.delegateFailureAndWrap(
+                (l, response) -> handle(
                     client,
                     response,
                     request.source(),
                     makeRowSet(response),
-                    listener,
+                    l,
                     includeFrozen,
                     allowPartialSearchResults
-                ),
-                listener::onFailure
+                )
             )
         );
     }
@@ -162,11 +161,7 @@ public class SearchHitCursor implements Cursor {
         SearchHitRowSet rowSet = makeRowSet.get();
 
         if (rowSet.hasRemaining() == false) {
-            closePointInTime(
-                client,
-                response.pointInTimeId(),
-                ActionListener.wrap(r -> listener.onResponse(Page.last(rowSet)), listener::onFailure)
-            );
+            closePointInTime(client, response.pointInTimeId(), listener.delegateFailureAndWrap((l, r) -> l.onResponse(Page.last(rowSet))));
         } else {
             updateSearchAfter(hits, source);
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Debug.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Debug.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.ActionListener.wrap;
 
 public class Debug extends Command {
 
@@ -80,11 +79,11 @@ public class Debug extends Command {
     @Override
     public void execute(SqlSession session, ActionListener<Page> listener) {
         switch (type) {
-            case ANALYZED -> session.debugAnalyzedPlan(plan, wrap(i -> handleInfo(i, listener), listener::onFailure));
+            case ANALYZED -> session.debugAnalyzedPlan(plan, listener.delegateFailureAndWrap((l, i) -> handleInfo(i, l)));
             case OPTIMIZED -> session.analyzedPlan(
                 plan,
                 true,
-                wrap(analyzedPlan -> handleInfo(session.optimizer().debugOptimize(analyzedPlan), listener), listener::onFailure)
+                listener.delegateFailureAndWrap((l, analyzedPlan) -> handleInfo(session.optimizer().debugOptimize(analyzedPlan), l))
             );
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
@@ -80,15 +80,15 @@ public class ShowColumns extends Command {
         idx = hasText(cat) && cat.equals(cluster) == false ? buildRemoteIndexName(cat, idx) : idx;
 
         boolean withFrozen = includeFrozen || session.configuration().includeFrozen();
-        session.indexResolver().resolveAsMergedMapping(idx, withFrozen, emptyMap(), ActionListener.wrap(indexResult -> {
+        session.indexResolver().resolveAsMergedMapping(idx, withFrozen, emptyMap(), listener.delegateFailureAndWrap((l, indexResult) -> {
             List<List<?>> rows = emptyList();
             if (indexResult.isValid()) {
                 rows = new ArrayList<>();
                 Version version = Version.fromId(session.configuration().version().id);
                 fillInRows(IndexCompatibility.compatible(indexResult, version).get().mapping(), null, rows);
             }
-            listener.onResponse(of(session, rows));
-        }, listener::onFailure));
+            l.onResponse(of(session, rows));
+        }));
     }
 
     static void fillInRows(Map<String, EsField> mapping, String prefix, List<List<?>> rows) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
@@ -68,14 +68,21 @@ public class ShowTables extends Command {
         boolean withFrozen = session.configuration().includeFrozen() || includeFrozen;
         // to avoid redundancy, indicate whether frozen fields are required by specifying the type
         EnumSet<IndexType> indexType = withFrozen ? IndexType.VALID_INCLUDE_FROZEN : IndexType.VALID_REGULAR;
-        session.indexResolver().resolveNames(cat, idx, regex, indexType, ActionListener.wrap(result -> {
-            listener.onResponse(
-                of(
-                    session,
-                    result.stream().map(t -> asList(t.cluster(), t.name(), t.type().toSql(), t.type().toNative())).collect(toList())
+        session.indexResolver()
+            .resolveNames(
+                cat,
+                idx,
+                regex,
+                indexType,
+                listener.delegateFailureAndWrap(
+                    (l, result) -> l.onResponse(
+                        of(
+                            session,
+                            result.stream().map(t -> asList(t.cluster(), t.name(), t.type().toSql(), t.type().toNative())).collect(toList())
+                        )
+                    )
                 )
             );
-        }, listener::onFailure));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -144,8 +144,8 @@ public class SysTables extends Command {
                 idx,
                 regex,
                 tableTypes,
-                ActionListener.wrap(
-                    result -> listener.onResponse(
+                listener.delegateFailureAndWrap(
+                    (delegate, result) -> delegate.onResponse(
                         of(
                             session,
                             result.stream()
@@ -158,8 +158,7 @@ public class SysTables extends Command {
                                 .map(t -> asList(t.cluster(), null, t.name(), t.type().toSql(), EMPTY, null, null, null, null, null))
                                 .collect(toList())
                         )
-                    ),
-                    listener::onFailure
+                    )
                 )
             );
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/CommandExec.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/CommandExec.java
@@ -17,8 +17,6 @@ import org.elasticsearch.xpack.sql.session.SqlSession;
 import java.util.List;
 import java.util.Objects;
 
-import static org.elasticsearch.action.ActionListener.wrap;
-
 public class CommandExec extends LeafExec {
 
     private final Command command;
@@ -39,7 +37,7 @@ public class CommandExec extends LeafExec {
 
     @Override
     public void execute(SqlSession session, ActionListener<Page> listener) {
-        command.execute(session, wrap(listener::onResponse, listener::onFailure));
+        command.execute(session, listener.delegateFailureAndWrap((l, r) -> l.onResponse(r)));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
@@ -50,7 +50,7 @@ public class TransportSqlClearCursorAction extends HandledTransportAction<SqlCle
         Cursor cursor = Cursors.decodeFromStringWithZone(request.getCursor(), planExecutor.writeableRegistry()).v1();
         planExecutor.cleanCursor(
             cursor,
-            ActionListener.<Boolean>wrap(success -> listener.onResponse(new SqlClearCursorResponse(success)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, success) -> l.onResponse(new SqlClearCursorResponse(success)))
         );
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -183,7 +183,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
             planExecutor.nextPage(
                 cfg,
                 decoded.v1(),
-                wrap(p -> listener.onResponse(createResponse(request, decoded.v2(), null, p, task)), listener::onFailure)
+                listener.delegateFailureAndWrap((l, p) -> l.onResponse(createResponse(request, decoded.v2(), null, p, task)))
             );
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -84,10 +84,7 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
             cfg,
             request.query(),
             request.params(),
-            ActionListener.wrap(
-                searchSourceBuilder -> listener.onResponse(new SqlTranslateResponse(searchSourceBuilder)),
-                listener::onFailure
-            )
+            listener.delegateFailureAndWrap((l, searchSourceBuilder) -> l.onResponse(new SqlTranslateResponse(searchSourceBuilder)))
         );
     }
 }


### PR DESCRIPTION
Went through this code for unrelated reasons and found lots of use of `ActionListener.wrap` that could be replaced by `delegateFailureAndWrap` to save some duplication and memory so I fixed those real quick.
