### PR TITLE
Don't wrap the IndexSearcher in AbstractNumberNestedSortingTestCase 

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
@@ -47,7 +47,6 @@ public abstract class AbstractNumberNestedSortingTestCase extends AbstractFieldD
         return true;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98789")
     public void testNestedSorting() throws Exception {
         List<Document> docs = new ArrayList<>();
         Document document = new Document();

--- a/server/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
@@ -207,7 +207,7 @@ public abstract class AbstractNumberNestedSortingTestCase extends AbstractFieldD
         MultiValueMode sortMode = MultiValueMode.SUM;
         DirectoryReader directoryReader = DirectoryReader.open(writer);
         directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(indexService.index(), 0));
-        IndexSearcher searcher = newSearcher(directoryReader);
+        IndexSearcher searcher = newSearcher(directoryReader, false);
         Query parentFilter = new TermQuery(new Term("__type", "parent"));
         Query childFilter = Queries.not(parentFilter);
         XFieldComparatorSource nestedComparatorSource = createFieldComparator(


### PR DESCRIPTION
another failure if this sage, we need to prevent wrapping of the Index reader.

fixes https://github.com/elastic/elasticsearch/issues/98789