### PR TITLE
[DOCS] mention closed indices are included by default for snapshot

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -78,7 +78,7 @@ match data streams and indices. Supports comma-separated values, such as
 `open,hidden`. Defaults to `all`. Valid values are:
 
 `all`:::
-Match any data stream or index, including <<multi-hidden,hidden>> ones.
+Match any data stream or index, including closed and <<multi-hidden,hidden>> ones.
 
 `open`:::
 Match open indices and data streams.


### PR DESCRIPTION
Minor addition to note that closed indices are also included by default.