### PR TITLE
ESQL: Support queries that don't return underlying fields

### DIFF
--- a/docs/changelog/98759.yaml
+++ b/docs/changelog/98759.yaml
@@ -1,0 +1,6 @@
+pr: 98759
+summary: "ESQL: Support queries that don't return underlying fields"
+area: ES|QL
+type: bug
+issues:
+ - 98404

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -520,3 +520,13 @@ emp_no:integer |   salary_change:double   |salary_change.int:integer|salary_chan
 10009          |null                      |null                     |null              
 10010          |[-6.77, 4.69, 5.05, 12.15]|[-6, 4, 5, 12]           |[-6, 4, 5, 12]               
 ;
+
+
+projectAllButConstant
+from employees | eval c = 1 | keep c | limit 2
+;
+
+c:i
+1
+1
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -472,3 +472,11 @@ from employees | stats min(salary), max(salary), c = count(salary);
 min(salary):i | max(salary):i | c:l
 25324         | 74999         | 100
 ;
+
+statsWithLiterals
+from employees | limit 10 | eval x = 1 | stats c = count(x)
+;
+
+c:l
+10
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "to better understand planning")
+@TestLogging(value = "org.elasticsearch.xpack.esql.session:DEBUG", reason = "to better understand planning")
 public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
 
     @After

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-@TestLogging(value = "org.elasticsearch.xpack.esql.session:DEBUG", reason = "to better understand planning")
+@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "to better understand planning")
 public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
 
     @After

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -74,6 +74,20 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         createAndPopulateIndex("test");
     }
 
+    public void testProjectConstant() {
+        EsqlQueryResponse results = run("from test | eval x = 1 | keep x");
+        assertThat(results.columns(), equalTo(List.of(new ColumnInfo("x", "integer"))));
+        assertThat(results.values().size(), equalTo(40));
+        assertThat(results.values().get(0).get(0), equalTo(1));
+    }
+
+    public void testStatsOverConstant() {
+        EsqlQueryResponse results = run("from test | eval x = 1 | stats x = count(x)");
+        assertThat(results.columns(), equalTo(List.of(new ColumnInfo("x", "long"))));
+        assertThat(results.values().size(), equalTo(1));
+        assertThat(results.values().get(0).get(0), equalTo(40L));
+    }
+
     public void testRow() {
         long value = randomLongBetween(0, Long.MAX_VALUE);
         EsqlQueryResponse response = run("row " + value);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
@@ -20,7 +21,10 @@ import org.elasticsearch.xpack.esql.planner.PhysicalVerifier;
 import org.elasticsearch.xpack.ql.common.Failure;
 import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Attribute;
+import org.elasticsearch.xpack.ql.expression.AttributeMap;
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.Expressions;
+import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.ql.plan.logical.Project;
@@ -32,13 +36,13 @@ import org.elasticsearch.xpack.ql.util.Holder;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 /**
  * Performs global (coordinator) optimization of the physical plan.
@@ -88,7 +92,7 @@ public class PhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPla
             var projectAll = new Holder<>(TRUE);
             var keepCollecting = new Holder<>(TRUE);
             var attributes = new LinkedHashSet<Attribute>();
-            var aliases = new HashMap<Attribute, Expression>();
+            var aliases = new AttributeMap<Expression>();
 
             return plan.transformDown(UnaryExec.class, p -> {
                 // no need for project all
@@ -113,6 +117,7 @@ public class PhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPla
                     }
                     if (p instanceof EnrichExec ee) {
                         for (NamedExpression enrichField : ee.enrichFields()) {
+                            // TODO: why is this different then the remove above?
                             attributes.remove(enrichField instanceof Alias a ? a.child() : enrichField);
                         }
                     }
@@ -123,13 +128,21 @@ public class PhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPla
                     // otherwise expect a Fragment
                     if (child instanceof FragmentExec fragmentExec) {
                         var logicalFragment = fragmentExec.fragment();
+                        var skipProject = false;
                         // no need for projection when dealing with aggs
                         if (logicalFragment instanceof Aggregate) {
-                            attributes.clear();
+                            skipProject = true;
                         }
                         var selectAll = projectAll.get();
-                        if (attributes.isEmpty() == false || selectAll) {
+                        if (skipProject == false) {
                             var output = selectAll ? exec.child().output() : new ArrayList<>(attributes);
+                            // a physical plan cannot be empty - return a constant instead
+                            if (output.isEmpty()) {
+                                var alias = new Alias(logicalFragment.source(), "<all-fields-projected>", null, Literal.NULL, null, true);
+                                List<NamedExpression> fields = singletonList(alias);
+                                logicalFragment = new Eval(logicalFragment.source(), logicalFragment, fields);
+                                output = Expressions.asAttributes(fields);
+                            }
                             // add a logical projection (let the local replanning remove it if needed)
                             p = exec.replaceChild(
                                 new FragmentExec(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
@@ -97,7 +97,7 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
         sb.append(esFilter);
         sb.append(", estimatedRowSize=");
         sb.append(estimatedRowSize);
-        sb.append(", fragment=[<>");
+        sb.append(", fragment=[<>\n");
         sb.append(fragment.toString());
         sb.append("<>]]");
         return sb.toString();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -60,6 +60,7 @@ import org.elasticsearch.xpack.esql.stats.Metrics;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Attribute;
+import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.MetadataAttribute;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
@@ -1644,6 +1645,57 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         }
     }
 
+    public void testFieldExtractWithoutSourceAttributes() {
+        PhysicalPlan verifiedPlan = optimizedPlan(physicalPlan("""
+            from test
+            | where round(emp_no) > 10
+            """));
+        // Transform the verified plan so that it is invalid (i.e. no source attributes)
+        List<Attribute> emptyAttrList = List.of();
+        var badPlan = verifiedPlan.transformDown(
+            EsQueryExec.class,
+            node -> new EsSourceExec(node.source(), node.index(), emptyAttrList, node.query())
+        );
+
+        var e = expectThrows(PhysicalVerificationException.class, () -> physicalPlanOptimizer.verify(badPlan));
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "Need to add field extractor for [[emp_no]] but cannot detect source attributes from node [EsSourceExec[test][]]"
+            )
+        );
+    }
+
+    /**
+     * Expects
+     * ProjectExec[[x{r}#3]]
+     * \_EvalExec[[1[INTEGER] AS x]]
+     *   \_LimitExec[10000[INTEGER]]
+     *     \_ExchangeExec[[],false]
+     *       \_ProjectExec[[<all-fields-projected>{r}#12]]
+     *         \_EvalExec[[null[NULL] AS <all-fields-projected>]]
+     *           \_EsQueryExec[test], query[{"esql_single_value":{"field":"emp_no","next":{"range":{"emp_no":{"gt":10,"boost":1.0}}}}}][_doc{f}#13], limit[10000], sort[] estimatedRowSize[8]
+     */
+    public void testProjectAllFieldsWhenOnlyTheCountMatters() {
+        var plan = optimizedPlan(physicalPlan("""
+            from test
+            | where emp_no > 10
+            | eval x = 1
+            | keep x
+            """));
+
+        var project = as(plan, ProjectExec.class);
+        var eval = as(project.child(), EvalExec.class);
+        var limit = as(eval.child(), LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var nullField = "<all-fields-projected>";
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(Expressions.names(project.projections()), contains(nullField));
+        eval = as(project.child(), EvalExec.class);
+        assertThat(Expressions.names(eval.fields()), contains(nullField));
+        var source = source(eval.child());
+    }
+
     private static EsQueryExec source(PhysicalPlan plan) {
         if (plan instanceof ExchangeExec exchange) {
             plan = exchange.child();
@@ -1686,27 +1738,6 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
 
     private ExchangeExec asRemoteExchange(PhysicalPlan plan) {
         return as(plan, ExchangeExec.class);
-    }
-
-    public void testFieldExtractWithoutSourceAttributes() {
-        PhysicalPlan verifiedPlan = optimizedPlan(physicalPlan("""
-            from test
-            | where round(emp_no) > 10
-            """));
-        // Transform the verified plan so that it is invalid (i.e. no source attributes)
-        List<Attribute> emptyAttrList = List.of();
-        var badPlan = verifiedPlan.transformDown(
-            EsQueryExec.class,
-            node -> new EsSourceExec(node.source(), node.index(), emptyAttrList, node.query())
-        );
-
-        var e = expectThrows(PhysicalVerificationException.class, () -> physicalPlanOptimizer.verify(badPlan));
-        assertThat(
-            e.getMessage(),
-            containsString(
-                "Need to add field extractor for [[emp_no]] but cannot detect source attributes from node [EsSourceExec[test][]]"
-            )
-        );
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -1672,9 +1672,10 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * \_EvalExec[[1[INTEGER] AS x]]
      *   \_LimitExec[10000[INTEGER]]
      *     \_ExchangeExec[[],false]
-     *       \_ProjectExec[[<all-fields-projected>{r}#12]]
-     *         \_EvalExec[[null[NULL] AS <all-fields-projected>]]
-     *           \_EsQueryExec[test], query[{"esql_single_value":{"field":"emp_no","next":{"range":{"emp_no":{"gt":10,"boost":1.0}}}}}][_doc{f}#13], limit[10000], sort[] estimatedRowSize[8]
+     *       \_ProjectExec[[&lt;all-fields-projected&gt;{r}#12]]
+     *         \_EvalExec[[null[NULL] AS &lt;all-fields-projected&gt;]]
+     *           \_EsQueryExec[test], query[{"esql_single_value":{"field":"emp_no","next":{"range":{"emp_no":{"gt":10,"boost":1.0}}}}}]
+     *            [_doc{f}#13], limit[10000], sort[] estimatedRowSize[8]
      */
     public void testProjectAllFieldsWhenOnlyTheCountMatters() {
         var plan = optimizedPlan(physicalPlan("""


### PR DESCRIPTION
Improve ProjectAwayColumns rule to take into account queries that don't
 return the actual values of the underlying data rather just care about
 the number of entries returned.

Fix #98404