### PR TITLE
Mute AsyncStatusResponseTests.testGetStatusFromStoredSearchWithNonEmptyClustersStillRunning

### DIFF
--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -400,6 +400,7 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         assertEquals(successfulClusters, statusFromStoredSearch.getClusters().getSuccessful());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98706")
     public void testGetStatusFromStoredSearchWithNonEmptyClustersStillRunning() {
         String searchId = randomSearchId();
 


### PR DESCRIPTION
Mute test failing #98706