### PR TITLE
Accept empty chunked responses

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -612,7 +612,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
             public void dispatchRequest(final RestRequest request, final RestChannel channel, final ThreadContext threadContext) {
                 try {
                     channel.sendResponse(
-                        new RestResponse(OK, ChunkedRestResponseBody.fromXContent(ignored -> Iterators.single((builder, params) -> {
+                        RestResponse.chunked(OK, ChunkedRestResponseBody.fromXContent(ignored -> Iterators.single((builder, params) -> {
                             throw new AssertionError("should not be called for HEAD REQUEST");
                         }), ToXContent.EMPTY_PARAMS, channel))
                     );

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -79,8 +79,12 @@ public class RestResponse {
         this(status, responseMediaType, content, null);
     }
 
-    public RestResponse(RestStatus status, ChunkedRestResponseBody content) {
-        this(status, content.getResponseContentTypeString(), null, content);
+    public static RestResponse chunked(RestStatus restStatus, ChunkedRestResponseBody content) {
+        if (content.isDone()) {
+            return new RestResponse(restStatus, content.getResponseContentTypeString(), BytesArray.EMPTY);
+        } else {
+            return new RestResponse(restStatus, content.getResponseContentTypeString(), null, content);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
@@ -36,7 +36,9 @@ public class RestChunkedToXContentListener<Response extends ChunkedToXContent> e
 
     @Override
     protected void processResponse(Response response) throws IOException {
-        channel.sendResponse(new RestResponse(getRestStatus(response), ChunkedRestResponseBody.fromXContent(response, params, channel)));
+        channel.sendResponse(
+            RestResponse.chunked(getRestStatus(response), ChunkedRestResponseBody.fromXContent(response, params, channel))
+        );
     }
 
     protected RestStatus getRestStatus(Response response) {

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -62,7 +62,7 @@ public class RestTable {
         final List<Integer> rowOrder = getRowOrder(table, channel.request());
         final List<DisplayHeader> displayHeaders = buildDisplayHeaders(table, request);
 
-        return new RestResponse(
+        return RestResponse.chunked(
             RestStatus.OK,
             ChunkedRestResponseBody.fromXContent(
                 ignored -> Iterators.concat(
@@ -96,7 +96,7 @@ public class RestTable {
             return new RestResponse(RestStatus.OK, RestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY);
         }
 
-        return new RestResponse(
+        return RestResponse.chunked(
             RestStatus.OK,
             ChunkedRestResponseBody.fromTextChunks(
                 RestResponse.TEXT_CONTENT_TYPE,

--- a/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
@@ -119,7 +119,7 @@ public class RestClusterInfoAction extends BaseRestHandler {
                 public RestResponse buildResponse(NodesStatsResponse response) throws Exception {
                     var chunkedResponses = targets.stream().map(RESPONSE_MAPPER::get).map(mapper -> mapper.apply(response)).iterator();
 
-                    return new RestResponse(
+                    return RestResponse.chunked(
                         RestStatus.OK,
                         ChunkedRestResponseBody.fromXContent(
                             outerParams -> Iterators.concat(

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -525,7 +525,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         }
         {
             // chunked response
-            channel.sendResponse(new RestResponse(RestStatus.OK, new ChunkedRestResponseBody() {
+            channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
 
                 @Override
                 public boolean isDone() {
@@ -710,7 +710,7 @@ public class DefaultRestChannelTests extends ESTestCase {
                 Level.TRACE,
                 "[" + request.getRequestId() + "] response body",
                 ReferenceDocs.HTTP_TRACER,
-                () -> channel.sendResponse(new RestResponse(RestStatus.OK, new ChunkedRestResponseBody() {
+                () -> channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
 
                     boolean isDone;
 

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -529,7 +529,7 @@ public class DefaultRestChannelTests extends ESTestCase {
 
                 @Override
                 public boolean isDone() {
-                    throw new AssertionError("should not try to serialize response body for HEAD request");
+                    return false;
                 }
 
                 @Override

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -66,6 +66,16 @@ public class RestResponseTests extends ESTestCase {
         assertThat(response.getHeaders().get("n2"), contains("v21", "v22"));
     }
 
+    public void testEmptyChunkedBody() {
+        RestResponse response = RestResponse.chunked(
+            RestStatus.OK,
+            ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator())
+        );
+        assertFalse(response.isChunked());
+        assertNotNull(response.content());
+        assertEquals(0, response.content().length());
+    }
+
     public void testSimpleExceptionMessage() throws Exception {
         RestRequest request = new FakeRestRequest();
         RestChannel channel = new SimpleExceptionRestChannel(request);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -61,7 +61,10 @@ public class EsqlResponseListener extends RestResponseListener<EsqlQueryResponse
         if (mediaType instanceof TextFormat format) {
             restResponse = new RestResponse(RestStatus.OK, format.contentType(restRequest), format.format(restRequest, esqlResponse));
         } else {
-            restResponse = new RestResponse(RestStatus.OK, ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel));
+            restResponse = RestResponse.chunked(
+                RestStatus.OK,
+                ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel)
+            );
         }
         restResponse.addHeader(HEADER_NAME_TOOK_NANOS, Long.toString(System.nanoTime() - startNanos));
 


### PR DESCRIPTION
Today we assert that every chunked response contains at least one chunk.
In practice it is sometimes useful to yield no chunks too. This commit
permits a zero-chunk chunked response, by converting it into a regular
unchunked response at the start.