### PR TITLE
Add some leniency when reading index version

### DIFF
--- a/docs/changelog/98742.yaml
+++ b/docs/changelog/98742.yaml
@@ -1,5 +1,0 @@
-pr: 98742
-summary: Add some leniency when reading index version
-area: Infra/Core
-type: bug
-issues: []

--- a/docs/changelog/98742.yaml
+++ b/docs/changelog/98742.yaml
@@ -1,0 +1,5 @@
+pr: 98742
+summary: Add some leniency when reading index version
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -155,7 +155,7 @@ public abstract class Engine implements Closeable {
         if (esVersion.contains(".")) {
             // backwards-compatible Version-style
             org.elasticsearch.Version v = org.elasticsearch.Version.fromString(esVersion);
-            assert v.before(org.elasticsearch.Version.V_8_11_0);
+            assert v.onOrBefore(org.elasticsearch.Version.V_8_11_0);
             return IndexVersion.fromId(v.id);
         } else {
             return IndexVersion.fromId(Integer.parseInt(esVersion));


### PR DESCRIPTION
Serverless already has indexes that were created with `Version.CURRENT` == 8.11. So make this check lenient to allow 8.11 to be used.

This won't be used for the actual 8.11 release, we would have moved to a separated IndexVersion by then