### PR TITLE
[8.10] Add request header size limit for RCS transport connections (#98692)

### DIFF
--- a/docs/changelog/98692.yaml
+++ b/docs/changelog/98692.yaml
@@ -1,0 +1,5 @@
+pr: 98692
+summary: Add request header size limit for RCS transport connections
+area: Network
+type: enhancement
+issues: []

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageInboundHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageInboundHandler.java
@@ -11,17 +11,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
-import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.InboundPipeline;
-import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.Transports;
 
 /**
@@ -34,19 +30,9 @@ public class Netty4MessageInboundHandler extends ChannelInboundHandlerAdapter {
 
     private final InboundPipeline pipeline;
 
-    public Netty4MessageInboundHandler(Netty4Transport transport, Recycler<BytesRef> recycler) {
+    public Netty4MessageInboundHandler(Netty4Transport transport, InboundPipeline inboundPipeline) {
         this.transport = transport;
-        final ThreadPool threadPool = transport.getThreadPool();
-        final Transport.RequestHandlers requestHandlers = transport.getRequestHandlers();
-        this.pipeline = new InboundPipeline(
-            transport.getStatsTracker(),
-            recycler,
-            threadPool::relativeTimeInMillis,
-            transport.getInflightBreaker(),
-            requestHandlers::getHandler,
-            transport::inboundMessage,
-            transport.ignoreDeserializationErrors()
-        );
+        this.pipeline = inboundPipeline;
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -43,6 +43,9 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.InboundAggregator;
+import org.elasticsearch.transport.InboundDecoder;
+import org.elasticsearch.transport.InboundPipeline;
 import org.elasticsearch.transport.NetworkTraceFlag;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportSettings;
@@ -55,6 +58,8 @@ import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
 import static org.elasticsearch.common.settings.Setting.intSetting;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUSTER_PROFILE;
+import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED;
 
 /**
  * There are 4 types of connections per node, low/med/high/ping. Low if for batch oriented APIs (like recovery or
@@ -100,6 +105,7 @@ public class Netty4Transport extends TcpTransport {
     private final Map<String, ServerBootstrap> serverBootstraps = newConcurrentMap();
     private volatile Bootstrap clientBootstrap;
     private volatile SharedGroupFactory.SharedGroup sharedGroup;
+    protected final boolean remoteClusterPortEnabled;
 
     public Netty4Transport(
         Settings settings,
@@ -128,6 +134,7 @@ public class Netty4Transport extends TcpTransport {
                 (int) receivePredictorMax.getBytes()
             );
         }
+        this.remoteClusterPortEnabled = REMOTE_CLUSTER_SERVER_ENABLED.get(settings);
     }
 
     @Override
@@ -331,7 +338,7 @@ public class Netty4Transport extends TcpTransport {
             addClosedExceptionLogger(ch);
             assert ch instanceof Netty4NioSocketChannel;
             NetUtils.tryEnsureReasonableKeepAliveConfig(((Netty4NioSocketChannel) ch).javaChannel());
-            setupPipeline(ch);
+            setupPipeline(ch, false);
         }
 
         @Override
@@ -344,9 +351,11 @@ public class Netty4Transport extends TcpTransport {
     protected class ServerChannelInitializer extends ChannelInitializer<Channel> {
 
         protected final String name;
+        private final boolean isRemoteClusterServerChannel;
 
         protected ServerChannelInitializer(String name) {
             this.name = name;
+            this.isRemoteClusterServerChannel = remoteClusterPortEnabled && REMOTE_CLUSTER_PROFILE.equals(name);
         }
 
         @Override
@@ -356,7 +365,7 @@ public class Netty4Transport extends TcpTransport {
             NetUtils.tryEnsureReasonableKeepAliveConfig(((Netty4NioSocketChannel) ch).javaChannel());
             Netty4TcpChannel nettyTcpChannel = new Netty4TcpChannel(ch, true, name, rstOnClose, ch.newSucceededFuture());
             ch.attr(CHANNEL_KEY).set(nettyTcpChannel);
-            setupPipeline(ch);
+            setupPipeline(ch, isRemoteClusterServerChannel);
             serverAcceptedChannel(nettyTcpChannel);
         }
 
@@ -367,14 +376,24 @@ public class Netty4Transport extends TcpTransport {
         }
     }
 
-    private void setupPipeline(Channel ch) {
+    private void setupPipeline(Channel ch, boolean isRemoteClusterServerChannel) {
         final var pipeline = ch.pipeline();
         pipeline.addLast("byte_buf_sizer", NettyByteBufSizer.INSTANCE);
         if (NetworkTraceFlag.TRACE_ENABLED) {
             pipeline.addLast("logging", ESLoggingHandler.INSTANCE);
         }
         pipeline.addLast("chunked_writer", new Netty4WriteThrottlingHandler(getThreadPool().getThreadContext()));
-        pipeline.addLast("dispatcher", new Netty4MessageInboundHandler(this, recycler));
+        pipeline.addLast("dispatcher", new Netty4MessageInboundHandler(this, getInboundPipeline(isRemoteClusterServerChannel)));
+    }
+
+    protected InboundPipeline getInboundPipeline(boolean isRemoteClusterServerChannel) {
+        return new InboundPipeline(
+            getStatsTracker(),
+            threadPool::relativeTimeInMillis,
+            new InboundDecoder(recycler),
+            new InboundAggregator(getInflightBreaker(), getRequestHandlers()::getHandler, ignoreDeserializationErrors()),
+            this::inboundMessage
+        );
     }
 
     private static void addClosedExceptionLogger(Channel channel) {

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -569,6 +569,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         RemoteClusterPortSettings.TCP_NO_DELAY,
         RemoteClusterPortSettings.TCP_REUSE_ADDRESS,
         RemoteClusterPortSettings.TCP_SEND_BUFFER_SIZE,
+        RemoteClusterPortSettings.MAX_REQUEST_HEADER_SIZE,
         HealthPeriodicLogger.POLL_INTERVAL_SETTING,
         HealthPeriodicLogger.ENABLED_SETTING,
         DataStreamLifecycle.isFeatureEnabled() ? DataStreamLifecycle.CLUSTER_LIFECYCLE_DEFAULT_ROLLOVER_SETTING : null,

--- a/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
@@ -14,10 +14,13 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
+import java.io.StreamCorruptedException;
 import java.util.function.Consumer;
 
 public class InboundDecoder implements Releasable {
@@ -31,9 +34,15 @@ public class InboundDecoder implements Releasable {
     private int bytesConsumed = 0;
     private boolean isCompressed = false;
     private boolean isClosed = false;
+    private final ByteSizeValue maxHeaderSize;
 
     public InboundDecoder(Recycler<BytesRef> recycler) {
+        this(recycler, new ByteSizeValue(2, ByteSizeUnit.GB));
+    }
+
+    public InboundDecoder(Recycler<BytesRef> recycler, ByteSizeValue maxHeaderSize) {
         this.recycler = recycler;
+        this.maxHeaderSize = maxHeaderSize;
     }
 
     public int decode(ReleasableBytesReference reference, Consumer<Object> fragmentConsumer) throws IOException {
@@ -55,7 +64,7 @@ public class InboundDecoder implements Releasable {
                 fragmentConsumer.accept(PING);
                 return 6;
             } else {
-                int headerBytesToRead = headerBytesToRead(reference);
+                int headerBytesToRead = headerBytesToRead(reference, maxHeaderSize);
                 if (headerBytesToRead == 0) {
                     return 0;
                 } else {
@@ -147,7 +156,7 @@ public class InboundDecoder implements Releasable {
         return bytesConsumed == totalNetworkSize;
     }
 
-    private static int headerBytesToRead(BytesReference reference) {
+    private static int headerBytesToRead(BytesReference reference, ByteSizeValue maxHeaderSize) throws StreamCorruptedException {
         if (reference.length() < TcpHeader.BYTES_REQUIRED_FOR_VERSION) {
             return 0;
         }
@@ -160,6 +169,14 @@ public class InboundDecoder implements Releasable {
             return fixedHeaderSize;
         } else {
             int variableHeaderSize = reference.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
+            if (variableHeaderSize < 0) {
+                throw new StreamCorruptedException("invalid negative variable header size: " + variableHeaderSize);
+            }
+            if (variableHeaderSize > maxHeaderSize.getBytes() - fixedHeaderSize) {
+                throw new StreamCorruptedException(
+                    "header size [" + (fixedHeaderSize + variableHeaderSize) + "] exceeds limit of [" + maxHeaderSize + "]"
+                );
+            }
             int totalHeaderSize = fixedHeaderSize + variableHeaderSize;
             if (totalHeaderSize > reference.length()) {
                 return 0;

--- a/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
@@ -8,11 +8,8 @@
 
 package org.elasticsearch.transport;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
-import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
@@ -20,9 +17,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
-import java.util.function.Supplier;
 
 public class InboundPipeline implements Releasable {
 
@@ -37,24 +32,6 @@ public class InboundPipeline implements Releasable {
     private Exception uncaughtException;
     private final ArrayDeque<ReleasableBytesReference> pending = new ArrayDeque<>(2);
     private boolean isClosed = false;
-
-    public InboundPipeline(
-        StatsTracker statsTracker,
-        Recycler<BytesRef> recycler,
-        LongSupplier relativeTimeInMillis,
-        Supplier<CircuitBreaker> circuitBreaker,
-        Function<String, RequestHandlerRegistry<TransportRequest>> registryFunction,
-        BiConsumer<TcpChannel, InboundMessage> messageHandler,
-        boolean ignoreDeserializationErrors
-    ) {
-        this(
-            statsTracker,
-            relativeTimeInMillis,
-            new InboundDecoder(recycler),
-            new InboundAggregator(circuitBreaker, registryFunction, ignoreDeserializationErrors),
-            messageHandler
-        );
-    }
 
     public InboundPipeline(
         StatsTracker statsTracker,

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterPortSettings.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterPortSettings.java
@@ -11,6 +11,7 @@ package org.elasticsearch.transport;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.util.List;
@@ -127,6 +128,14 @@ public class RemoteClusterPortSettings {
     public static final Setting<ByteSizeValue> TCP_RECEIVE_BUFFER_SIZE = Setting.byteSizeSetting(
         REMOTE_CLUSTER_PREFIX + "tcp.receive_buffer_size",
         TransportSettings.TCP_RECEIVE_BUFFER_SIZE,
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<ByteSizeValue> MAX_REQUEST_HEADER_SIZE = Setting.byteSizeSetting(
+        REMOTE_CLUSTER_PREFIX + "max_request_header_size",
+        new ByteSizeValue(64, ByteSizeUnit.KB), // should cover typical querying user/key authn serialized to the fulfilling cluster
+        new ByteSizeValue(64, ByteSizeUnit.BYTES), // toBytes must be higher than fixed header length
+        new ByteSizeValue(2, ByteSizeUnit.GB), // toBytes must be lower than INT_MAX (>2 GB)
         Setting.Property.NodeScope
     );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HeaderSizeLimitTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HeaderSizeLimitTests.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.transport.netty4;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.mocksocket.MockSocket;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.tracing.Tracer;
+import org.elasticsearch.transport.RemoteClusterPortSettings;
+import org.elasticsearch.transport.RequestHandlerRegistry;
+import org.elasticsearch.transport.TcpHeader;
+import org.elasticsearch.transport.TestRequest;
+import org.elasticsearch.transport.TransportMessageListener;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.netty4.SharedGroupFactory;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.elasticsearch.transport.AbstractSimpleTransportTestCase.IGNORE_DESERIALIZATION_ERRORS_SETTING;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests that request header size limits are enforced (connection dropped) for the RCS transport port (because this port can
+ * possibly be exposed without TLS protection)
+ */
+public final class SecurityNetty4HeaderSizeLimitTests extends ESTestCase {
+
+    private final int maxHeaderSize = randomIntBetween(64, 128);
+    private final BigArrays bigarrays = new BigArrays(null, new NoneCircuitBreakerService(), CircuitBreaker.REQUEST);
+    private final Settings settings = Settings.builder()
+        .put("node.name", "SecurityNetty4HeaderSizeLimitTests")
+        .put(RemoteClusterPortSettings.MAX_REQUEST_HEADER_SIZE.getKey(), maxHeaderSize + "b")
+        .put(XPackSettings.TRANSPORT_SSL_ENABLED.getKey(), "false")
+        .put(XPackSettings.REMOTE_CLUSTER_SERVER_SSL_ENABLED.getKey(), "false")
+        .put(XPackSettings.REMOTE_CLUSTER_CLIENT_SSL_ENABLED.getKey(), "false")
+        .put(RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED.getKey(), "true")
+        .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), "true")
+        .build();
+    private ThreadPool threadPool;
+    private SecurityNetty4ServerTransport securityNettyTransport;
+    private int remoteIngressPort;
+    private InetAddress remoteIngressHost;
+    private int defaultTransportPort;
+    private InetAddress defaultTransportHost;
+    private AtomicLong requestIdReceived;
+
+    @Before
+    public void startThreadPool() {
+        threadPool = new ThreadPool(settings);
+        TaskManager taskManager = new TaskManager(settings, threadPool, Collections.emptySet());
+        NetworkService networkService = new NetworkService(Collections.emptyList());
+        PageCacheRecycler recycler = new MockPageCacheRecycler(Settings.EMPTY);
+        securityNettyTransport = new SecurityNetty4ServerTransport(
+            settings,
+            TransportVersion.current(),
+            threadPool,
+            networkService,
+            recycler,
+            new NamedWriteableRegistry(Collections.emptyList()),
+            new NoneCircuitBreakerService(),
+            null,
+            mock(SSLService.class),
+            new SharedGroupFactory(settings)
+        );
+        requestIdReceived = new AtomicLong(-1L);
+        securityNettyTransport.setMessageListener(new TransportMessageListener() {
+            @Override
+            public void onRequestReceived(long requestId, String action) {
+                requestIdReceived.set(requestId);
+            }
+        });
+        securityNettyTransport.registerRequestHandler(
+            new RequestHandlerRegistry<>(
+                "internal:test",
+                TestRequest::new,
+                taskManager,
+                (request, channel, task) -> channel.sendResponse(TransportResponse.Empty.INSTANCE),
+                ThreadPool.Names.SAME,
+                false,
+                true,
+                Tracer.NOOP
+            )
+        );
+        securityNettyTransport.start();
+
+        TransportAddress[] boundRemoteIngressAddresses = securityNettyTransport.boundRemoteIngressAddress().boundAddresses();
+        TransportAddress remoteIngressTransportAddress = randomFrom(boundRemoteIngressAddresses);
+        remoteIngressPort = remoteIngressTransportAddress.address().getPort();
+        remoteIngressHost = remoteIngressTransportAddress.address().getAddress();
+
+        TransportAddress[] boundAddresses = securityNettyTransport.boundAddress().boundAddresses();
+        TransportAddress transportAddress = randomFrom(boundAddresses);
+        defaultTransportPort = transportAddress.address().getPort();
+        defaultTransportHost = transportAddress.address().getAddress();
+    }
+
+    @After
+    public void terminateThreadPool() {
+        securityNettyTransport.stop();
+        terminate(threadPool);
+        threadPool = null;
+    }
+
+    public void testThatAcceptableHeaderSizeGoesThroughTheRemoteClusterPort() throws Exception {
+        int messageLength = randomIntBetween(128, 256);
+        long requestId = randomLongBetween(1L, 1000L);
+        int acceptableHeaderSize = randomIntBetween(0, maxHeaderSize - TcpHeader.headerSize(TransportVersion.current()));
+        try (
+            ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(
+                messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE,
+                bigarrays
+            )
+        ) {
+            assembleDummyRequest(out, messageLength, requestId, acceptableHeaderSize);
+
+            try (Socket socket = new MockSocket(remoteIngressHost, remoteIngressPort)) {
+                socket.getOutputStream().write(out.bytes().array());
+                socket.getOutputStream().flush();
+
+                // an error response is returned because the request is malformed
+                assertThat(socket.getInputStream().read(), greaterThan(0));
+                // but the request has been certainly received and processed
+                assertThat(requestIdReceived.get(), is(requestId));
+            }
+        }
+    }
+
+    public void testThatLargerHeaderSizeClosesTheRemoteClusterPort() throws Exception {
+        int messageLength = randomIntBetween(128, 256);
+        long requestId = randomLongBetween(1L, 1000L);
+        int largeHeaderSize = randomIntBetween(
+            maxHeaderSize - TcpHeader.headerSize(TransportVersion.current()) + 1,
+            messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.headerSize(TransportVersion.current())
+        );
+        try (
+            ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(
+                messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE,
+                bigarrays
+            )
+        ) {
+            assembleDummyRequest(out, messageLength, requestId, largeHeaderSize);
+
+            try (Socket socket = new MockSocket(remoteIngressHost, remoteIngressPort)) {
+                socket.getOutputStream().write(out.bytes().array());
+                socket.getOutputStream().flush();
+
+                // channel is closed
+                assertThat(socket.getInputStream().read(), is(-1));
+                // and a request has NOT been received
+                assertThat(requestIdReceived.get(), is(-1L));
+            }
+        }
+    }
+
+    public void testThatLargerHeaderSizeIsAcceptableForDefaultTransportPort() throws Exception {
+        int messageLength = randomIntBetween(128, 256);
+        long requestId = randomLongBetween(1L, 1000L);
+        int largeHeaderSize = randomIntBetween(
+            maxHeaderSize - TcpHeader.headerSize(TransportVersion.current()) + 1,
+            messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.headerSize(TransportVersion.current())
+        );
+        try (
+            ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(
+                messageLength + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE,
+                bigarrays
+            )
+        ) {
+            assembleDummyRequest(out, messageLength, requestId, largeHeaderSize);
+
+            try (Socket socket = new MockSocket(defaultTransportHost, defaultTransportPort)) {
+                socket.getOutputStream().write(out.bytes().array());
+                socket.getOutputStream().flush();
+
+                // an error response is returned because the request is malformed
+                assertThat(socket.getInputStream().read(), greaterThan(0));
+                // but the request has been certainly received and processed
+                assertThat(requestIdReceived.get(), is(requestId));
+            }
+        }
+    }
+
+    private void assembleDummyRequest(BytesStreamOutput out, int messageLength, long requestId, int variableHeaderSize) throws IOException {
+        out.writeByte((byte) 'E');
+        out.writeByte((byte) 'S');
+        out.writeInt(messageLength); // message length must not be higher than the bytes array length that's sent on the socket
+        out.writeLong(requestId); // request id
+        out.writeByte((byte) 0); // status byte (request)
+        out.writeInt(TransportVersion.current().id());
+        out.writeInt(variableHeaderSize); // variable header size
+        out.writeMap(Map.of()); // request headers
+        out.writeMap(Map.of()); // response headers
+        out.writeString("internal:test"); // action name in header
+        out.writeVInt(-1); // make sure request is malformed (it's also possibly malformed for other reasons)
+    }
+}


### PR DESCRIPTION
Add and enforce request header size limits for the transport port of RCS 2.0 connections.

Backport of: https://github.com/elastic/elasticsearch/pull/98692

Co-authored-by: Yang Wang ywangd@gmail.com
