### PR TITLE
Simplifying testGeoIpDatabasesDownloadNoGeoipProcessors in order to avoid a race condition in cleanup

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -294,18 +294,16 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             PersistentTasksCustomMetadata.PersistentTask<PersistentTaskParams> task = getTask();
             assertNotNull(task);
             assertNotNull(task.getState());
-            putGeoIpPipeline(pipelineId); // This is to work around the race condition described in #92888
         });
         putNonGeoipPipeline(pipelineId);
         assertNotNull(getTask().getState()); // removing all geoip processors should not result in the task being stopped
-        putGeoIpPipeline();
         assertBusy(() -> {
             GeoIpTaskState state = getGeoIpTaskState();
             assertEquals(
                 Set.of("GeoLite2-ASN.mmdb", "GeoLite2-City.mmdb", "GeoLite2-Country.mmdb", "MyCustomGeoLite2-City.mmdb"),
                 state.getDatabases().keySet()
             );
-        }, 2, TimeUnit.MINUTES);
+        });
     }
 
     public void testDoNotDownloadDatabaseOnPipelineCreation() throws Exception {


### PR DESCRIPTION
I have not been able to reproduce it yet locally after thousands of runs, but based on the failure in #98755, it looks like something was creating the database file _after_ it had been deleted in the cleanup method. So the assertion in the cleanup method after the deletion was failing because there were files where there should have been none. Since I can't reproduce it I can't say for sure, but I am fairly sure that the problem is that the task from a call to putGeoIpPipeline() after the first call to that method is still running after the test completes. This is made possible by the fix in #98751 -- previously two repeated calls to putGeoIpPipeline() would have resulted in the 2nd one being a no-op. I am removing all but one call to putGeoIpPipeline() in this PR. The test has succeeded well over a thousand times locally.
Closes #98755