### PR TITLE
Close IndexReader in AbstractFieldDataImplTestCase

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTestCase.java
@@ -117,6 +117,9 @@ public abstract class AbstractFieldDataImplTestCase extends AbstractFieldDataTes
             assertThat(topDocs.scoreDocs[0].doc, equalTo(2));
             assertThat(topDocs.scoreDocs[1].doc, equalTo(0));
             assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
+            // No need to close the index reader here, because it gets closed on test teardown.
+            // (This test uses refreshReader(...) which sets topLevelReader in super class and
+            // that gets closed.
         }
     }
 
@@ -191,6 +194,7 @@ public abstract class AbstractFieldDataImplTestCase extends AbstractFieldDataTes
             assertThat(topDocs.scoreDocs[0].doc, equalTo(0));
             assertThat(topDocs.scoreDocs[1].doc, equalTo(2));
             assertThat(topDocs.scoreDocs[2].doc, equalTo(1));
+            searcher.getIndexReader().close();
         }
     }
 
@@ -282,6 +286,7 @@ public abstract class AbstractFieldDataImplTestCase extends AbstractFieldDataTes
         assertThat(((FieldDoc) topDocs.scoreDocs[6]).fields[0], equalTo(null));
         assertThat(topDocs.scoreDocs[7].doc, equalTo(5));
         assertThat(((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(null));
+        searcher.getIndexReader().close();
     }
 
     protected abstract void fillExtendedMvSet() throws Exception;

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -254,7 +254,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
 
         final IndexFieldData<?> indexFieldData = getForField("value");
         final String missingValue = values[1];
-        IndexSearcher searcher = newSearcher(DirectoryReader.open(writer));
+        IndexSearcher searcher = newIndexSearcher(DirectoryReader.open(writer));
         SortField sortField = indexFieldData.sortField(missingValue, MultiValueMode.MIN, null, reverse);
         TopFieldDocs topDocs = searcher.search(
             new MatchAllDocsQuery(),
@@ -312,7 +312,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
             }
         }
         final IndexFieldData<?> indexFieldData = getForField("value");
-        IndexSearcher searcher = newSearcher(DirectoryReader.open(writer));
+        IndexSearcher searcher = newIndexSearcher(DirectoryReader.open(writer));
         SortField sortField = indexFieldData.sortField(first ? "_first" : "_last", MultiValueMode.MIN, null, reverse);
         TopFieldDocs topDocs = searcher.search(
             new MatchAllDocsQuery(),
@@ -387,7 +387,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         }
         DirectoryReader directoryReader = DirectoryReader.open(writer);
         directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(indexService.index(), 0));
-        IndexSearcher searcher = newSearcher(directoryReader);
+        IndexSearcher searcher = newIndexSearcher(directoryReader);
         IndexFieldData<?> fieldData = getForField("text");
         final Object missingValue = switch (randomInt(4)) {
             case 0 -> "_first";

--- a/server/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.fielddata;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -23,11 +22,10 @@ import org.elasticsearch.search.sort.SortOrder;
 
 /** Returns an implementation based on paged bytes which doesn't implement WithOrdinals in order to visit different paths in the code,
  *  eg. BytesRefFieldComparatorSource makes decisions based on whether the field data implements WithOrdinals. */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98720")
 public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTests {
 
     public static IndexFieldData<LeafFieldData> hideOrdinals(final IndexFieldData<?> in) {
-        return new IndexFieldData<LeafFieldData>() {
+        return new IndexFieldData<>() {
             @Override
             public String getFieldName() {
                 return in.getFieldName();

--- a/server/src/test/java/org/elasticsearch/index/fielddata/PagedBytesStringFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/PagedBytesStringFieldDataTests.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.index.fielddata;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98720")
 public class PagedBytesStringFieldDataTests extends AbstractStringFieldDataTestCase {
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/fielddata/SortedSetDVStringFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/SortedSetDVStringFieldDataTests.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.index.fielddata;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98720")
 public class SortedSetDVStringFieldDataTests extends AbstractStringFieldDataTestCase {
 
     @Override


### PR DESCRIPTION
Close IndexReader in AbstractFieldDataImplTestCase.testMissingValueForAll() and AbstractFieldDataImplTestCase.testSortMultiValuesFields() tests.

Closes #98720