### PR TITLE
Update migration and release notes for v8.10.0 release

### DIFF
--- a/docs/reference/migration/migrate_8_10.asciidoc
+++ b/docs/reference/migration/migrate_8_10.asciidoc
@@ -16,4 +16,77 @@ coming::[8.10.0]
 [[breaking-changes-8.10]]
 === Breaking changes
 
-There are no breaking changes in {es} 8.10.
+The following changes in {es} 8.10 might affect your applications
+and prevent them from operating normally.
+Before upgrading to 8.10, review these changes and take the described steps
+to mitigate the impact.
+
+
+There are no notable breaking changes in {es} 8.10.
+But there are some less critical breaking changes.
+
+[discrete]
+[[breaking_810_cluster_and_node_setting_changes]]
+==== Cluster and node setting changes
+
+[[remove_unused_executor_builder_for_vector_tile_plugin]]
+.Remove the unused executor builder for vector tile plugin
+[%collapsible]
+====
+*Details* +
+The threadpool called `vectortile` is a left over from the original development of the vector tile search end point and it is used nowhere. It can still be a breaking change if it is configured on the elasticsearch yml file, for example by changing the threadpool size `thread_pool.vectortile.size=8`'
+
+*Impact* +
+In the case the threadpool appears on the yaml file, Elasticsearch will not start until those lines are removed.
+====
+
+[discrete]
+[[breaking_810_java_api_changes]]
+==== Java API changes
+
+[[change_pre_configured_cached_analyzer_components_to_use_indexversion_instead_of_version]]
+.Change pre-configured and cached analyzer components to use IndexVersion instead of Version
+[%collapsible]
+====
+*Details* +
+This PR changes the types used to obtain pre-configured components from Version to IndexVersion,
+with corresponding changes to method names.
+
+Prior to 8.10, there is a one-to-one mapping between node version and index version, with corresponding constants
+in the IndexVersion class.
+Starting in 8.10, IndexVersion is versioned independently of node version, and will be a simple incrementing number.
+For more information on how to use IndexVersion and other version types, please see the contributing guide.
+
+*Impact* +
+Analysis components now take IndexVersion instead of Version
+====
+
+
+[discrete]
+[[deprecated-8.10]]
+=== Deprecations
+
+The following functionality has been deprecated in {es} 8.10
+and will be removed in a future version.
+While this won't have an immediate impact on your applications,
+we strongly encourage you to take the described steps to update your code
+after upgrading to 8.10.
+
+To find out if you are using any deprecated functionality,
+enable <<deprecation-logging, deprecation logging>>.
+
+[discrete]
+[[deprecations_810_authorization]]
+==== Authorization deprecations
+
+[[mark_apm_user_for_removal_in_future_major_release]]
+.Mark `apm_user` for removal in a future major release
+[%collapsible]
+====
+*Details* +
+The `apm_user` role has been deprecated and will be removed in a future major release. Users should migrate to `editor` and `viewer` roles
+
+*Impact* +
+Users will have to migrate to `editor` and `viewer` roles
+====
+

--- a/docs/reference/release-notes/8.10.0.asciidoc
+++ b/docs/reference/release-notes/8.10.0.asciidoc
@@ -5,4 +5,227 @@ coming[8.10.0]
 
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
+[[breaking-8.10.0]]
+[float]
+=== Breaking changes
+
+Analysis::
+* Change pre-configured and cached analyzer components to use IndexVersion instead of Version {es-pull}97319[#97319]
+
+Geo::
+* Remove the unused executor builder for vector tile plugin {es-pull}96577[#96577]
+
+[[bug-8.10.0]]
+[float]
+=== Bug fixes
+
+Aggregations::
+* Skip segment for `MatchNoDocsQuery` filters {es-pull}98295[#98295] (issue: {es-issue}94637[#94637])
+
+Allocation::
+* Do not assign ignored shards {es-pull}98265[#98265]
+* Remove exception wrapping in `BatchedRerouteService` {es-pull}97224[#97224]
+
+Application::
+* [Profiling] Consider static settings in status {es-pull}97890[#97890]
+
+CRUD::
+* Add missing sync on `indicesThatCannotBeCreated` {es-pull}97869[#97869]
+
+Cluster Coordination::
+* Fix cluster bootstrap warning for single-node discovery {es-pull}96895[#96895] (issue: {es-issue}96874[#96874])
+* Fix election scheduling after discovery outage {es-pull}98420[#98420]
+* Improve reliability of elections with message delays {es-pull}98354[#98354] (issue: {es-issue}97909[#97909])
+* Make `TransportAddVotingConfigExclusionsAction` retryable {es-pull}98386[#98386]
+* Release master service task on timeout {es-pull}97711[#97711]
+
+Data streams::
+* Avoid lifecycle NPE in the data stream lifecycle usage API {es-pull}98260[#98260]
+
+Distributed::
+* Avoid `transport_worker` thread in `TransportBroadcastAction` {es-pull}98001[#98001]
+* Avoid `transport_worker` thread in `TransportBroadcastByNodeAction` {es-pull}97920[#97920] (issue: {es-issue}97914[#97914])
+* Fork response reading in `TransportNodesAction` {es-pull}97899[#97899]
+
+Downsampling::
+* Copy "index.lifecycle.name" for ILM managed indices {es-pull}97110[#97110] (issue: {es-issue}96732[#96732])
+* Downsampling: copy the `_tier_preference` setting {es-pull}96982[#96982] (issue: {es-issue}96733[#96733])
+
+EQL::
+* Fix async missing events {es-pull}97718[#97718] (issue: {es-issue}97644[#97644])
+
+Indices APIs::
+* Ensure frozen indices have correct tier preference {es-pull}97967[#97967]
+
+Infra/REST API::
+* Fix possible NPE when transportversion is null in `MainResponse` {es-pull}97203[#97203]
+
+Machine Learning::
+* Avoid risk of OOM in datafeeds when memory is constrained {es-pull}98324[#98324] (issue: {es-issue}89769[#89769])
+* Detect infinite loop in the WordPiece tokenizer {es-pull}98206[#98206]
+* Fix to stop aggregatable subobjects from being considered multi-fields, to support `"subobjects": false` in data frame analytics {es-pull}97705[#97705] (issue: {es-issue}88605[#88605])
+* Fix weird `change_point` bug where all data values are equivalent {es-pull}97588[#97588]
+* The model loading service should not notify listeners in a sync block {es-pull}97142[#97142]
+
+Mapping::
+* Fix `fields` API with `subobjects: false` {es-pull}97092[#97092] (issue: {es-issue}96700[#96700])
+
+Network::
+* Fork remote-cluster response handling {es-pull}97922[#97922]
+
+Search::
+* Fork CCS remote-cluster responses {es-pull}98124[#98124] (issue: {es-issue}97997[#97997])
+* Fork CCS search-shards handling {es-pull}98209[#98209]
+* Improve test coverage for CCS search cancellation and fix response bugs {es-pull}97029[#97029]
+* Make `terminate_after` early termination friendly {es-pull}97540[#97540] (issue: {es-issue}97269[#97269])
+* Track `max_score` in collapse when requested {es-pull}97703[#97703] (issue: {es-issue}97653[#97653])
+
+TSDB::
+* Mapped field types searchable with doc values {es-pull}97724[#97724]
+
+Transform::
+* Fix transform incorrectly calculating date bucket on updating old data {es-pull}97401[#97401] (issue: {es-issue}97101[#97101])
+
+Watcher::
+* Changing watcher to disable cookies in shared http client {es-pull}97591[#97591]
+
+[[deprecation-8.10.0]]
+[float]
+=== Deprecations
+
+Authorization::
+* Mark `apm_user` for removal in a future major release {es-pull}87674[#87674]
+
+[[enhancement-8.10.0]]
+[float]
+=== Enhancements
+
+Aggregations::
+* Improve error message when aggregation doesn't support counter field {es-pull}93545[#93545]
+
+Allocation::
+* Add `node.roles` to cat allocation API {es-pull}96994[#96994]
+
+Application::
+* [Profiling] Add initial support for upgrades {es-pull}97380[#97380]
+* [Profiling] Support index migrations {es-pull}97773[#97773]
+
+Authentication::
+* Avoid double get {es-pull}98067[#98067] (issue: {es-issue}97928[#97928])
+* Give all acces to .slo-observability.* indice to kibana user {es-pull}97539[#97539]
+* Refresh tokens without search {es-pull}97395[#97395]
+
+Authorization::
+* Add "operator" field to authenticate response {es-pull}97234[#97234]
+* Read operator privs enabled from Env settings {es-pull}98246[#98246]
+* [Fleet] Allow `kibana_system` to put datastream lifecycle {es-pull}97732[#97732]
+
+Data streams::
+* Install data stream template for Kibana reporting {es-pull}97765[#97765]
+
+Downsampling::
+* Change `MetricFieldProducer#metrics` field type from list to array {es-pull}97344[#97344]
+* Improve iterating over many field producers during downsample operation {es-pull}97281[#97281]
+* Run downsampling using persistent tasks {es-pull}97557[#97557] (issue: {es-issue}93582[#93582])
+
+Engine::
+* Fix edge case for active flag for flush on idle {es-pull}97332[#97332] (issue: {es-issue}97154[#97154])
+
+Health::
+* Adding special logic to the disk health check for search-only nodes {es-pull}98508[#98508]
+* Health API Periodic Logging {es-pull}96772[#96772]
+
+ILM+SLM::
+* Separating SLM from ILM {es-pull}98184[#98184]
+
+Infra/Core::
+* Infrastructure to report upon document parsing {es-pull}97961[#97961]
+
+Infra/Node Lifecycle::
+* Check ILM status before reporting node migration STALLED {es-pull}98367[#98367] (issue: {es-issue}89486[#89486])
+
+Infra/Plugins::
+* Adding `ApiFilteringActionFilter` {es-pull}97985[#97985]
+
+Infra/REST API::
+* Enable Serverless API protections dynamically {es-pull}97079[#97079]
+* Make `RestController` pluggable {es-pull}98187[#98187]
+
+Infra/Settings::
+* Mark customer settings for serverless {es-pull}98051[#98051]
+
+Ingest Node::
+* Allow custom geo ip database files to be downloaded {es-pull}97850[#97850]
+
+Search::
+* Add `completion_time` time field to `async_search` get and status response {es-pull}97700[#97700] (issue: {es-issue}88640[#88640])
+* Add setting for search parallelism {es-pull}98455[#98455]
+* Add support for concurrent collection when size is greater than zero {es-pull}98425[#98425]
+* Cross-cluster search provides details about search on each cluster {es-pull}97731[#97731]
+* Enable parallel collection in Dfs phase {es-pull}97416[#97416]
+* Exclude clusters from a cross-cluster search {es-pull}97865[#97865]
+* Improve MatchNoDocsQuery description {es-pull}96069[#96069] (issue: {es-issue}95741[#95741])
+* Improve exists query rewrite {es-pull}97159[#97159]
+* Improve match query rewrite {es-pull}97208[#97208]
+* Improve prefix query rewrite {es-pull}97209[#97209]
+* Improve wildcard query and terms query rewrite {es-pull}97594[#97594]
+* Introduce Synonyms Management API used for synonym and synonym_graph filters {es-pull}97962[#97962] (issue: {es-issue}38523[#38523])
+* Introduce a collector manager for `PartialHitCountCollector` {es-pull}97550[#97550]
+* Introduce a collector manager for `QueryPhaseCollector` {es-pull}97410[#97410]
+* Limit `_terms_enum` prefix size {es-pull}97488[#97488] (issue: {es-issue}96572[#96572])
+* Support minimum_should_match field for terms_set query {es-pull}96082[#96082]
+* Support type for simple query string {es-pull}96717[#96717]
+* Unwrap IOException in `ContextIndexSearcher` concurrent code-path {es-pull}98459[#98459]
+* Use a collector manager in DfsPhase Knn Search {es-pull}96689[#96689]
+* Use the Weight#matches mode for highlighting by default {es-pull}96068[#96068]
+* Wire `QueryPhaseCollectorManager` into the query phase {es-pull}97726[#97726]
+* Wire concurrent top docs collector managers when size is 0 {es-pull}97755[#97755]
+* `ProfileCollectorManager` to support child profile collectors {es-pull}97387[#97387]
+* cleanup some code NoriTokenizerFactory and KuromojiTokenizerFactory {es-pull}92574[#92574]
+
+Security::
+* Add an API for managing the settings of Security system indices {es-pull}97630[#97630]
+* Support getting active-only API keys via Get API keys API {es-pull}98259[#98259] (issue: {es-issue}97995[#97995])
+
+Snapshot/Restore::
+* Add Setting to optionally use mmap for shared cache IO {es-pull}97581[#97581]
+* Collect additional object store stats for S3 {es-pull}98083[#98083]
+* HDFS plugin add replication_factor param {es-pull}94132[#94132]
+
+Store::
+* Allow Lucene directory implementations to estimate their size {es-pull}97822[#97822]
+* Allow `ByteSizeDirectory` to expose their data set sizes {es-pull}98085[#98085]
+
+TSDB::
+* Add tsdb metrics builtin component template {es-pull}97602[#97602]
+* Include more downsampling status statistics {es-pull}96930[#96930] (issue: {es-issue}96760[#96760])
+* `TimeSeriesIndexSearcher` to offload to the provided executor {es-pull}98414[#98414]
+
+Transform::
+* Support boxplot aggregation in transform {es-pull}96515[#96515]
+
+[[feature-8.10.0]]
+[float]
+=== New features
+
+Application::
+* Enable Query Rules as technical preview {es-pull}97466[#97466]
+* [Enterprise Search] Add connectors indices and ent-search pipeline {es-pull}97463[#97463]
+
+Data streams::
+* Introduce downsampling configuration for data stream lifecycle {es-pull}97041[#97041]
+
+Search::
+* Introduce executor for concurrent search {es-pull}98204[#98204]
+
+Security::
+* Beta release for API key based cross-cluster access {es-pull}98307[#98307]
+
+[[upgrade-8.10.0]]
+[float]
+=== Upgrades
+
+Network::
+* Upgrade Netty to 4.1.94.Final {es-pull}97040[#97040]
+
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -24,53 +24,79 @@ Other versions:
 
 endif::[]
 
-// The notable-highlights tag marks entries that
-// should be featured in the Stack Installation and Upgrade Guide:
 // tag::notable-highlights[]
 
 [discrete]
-[[better_indexing_search_performance_under_concurrent_indexing_search]]
-=== Better indexing and search performance under concurrent indexing and search
-When a query like a match phrase query or a terms query targets a constant keyword field we can skip query execution on shards where the query is rewritten to match no documents. We take advantage of index mappings including constant keyword fields and rewrite queries in such a way that, if a constant keyword field does not match the value defined in the index mapping, we rewrite the query to match no document. This will result in the shard level request to return immediately, before the query is executed on the data node and, as a result, skipping the shard completely. Here we leverage the ability to skip shards whenever possible to avoid unnecessary shard refreshes and improve query latency (by not doing any search-related I/O). Avoiding such unnecessary shard refreshes improves query latency since the search thread does not need to wait anymore for unnecessary shard refreshes. Shards not matching the query criteria will remain in a search-idle state and indexing throughput will not be negatively affected by a refresh. Before introducing this change a query hitting multiple shards, including those with no documents matching the search criteria (think about using index patterns or data streams with many backing indices), would potentially result in a "shard refresh storm" increasing query latency as a result of the search thread waiting on all shard refreshes to complete before being able to initiate and carry out the search operation. After introducing this change the search thread will just need to wait for refreshes to be completed on shards including relevant data. Note that execution of the shard pre-filter and the corresponding "can match" phase where rewriting happens, depends on the overall number of shards involved and on whether there is at least one of them returning a non-empty result (see 'pre_filter_shard_size' setting to understand how to control this behavior). Elasticsearch does the rewrite operation on the data node in the so called "can match" phase, taking advantage of the fact that, at that moment, we can access index mappings and extract information about constant keyword fields and their values. This means we still "fan-out" search queries from the coordinator node to involved data nodes. Rewriting queries based on index mappings is not possible on the coordinator node because the coordinator node is missing index mapping information.
+[[cross_cluster_search_provides_details_about_search_on_each_cluster]]
+=== Cross-cluster search provides details about search on each cluster
+Previously with cross-cluster searches using ccs_minimize_roundtrips=true,
+when an error was returned, it was unclear which cluster caused the problem.
+We have improved the search response for both synchronous and asynchronous
+searches to have status and error details in the `_clusters` section, listing
+each cluster involved in the search by name (alias). It includes
+status info, shard accounting counts and error information that
+are updated incrementally as the search progresses. In case of errors or partial
+results, you can use this information to determine to what extent the search
+results might be usable and if any follow-up action is needed to reduce errors.
 
-{es-pull}96161[#96161]
+The search on each cluster can be in one of 5 states: `RUNNING`,
+`SUCCESSFUL` (all shards were successfully searched), `PARTIAL` (some shard
+searches failed, but at least one succeeded and partial data has been returned),
+`SKIPPED` (no shards were successfully searched on a cluster marked with
+skip_unavailable=true), and `FAILED` (no shards were successfully searched on a
+cluster marked with skip_unavailable=false).
+
+Kibana users can access this information by viewing the search response in the Inspect flyout.
+
+{es-pull}97731[#97731]
 
 [discrete]
-[[add_multiple_queries_for_ranking_to_search_endpoint]]
-=== Add multiple queries for ranking to the search endpoint
-The search endpoint adds a new top-level element called `sub_searches`. This top-level element is a list of searches used for ranking where each "sub search" is executed independently. The `sub_searches` element is used instead of `query` to allow a search using ranking to execute multiple queries. The `sub_searches` and `query` elements cannot be used together.
+[[exclude_clusters_from_cross_cluster_search]]
+=== Exclude clusters from a cross-cluster search
+When doing a cross-cluster search, if you use a wildcard to include a list of clusters, you
+can explicitly exclude one or more clusters with a minus sign ('-'). To exclude an entire cluster,
+put the minus sign in front of the cluster alias, such as: `remote*:*,-remote3:*,-remote5:*`.
+In that case, clusters with the alias "remote3" and "remote5" will be excluded from the search.
+For this feature, you must use `*` in the index position or an error will be returned.
 
-{es-pull}96224[#96224]
+{es-pull}97865[#97865]
 
 [discrete]
-[[make_text_embedding_for_knn_search_ga]]
-=== Make text embedding for kNN search GA
-From 8.9, the `text_embedding` `query_vector_builder` extension to kNN search is generally available. This functionality is required to perform <<semantic-search,semantic search>> by converting text to dense vectors.
+[[enable_parallel_knn_search_across_segments]]
+=== Enable parallel knn search across segments
+Elasticsearch has until now performed search sequentially across the
+segments within each shard. This change makes knn queries faster on shards
+that are made of more than one segment, by rewriting and collecting each
+segment in parallel.
 
-{es-pull}96735[#96735]
+{es-pull}98204[#98204]
 
 // end::notable-highlights[]
 
 
 [discrete]
-[[asset_tracking_geo_line_in_time_series_aggregations]]
-=== Asset tracking - geo_line in time-series aggregations
-The <<search-aggregations-metrics-geo-line,`geo_line` aggregation>> builds tracks from `geo_points`.
-It has previously needed to use large arrays in memory for collecting points into multiple buckets
-and sorting those buckets.
+[[change_pre_configured_cached_analyzer_components_to_use_indexversion_instead_of_version]]
+=== Change pre-configured and cached analyzer components to use IndexVersion instead of Version
+As part of ongoing refactoring work, we are separating out various component versions into their own types.
+For this, we have introduced a new `IndexVersion` type to represent the version of index data and metadata.
 
-With the advances made in TSDB features and the `time_series` aggregation in particular,
-it is now possible to rely on data aggregating in both TSID and timestamp order,
-enabling the removal of all sorting, as well as the use of only a single bucket's
-worth of memory, a dramatic improvement in memory footprint. In addition, we can use the streaming line
-simplifier algorithm introduced in https://github.com/elastic/elasticsearch/pull/94859 to replace the previous
-behaviour of truncating very large tracks with the far more preferable approach of simplifying those tracks.
+This PR changes the types used to obtain pre-configured components from Version to IndexVersion,
+with corresponding changes to method names.
 
-[role="screenshot"]
-image:images/spatial/kodiak_geo_line_simplified.png[North short of Kodiak Island simplified to 100 points]
+Prior to 8.10, there is a one-to-one mapping between node version and index version, with corresponding constants
+in the IndexVersion class.
+Starting in 8.10, IndexVersion is versioned independently of node version, and will be a simple incrementing number.
+For more information on how to use IndexVersion and other version types, please see the contributing guide.
 
-In this diagram, the grey line is the original geometry, the blue line is the truncated geometry as would be
-produced by the original `geo_line` aggregation, and the magenta line is the new simplified geometry.
+{es-pull}97319[#97319]
 
-{es-pull}94954[#94954]
+[discrete]
+[[api_key_based_cross_cluster_search_replication_beta]]
+=== API key based cross-cluster search and replication (Beta)
+This <<remote-clusters-api-key,new model>> uses a cross-cluster API key to authenticate
+and authorize cross-cluster operations to a remote cluster. It completely separates
+network security controls between the local and remote cluster as well as offers
+administrators of both the local and the remote cluster fine-grained access controls.
+
+{es-pull}98307[#98307]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -75,7 +75,7 @@ segment in parallel.
 
 
 [discrete]
-[[change_pre_configured_cached_analyzer_components_to_use_indexversion_instead_of_version]]
+[[change_pre_configured_cached_analyzer_components_to_use_indexversion_instead_of_version-highlight]]
 === Change pre-configured and cached analyzer components to use IndexVersion instead of Version
 As part of ongoing refactoring work, we are separating out various component versions into their own types.
 For this, we have introduced a new `IndexVersion` type to represent the version of index data and metadata.


### PR DESCRIPTION
From running `./gradlew generateReleaseNotes` on 8.10 branch