### PR TITLE
ES|QL deserves a new hash table

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/HashBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/HashBenchmark.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.benchmark.compute.operator;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.common.util.LongLongHash;
+import org.elasticsearch.common.util.LongObjectPagedHashMap;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.aggregation.blockhash.Ordinator64;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 7)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(value = 1, jvmArgsAppend = { "--enable-preview", "--add-modules", "jdk.incubator.vector" })
+public class HashBenchmark {
+    static {
+        // Smoke test all the expected values and force loading subclasses more like prod
+        try {
+            for (String unique : HashBenchmark.class.getField("unique").getAnnotationsByType(Param.class)[0].value()) {
+                HashBenchmark bench = new HashBenchmark();
+                bench.unique = Integer.parseInt(unique);
+                bench.initTestData();
+                bench.longHash();
+                bench.bytesRefHash();
+                bench.longLongHash();
+                bench.longObjectHash();
+                bench.ordinator();
+                bench.ordinatorArray();
+            }
+        } catch (NoSuchFieldException e) {
+            throw new AssertionError();
+        }
+    }
+
+    private static final int ITERATIONS = 10_000_000;
+
+    @Param({ "5", "1000", "10000", "100000", "1000000" })
+    public int unique;
+
+    private long[] testLongs;
+    private BytesRef[] testBytes;
+    private int[] targetInts;
+    private long[] targetLongs;
+    private Object[] targetObject;
+
+    @Setup
+    public void initTestData() {
+        testLongs = LongStream.range(0, ITERATIONS).map(l -> l % unique).toArray();
+        BytesRef[] uniqueBytes = IntStream.range(0, unique).mapToObj(i -> new BytesRef(Integer.toString(i))).toArray(BytesRef[]::new);
+        testBytes = IntStream.range(0, ITERATIONS).mapToObj(i -> uniqueBytes[i % unique]).toArray(BytesRef[]::new);
+        targetInts = new int[ITERATIONS];
+        targetLongs = new long[ITERATIONS];
+        targetObject = new Object[ITERATIONS];
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void longHash() {
+        LongHash hash = new LongHash(16, BigArrays.NON_RECYCLING_INSTANCE);
+        for (int i = 0; i < testLongs.length; i++) {
+            targetLongs[i] = hash.add(testLongs[i]);
+        }
+        if (hash.size() != unique) {
+            throw new AssertionError();
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void bytesRefHash() {
+        BytesRefHash hash = new BytesRefHash(16, BigArrays.NON_RECYCLING_INSTANCE);
+        for (int i = 0; i < testLongs.length; i++) {
+            targetLongs[i] = hash.add(testBytes[i]);
+        }
+        if (hash.size() != unique) {
+            throw new AssertionError();
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void longLongHash() {
+        LongLongHash hash = new LongLongHash(16, BigArrays.NON_RECYCLING_INSTANCE);
+        for (int i = 0; i < testLongs.length; i++) {
+            targetLongs[i] = hash.add(testLongs[i], testLongs[i]);
+        }
+        if (hash.size() != unique) {
+            throw new AssertionError();
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void longObjectHash() {
+        LongObjectPagedHashMap<Object> hash = new LongObjectPagedHashMap<>(16, BigArrays.NON_RECYCLING_INSTANCE);
+        Object o = new Object();
+        for (int i = 0; i < testLongs.length; i++) {
+            targetObject[i] = hash.put(testLongs[i], o);
+        }
+        if (hash.size() != unique) {
+            throw new AssertionError();
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void ordinator() {
+        Ordinator64 hash = new Ordinator64(
+            new PageCacheRecycler(Settings.EMPTY),
+            new NoopCircuitBreaker("bench"),
+            new Ordinator64.IdSpace()
+        );
+        for (int i = 0; i < testLongs.length; i++) {
+            targetInts[i] = hash.add(testLongs[i]);
+        }
+        if (hash.currentSize() != unique) {
+            throw new AssertionError("expected " + hash.currentSize() + " to be " + unique);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void ordinatorArray() {
+        Ordinator64 hash = new Ordinator64(
+            new PageCacheRecycler(Settings.EMPTY),
+            new NoopCircuitBreaker("bench"),
+            new Ordinator64.IdSpace()
+        );
+        hash.add(testLongs, targetInts, testLongs.length);
+        if (hash.currentSize() != unique) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -161,7 +161,9 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
               '--add-opens=java.base/java.nio.file=ALL-UNNAMED',
               '--add-opens=java.base/java.time=ALL-UNNAMED',
               '--add-opens=java.base/java.lang=ALL-UNNAMED',
-              '--add-opens=java.management/java.lang.management=ALL-UNNAMED'
+              '--add-opens=java.management/java.lang.management=ALL-UNNAMED',
+              '--enable-preview',
+              '--add-modules=jdk.incubator.vector'
             ].join(' ')
           }
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -123,7 +123,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
             // fail on all javac warnings.
             // TODO Discuss moving compileOptions.getCompilerArgs() to use provider api with Gradle team.
             List<String> compilerArgs = compileOptions.getCompilerArgs();
-            compilerArgs.add("-Werror");
+            // compilerArgs.add("-Werror"); NOCOMMIT add me back once we figure out how to not fail compiling with preview features
             compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try,-removal");
             compilerArgs.add("-Xdoclint:all");
             compilerArgs.add("-Xdoclint:-missing");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -108,7 +108,9 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                 "--add-opens=java.base/java.nio.file=ALL-UNNAMED",
                 "--add-opens=java.base/java.time=ALL-UNNAMED",
                 "--add-opens=java.management/java.lang.management=ALL-UNNAMED",
-                "-XX:+HeapDumpOnOutOfMemoryError"
+                "-XX:+HeapDumpOnOutOfMemoryError",
+                "--enable-preview",
+                "--add-modules=jdk.incubator.vector"
             );
 
             test.getJvmArgumentProviders().add(new SimpleCommandLineArgumentProvider("-XX:HeapDumpPath=" + heapdumpDir));

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -14,6 +14,10 @@ tasks.named("compileJava").configure {
   options.compilerArgs.addAll(["-s", "${projectDir}/src/main/generated"])
 }
 
+tasks.named('forbiddenApisMain').configure {
+  failOnMissingClasses = false  // Ignore the vector apis
+}
+
 tasks.named('checkstyleMain').configure {
   source = "src/main/java"
   excludes = [ "**/*.java.st" ]
@@ -395,5 +399,21 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  multivalueDedupeInputFile
     it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java"
+  }
+  File blockHashInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile =  blockHashInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile =  blockHashInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile =  blockHashInputFile
+    it.outputFile = "org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java"
   }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -7,9 +7,10 @@
 
 package org.elasticsearch.compute.aggregation.blockhash;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
-import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
@@ -28,11 +29,12 @@ import org.elasticsearch.compute.operator.MultivalueDedupeDouble;
 import java.util.BitSet;
 
 /**
- * Maps a {@link DoubleBlock} column to group ids.
+ * Maps {@link DoubleBlock} to group ids.
+ * This class is generated. Edit {@code X-BlockHash.java.st} instead.
  */
 final class DoubleBlockHash extends BlockHash {
     private final int channel;
-    private final LongHash longHash;
+    private final Ordinator64 ordinator;
 
     /**
      * Have we seen any {@code null} values?
@@ -43,9 +45,11 @@ final class DoubleBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
-    DoubleBlockHash(int channel, BigArrays bigArrays) {
+    DoubleBlockHash(PageCacheRecycler recycler, CircuitBreaker breaker, int channel) {
         this.channel = channel;
-        this.longHash = new LongHash(1, bigArrays);
+        Ordinator64.IdSpace idSpace = new Ordinator64.IdSpace();
+        idSpace.next();  // Reserve 0 for nulls.
+        this.ordinator = new Ordinator64(recycler, breaker, idSpace);
     }
 
     @Override
@@ -61,58 +65,61 @@ final class DoubleBlockHash extends BlockHash {
 
     private LongVector add(DoubleVector vector) {
         long[] groups = new long[vector.getPositionCount()];
+        // TODO use the array flavored add
         for (int i = 0; i < vector.getPositionCount(); i++) {
-            groups[i] = hashOrdToGroupNullReserved(longHash.add(Double.doubleToLongBits(vector.getDouble(i))));
+            groups[i] = ordinator.add(Double.doubleToLongBits(vector.getDouble(i)));
         }
         return new LongArrayVector(groups, groups.length);
     }
 
     private LongBlock add(DoubleBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hash(longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hash(ordinator);
         seenNull |= result.sawNull();
         return result.ords();
     }
 
     @Override
     public DoubleBlock[] getKeys() {
+        // TODO call something like takeKeyOwnership to claim the keys array directly
+
+        // If we've seen null we'll store it in 0
         if (seenNull) {
-            final int size = Math.toIntExact(longHash.size() + 1);
-            final double[] keys = new double[size];
-            for (int i = 1; i < size; i++) {
-                keys[i] = Double.longBitsToDouble(longHash.get(i - 1));
+            double[] keys = new double[ordinator.currentSize() + 1];
+            for (Ordinator64.Itr itr = ordinator.iterator(); itr.next();) {
+                keys[itr.id()] = Double.longBitsToDouble(itr.key());
             }
             BitSet nulls = new BitSet(1);
             nulls.set(0);
             return new DoubleBlock[] { new DoubleArrayBlock(keys, keys.length, null, nulls, Block.MvOrdering.ASCENDING) };
         }
-
-        final int size = Math.toIntExact(longHash.size());
-        final double[] keys = new double[size];
-        for (int i = 0; i < size; i++) {
-            keys[i] = Double.longBitsToDouble(longHash.get(i));
+        double[] keys = new double[ordinator.currentSize() + (seenNull ? 1 : 0)];
+        for (Ordinator64.Itr itr = ordinator.iterator(); itr.next();) {
+            // We reserved the id 0 for null but didn't see it.
+            keys[itr.id() - 1] = Double.longBitsToDouble(itr.key());
         }
 
-        // TODO claim the array and wrap?
         return new DoubleBlock[] { new DoubleArrayVector(keys, keys.length).asBlock() };
     }
 
     @Override
     public IntVector nonEmpty() {
-        return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(longHash.size() + 1));
+        return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(ordinator.currentSize() + 1));
     }
 
     @Override
     public BitArray seenGroupIds(BigArrays bigArrays) {
-        return new SeenGroupIds.Range(seenNull ? 0 : 1, Math.toIntExact(longHash.size() + 1)).seenGroupIds(bigArrays);
+        return new SeenGroupIds.Range(seenNull ? 0 : 1, Math.toIntExact(ordinator.currentSize() + 1)).seenGroupIds(bigArrays);
     }
 
     @Override
     public void close() {
-        longHash.close();
+        ordinator.close();
     }
 
     @Override
     public String toString() {
-        return "DoubleBlockHash{channel=" + channel + ", entries=" + longHash.size() + ", seenNull=" + seenNull + '}';
+        return "DoubleBlockHash{channel=" + channel + ", entries=" + ordinator.currentSize() + ", seenNull=" + seenNull + '}';
     }
+
+    // TODO plumb ordinator.status
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
@@ -312,14 +312,15 @@ public class MultivalueDedupeBytesRef {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(BytesRefHash ordinator, LongBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
+        // TODO use array flavored add
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hash(builder, ordinator, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -327,18 +328,18 @@ public class MultivalueDedupeBytesRef {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(BytesRefHash ordinator, LongBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
         BytesRef prev = work[0];
-        hash(builder, hash, prev);
+        hash(builder, ordinator, prev);
         for (int i = 1; i < w; i++) {
             if (false == prev.equals(work[i])) {
                 prev = work[i];
-                hash(builder, hash, prev);
+                hash(builder, ordinator, prev);
             }
         }
         builder.endPositionEntry();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
@@ -8,9 +8,8 @@
 package org.elasticsearch.compute.operator;
 
 import org.apache.lucene.util.ArrayUtil;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
-import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.aggregation.blockhash.Ordinator64;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -140,7 +139,7 @@ public class MultivalueDedupeInt {
      * Dedupe values and build a {@link LongBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
-    public MultivalueDedupe.HashResult hash(LongHash hash) {
+    public MultivalueDedupe.HashResult hash(Ordinator64 hash) {
         LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
@@ -301,14 +300,15 @@ public class MultivalueDedupeInt {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(Ordinator64 ordinator, LongBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
+        // TODO use array flavored add
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hash(builder, ordinator, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -316,18 +316,18 @@ public class MultivalueDedupeInt {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(Ordinator64 ordinator, LongBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
         int prev = work[0];
-        hash(builder, hash, prev);
+        hash(builder, ordinator, prev);
         for (int i = 1; i < w; i++) {
             if (prev != work[i]) {
                 prev = work[i];
-                hash(builder, hash, prev);
+                hash(builder, ordinator, prev);
             }
         }
         builder.endPositionEntry();
@@ -361,7 +361,7 @@ public class MultivalueDedupeInt {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(LongBlock.Builder builder, LongHash hash, int v) {
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+    private void hash(LongBlock.Builder builder, Ordinator64 ordinator, int v) {
+        builder.appendLong(ordinator.add(v));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
@@ -8,9 +8,8 @@
 package org.elasticsearch.compute.operator;
 
 import org.apache.lucene.util.ArrayUtil;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
-import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.aggregation.blockhash.Ordinator64;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.LongBlock;
 
@@ -140,7 +139,7 @@ public class MultivalueDedupeLong {
      * Dedupe values and build a {@link LongBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
-    public MultivalueDedupe.HashResult hash(LongHash hash) {
+    public MultivalueDedupe.HashResult hash(Ordinator64 hash) {
         LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
@@ -301,14 +300,15 @@ public class MultivalueDedupeLong {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(Ordinator64 ordinator, LongBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
+        // TODO use array flavored add
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hash(builder, ordinator, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -316,18 +316,18 @@ public class MultivalueDedupeLong {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(Ordinator64 ordinator, LongBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
         long prev = work[0];
-        hash(builder, hash, prev);
+        hash(builder, ordinator, prev);
         for (int i = 1; i < w; i++) {
             if (prev != work[i]) {
                 prev = work[i];
-                hash(builder, hash, prev);
+                hash(builder, ordinator, prev);
             }
         }
         builder.endPositionEntry();
@@ -361,7 +361,7 @@ public class MultivalueDedupeLong {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(LongBlock.Builder builder, LongHash hash, long v) {
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+    private void hash(LongBlock.Builder builder, Ordinator64 ordinator, long v) {
+        builder.appendLong(ordinator.add(v));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/module-info.java
+++ b/x-pack/plugin/esql/compute/src/main/java/module-info.java
@@ -6,6 +6,7 @@
  */
 
 module org.elasticsearch.compute {
+    requires jdk.incubator.vector;
     requires org.apache.lucene.core;
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class Ordinator {
+    protected final PageCacheRecycler recycler;
+    protected final CircuitBreaker breaker;
+    protected final IdSpace idSpace;
+
+    protected int capacity;
+    protected int mask;
+    protected int nextGrowSize;
+    protected int currentSize;
+    protected int growCount;
+
+    protected Ordinator(
+        PageCacheRecycler recycler,
+        CircuitBreaker breaker,
+        IdSpace idSpace,
+        int initialCapacity,
+        float smallCoreFillFactor
+    ) {
+        this.recycler = recycler;
+        this.breaker = breaker;
+        this.idSpace = idSpace;
+
+        this.capacity = initialCapacity;
+        this.mask = capacity - 1;
+        this.nextGrowSize = (int) (capacity * smallCoreFillFactor);
+
+        assert initialCapacity == Integer.highestOneBit(initialCapacity) : "intial capacity is a power of two";
+    }
+
+    /**
+     * How many entries are in the {@link Ordinator64}.
+     */
+    public final int currentSize() {
+        return currentSize;
+    }
+
+    /**
+     * Performance information hopefully useful for debugging.
+     */
+    public abstract Status status();
+
+    /**
+     * Build an iterator to walk all values and ids.
+     */
+    public abstract Itr iterator();
+
+    /**
+     * Sequence of {@code int}s assigned to ids. These can be shared between
+     * {@link Ordinator}s.
+     */
+    public static class IdSpace {
+        private int id;
+
+        /**
+         * Allocate the next id.
+         */
+        public int next() {
+            return id++;
+        }
+    }
+
+    /**
+     * Performance information about the {@link Ordinator} hopefully useful for debugging.
+     */
+    public abstract static class Status implements NamedWriteable, ToXContentObject {
+        private final int growCount;
+        private final int capacity;
+        private final int size;
+        private final int nextGrowSize;
+
+        protected Status(int growCount, int capacity, int size, int nextGrowSize) {
+            this.growCount = growCount;
+            this.capacity = capacity;
+            this.size = size;
+            this.nextGrowSize = nextGrowSize;
+        }
+
+        protected Status(StreamInput in) throws IOException {
+            this(in.readVInt(), in.readVInt(), in.readVInt(), in.readVInt());
+        }
+
+        /**
+         * The number of times this {@link Ordinator} has grown.
+         */
+        public int growCount() {
+            return growCount;
+        }
+
+        /**
+         * The size of the {@link Ordinator}.
+         */
+        public int capacity() {
+            return capacity;
+        }
+
+        /**
+         * Number of entries added to the {@link Ordinator}.
+         */
+        public int size() {
+            return size;
+        }
+
+        /**
+         * When {@link #size} grows to this number the hash will grow again.
+         */
+        public int nextGrowSize() {
+            return nextGrowSize;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(growCount);
+            out.writeVInt(capacity);
+            out.writeVInt(size);
+            out.writeVInt(nextGrowSize);
+        }
+
+        @Override
+        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("grow_count", growCount);
+            builder.field("capacity", capacity);
+            builder.field("size", size);
+            builder.field("next_grow_size", nextGrowSize);
+            builder.field("core", getWriteableName());
+            toXContentFragment(builder, params);
+            return builder.endObject();
+        }
+
+        protected abstract void toXContentFragment(XContentBuilder builder, Params params) throws IOException;
+    }
+
+    static class SmallCoreStatus extends Status {
+        SmallCoreStatus(int growCount, int capacity, int size, int nextGrowSize) {
+            super(growCount, capacity, size, nextGrowSize);
+        }
+
+        SmallCoreStatus(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "small";
+        }
+
+        @Override
+        protected void toXContentFragment(XContentBuilder builder, Params params) throws IOException {}
+    }
+
+    static class BigCoreStatus extends Status {
+        /**
+         * The number of times and {@link Ordinator64#add} operation needed to probe additional
+         * entries. If all is right with the world this should be {@code 0}, meaning
+         * every entry found an empty slot within {@code SIMD_WIDTH} slots from its
+         * natural positions. Such hashes will never have to probe on read. More
+         * generally, a {@code find} operation should take on average
+         * {@code insertProbes / size} probes.
+         */
+        private final int insertProbes;
+
+        /**
+         * The number of {@link PageCacheRecycler#PAGE_SIZE_IN_BYTES} pages allocated for keys.
+         */
+        public final int keyPages;
+
+        /**
+         * The number of {@link PageCacheRecycler#PAGE_SIZE_IN_BYTES} pages allocated for ids.
+         */
+        public final int idPages;
+
+        BigCoreStatus(int growCount, int capacity, int size, int nextGrowSize, int insertProbes, int keyPages, int idPages) {
+            super(growCount, capacity, size, nextGrowSize);
+            this.insertProbes = insertProbes;
+            this.keyPages = keyPages;
+            this.idPages = idPages;
+        }
+
+        BigCoreStatus(StreamInput in) throws IOException {
+            super(in);
+            insertProbes = in.readVInt();
+            keyPages = in.readVInt();
+            idPages = in.readVInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeVInt(insertProbes);
+            out.writeVInt(keyPages);
+            out.writeVInt(idPages);
+        }
+
+        /**
+         * The number of {@link PageCacheRecycler#PAGE_SIZE_IN_BYTES} pages allocated for keys.
+         */
+        public int keyPages() {
+            return keyPages;
+        }
+
+        /**
+         * The number of {@link PageCacheRecycler#PAGE_SIZE_IN_BYTES} pages allocated for ids.
+         */
+        public int idPages() {
+            return idPages;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "big";
+        }
+
+        @Override
+        protected void toXContentFragment(XContentBuilder builder, Params params) throws IOException {
+            builder.field("insert_probes", insertProbes);
+            builder.field("key_pages", keyPages);
+            builder.field("id_pages", idPages);
+        }
+    }
+
+    /**
+     * Shared superstructure for hash cores. Basically just page tracking
+     * and {@link Releasable}.
+     */
+    abstract class Core implements Releasable {
+        final List<Releasable> toClose = new ArrayList<>();
+
+        byte[] grabPage() {
+            breaker.addEstimateBytesAndMaybeBreak(PageCacheRecycler.PAGE_SIZE_IN_BYTES, "ordinator");
+            toClose.add(() -> breaker.addWithoutBreaking(-PageCacheRecycler.PAGE_SIZE_IN_BYTES));
+            Recycler.V<byte[]> page = recycler.bytePage(false);
+            toClose.add(page);
+            return page.v();
+        }
+
+        /**
+         * Build the status for this core.
+         */
+        protected abstract Status status();
+
+        /**
+         * Build an iterator for all values in the core.
+         */
+        protected abstract Itr iterator();
+
+        @Override
+        public void close() {
+            Releasables.close(toClose);
+        }
+    }
+
+    /**
+     * Iterates the entries in the {@link Ordinator}.
+     */
+    public abstract class Itr {
+        protected int slot = -1;
+
+        /**
+         * Advance to the next entry in the {@link Ordinator}, returning {@code false}
+         * if there aren't any more entries..
+         */
+        public abstract boolean next();
+
+        /**
+         * The id the iterator is current pointing to.
+         */
+        public abstract int id();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator.java
@@ -22,6 +22,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Superclass of table to assign {@code int} ids to various key types,
+ * vending the ids in order they are added.
+ */
 public abstract class Ordinator {
     protected final PageCacheRecycler recycler;
     protected final CircuitBreaker breaker;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator64.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator64.java
@@ -24,7 +24,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 /**
- * Assigns {@code int} ids to {@code long}s, vending the in order they are added.
+ * Assigns {@code int} ids to {@code long}s, vending the ids in order they are added.
  * <p>
  *     At it's core there are two hash table implementations, a "small core" and
  *     a "big core". The "small core" is a simple
@@ -348,7 +348,12 @@ public class Ordinator64 extends Ordinator implements Releasable {
     }
 
     /**
-     * A Swisstable inspired hashtable.
+     * A Swisstable inspired hashtable. This differs from the normal swisstable
+     * in because it's adapted to Elasticsearch's {@link PageCacheRecycler}.
+     * The keys and ids are stored many {@link PageCacheRecycler#PAGE_SIZE_IN_BYTES}
+     * arrays, with the keys separated from the values. This is mostly so that we
+     * can be sure the array and offset into the array can be calculated by right
+     * shifts.
      */
     class BigCore extends Core {
         static final float FILL_FACTOR = 0.85F;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator64.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator64.java
@@ -1,0 +1,622 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+import org.apache.lucene.util.hppc.BitMixer;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+/**
+ * Assigns {@code int} ids to {@code long}s, vending the in order they are added.
+ * <p>
+ *     At it's core there are two hash table implementations, a "small core" and
+ *     a "big core". The "small core" is a simple
+ *     <a href="https://en.wikipedia.org/wiki/Open_addressing">open addressed</a>
+ *     hash table with a fixed 60% load factor and a table of 2048. It quite quick
+ *     because it has a fixed size and never grows.
+ * </p>
+ * <p>
+ *     When the "small core" has more entries than it's load factor the "small core"
+ *     is replaced with a "big core". The "big core" functions quite similarly to
+ *     a <a href="https://faultlore.com/blah/hashbrown-tldr/">Swisstable</a>, Google's
+ *     fancy SIMD hash table. In this table there's a contiguous array of "control"
+ *     bytes that are either {@code 0b1111_1111} for empty entries or
+ *     {@code 0b0aaa_aaaa} for populated entries, where {@code aaa_aaaa} are the top
+ *     7 bytes of the hash. To find an entry by key you hash it, grab the top 7 bytes
+ *     or it, and perform a SIMD read of the control array starting at the expected
+ *     slot. We use the widest SIMD instruction the CPU supports, meaning 64 or 32
+ *     bytes. If any of those match we check the actual key. So instead of scanning
+ *     one slot at a time "small core", we effectively scan a whole bunch at once.
+ *     This allows us to run a much higher load factor (85%) without any performance
+ *     penalty so the extra byte feels super worth it.
+ * </p>
+ * <p>
+ *     When a "big core" fills it's table to the fill factor, we build a new "big core"
+ *     and read all values in the old "big core" into the new one.
+ * </p>
+ */
+@SuppressWarnings("preview")
+public class Ordinator64 extends Ordinator implements Releasable {
+    private static final VectorSpecies<Byte> BS = ByteVector.SPECIES_PREFERRED;
+
+    private static final int PAGE_SHIFT = 14;
+
+    private static final int PAGE_MASK = PageCacheRecycler.PAGE_SIZE_IN_BYTES - 1;
+
+    private static final int KEY_SIZE = Long.BYTES;
+
+    private static final int ID_SIZE = Integer.BYTES;
+
+    static final int INITIAL_CAPACITY = PageCacheRecycler.PAGE_SIZE_IN_BYTES / KEY_SIZE;
+
+    static {
+        if (PageCacheRecycler.PAGE_SIZE_IN_BYTES >> PAGE_SHIFT != 1) {
+            throw new AssertionError("bad constants");
+        }
+        if (Integer.highestOneBit(KEY_SIZE) != KEY_SIZE) {
+            throw new AssertionError("not a power of two");
+        }
+        if (Integer.highestOneBit(ID_SIZE) != ID_SIZE) {
+            throw new AssertionError("not a power of two");
+        }
+        if (Integer.highestOneBit(INITIAL_CAPACITY) != INITIAL_CAPACITY) {
+            throw new AssertionError("not a power of two");
+        }
+        if (ID_SIZE > KEY_SIZE) {
+            throw new AssertionError("key too small");
+        }
+    }
+
+    private static final VarHandle longHandle = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.nativeOrder());
+    private static final VarHandle intHandle = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
+
+    private SmallCore smallCore;
+    private BigCore bigCore;
+
+    public Ordinator64(PageCacheRecycler recycler, CircuitBreaker breaker, IdSpace idSpace) {
+        super(recycler, breaker, idSpace, INITIAL_CAPACITY, Ordinator64.SmallCore.FILL_FACTOR);
+        this.smallCore = new SmallCore();
+    }
+
+    /**
+     * Find an {@code id} by a {@code key}.
+     */
+    public int find(long key) {
+        int hash = hash(key);
+        if (smallCore != null) {
+            return smallCore.find(key, hash);
+        } else {
+            return bigCore.find(key, hash, control(hash));
+        }
+    }
+
+    /**
+     * Add many {@code key}s at once, putting their {@code id}s into an array.
+     * If any {@code key} was already present it's previous assigned {@code id}
+     * will be added to the array. If it wasn't present it'll be assigned a new
+     * {@code id}.
+     * <p>
+     *     This method tends to be faster than {@link #add(long)}.
+     * </p>
+     */
+    public void add(long[] keys, int[] ids, int length) {
+        int i = 0;
+        for (; i < length; i++) {
+            if (bigCore != null) {
+                for (; i < length; i++) {
+                    long k = keys[i];
+                    ids[i] = bigCore.add(k, hash(k));
+                }
+                return;
+            }
+
+            ids[i] = add(keys[i]);
+        }
+    }
+
+    /**
+     * Add many {@code key}s at once, putting their {@code id}s into a builder.
+     * If any {@code key} was already present it's previous assigned {@code id}
+     * will be added to the builder. If it wasn't present it'll be assigned a new
+     * {@code id}.
+     * <p>
+     *     This method tends to be faster than {@link #add(long)}.
+     * </p>
+     */
+    public void add(long[] keys, LongBlock.Builder ids, int length) {
+        int i = 0;
+        for (; i < length; i++) {
+            if (bigCore != null) {
+                for (; i < length; i++) {
+                    long k = keys[i];
+                    ids.appendLong(bigCore.add(k, hash(k)));
+                }
+                return;
+            }
+
+            ids.appendLong(add(keys[i]));
+        }
+    }
+
+    /**
+     * Add a {@code key}, returning its {@code id}s. If it was already present
+     * it's previous assigned {@code id} will be returned. If it wasn't present
+     * it'll be assigned a new {@code id}.
+     */
+    public int add(long key) {
+        int hash = hash(key);
+        if (smallCore != null) {
+            if (currentSize < nextGrowSize) {
+                return smallCore.add(key, hash);
+            }
+            smallCore.transitionToBigCore();
+        }
+        return bigCore.add(key, hash);
+    }
+
+    @Override
+    public Status status() {
+        return smallCore != null ? smallCore.status() : bigCore.status();
+    }
+
+    public abstract class Itr extends Ordinator.Itr {
+        /**
+         * The key the iterator is current pointing to.
+         */
+        public abstract long key();
+    }
+
+    @Override
+    public Itr iterator() {
+        return smallCore != null ? smallCore.iterator() : bigCore.iterator();
+    }
+
+    /**
+     * Build the control byte for a populated entry out of the hash.
+     * The control bytes for a populated entry has the high bit clear
+     * and the remaining 7 bits contain the top 7 bits of the hash.
+     * So it looks like {@code 0b0xxx_xxxx}.
+     */
+    private byte control(int hash) {
+        return (byte) (hash >>> (Integer.SIZE - 7));
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(smallCore, bigCore);
+    }
+
+    private int growTracking() {
+        // Juggle constants for the new page size
+        growCount++;
+        // TODO what about MAX_INT?
+        int oldCapacity = capacity;
+        capacity <<= 1;
+        mask = capacity - 1;
+        nextGrowSize = (int) (capacity * BigCore.FILL_FACTOR);
+        return oldCapacity;
+    }
+
+    /**
+     * Open addressed hash table the probes by triangle numbers. Empty
+     * {@code id}s are encoded as {@code -1}. This hash table can't
+     * grow, and is instead replaced by a {@link BigCore}.
+     * <p>
+     *     This uses two pages from the {@link PageCacheRecycler}, one
+     *     for the {@code keys} and one for the {@code ids}.
+     * </p>
+     */
+    class SmallCore extends Core {
+        static final float FILL_FACTOR = 0.6F;
+
+        private final byte[] keyPage;
+        private final byte[] idPage;
+
+        private SmallCore() {
+            boolean success = false;
+            try {
+                keyPage = grabPage();
+                idPage = grabPage();
+                Arrays.fill(idPage, (byte) 0xff);
+                success = true;
+            } finally {
+                if (success == false) {
+                    close();
+                }
+            }
+        }
+
+        int find(long key, int hash) {
+            int slotIncrement = 0;
+            int slot = slot(hash);
+            while (true) {
+                int id = id(slot);
+                if (id < 0) {
+                    // Empty
+                    return -1;
+                }
+                if (key(slot) == key) {
+                    return id;
+                }
+
+                slotIncrement++;
+                slot = slot(slot + slotIncrement);
+            }
+        }
+
+        int add(long key, int hash) {
+            int slotIncrement = 0;
+            int slot = slot(hash);
+            while (true) {
+                int keyOffset = keyOffset(slot);
+                int idOffset = idOffset(slot);
+                long slotKey = (long) longHandle.get(keyPage, keyOffset);
+                int slotId = (int) intHandle.get(idPage, idOffset);
+                if (slotId >= 0) {
+                    if (slotKey == key) {
+                        return slotId;
+                    }
+                } else {
+                    currentSize++;
+                    longHandle.set(keyPage, keyOffset, key);
+                    int id = idSpace.next();
+                    intHandle.set(idPage, idOffset, id);
+                    return id;
+                }
+
+                slotIncrement++;
+                slot = slot(slot + slotIncrement);
+            }
+        }
+
+        void transitionToBigCore() {
+            int oldCapacity = growTracking();
+
+            try {
+                bigCore = new BigCore();
+                rehash(oldCapacity);
+            } finally {
+                close();
+                smallCore = null;
+            }
+        }
+
+        @Override
+        protected Status status() {
+            return new SmallCoreStatus(growCount, capacity, currentSize, nextGrowSize);
+        }
+
+        @Override
+        protected Itr iterator() {
+            return new Itr() {
+                @Override
+                public boolean next() {
+                    do {
+                        slot++;
+                    } while (slot < capacity && SmallCore.this.id(slot) < 0);
+                    return slot < capacity;
+                }
+
+                @Override
+                public int id() {
+                    return SmallCore.this.id(slot);
+                }
+
+                @Override
+                public long key() {
+                    return SmallCore.this.key(slot);
+                }
+            };
+        }
+
+        private void rehash(int oldCapacity) {
+            for (int slot = 0; slot < oldCapacity; slot++) {
+                int id = (int) intHandle.get(idPage, idOffset(slot));
+                if (id < 0) {
+                    continue;
+                }
+                long key = (long) longHandle.get(keyPage, keyOffset(slot));
+                int hash = hash(key);
+                bigCore.insert(key, hash, control(hash), id);
+            }
+        }
+
+        private long key(int slot) {
+            return (long) longHandle.get(keyPage, keyOffset(slot));
+        }
+
+        private int id(int slot) {
+            return (int) intHandle.get(idPage, idOffset(slot));
+        }
+    }
+
+    /**
+     * A Swisstable inspired hashtable.
+     */
+    class BigCore extends Core {
+        static final float FILL_FACTOR = 0.85F;
+
+        private static final byte CONTROL_EMPTY = (byte) 0b1111_1111;
+
+        /**
+         * The "control" bytes from the Swisstable algorithm. This'll contain
+         * {@link #CONTROL_EMPTY} for empty entries and {@code 0b0aaa_aaaa} for
+         * filled entries, where {@code aaa_aaaa} are the top seven bits of the
+         * hash. These are tests by SIMD instructions as a quick first pass to
+         * check many entries at once.
+         * <p>
+         *     This array has to be contiguous or we loose too much speed so it
+         *     isn't managed by the {@link PageCacheRecycler}, instead we
+         *     allocate it directly.
+         * </p>
+         * <p>
+         *     This array contains {@code capacity + SIMD_LANES} entries with the
+         *     first {@code SIMD_LANES} bytes cloned to the end of the array so
+         *     the simd probes for possible matches never had to worry about
+         *     "wrapping" around the array.
+         */
+        private final byte[] controlData;
+
+        /**
+         * Pages of {@code keys}, vended by the {@link PageCacheRecycler}. It's
+         * important that the size of keys be a power of two, so we can quickly
+         * select the appropriate page and keys never span multiple pages.
+         */
+        private final byte[][] keyPages;
+
+        /**
+         * Pages of {@code ids}, vended by the {@link PageCacheRecycler}. Ids
+         * are {@code int}s so it's very quick to select the appropriate page
+         * for each slot.
+         */
+        private final byte[][] idPages;
+
+        /**
+         * The number of times and {@link #add} operation needed to probe additional
+         * entries. If all is right with the world this should be {@code 0}, meaning
+         * every entry found an empty slot within {@code SIMD_WIDTH} slots from its
+         * natural positions. Such hashes will never have to probe on read. More
+         * generally, a {@code find} operation should take on average
+         * {@code insertProbes / size} probes.
+         */
+        private int insertProbes;
+
+        BigCore() {
+            int controlLength = capacity + BS.length();
+            breaker.addEstimateBytesAndMaybeBreak(controlLength, "ordinator");
+            toClose.add(() -> breaker.addWithoutBreaking(-controlLength));
+            controlData = new byte[controlLength];
+            Arrays.fill(controlData, (byte) 0xFF);
+
+            boolean success = false;
+            try {
+                int keyPagesNeeded = (capacity * KEY_SIZE - 1) >> PAGE_SHIFT;
+                keyPagesNeeded++;
+                keyPages = new byte[keyPagesNeeded][];
+                for (int i = 0; i < keyPagesNeeded; i++) {
+                    keyPages[i] = grabPage();
+                }
+                assert keyPages[keyOffset(mask) >> PAGE_SHIFT] != null;
+
+                int idPagesNeeded = (capacity * ID_SIZE - 1) >> PAGE_SHIFT;
+                idPagesNeeded++;
+                idPages = new byte[idPagesNeeded][];
+                for (int i = 0; i < idPagesNeeded; i++) {
+                    idPages[i] = grabPage();
+                }
+                assert idPages[idOffset(mask) >> PAGE_SHIFT] != null;
+                success = true;
+            } finally {
+                if (false == success) {
+                    close();
+                }
+            }
+        }
+
+        /**
+         * Probe chunks for the value.
+         * <p>
+         *     Each probe is:
+         * </p>
+         * <ol>
+         *     <li>Build a bit mask of all matching control values.</li>
+         *     <li>If any match, check if the actual values. If any of those match, return them.</li>
+         *     <li>No values matched, so check the control values for EMPTY flags. If there are any then the value isn't in the hash.</li>
+         *     <li>There aren't any EMPTY flags, meaning this chunk is full. So we should continue probing.</li>
+         * </ol>
+         * <p>
+         *     We probe via triangle numbers, adding 1, then 2, then 3, then 4, etc. That'll
+         *     help protect us from chunky hashes. And it's simple math. And it'll hit all the
+         *     buckets (<a href="https://fgiesen.wordpress.com/2015/02/22/triangular-numbers-mod-2n/">proof</a>).
+         *     The probe loop doesn't stop if it never finds an EMPTY flag. But it'll always
+         *     find one because we keep a load factor lower than 100%.
+         * </p>
+         */
+        private int find(long key, int hash, byte control) {
+            int slotIncrement = 0;
+            int slot = slot(hash);
+            while (true) {
+                VectorMask<Byte> candidateMatches = controlMatches(slot, control);
+                // TODO the double checking could be vectorized for some key types. Longs, probably.
+
+                int first;
+                while ((first = candidateMatches.firstTrue()) < candidateMatches.length()) {
+                    int checkSlot = slot(slot + first);
+
+                    if (key(checkSlot) == key) {
+                        return id(checkSlot);
+                    }
+                    // Clear the first set bit and try again
+                    candidateMatches = candidateMatches.indexInRange(-1 - first, candidateMatches.length());
+                }
+
+                if (controlMatches(slot, CONTROL_EMPTY).anyTrue()) {
+                    return -1;
+                }
+
+                slotIncrement += BS.length();
+                slot = slot(slot + slotIncrement);
+            }
+        }
+
+        int add(long key, int hash) {
+            byte control = control(hash);
+            int found = find(key, hash, control);
+            if (found >= 0) {
+                return found;
+            }
+
+            currentSize++;
+            if (currentSize >= nextGrowSize) {
+                assert currentSize == nextGrowSize;
+                grow();
+            }
+
+            int id = idSpace.next();
+            bigCore.insert(key, hash, control, id);
+            return id;
+        }
+
+        /**
+         * Insert the key into the first empty slot that allows it. Used by {@link #add}
+         * after we verify that the key isn't in the index. And used by {@link #rehash}
+         * because we know all keys are unique.
+         */
+        void insert(long key, int hash, byte control, int id) {
+            int slotIncrement = 0;
+            int slot = slot(hash);
+            while (true) {
+                VectorMask<Byte> empty = controlMatches(slot, CONTROL_EMPTY);
+                if (empty.anyTrue()) {
+                    slot = slot(slot + empty.firstTrue());
+                    int keyOffset = keyOffset(slot);
+                    int idOffset = idOffset(slot);
+
+                    longHandle.set(keyPages[keyOffset >> PAGE_SHIFT], keyOffset & PAGE_MASK, key);
+                    intHandle.set(idPages[idOffset >> PAGE_SHIFT], idOffset & PAGE_MASK, id);
+                    controlData[slot] = control;
+                    /*
+                     * Mirror the first BS.length bytes to the end of the array. All
+                     * other positions are just written twice.
+                     */
+                    controlData[((slot - BS.length()) & mask) + BS.length()] = control;
+                    return;
+                }
+
+                slotIncrement += BS.length();
+                slot = slot(slot + slotIncrement);
+                insertProbes++;
+            }
+        }
+
+        @Override
+        protected Status status() {
+            return new BigCoreStatus(growCount, capacity, currentSize, nextGrowSize, insertProbes, keyPages.length, idPages.length);
+        }
+
+        @Override
+        protected Itr iterator() {
+            return new Itr() {
+                @Override
+                public boolean next() {
+                    do {
+                        slot++;
+                    } while (slot < capacity && controlData[slot] == CONTROL_EMPTY);
+                    return slot < capacity;
+                }
+
+                @Override
+                public int id() {
+                    return BigCore.this.id(slot);
+                }
+
+                @Override
+                public long key() {
+                    return BigCore.this.key(slot);
+                }
+            };
+        }
+
+        private void grow() {
+            int oldCapacity = growTracking();
+            try {
+                bigCore = new BigCore();
+                rehash(oldCapacity);
+            } finally {
+                close();
+            }
+        }
+
+        private void rehash(int oldCapacity) {
+            int slot = 0;
+            while (slot < oldCapacity) {
+                VectorMask<Byte> empty = controlMatches(slot, CONTROL_EMPTY);
+                // TODO iterate like in find - it's faster.
+                for (int i = 0; i < empty.length(); i++) {
+                    if (empty.laneIsSet(i)) {
+                        slot++;
+                        continue;
+                    }
+                    long key = key(slot);
+                    int hash = hash(key);
+                    int id = id(slot);
+                    bigCore.insert(key, hash, control(hash), id);
+                    slot++;
+                }
+            }
+        }
+
+        /**
+         * Checks the control byte at {@code slot} and the next few bytes ahead
+         * of {@code slot} for the control bits. The extra probed bytes is as
+         * many as will fit in your widest simd instruction. So, 32 or 64 will
+         * be common.
+         */
+        private VectorMask<Byte> controlMatches(int slot, byte control) {
+            return ByteVector.fromArray(BS, controlData, slot).eq(control);
+        }
+
+        private long key(int slot) {
+            int keyOffset = keyOffset(slot);
+            return (long) longHandle.get(keyPages[keyOffset >> PAGE_SHIFT], keyOffset & PAGE_MASK);
+        }
+
+        private int id(int slot) {
+            int idOffset = idOffset(slot);
+            return (int) intHandle.get(idPages[idOffset >> PAGE_SHIFT], idOffset & PAGE_MASK);
+        }
+    }
+
+    int keyOffset(int slot) {
+        return slot * KEY_SIZE;
+    }
+
+    int idOffset(int slot) {
+        return slot * ID_SIZE;
+    }
+
+    int hash(long v) {
+        return BitMixer.mix(v);
+    }
+
+    int slot(int hash) {
+        return hash & mask;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.SeenGroupIds;
+import org.elasticsearch.compute.data.Block;
+$if(double)$
+import org.elasticsearch.compute.data.DoubleArrayBlock;
+import org.elasticsearch.compute.data.DoubleArrayVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+$endif$
+$if(int)$
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntArrayVector;
+import org.elasticsearch.compute.data.IntBlock;
+$endif$
+import org.elasticsearch.compute.data.IntVector;
+$if(long)$
+import org.elasticsearch.compute.data.LongArrayBlock;
+$endif$
+import org.elasticsearch.compute.data.LongArrayVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.MultivalueDedupe;
+import org.elasticsearch.compute.operator.MultivalueDedupe$Type$;
+
+import java.util.BitSet;
+
+/**
+ * Maps {@link $Type$Block} to group ids.
+ * This class is generated. Edit {@code X-BlockHash.java.st} instead.
+ */
+final class $Type$BlockHash extends BlockHash {
+    private final int channel;
+    private final Ordinator64 ordinator;
+
+    /**
+     * Have we seen any {@code null} values?
+     * <p>
+     *     We reserve the 0 ordinal for the {@code null} key so methods like
+     *     {@link #nonEmpty} need to skip 0 if we haven't seen any null values.
+     * </p>
+     */
+    private boolean seenNull;
+
+    $Type$BlockHash(PageCacheRecycler recycler, CircuitBreaker breaker, int channel) {
+        this.channel = channel;
+$if(int)$
+        // TODO build and use Ordinator32
+$endif$
+        Ordinator64.IdSpace idSpace = new Ordinator64.IdSpace();
+        idSpace.next();  // Reserve 0 for nulls.
+        this.ordinator = new Ordinator64(recycler, breaker, idSpace);
+    }
+
+    @Override
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+        $Type$Block block = page.getBlock(channel);
+        $Type$Vector vector = block.asVector();
+        if (vector == null) {
+            addInput.add(0, add(block));
+        } else {
+            addInput.add(0, add(vector));
+        }
+    }
+
+    private LongVector add($Type$Vector vector) {
+        long[] groups = new long[vector.getPositionCount()];
+        // TODO use the array flavored add
+        for (int i = 0; i < vector.getPositionCount(); i++) {
+$if(double)$
+            groups[i] = ordinator.add(Double.doubleToLongBits(vector.get$Type$(i)));
+$else$
+            groups[i] = ordinator.add(vector.get$Type$(i));
+$endif$
+        }
+        return new LongArrayVector(groups, groups.length);
+    }
+
+    private LongBlock add($Type$Block block) {
+        MultivalueDedupe.HashResult result = new MultivalueDedupe$Type$(block).hash(ordinator);
+        seenNull |= result.sawNull();
+        return result.ords();
+    }
+
+    @Override
+    public $Type$Block[] getKeys() {
+        // TODO call something like takeKeyOwnership to claim the keys array directly
+
+        // If we've seen null we'll store it in 0
+        if (seenNull) {
+            $type$[] keys = new $type$[ordinator.currentSize() + 1];
+            for (Ordinator64.Itr itr = ordinator.iterator(); itr.next();) {
+$if(int)$
+                // TODO build and use Ordinator32 and drop the cast
+                keys[itr.id()] = Math.toIntExact(itr.key());
+$elseif(double)$
+                keys[itr.id()] = Double.longBitsToDouble(itr.key());
+$else$
+                keys[itr.id()] = itr.key();
+$endif$
+            }
+            BitSet nulls = new BitSet(1);
+            nulls.set(0);
+            return new $Type$Block[] { new $Type$ArrayBlock(keys, keys.length, null, nulls, Block.MvOrdering.ASCENDING) };
+        }
+        $type$[] keys = new $type$[ordinator.currentSize() + (seenNull ? 1 : 0)];
+        for (Ordinator64.Itr itr = ordinator.iterator(); itr.next();) {
+            // We reserved the id 0 for null but didn't see it.
+$if(int)$
+            // TODO build and use Ordinator32 and drop the cast
+            keys[itr.id() - 1] = Math.toIntExact(itr.key());
+$elseif(double)$
+            keys[itr.id() - 1] = Double.longBitsToDouble(itr.key());
+$else$
+            keys[itr.id() - 1] = itr.key();
+$endif$
+        }
+
+        return new $Type$Block[] { new $Type$ArrayVector(keys, keys.length).asBlock() };
+    }
+
+    @Override
+    public IntVector nonEmpty() {
+        return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(ordinator.currentSize() + 1));
+    }
+
+    @Override
+    public BitArray seenGroupIds(BigArrays bigArrays) {
+        return new SeenGroupIds.Range(seenNull ? 0 : 1, Math.toIntExact(ordinator.currentSize() + 1)).seenGroupIds(bigArrays);
+    }
+
+    @Override
+    public void close() {
+        ordinator.close();
+    }
+
+    @Override
+    public String toString() {
+        return "$Type$BlockHash{channel=" + channel + ", entries=" + ordinator.currentSize() + ", seenNull=" + seenNull + '}';
+    }
+
+    // TODO plumb ordinator.status
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
@@ -36,11 +35,11 @@ public class HashAggregationOperator implements Operator {
         List<GroupSpec> groups,
         List<GroupingAggregator.Factory> aggregators,
         int maxPageSize,
-        BigArrays bigArrays
+        BlockHash.Factory blockHashFactory
     ) implements OperatorFactory {
         @Override
         public Operator get(DriverContext driverContext) {
-            return new HashAggregationOperator(aggregators, () -> BlockHash.build(groups, bigArrays, maxPageSize), driverContext);
+            return new HashAggregationOperator(aggregators, () -> blockHashFactory.build(groups, maxPageSize), driverContext);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -57,12 +57,22 @@ public class OrdinalsGroupingOperator implements Operator {
         String groupingField,
         List<Factory> aggregators,
         int maxPageSize,
+        BlockHash.Factory blockHashFactory,
         BigArrays bigArrays
     ) implements OperatorFactory {
 
         @Override
         public Operator get(DriverContext driverContext) {
-            return new OrdinalsGroupingOperator(sources, docChannel, groupingField, aggregators, maxPageSize, bigArrays, driverContext);
+            return new OrdinalsGroupingOperator(
+                sources,
+                docChannel,
+                groupingField,
+                aggregators,
+                maxPageSize,
+                blockHashFactory,
+                bigArrays,
+                driverContext
+            );
         }
 
         @Override
@@ -77,6 +87,7 @@ public class OrdinalsGroupingOperator implements Operator {
 
     private final List<Factory> aggregatorFactories;
     private final Map<SegmentID, OrdinalSegmentAggregator> ordinalAggregators;
+    private final BlockHash.Factory blockHashFactory;
     private final BigArrays bigArrays;
 
     private final DriverContext driverContext;
@@ -93,6 +104,7 @@ public class OrdinalsGroupingOperator implements Operator {
         String groupingField,
         List<GroupingAggregator.Factory> aggregatorFactories,
         int maxPageSize,
+        BlockHash.Factory blockHashFactory,
         BigArrays bigArrays,
         DriverContext driverContext
     ) {
@@ -109,6 +121,7 @@ public class OrdinalsGroupingOperator implements Operator {
         this.aggregatorFactories = aggregatorFactories;
         this.ordinalAggregators = new HashMap<>();
         this.maxPageSize = maxPageSize;
+        this.blockHashFactory = blockHashFactory;
         this.bigArrays = bigArrays;
         this.driverContext = driverContext;
     }
@@ -166,7 +179,7 @@ public class OrdinalsGroupingOperator implements Operator {
                     channelIndex,
                     aggregatorFactories,
                     maxPageSize,
-                    bigArrays,
+                    blockHashFactory,
                     driverContext
                 );
             }
@@ -416,13 +429,13 @@ public class OrdinalsGroupingOperator implements Operator {
             int channelIndex,
             List<GroupingAggregator.Factory> aggregatorFactories,
             int maxPageSize,
-            BigArrays bigArrays,
+            BlockHash.Factory blockHashFactory,
             DriverContext driverContext
         ) {
             this.extractor = new ValuesSourceReaderOperator(sources, docChannel, groupingField);
             this.aggregator = new HashAggregationOperator(
                 aggregatorFactories,
-                () -> BlockHash.build(List.of(new GroupSpec(channelIndex, sources.get(0).elementType())), bigArrays, maxPageSize),
+                () -> blockHashFactory.build(List.of(new GroupSpec(channelIndex, sources.get(0).elementType())), maxPageSize),
                 driverContext
             );
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -11,11 +11,12 @@ import org.apache.lucene.util.ArrayUtil;
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BytesRefHash;
-$else$
-import org.elasticsearch.common.util.LongHash;
-$endif$
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+$else$
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.blockhash.Ordinator64;
+$endif$
 $if(long)$
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.LongBlock;
@@ -24,8 +25,8 @@ $else$
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.LongBlock;
-$endif$
 
+$endif$
 import java.util.Arrays;
 
 /**
@@ -179,7 +180,7 @@ $endif$
 $if(BytesRef)$
     public MultivalueDedupe.HashResult hash(BytesRefHash hash) {
 $else$
-    public MultivalueDedupe.HashResult hash(LongHash hash) {
+    public MultivalueDedupe.HashResult hash(Ordinator64 hash) {
 $endif$
         LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
@@ -389,17 +390,18 @@ $endif$
      * Writes an already deduplicated {@link #work} to a hash.
      */
 $if(BytesRef)$
-    private void hashUniquedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(BytesRefHash ordinator, LongBlock.Builder builder) {
 $else$
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(Ordinator64 ordinator, LongBlock.Builder builder) {
 $endif$
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
+        // TODO use array flavored add
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hash(builder, ordinator, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -408,17 +410,17 @@ $endif$
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
 $if(BytesRef)$
-    private void hashSortedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(BytesRefHash ordinator, LongBlock.Builder builder) {
 $else$
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(Ordinator64 ordinator, LongBlock.Builder builder) {
 $endif$
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hash(builder, ordinator, work[0]);
             return;
         }
         builder.beginPositionEntry();
         $type$ prev = work[0];
-        hash(builder, hash, prev);
+        hash(builder, ordinator, prev);
         for (int i = 1; i < w; i++) {
 $if(BytesRef)$
             if (false == prev.equals(work[i])) {
@@ -426,7 +428,7 @@ $else$
             if (prev != work[i]) {
 $endif$
                 prev = work[i];
-                hash(builder, hash, prev);
+                hash(builder, ordinator, prev);
             }
         }
         builder.endPositionEntry();
@@ -487,12 +489,14 @@ $endif$
 $if(BytesRef)$
     private void hash(LongBlock.Builder builder, BytesRefHash hash, BytesRef v) {
 $else$
-    private void hash(LongBlock.Builder builder, LongHash hash, $type$ v) {
+    private void hash(LongBlock.Builder builder, Ordinator64 ordinator, $type$ v) {
 $endif$
 $if(double)$
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v))));
-$else$
+        builder.appendLong(ordinator.add(Double.doubleToLongBits(v)));
+$elseif(BytesRef)$
         builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+$else$
+        builder.appendLong(ordinator.add(v));
 $endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -8,9 +8,13 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -68,11 +72,12 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         if (randomBoolean()) {
             supplier = chunkGroups(emitChunkSize, supplier);
         }
+        // TOOD pass PageCacheRecycler and Breaker too
         return new HashAggregationOperator.HashAggregationOperatorFactory(
             List.of(new HashAggregationOperator.GroupSpec(0, ElementType.LONG)),
             List.of(supplier.groupingAggregatorFactory(mode)),
             randomPageSize(),
-            bigArrays
+            new BlockHash.Factory(bigArrays, new PageCacheRecycler(Settings.EMPTY), () -> new NoopCircuitBreaker("test"))
         );
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator64Tests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/Ordinator64Tests.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.LongArrayVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntUnaryOperator;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+
+public class Ordinator64Tests extends ESTestCase {
+    @ParametersFactory
+    public static List<Object[]> params() {
+        List<Object[]> params = new ArrayList<>();
+        for (AddType addType : AddType.values()) {
+            params.add(new Object[] { addType, "tiny", 5, 0, 1, 1 });
+            params.add(new Object[] { addType, "small", Ordinator64.INITIAL_CAPACITY / 2, 0, 1, 1 });
+            params.add(new Object[] { addType, "two key pages", PageCacheRecycler.PAGE_SIZE_IN_BYTES / Long.BYTES, 1, 2, 1 });
+            params.add(new Object[] { addType, "two id pages", PageCacheRecycler.PAGE_SIZE_IN_BYTES / Integer.BYTES, 2, 4, 2 });
+            params.add(new Object[] { addType, "many", PageCacheRecycler.PAGE_SIZE_IN_BYTES, 4, 16, 8 });
+            params.add(new Object[] { addType, "huge", 100_000, 6, 64, 32 });
+        }
+        return params;
+    }
+
+    private enum AddType {
+        SINGLE_VALUE,
+        ARRAY,
+        BUILDER;
+    }
+
+    private final AddType addType;
+    private final String name;
+    private final int count;
+    private final int expectedGrowCount;
+    private final int expectedKeyPageCount;
+    private final int expectedIdPageCount;
+
+    public Ordinator64Tests(
+        @Name("addType") AddType addType,
+        @Name("name") String name,
+        @Name("count") int count,
+        @Name("expectedGrowCount") int expectedGrowCount,
+        @Name("expectedKeyPageCount") int expectedKeyPageCount,
+        @Name("expectedIdPageCount") int expectedIdPageCount
+    ) {
+        this.addType = addType;
+        this.name = name;
+        this.count = count;
+        this.expectedGrowCount = expectedGrowCount;
+        this.expectedKeyPageCount = expectedKeyPageCount;
+        this.expectedIdPageCount = expectedIdPageCount;
+    }
+
+    public void testValues() {
+        Set<Long> values = randomValues(count);
+        long[] v = values.stream().mapToLong(Long::longValue).toArray();
+
+        TestRecycler recycler = new TestRecycler();
+        CircuitBreaker breaker = new NoopCircuitBreaker("test");
+        try (Ordinator64 ord = new Ordinator64(recycler, breaker, new Ordinator64.IdSpace())) {
+            assertThat(ord.currentSize(), equalTo(0));
+
+            switch (addType) {
+                case SINGLE_VALUE -> {
+                    for (int i = 0; i < v.length; i++) {
+                        assertThat(ord.add(v[i]), equalTo(i));
+                        assertThat(ord.currentSize(), equalTo(i + 1));
+                        assertThat(ord.add(v[i]), equalTo(i));
+                        assertThat(ord.currentSize(), equalTo(i + 1));
+                    }
+                    for (int i = 0; i < v.length; i++) {
+                        assertThat(ord.add(v[i]), equalTo(i));
+                    }
+                    assertThat(ord.currentSize(), equalTo(v.length));
+                }
+                case ARRAY -> {
+                    int[] target = new int[v.length];
+                    ord.add(v, target, v.length);
+                    assertThat(target, equalTo(IntStream.range(0, count).toArray()));
+                    assertThat(ord.currentSize(), equalTo(v.length));
+
+                    Arrays.fill(target, 0);
+                    ord.add(v, target, v.length);
+                    assertThat(target, equalTo(IntStream.range(0, count).toArray()));
+                    assertThat(ord.currentSize(), equalTo(v.length));
+                }
+                case BUILDER -> {
+                    LongBlock.Builder target = LongBlock.newBlockBuilder(count);
+                    ord.add(v, target, v.length);
+                    assertThat(target.build(), equalTo(new LongArrayVector(LongStream.range(0, count).toArray(), count).asBlock()));
+                    assertThat(ord.currentSize(), equalTo(v.length));
+
+                    target = LongBlock.newBlockBuilder(count);
+                    ord.add(v, target, v.length);
+                    assertThat(target.build(), equalTo(new LongArrayVector(LongStream.range(0, count).toArray(), count).asBlock()));
+                    assertThat(ord.currentSize(), equalTo(v.length));
+                }
+                default -> throw new IllegalArgumentException();
+            }
+            for (int i = 0; i < v.length; i++) {
+                assertThat(ord.find(v[i]), equalTo(i));
+            }
+            assertThat(ord.currentSize(), equalTo(v.length));
+            assertThat(ord.find(randomValueOtherThanMany(values::contains, ESTestCase::randomLong)), equalTo(-1));
+
+            assertStatus(ord);
+            assertThat("Only currently used pages are open", recycler.open, hasSize(expectedKeyPageCount + expectedIdPageCount));
+
+            Long[] iterated = new Long[count];
+            for (Ordinator64.Itr itr = ord.iterator(); itr.next();) {
+                assertThat(iterated[itr.id()], nullValue());
+                iterated[itr.id()] = itr.key();
+            }
+            for (int i = 0; i < v.length; i++) {
+                assertThat(iterated[i], equalTo(v[i]));
+            }
+        }
+        assertThat(recycler.open, hasSize(0));
+    }
+
+    public void testSharedIdSpace() {
+        Set<Long> leftValues = randomValues(count);
+        Set<Long> rightValues = randomValues(count);
+        long[] left = leftValues.stream().mapToLong(Long::longValue).toArray();
+        long[] right = rightValues.stream().mapToLong(Long::longValue).toArray();
+
+        TestRecycler recycler = new TestRecycler();
+        CircuitBreaker breaker = new NoopCircuitBreaker("test");
+        Ordinator64.IdSpace idSpace = new Ordinator64.IdSpace();
+        try (
+            Ordinator64 leftOrd = new Ordinator64(recycler, breaker, idSpace);
+            Ordinator64 rightOrd = new Ordinator64(recycler, breaker, idSpace);
+        ) {
+            assertThat(leftOrd.currentSize(), equalTo(0));
+            assertThat(rightOrd.currentSize(), equalTo(0));
+
+            IntUnaryOperator leftMap, rightMap, leftMapInverse, rightMapInverse;
+            switch (addType) {
+                case SINGLE_VALUE -> {
+                    leftMap = i -> 2 * i;
+                    rightMap = i -> 2 * i + 1;
+                    leftMapInverse = i -> i / 2;
+                    rightMapInverse = i -> (i - 1) / 2;
+
+                    for (int i = 0; i < count; i++) {
+                        assertThat(leftOrd.add(left[i]), equalTo(2 * i));
+                        assertThat(leftOrd.currentSize(), equalTo(i + 1));
+                        assertThat(rightOrd.add(right[i]), equalTo(2 * i + 1));
+                        assertThat(rightOrd.currentSize(), equalTo(i + 1));
+
+                        assertThat(leftOrd.add(left[i]), equalTo(2 * i));
+                        assertThat(leftOrd.currentSize(), equalTo(i + 1));
+                        assertThat(rightOrd.add(right[i]), equalTo(2 * i + 1));
+                        assertThat(rightOrd.currentSize(), equalTo(i + 1));
+                    }
+                    for (int i = 0; i < count; i++) {
+                        assertThat(leftOrd.add(left[i]), equalTo(2 * i));
+                        assertThat(leftOrd.currentSize(), equalTo(count));
+                        assertThat(rightOrd.add(right[i]), equalTo(2 * i + 1));
+                        assertThat(rightOrd.currentSize(), equalTo(count));
+                    }
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+                    assertThat(rightOrd.currentSize(), equalTo(count));
+                }
+                case ARRAY -> {
+                    leftMap = i -> i;
+                    rightMap = i -> count + i;
+                    leftMapInverse = i -> i;
+                    rightMapInverse = i -> i - count;
+
+                    int[] target = new int[count];
+
+                    leftOrd.add(left, target, count);
+                    assertThat(target, equalTo(IntStream.range(0, count).toArray()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    Arrays.fill(target, 0);
+                    rightOrd.add(right, target, count);
+                    assertThat(target, equalTo(IntStream.range(count, 2 * count).toArray()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    Arrays.fill(target, 0);
+                    leftOrd.add(left, target, count);
+                    assertThat(target, equalTo(IntStream.range(0, count).toArray()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    Arrays.fill(target, 0);
+                    rightOrd.add(right, target, count);
+                    assertThat(target, equalTo(IntStream.range(count, 2 * count).toArray()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    for (int i = 0; i < count; i++) {
+                        assertThat(leftOrd.find(left[i]), equalTo(i));
+                        assertThat(rightOrd.find(right[i]), equalTo(count + i));
+                    }
+                }
+                case BUILDER -> {
+                    leftMap = i -> i;
+                    rightMap = i -> count + i;
+                    leftMapInverse = i -> i;
+                    rightMapInverse = i -> i - count;
+
+                    LongBlock.Builder target = LongBlock.newBlockBuilder(count);
+
+                    leftOrd.add(left, target, count);
+                    assertThat(target.build(), equalTo(new LongArrayVector(LongStream.range(0, count).toArray(), count).asBlock()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    target = LongBlock.newBlockBuilder(count);
+                    rightOrd.add(right, target, count);
+                    assertThat(target.build(), equalTo(new LongArrayVector(LongStream.range(count, 2 * count).toArray(), count).asBlock()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    target = LongBlock.newBlockBuilder(count);
+                    leftOrd.add(left, target, count);
+                    assertThat(target.build(), equalTo(new LongArrayVector(LongStream.range(0, count).toArray(), count).asBlock()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    target = LongBlock.newBlockBuilder(count);
+                    rightOrd.add(right, target, count);
+                    assertThat(target.build(), equalTo(new LongArrayVector(LongStream.range(count, 2 * count).toArray(), count).asBlock()));
+                    assertThat(leftOrd.currentSize(), equalTo(count));
+
+                    for (int i = 0; i < count; i++) {
+                        assertThat(leftOrd.find(left[i]), equalTo(i));
+                        assertThat(rightOrd.find(right[i]), equalTo(count + i));
+                    }
+                }
+                default -> throw new IllegalArgumentException();
+            }
+            for (int i = 0; i < count; i++) {
+                assertThat(leftOrd.find(left[i]), equalTo(leftMap.applyAsInt(i)));
+                assertThat(rightOrd.find(right[i]), equalTo(rightMap.applyAsInt(i)));
+            }
+
+            assertStatus(leftOrd);
+            assertStatus(rightOrd);
+            assertThat("Only currently used pages are open", recycler.open, hasSize(2 * (expectedKeyPageCount + expectedIdPageCount)));
+
+            Long[] iterated = new Long[count];
+            for (Ordinator64.Itr itr = leftOrd.iterator(); itr.next();) {
+                int id = leftMapInverse.applyAsInt(itr.id());
+                assertThat(iterated[id], nullValue());
+                iterated[id] = itr.key();
+            }
+            for (int i = 0; i < left.length; i++) {
+                assertThat(iterated[i], equalTo(left[i]));
+            }
+
+            iterated = new Long[count];
+            for (Ordinator64.Itr itr = rightOrd.iterator(); itr.next();) {
+                int id = rightMapInverse.applyAsInt(itr.id());
+                assertThat(iterated[id], nullValue());
+                iterated[id] = itr.key();
+            }
+            for (int i = 0; i < right.length; i++) {
+                assertThat(iterated[i], equalTo(right[i]));
+            }
+        }
+        assertThat(recycler.open, hasSize(0));
+    }
+
+    public void testBreaker() {
+        Set<Long> values = randomValues(count);
+        long[] v = values.stream().mapToLong(Long::longValue).toArray();
+
+        TestRecycler recycler = new TestRecycler();
+        long breakAt = (expectedIdPageCount + expectedKeyPageCount) * PageCacheRecycler.PAGE_SIZE_IN_BYTES;
+        if (expectedGrowCount == 0) {
+            breakAt -= 10;
+        }
+        CircuitBreaker breaker = new MockBigArrays.LimitedBreaker("test", ByteSizeValue.ofBytes(breakAt));
+        Exception e = expectThrows(CircuitBreakingException.class, () -> {
+            try (Ordinator64 ord = new Ordinator64(recycler, breaker, new Ordinator64.IdSpace())) {
+                switch (addType) {
+                    case SINGLE_VALUE -> {
+                        for (int i = 0; i < v.length; i++) {
+                            assertThat(ord.add(v[i]), equalTo(i));
+                        }
+                    }
+                    case ARRAY -> {
+                        int[] target = new int[v.length];
+                        ord.add(v, target, v.length);
+                    }
+                    case BUILDER -> {
+                        LongBlock.Builder target = LongBlock.newBlockBuilder(count);
+                        ord.add(v, target, v.length);
+                    }
+                    default -> throw new IllegalArgumentException();
+                }
+            }
+        });
+        assertThat(e.getMessage(), equalTo("over test limit"));
+        assertThat(recycler.open, hasSize(0));
+    }
+
+    private void assertStatus(Ordinator64 ord) {
+        Ordinator.Status status = ord.status();
+        assertThat(status.size(), equalTo(count));
+        if (expectedGrowCount == 0) {
+            assertThat(status.growCount(), equalTo(0));
+            assertThat(status.capacity(), equalTo(Ordinator64.INITIAL_CAPACITY));
+            assertThat(status.nextGrowSize(), equalTo((int) (Ordinator64.INITIAL_CAPACITY * Ordinator64.SmallCore.FILL_FACTOR)));
+        } else {
+            assertThat(status.growCount(), equalTo(expectedGrowCount));
+            assertThat(status.capacity(), equalTo(Ordinator64.INITIAL_CAPACITY << expectedGrowCount));
+            assertThat(
+                status.nextGrowSize(),
+                equalTo((int) ((Ordinator64.INITIAL_CAPACITY << expectedGrowCount) * Ordinator64.BigCore.FILL_FACTOR))
+            );
+
+            Ordinator.BigCoreStatus s = (Ordinator.BigCoreStatus) status;
+            assertThat(s.keyPages(), equalTo(expectedKeyPageCount));
+            assertThat(s.idPages(), equalTo(expectedIdPageCount));
+        }
+    }
+
+    private Set<Long> randomValues(int count) {
+        Set<Long> values = new HashSet<>();
+        while (values.size() < count) {
+            values.add(randomLong());
+        }
+        return values;
+    }
+
+    static class TestRecycler extends PageCacheRecycler {
+        private final List<MyV<?>> open = new ArrayList<>();
+
+        TestRecycler() {
+            super(Settings.EMPTY);
+        }
+
+        @Override
+        public Recycler.V<byte[]> bytePage(boolean clear) {
+            return new MyV<>(super.bytePage(clear));
+        }
+
+        @Override
+        public Recycler.V<Object[]> objectPage() {
+            return new MyV<>(super.objectPage());
+        }
+
+        class MyV<T> implements Recycler.V<T> {
+            private final Recycler.V<T> delegate;
+
+            MyV(Recycler.V<T> delegate) {
+                this.delegate = delegate;
+                open.add(this);
+            }
+
+            @Override
+            public T v() {
+                return delegate.v();
+            }
+
+            @Override
+            public boolean isRecycled() {
+                return delegate.isRecycled();
+            }
+
+            @Override
+            public void close() {
+                open.remove(this);
+                delegate.close();
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -156,7 +156,7 @@ abstract class AbstractPhysicalOperationProviders implements PhysicalOperationPr
                     groupSpecs.stream().map(GroupSpec::toHashGroupSpec).toList(),
                     aggregatorFactories,
                     context.pageSize(aggregateExec.estimatedRowSize()),
-                    context.bigArrays()
+                    context.blockHashFactory()
                 );
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -173,6 +173,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             attrSource.name(),
             aggregatorFactories,
             context.pageSize(aggregateExec.estimatedRowSize()),
+            context.blockHashFactory(),
             context.bigArrays()
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.xpack.esql.planner;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.compute.Describable;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
@@ -41,6 +44,7 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.compute.operator.exchange.ExchangeSourceOperator.ExchangeSourceOperatorFactory;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.EsqlUnsupportedOperationException;
@@ -107,6 +111,8 @@ public class LocalExecutionPlanner {
     private final String sessionId;
     private final CancellableTask parentTask;
     private final BigArrays bigArrays;
+    private final PageCacheRecycler recycler;
+    private final CircuitBreakerService breakerService;
     private final EsqlConfiguration configuration;
     private final ExchangeSourceHandler exchangeSourceHandler;
     private final ExchangeSinkHandler exchangeSinkHandler;
@@ -117,6 +123,8 @@ public class LocalExecutionPlanner {
         String sessionId,
         CancellableTask parentTask,
         BigArrays bigArrays,
+        PageCacheRecycler recycler,
+        CircuitBreakerService breakerService,
         EsqlConfiguration configuration,
         ExchangeSourceHandler exchangeSourceHandler,
         ExchangeSinkHandler exchangeSinkHandler,
@@ -126,6 +134,8 @@ public class LocalExecutionPlanner {
         this.sessionId = sessionId;
         this.parentTask = parentTask;
         this.bigArrays = bigArrays;
+        this.recycler = recycler;
+        this.breakerService = breakerService;
         this.exchangeSourceHandler = exchangeSourceHandler;
         this.exchangeSinkHandler = exchangeSinkHandler;
         this.enrichLookupService = enrichLookupService;
@@ -143,7 +153,9 @@ public class LocalExecutionPlanner {
             configuration.pragmas().taskConcurrency(),
             configuration.pragmas().dataPartitioning(),
             configuration.pragmas().pageSize(),
-            bigArrays
+            bigArrays,
+            recycler,
+            breakerService
         );
 
         PhysicalOperation physicalOperation = plan(node, context);
@@ -652,7 +664,9 @@ public class LocalExecutionPlanner {
         int taskConcurrency,
         DataPartitioning dataPartitioning,
         int configuredPageSize,
-        BigArrays bigArrays
+        BigArrays bigArrays,
+        PageCacheRecycler recycler,
+        CircuitBreakerService breakerService
     ) {
         void addDriverFactory(DriverFactory driverFactory) {
             driverFactories.add(driverFactory);
@@ -673,6 +687,13 @@ public class LocalExecutionPlanner {
                 return configuredPageSize;
             }
             return Math.max(SourceOperator.MIN_TARGET_PAGE_SIZE, SourceOperator.TARGET_PAGE_SIZE / estimatedRowSize);
+        }
+
+        /**
+         * Builder {@link BlockHash} implementations for grouping grouping aggregations.
+         */
+        BlockHash.Factory blockHashFactory() {
+            return new BlockHash.Factory(bigArrays, recycler, () -> breakerService.getBreaker(CircuitBreaker.REQUEST));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -15,7 +15,9 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -56,7 +58,9 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         ExchangeService exchangeService,
         ClusterService clusterService,
         ThreadPool threadPool,
-        BigArrays bigArrays
+        BigArrays bigArrays,
+        PageCacheRecycler recycler,
+        CircuitBreakerService breakerService
     ) {
         // TODO replace SAME when removing workaround for https://github.com/elastic/elasticsearch/issues/97916
         super(EsqlQueryAction.NAME, transportService, actionFilters, EsqlQueryRequest::new, ThreadPool.Names.SAME);
@@ -72,7 +76,9 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             exchangeService,
             enrichLookupService,
             threadPool,
-            bigArrays
+            bigArrays,
+            recycler,
+            breakerService
         );
         this.settings = settings;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -19,11 +19,15 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.lucene.LuceneSourceOperator;
 import org.elasticsearch.compute.lucene.LuceneTopNSourceOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.TestSearchContext;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
@@ -109,10 +113,14 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
     }
 
     private LocalExecutionPlanner planner() throws IOException {
+        PageCacheRecycler recycler = new MockPageCacheRecycler(Settings.EMPTY);
+        CircuitBreakerService breakerService = new NoneCircuitBreakerService();
         return new LocalExecutionPlanner(
             "test",
             null,
             BigArrays.NON_RECYCLING_INSTANCE,
+            recycler,
+            breakerService,
             config(),
             null,
             null,


### PR DESCRIPTION
We've been using `LongHash` and `LongLongHash` which are open addressed, linear probing hash tables that grow in place. They have served us well, but we need to add features to them to support all of ES|QL. It turns out that there've been a lot of advances in the hash space in the ten years since we wrote these hash tables! And they weren't the most "advanced" thing back then. This PR creates a new hash table implementation the borrows significantly from google's Swiss Tables. It's 25% to 49% faster in microbenchmarks:

```
 unique   longHash          ordinator64
      5   7.470 ± 0.033 ->   4.158 ± 0.037 ns/op 45% faster
   1000   9.657 ± 0.375 ->   4.907 ± 0.036 ns/op 49% faster
  10000  15.505 ± 0.051 ->  11.609 ± 0.062 ns/op 25% faster
 100000  20.948 ± 0.112 ->  13.413 ± 0.764 ns/op 35% fsater
1000000  48.507 ± 0.586 ->  36.306 ± 0.296 ns/op 25% faster
```

This also integrates the new table into ES|QL's grouping functions, though imperfectly at the moment.
