### PR TITLE
Fix compilation error on JDK 20+

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
@@ -196,7 +196,7 @@ public class ValuesSourceReaderBenchmark {
                 case "double" -> {
                     DoubleVector values = op.getOutput().<DoubleBlock>getBlock(1).asVector();
                     for (int p = 0; p < values.getPositionCount(); p++) {
-                        sum += values.getDouble(p);
+                        sum += (long) values.getDouble(p);
                     }
                 }
                 case "keyword" -> {


### PR DESCRIPTION
JDK20+ is more picky with loosy conversions.

relate https://github.com/elastic/elasticsearch/issues/95839