### PR TITLE
Fix mvt error when returning partial results

### DIFF
--- a/docs/changelog/98765.yaml
+++ b/docs/changelog/98765.yaml
@@ -1,0 +1,6 @@
+pr: 98765
+summary: Fix mvt error when returning partial results
+area: Geo
+type: bug
+issues:
+ - 98730

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -963,6 +963,36 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat("Feature " + featureIndex + " tag count does not match", feature.getTagsCount(), Matchers.equalTo(2 * tags.length));
     }
 
+    public void testPartialResult() throws Exception {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
+        mvtRequest.setJsonEntity("""
+            {
+              "query": {
+                "error_query": {
+                  "indices": [
+                    {
+                      "error_type": "exception",
+                      "message": "local shard failure message 123",
+                      "name": "index-points"
+                    }
+                  ]
+                }
+              }
+            }""");
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
+        assertLayer(tile, AGGS_LAYER, 4096, 65536, 2);
+        assertLayer(tile, META_LAYER, 4096, 1, 28);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
+        assertStringTag(
+            getLayer(tile, META_LAYER),
+            getLayer(tile, META_LAYER).getFeatures(0),
+            "_shards.failures.0.reason.caused_by.reason",
+            "[index-points][0] local shard failure message 123"
+        );
+    }
+
     private void assertLayer(VectorTile.Tile tile, String name, int extent, int numFeatures, int numTags, String... tags) {
         final VectorTile.Tile.Layer layer = getLayer(tile, name);
         assertThat("Layer " + name + " extent does not match", layer.getExtent(), Matchers.equalTo(extent));
@@ -1007,7 +1037,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             String thisTag = layer.getKeys(feature.getTags(i));
             if (tag.equals(thisTag)) {
                 VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
-                assertEquals(thisValue.getStringValue(), value);
+                assertEquals(value, thisValue.getStringValue());
                 return;
             }
         }

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -929,6 +929,36 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
+    public void testPartialResult() throws Exception {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
+        mvtRequest.setJsonEntity("""
+            {
+              "query": {
+                "error_query": {
+                  "indices": [
+                    {
+                      "error_type": "exception",
+                      "message": "local shard failure message 123",
+                      "name": "index-points"
+                    }
+                  ]
+                }
+              }
+            }""");
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
+        assertLayer(tile, AGGS_LAYER, 4096, 65536, 2);
+        assertLayer(tile, META_LAYER, 4096, 1, 28);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
+        assertStringTag(
+            getLayer(tile, META_LAYER),
+            getLayer(tile, META_LAYER).getFeatures(0),
+            "_shards.failures.0.reason.caused_by.reason",
+            "[index-points][0] local shard failure message 123"
+        );
+    }
+
     private String getHttpMethod() {
         return random().nextBoolean() ? HttpGet.METHOD_NAME : HttpPost.METHOD_NAME;
     }
@@ -961,36 +991,6 @@ public class VectorTileRestIT extends ESRestTestCase {
             );
         }
         assertThat("Feature " + featureIndex + " tag count does not match", feature.getTagsCount(), Matchers.equalTo(2 * tags.length));
-    }
-
-    public void testPartialResult() throws Exception {
-        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
-        mvtRequest.setJsonEntity("""
-            {
-              "query": {
-                "error_query": {
-                  "indices": [
-                    {
-                      "error_type": "exception",
-                      "message": "local shard failure message 123",
-                      "name": "index-points"
-                    }
-                  ]
-                }
-              }
-            }""");
-        final VectorTile.Tile tile = execute(mvtRequest);
-        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
-        assertLayer(tile, AGGS_LAYER, 4096, 65536, 2);
-        assertLayer(tile, META_LAYER, 4096, 1, 28);
-        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
-        assertStringTag(
-            getLayer(tile, META_LAYER),
-            getLayer(tile, META_LAYER).getFeatures(0),
-            "_shards.failures.0.reason.caused_by.reason",
-            "[index-points][0] local shard failure message 123"
-        );
     }
 
     private void assertLayer(VectorTile.Tile tile, String name, int extent, int numFeatures, int numTags, String... tags) {

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -949,7 +949,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 65536, 2);
-        assertLayer(tile, META_LAYER, 4096, 1, 28);
+        assertLayer(tile, META_LAYER, 4096, 1, 22);
         assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
         assertStringTag(
             getLayer(tile, META_LAYER),

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
@@ -57,11 +57,26 @@ class VectorTileUtils {
     }
 
     /**
+     * Adds the provided map into the feature as tags.
+     */
+    public static void addMapToFeature(VectorTile.Tile.Feature.Builder feature, MvtLayerProps layerProps, Map<?, ?> map) {
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getValue() != null) {
+                addPropertyToFeature(feature, layerProps, entry.getKey().toString(), entry.getValue());
+            }
+        }
+    }
+
+    /**
      * Adds the provided key / value pair into the feature as tags.
      */
     public static void addPropertyToFeature(VectorTile.Tile.Feature.Builder feature, MvtLayerProps layerProps, String key, Object value) {
         if (value == null) {
             // guard for null values
+            return;
+        }
+        if (value instanceof Map<?, ?> map) {
+            addMapToFeature(feature, layerProps, map);
             return;
         }
         if (value instanceof Byte || value instanceof Short) {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
@@ -57,17 +57,6 @@ class VectorTileUtils {
     }
 
     /**
-     * Adds the provided map into the feature as tags.
-     */
-    public static void addMapToFeature(VectorTile.Tile.Feature.Builder feature, MvtLayerProps layerProps, Map<?, ?> map) {
-        for (Map.Entry<?, ?> entry : map.entrySet()) {
-            if (entry.getValue() != null) {
-                addPropertyToFeature(feature, layerProps, entry.getKey().toString(), entry.getValue());
-            }
-        }
-    }
-
-    /**
      * Adds the provided key / value pair into the feature as tags.
      */
     public static void addPropertyToFeature(VectorTile.Tile.Feature.Builder feature, MvtLayerProps layerProps, String key, Object value) {
@@ -76,7 +65,7 @@ class VectorTileUtils {
             return;
         }
         if (value instanceof Map<?, ?> map) {
-            addMapToFeature(feature, layerProps, map);
+            // maps should have been flattened already in Maps#flatten but still contains the original maps
             return;
         }
         if (value instanceof Byte || value instanceof Short) {

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
@@ -46,7 +46,7 @@ public class VectorTileUtilTests extends ESTestCase {
         // string
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "string", "7");
         assertPropertyToFeature(layerProps, featureBuilder, 8);
-        // map are ignored
+        // maps are ignored
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "parent", Map.of("child", "8"));
         assertPropertyToFeature(layerProps, featureBuilder, 8);
         // invalid

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
@@ -46,9 +46,9 @@ public class VectorTileUtilTests extends ESTestCase {
         // string
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "string", "7");
         assertPropertyToFeature(layerProps, featureBuilder, 8);
-        // map
+        // map are ignored
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "parent", Map.of("child", "8"));
-        assertPropertyToFeature(layerProps, featureBuilder, 9);
+        assertPropertyToFeature(layerProps, featureBuilder, 8);
         // invalid
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
@@ -12,6 +12,7 @@ import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Map;
 import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.containsString;
@@ -45,6 +46,9 @@ public class VectorTileUtilTests extends ESTestCase {
         // string
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "string", "7");
         assertPropertyToFeature(layerProps, featureBuilder, 8);
+        // map
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "parent", Map.of("child", "8"));
+        assertPropertyToFeature(layerProps, featureBuilder, 9);
         // invalid
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/97619, we make stricter the parsing of the query result and we throw an error when we cannot add part of the result to the vector tile. This had an undesirable side effect because the flattened method used to generate tags for the vector tile keeps the original maps. 

This PR adds the logic to be able to ignore map objects when adding properties to the tile

fixes https://github.com/elastic/elasticsearch/issues/98730