### PR TITLE
Resolve java toolchains when prefilling gradle cache

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -52,7 +52,7 @@ public abstract class ResolveAllDependencies extends DefaultTask {
 
     @TaskAction
     void resolveAll() {
-        if(resolveJavaToolChain) {
+        if (resolveJavaToolChain) {
             resolveDefaultJavaToolChain();
         }
     }
@@ -62,10 +62,8 @@ public abstract class ResolveAllDependencies extends DefaultTask {
             String bundledVendor = VersionProperties.getBundledJdkVendor();
             String bundledJdkMajorVersion = VersionProperties.getBundledJdkMajorVersion();
             javaToolchainSpec.getLanguageVersion().set(JavaLanguageVersion.of(bundledJdkMajorVersion));
-                javaToolchainSpec.getVendor().set(
-                    bundledVendor.equals("openjdk") ?
-                JvmVendorSpec.ORACLE :
-                JvmVendorSpec.matching(bundledVendor));
+            javaToolchainSpec.getVendor()
+                .set(bundledVendor.equals("openjdk") ? JvmVendorSpec.ORACLE : JvmVendorSpec.matching(bundledVendor));
         }).get();
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal;
 
+import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
@@ -15,6 +16,9 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -24,7 +28,12 @@ import javax.inject.Inject;
 import static org.elasticsearch.gradle.DistributionDownloadPlugin.DISTRO_EXTRACTED_CONFIG_PREFIX;
 import static org.elasticsearch.gradle.internal.test.rest.compat.compat.LegacyYamlRestCompatTestPlugin.BWC_MINOR_CONFIG_NAME;
 
-public class ResolveAllDependencies extends DefaultTask {
+public abstract class ResolveAllDependencies extends DefaultTask {
+
+    private boolean resolveJavaToolChain = false;
+
+    @Inject
+    protected abstract JavaToolchainService getJavaToolchainService();
 
     private final ObjectFactory objectFactory;
 
@@ -43,7 +52,21 @@ public class ResolveAllDependencies extends DefaultTask {
 
     @TaskAction
     void resolveAll() {
-        // do nothing, dependencies are resolved when snapshotting task inputs
+        if(resolveJavaToolChain) {
+            resolveDefaultJavaToolChain();
+        }
+    }
+
+    private void resolveDefaultJavaToolChain() {
+        getJavaToolchainService().launcherFor(javaToolchainSpec -> {
+            String bundledVendor = VersionProperties.getBundledJdkVendor();
+            String bundledJdkMajorVersion = VersionProperties.getBundledJdkMajorVersion();
+            javaToolchainSpec.getLanguageVersion().set(JavaLanguageVersion.of(bundledJdkMajorVersion));
+                javaToolchainSpec.getVendor().set(
+                    bundledVendor.equals("openjdk") ?
+                JvmVendorSpec.ORACLE :
+                JvmVendorSpec.matching(bundledVendor));
+        }).get();
     }
 
     @Internal
@@ -53,6 +76,15 @@ public class ResolveAllDependencies extends DefaultTask {
 
     public void setConfigs(Collection<Configuration> configs) {
         this.configs = configs;
+    }
+
+    @Internal
+    public boolean isResolveJavaToolChain() {
+        return resolveJavaToolChain;
+    }
+
+    public void setResolveJavaToolChain(boolean resolveJavaToolChain) {
+        this.resolveJavaToolChain = resolveJavaToolChain;
     }
 
     private static boolean canBeResolved(Configuration configuration) {
@@ -67,4 +99,5 @@ public class ResolveAllDependencies extends DefaultTask {
         return configuration.getName().startsWith(DISTRO_EXTRACTED_CONFIG_PREFIX) == false
             && configuration.getName().equals(BWC_MINOR_CONFIG_NAME) == false;
     }
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,7 @@ allprojects {
 
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     configs = project.configurations
+    resolveJavaToolChain = true
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }


### PR DESCRIPTION
As part of creating our ci images we prefill gradle caches to reduce build times. As part of that we now
also cache the java toolchain we resolve using the gradle toolchain provider.
This should reduce build failure caused by connection issues in our ci runs.