### PR TITLE
[8.10] Fix mvt error when returning partial results (#98765)

### DIFF
--- a/docs/changelog/98765.yaml
+++ b/docs/changelog/98765.yaml
@@ -1,0 +1,6 @@
+pr: 98765
+summary: Fix mvt error when returning partial results
+area: Geo
+type: bug
+issues:
+ - 98730

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
@@ -64,6 +64,10 @@ class VectorTileUtils {
             // guard for null values
             return;
         }
+        if (value instanceof Map<?, ?> map) {
+            // maps should have been flattened already in Maps#flatten but still contains the original maps
+            return;
+        }
         if (value instanceof Byte || value instanceof Short) {
             // mvt does not support byte and short data types
             value = ((Number) value).intValue();

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
@@ -12,6 +12,7 @@ import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Map;
 import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.containsString;
@@ -44,6 +45,9 @@ public class VectorTileUtilTests extends ESTestCase {
         assertPropertyToFeature(layerProps, featureBuilder, 7);
         // string
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "string", "7");
+        assertPropertyToFeature(layerProps, featureBuilder, 8);
+        // maps are ignored
+        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "parent", Map.of("child", "8"));
         assertPropertyToFeature(layerProps, featureBuilder, 8);
         // invalid
         IllegalArgumentException ex = expectThrows(


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix mvt error when returning partial results (#98765)