### PR TITLE
Include all modules in module path in module graph

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
@@ -219,7 +219,8 @@ public class ServerProcess {
         command.add(esHome.resolve("lib").toString());
         // Special circumstances require some modules (not depended on by the main server module) to be explicitly added:
         command.add("--add-modules=jdk.net"); // needed to reflectively set extended socket options
-        command.add("--add-modules=org.elasticsearch.preallocate"); // needed on boot layer as target to open java.io
+        // we control the module path, which may have additional modules not required by server
+        command.add("--add-modules=ALL-MODULE-PATH");
         command.add("-m");
         command.add("org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch");
 


### PR DESCRIPTION
Elasticsearch use lib as its module path, which includes all the dependencies of server. However, there are sometimes additional modules such as preallocate that are used dynamically and not direct dependencies of server. This commit switches the addition of these modules to be automatic by including all modules present in the module path.
