### PR TITLE
Avoiding the use of nodes that are no longer in the cluster when computing master stability

### DIFF
--- a/docs/changelog/98809.yaml
+++ b/docs/changelog/98809.yaml
@@ -1,0 +1,7 @@
+pr: 98809
+summary: Avoiding the use of nodes that are no longer in the cluster when computing
+  master stability
+area: Health
+type: enhancement
+issues:
+ - 98636

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryAction.java
@@ -135,7 +135,7 @@ public class MasterHistoryAction extends ActionType<MasterHistoryAction.Response
 
         @Override
         protected void doExecute(Task task, MasterHistoryAction.Request request, ActionListener<Response> listener) {
-            listener.onResponse(new MasterHistoryAction.Response(masterHistoryService.getLocalMasterHistory().getNodes()));
+            listener.onResponse(new MasterHistoryAction.Response(masterHistoryService.getLocalMasterHistory().getRawNodes()));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
@@ -21,8 +21,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 /**
  * This class represents a node's view of the history of which nodes have been elected master over the last 30 minutes. It is kept in
@@ -34,6 +36,7 @@ public class MasterHistory implements ClusterStateListener {
      * The maximum amount of time that the master history covers.
      */
     private final TimeValue maxHistoryAge;
+    private final ClusterService clusterService;
     // Note: While the master can be null, the TimeAndMaster object in this list is never null
     private volatile List<TimeAndMaster> masterHistory;
     private final LongSupplier currentTimeMillisSupplier;
@@ -57,6 +60,7 @@ public class MasterHistory implements ClusterStateListener {
         this.masterHistory = new ArrayList<>();
         this.currentTimeMillisSupplier = threadPool::relativeTimeInMillis;
         this.maxHistoryAge = MAX_HISTORY_AGE_SETTING.get(clusterService.getSettings());
+        this.clusterService = clusterService;
         clusterService.addListener(this);
     }
 
@@ -118,10 +122,10 @@ public class MasterHistory implements ClusterStateListener {
     }
 
     /**
-     * Returns true if for the life of this MasterHistory (30 minutes) non-null masters have transitioned to null n times.
-     * @param n The number of times a non-null master must have switched to null
-     * @return True if non-null masters have transitioned to null n or more times.
-     */
+       * Returns true if for the life of this MasterHistory (30 minutes) non-null masters have transitioned to null n times.
+       * @param n The number of times a non-null master must have switched to null
+       * @return True if non-null masters have transitioned to null n or more times.
+       */
     public boolean hasMasterGoneNullAtLeastNTimes(int n) {
         return hasMasterGoneNullAtLeastNTimes(getNodes(), n);
     }
@@ -247,12 +251,34 @@ public class MasterHistory implements ClusterStateListener {
     /**
      * This method returns an immutable view of this master history, typically for sending over the wire to another node. The returned List
      * is ordered by when the master was seen, with the earliest-seen masters being first. The List can contain null values. Times are
-     * intentionally not included because they cannot be compared across machines.
+     * intentionally not included because they cannot be compared across machines. This list contains nodes even if they are not currently
+     * in the cluster.
      * @return An immutable view of this master history
      */
-    public List<DiscoveryNode> getNodes() {
+    public List<DiscoveryNode> getRawNodes() {
         List<TimeAndMaster> masterHistoryCopy = getRecentMasterHistory(masterHistory);
         return masterHistoryCopy.stream().map(TimeAndMaster::master).toList();
+    }
+
+    /*
+     * This method is similar to getRawNodes(), except any non-null nodes whose ephemeral IDs are not in the nodes in the cluster
+     * state are removed. This is meant to be used to filter out nodes from the master history that are no longer part of the cluster. We
+     * need to keep these nodes in the master history in case they return to the cluster, but we do not want them to count toward our
+     * stability calculations.
+     */
+    public List<DiscoveryNode> getNodes() {
+        List<DiscoveryNode> nodes = getRawNodes();
+        if (nodes == null || nodes.isEmpty()) {
+            return nodes;
+        }
+        Set<String> ephemeralIdsCurrentlyInCluster = clusterService.state()
+            .nodes()
+            .stream()
+            .map(DiscoveryNode::getEphemeralId)
+            .collect(Collectors.toSet());
+        return nodes.stream()
+            .filter(node -> node == null || ephemeralIdsCurrentlyInCluster.contains(node.getEphemeralId()))
+            .collect(Collectors.toList());
     }
 
     private record TimeAndMaster(long startTimeMillis, DiscoveryNode master) {}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
@@ -122,10 +122,10 @@ public class MasterHistory implements ClusterStateListener {
     }
 
     /**
-      * Returns true if for the life of this MasterHistory (30 minutes) non-null masters have transitioned to null n times.
-      * @param n The number of times a non-null master must have switched to null
-      * @return True if non-null masters have transitioned to null n or more times.
-      */
+     * Returns true if for the life of this MasterHistory (30 minutes) non-null masters have transitioned to null n times.
+     * @param n The number of times a non-null master must have switched to null
+     * @return True if non-null masters have transitioned to null n or more times.
+     */
     public boolean hasMasterGoneNullAtLeastNTimes(int n) {
         return hasMasterGoneNullAtLeastNTimes(getNodes(), n);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
@@ -122,10 +122,10 @@ public class MasterHistory implements ClusterStateListener {
     }
 
     /**
-       * Returns true if for the life of this MasterHistory (30 minutes) non-null masters have transitioned to null n times.
-       * @param n The number of times a non-null master must have switched to null
-       * @return True if non-null masters have transitioned to null n or more times.
-       */
+      * Returns true if for the life of this MasterHistory (30 minutes) non-null masters have transitioned to null n times.
+      * @param n The number of times a non-null master must have switched to null
+      * @return True if non-null masters have transitioned to null n or more times.
+      */
     public boolean hasMasterGoneNullAtLeastNTimes(int n) {
         return hasMasterGoneNullAtLeastNTimes(getNodes(), n);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.coordination.AbstractCoordinatorTestCase.Cluster.EXTREME_DELAY_VARIABILITY;
@@ -77,64 +79,76 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
         node1 = DiscoveryNodeUtils.create("node1", randomNodeId());
         node2 = DiscoveryNodeUtils.create("node2", randomNodeId());
         node3 = DiscoveryNodeUtils.create("node3", randomNodeId());
-        nullMasterClusterState = createClusterState(null);
-        node1MasterClusterState = createClusterState(node1);
-        node2MasterClusterState = createClusterState(node2);
-        node3MasterClusterState = createClusterState(node3);
+        nullMasterClusterState = createClusterState(null, node1, node2, node3);
+        node1MasterClusterState = createClusterState(node1, node2, node3);
+        node2MasterClusterState = createClusterState(node2, node1, node3);
+        node3MasterClusterState = createClusterState(node3, node1, node2);
     }
 
     @SuppressWarnings("unchecked")
     public void testMoreThanThreeMasterChanges() throws Exception {
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
+        AtomicReference<ClusterState> currentClusterState = new AtomicReference<>(nullMasterClusterState);
+        ClusterService clusterService = createClusterService(currentClusterState::get);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
-        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(nullMasterClusterState, masterHistoryService);
+        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(clusterService, masterHistoryService);
         // First master:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
+        currentClusterState.set(node1MasterClusterState);
         CoordinationDiagnosticsService.CoordinationDiagnosticsResult result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Null, so not counted:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
+        currentClusterState.set(nullMasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Change 1:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node2MasterClusterState, nullMasterClusterState));
+        currentClusterState.set(node2MasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Null, so not counted:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node2MasterClusterState));
+        currentClusterState.set(nullMasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Change 2:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
+        currentClusterState.set(node1MasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Null, so not counted:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
+        currentClusterState.set(nullMasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Change 3:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node3MasterClusterState, nullMasterClusterState));
+        currentClusterState.set(node3MasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Null, so not counted:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node3MasterClusterState));
+        currentClusterState.set(nullMasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Still node 3, so no change:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node3MasterClusterState, nullMasterClusterState));
+        currentClusterState.set(node3MasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.GREEN));
 
         // Change 4:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node2MasterClusterState, node3MasterClusterState));
+        currentClusterState.set(node2MasterClusterState);
         result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.YELLOW));
         assertThat(result.summary(), equalTo("The elected master node has changed 4 times in the last 30m"));
@@ -146,6 +160,11 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
             assertThat(recentMaster.getName(), not(emptyOrNullString()));
             assertThat(recentMaster.getId(), not(emptyOrNullString()));
         }
+
+        // Now make sure that if a node is not in the cluster state it does not count against us:
+        currentClusterState.set(createClusterState(node2, node1));
+        result = service.diagnoseMasterStability(true);
+        assertThat(result.status(), equalTo(CoordinationDiagnosticsStatus.GREEN));
     }
 
     public void testMasterGoesNull() throws Exception {
@@ -158,9 +177,10 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
          * the local node. So we check the remote history. The remote history sees that the master went to null 4 times, the status is
          * YELLOW.
          */
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
+        ClusterService clusterService = createClusterService(nullMasterClusterState);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
-        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(nullMasterClusterState, masterHistoryService);
+        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(clusterService, masterHistoryService);
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         // Only start counting nulls once the master has been node1, so 1:
@@ -211,10 +231,12 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
          * In this case, the master identity changed 0 times as seen from the local node. The same master went null 4 times as seen from
          * the local node. So we check the remote history. The remote history throws an exception, so the status is YELLOW.
          */
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
+        AtomicReference<ClusterState> currentClusterState = new AtomicReference<>(nullMasterClusterState);
+        ClusterService clusterService = createClusterService(currentClusterState::get);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
+        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(clusterService, masterHistoryService);
         when(masterHistoryService.getRemoteMasterHistory()).thenThrow(new Exception("Failure on master"));
-        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(nullMasterClusterState, masterHistoryService);
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
@@ -231,6 +253,11 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
         CoordinationDiagnosticsService.CoordinationDiagnosticsDetails details = result.details();
         assertThat(details.currentMaster(), equalTo(null));
         assertThat(details.remoteExceptionMessage(), equalTo("Failure on master"));
+
+        // Now make sure that nodes that are not in the cluster don't count against us:
+        currentClusterState.set(createClusterState((DiscoveryNode) null));
+        result = service.diagnoseMasterStability(true);
+        assertThat(result.status(), equalTo(CoordinationDiagnosticsStatus.GREEN));
     }
 
     public void testMasterGoesNullLocallyButRemotelyChangesIdentity() throws Exception {
@@ -244,7 +271,8 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
          * still get a status of YELLOW. (Note: This scenario might not be possible in the real world for a couple of reasons, but it tests
          * edge cases)
          */
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
+        ClusterService clusterService = createClusterService(nullMasterClusterState);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
         List<DiscoveryNode> remoteMasterHistory = new ArrayList<>();
         remoteMasterHistory.add(node1);
@@ -255,7 +283,7 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
         remoteMasterHistory.add(node2);
         remoteMasterHistory.add(node3);
         when(masterHistoryService.getRemoteMasterHistory()).thenReturn(remoteMasterHistory);
-        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(nullMasterClusterState, masterHistoryService);
+        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(clusterService, masterHistoryService);
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
@@ -279,10 +307,11 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
          * check the remote master, and get a status of GREEN. (Note: This scenario is not possible in the real world because we would
          * see null values in between, so it is just here to test an edge case)
          */
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
+        ClusterService clusterService = createClusterService(nullMasterClusterState);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
         when(masterHistoryService.getRemoteMasterHistory()).thenThrow(new RuntimeException("Should never call this"));
-        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(nullMasterClusterState, masterHistoryService);
+        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(clusterService, masterHistoryService);
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, node1MasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, node1MasterClusterState));
@@ -329,9 +358,11 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
          * In this case we detect 2 identity changes (node1 -> node2, and node2 -> node1). We detect that node1 has gone to 5 times. So
          * we get a status of YELLOW.
          */
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
+        AtomicReference<ClusterState> currentClusterState = new AtomicReference<>(nullMasterClusterState);
+        ClusterService clusterService = createClusterService(currentClusterState::get);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
-        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(nullMasterClusterState, masterHistoryService);
+        CoordinationDiagnosticsService service = createCoordinationDiagnosticsService(clusterService, masterHistoryService);
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
@@ -347,6 +378,11 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
         when(masterHistoryService.getRemoteMasterHistory()).thenReturn(remoteHistory);
         CoordinationDiagnosticsService.CoordinationDiagnosticsResult result = service.diagnoseMasterStability(true);
         assertThat(result.status(), equalTo(expectedStatus));
+
+        // Now we make sure that nodes that are no longer in the cluster don't count against us
+        currentClusterState.set(createClusterState(null, node2));
+        result = service.diagnoseMasterStability(true);
+        assertThat(result.status(), equalTo(CoordinationDiagnosticsStatus.GREEN));
     }
 
     public void testGreenForStableCluster() {
@@ -965,10 +1001,8 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
     }
 
     public void testBeginPollingClusterFormationInfo() throws Exception {
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
-        var clusterService = mock(ClusterService.class);
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
-        when(clusterService.state()).thenReturn(nullMasterClusterState);
+        ClusterService clusterService = createClusterService(nullMasterClusterState);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         DiscoveryNode localNode = node3;
         when(clusterService.localNode()).thenReturn(localNode);
         Coordinator coordinator = mock(Coordinator.class);
@@ -1037,15 +1071,12 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
     }
 
     public void testBeginPollingRemoteMasterStabilityDiagnostic() throws Exception {
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
-        var clusterService = mock(ClusterService.class);
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
-        when(clusterService.state()).thenReturn(nullMasterClusterState);
+        ClusterService clusterService = createClusterService(nullMasterClusterState);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         DiscoveryNode localNode = DiscoveryNodeUtils.builder(randomNodeId())
             .name("node4")
             .roles(Set.of(DiscoveryNodeRole.DATA_ROLE))
             .build();
-        when(clusterService.localNode()).thenReturn(localNode);
         Coordinator coordinator = mock(Coordinator.class);
         when(coordinator.getFoundPeers()).thenReturn(List.of(node1, node2, localNode));
         DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
@@ -1128,10 +1159,8 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
     }
 
     public void testRandomMasterEligibleNode() throws Exception {
-        MasterHistoryService masterHistoryService = createMasterHistoryService();
-        ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
-        when(clusterService.state()).thenReturn(nullMasterClusterState);
+        ClusterService clusterService = createClusterService(nullMasterClusterState);
+        MasterHistoryService masterHistoryService = createMasterHistoryService(clusterService);
         when(clusterService.localNode()).thenReturn(node3);
         Coordinator coordinator = mock(Coordinator.class);
         Set<DiscoveryNode> allMasterEligibleNodes = Set.of(node1, node2, node3);
@@ -1314,13 +1343,21 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
         return randomAlphaOfLengthBetween(minCodeUnits, maxCodeUnits);
     }
 
-    private static ClusterState createClusterState(DiscoveryNode masterNode) {
+    /*
+     * If not null, the first node given will be the elected master. If the first entry is null, there will be no elected master.
+     */
+    private static ClusterState createClusterState(DiscoveryNode... nodes) {
         var routingTableBuilder = RoutingTable.builder();
         Metadata.Builder metadataBuilder = Metadata.builder();
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
-        if (masterNode != null) {
-            nodesBuilder.masterNodeId(masterNode.getId());
-            nodesBuilder.add(masterNode);
+        for (int i = 0; i < nodes.length; i++) {
+            DiscoveryNode node = nodes[i];
+            if (node != null) {
+                if (i == 0) {
+                    nodesBuilder.masterNodeId(node.getId());
+                }
+                nodesBuilder.add(node);
+            }
         }
         return ClusterState.builder(new ClusterName("test-cluster"))
             .routingTable(routingTableBuilder.build())
@@ -1337,9 +1374,7 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
      * Creates a mocked MasterHistoryService with a non-mocked local master history (which can be updated with clusterChanged calls). The
      * remote master history is mocked.
      */
-    private static MasterHistoryService createMasterHistoryService() throws Exception {
-        var clusterService = mock(ClusterService.class);
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+    private static MasterHistoryService createMasterHistoryService(ClusterService clusterService) throws Exception {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.relativeTimeInMillis()).thenReturn(System.currentTimeMillis());
         MasterHistory localMasterHistory = new MasterHistory(threadPool, clusterService);
@@ -1351,20 +1386,28 @@ public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTest
     }
 
     private static CoordinationDiagnosticsService createCoordinationDiagnosticsService(
-        ClusterState clusterState,
+        ClusterService clusterService,
         MasterHistoryService masterHistoryService
     ) {
-        var clusterService = mock(ClusterService.class);
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
-        when(clusterService.state()).thenReturn(clusterState);
-        DiscoveryNode localNode = mock(DiscoveryNode.class);
-        when(clusterService.localNode()).thenReturn(localNode);
-        when(localNode.isMasterNode()).thenReturn(false);
         Coordinator coordinator = mock(Coordinator.class);
         when(coordinator.getFoundPeers()).thenReturn(Collections.emptyList());
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
         return new CoordinationDiagnosticsService(clusterService, transportService, coordinator, masterHistoryService);
+    }
+
+    private static ClusterService createClusterService(ClusterState clusterState) {
+        return createClusterService(() -> clusterState);
+    }
+
+    private static ClusterService createClusterService(Supplier<ClusterState> clusterStateSupplier) {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.state()).thenAnswer((Answer<ClusterState>) invocation -> clusterStateSupplier.get());
+        DiscoveryNode localNode = mock(DiscoveryNode.class);
+        when(clusterService.localNode()).thenReturn(localNode);
+        when(localNode.isMasterNode()).thenReturn(false);
+        return clusterService;
     }
 
     private void createAndAddNonMasterNode(Cluster cluster) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
@@ -22,10 +22,11 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
+import org.mockito.stubbing.Answer;
 
-import java.net.UnknownHostException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -34,6 +35,9 @@ import static org.mockito.Mockito.when;
 
 public class MasterHistoryTests extends ESTestCase {
 
+    private DiscoveryNode node1;
+    private DiscoveryNode node2;
+    private DiscoveryNode node3;
     private ClusterState nullMasterClusterState;
     private ClusterState node1MasterClusterState;
     private ClusterState node2MasterClusterState;
@@ -42,13 +46,13 @@ public class MasterHistoryTests extends ESTestCase {
 
     @Before
     public void setup() throws Exception {
-        String node1 = randomNodeId();
-        String node2 = randomNodeId();
-        String node3 = randomNodeId();
-        nullMasterClusterState = createClusterState(null);
-        node1MasterClusterState = createClusterState(node1);
-        node2MasterClusterState = createClusterState(node2);
-        node3MasterClusterState = createClusterState(node3);
+        node1 = DiscoveryNodeUtils.create("node1", randomNodeId());
+        node2 = DiscoveryNodeUtils.create("node2", randomNodeId());
+        node3 = DiscoveryNodeUtils.create("node3", randomNodeId());
+        nullMasterClusterState = createClusterState(null, node1, node2, node3);
+        node1MasterClusterState = createClusterState(node1, node2, node3);
+        node2MasterClusterState = createClusterState(node2, node1, node3);
+        node3MasterClusterState = createClusterState(node3, node1, node2);
     }
 
     public void testGetBasicUse() {
@@ -76,6 +80,8 @@ public class MasterHistoryTests extends ESTestCase {
     public void testHasMasterGoneNull() {
         var clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        AtomicReference<ClusterState> clusterStateReference = new AtomicReference<>(nullMasterClusterState);
+        when(clusterService.state()).thenAnswer((Answer<ClusterState>) invocation -> clusterStateReference.get());
         ThreadPool threadPool = mock(ThreadPool.class);
         MasterHistory masterHistory = new MasterHistory(threadPool, clusterService);
         long oneHourAgo = System.currentTimeMillis() - (60 * 60 * 1000);
@@ -95,6 +101,13 @@ public class MasterHistoryTests extends ESTestCase {
         assertFalse(masterHistory.hasMasterGoneNullAtLeastNTimes(3));
         masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
         assertTrue(masterHistory.hasMasterGoneNullAtLeastNTimes(3));
+
+        // Now make sure that nodes that have left the cluster don't count against us:
+        clusterStateReference.set(createClusterState(null, node2));
+        assertFalse(masterHistory.hasMasterGoneNullAtLeastNTimes(3));
+        clusterStateReference.set(nullMasterClusterState);
+        assertTrue(masterHistory.hasMasterGoneNullAtLeastNTimes(3));
+
         masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         assertTrue(masterHistory.hasMasterGoneNullAtLeastNTimes(3));
         when(threadPool.relativeTimeInMillis()).thenReturn(System.currentTimeMillis());
@@ -191,6 +204,8 @@ public class MasterHistoryTests extends ESTestCase {
     public void testGetNumberOfMasterChanges() {
         var clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        AtomicReference<ClusterState> clusterStateReference = new AtomicReference<>(nullMasterClusterState);
+        when(clusterService.state()).thenAnswer((Answer<ClusterState>) invocation -> clusterStateReference.get());
         ThreadPool threadPool = mock(ThreadPool.class);
         MasterHistory masterHistory = new MasterHistory(threadPool, clusterService);
         assertThat(MasterHistory.getNumberOfMasterIdentityChanges(masterHistory.getNodes()), equalTo(0));
@@ -213,11 +228,15 @@ public class MasterHistoryTests extends ESTestCase {
         masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         assertThat(MasterHistory.getNumberOfMasterIdentityChanges(masterHistory.getNodes()), equalTo(2)); // Back to node1, but it's
                                                                                                           // a change from node2
+        // Make sure that nodes that are no longer in the cluster don't count towards master changes:
+        clusterStateReference.set(createClusterState(node1));
+        assertThat(MasterHistory.getNumberOfMasterIdentityChanges(masterHistory.getNodes()), equalTo(0));
     }
 
     public void testMaxSize() {
         var clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.state()).thenReturn(nullMasterClusterState);
         ThreadPool threadPool = mock(ThreadPool.class);
         MasterHistory masterHistory = new MasterHistory(threadPool, clusterService);
         for (int i = 0; i < MasterHistory.MAX_HISTORY_SIZE; i++) {
@@ -232,14 +251,21 @@ public class MasterHistoryTests extends ESTestCase {
         return UUID.randomUUID().toString();
     }
 
-    private static ClusterState createClusterState(String masterNodeId) throws UnknownHostException {
+    /*
+     * If not null, the first node given will be the elected master. If the first entry is null, there will be no elected master.
+     */
+    private static ClusterState createClusterState(DiscoveryNode... nodes) {
         var routingTableBuilder = RoutingTable.builder();
         Metadata.Builder metadataBuilder = Metadata.builder();
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
-        if (masterNodeId != null) {
-            DiscoveryNode node = DiscoveryNodeUtils.create(masterNodeId);
-            nodesBuilder.masterNodeId(masterNodeId);
-            nodesBuilder.add(node);
+        for (int i = 0; i < nodes.length; i++) {
+            DiscoveryNode node = nodes[i];
+            if (node != null) {
+                if (i == 0) {
+                    nodesBuilder.masterNodeId(node.getId());
+                }
+                nodesBuilder.add(node);
+            }
         }
         return ClusterState.builder(new ClusterName("test-cluster"))
             .routingTable(routingTableBuilder.build())
@@ -247,4 +273,5 @@ public class MasterHistoryTests extends ESTestCase {
             .nodes(nodesBuilder)
             .build();
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -275,9 +275,10 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
      * Creates a mocked MasterHistoryService with a non-mocked local master history (which can be updated with clusterChanged calls). The
      * remote master history is mocked.
      */
-    private static MasterHistoryService createMasterHistoryService() throws Exception {
+    private MasterHistoryService createMasterHistoryService() throws Exception {
         var clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.state()).thenReturn(nullMasterClusterState);
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.relativeTimeInMillis()).thenReturn(System.currentTimeMillis());
         MasterHistory localMasterHistory = new MasterHistory(threadPool, clusterService);


### PR DESCRIPTION
This PR removes nodes from master stability calculations if they are no longer in the cluster state. This avoids the problem of the master stability health indicator reporting a non-green status after node restarts.
Closes #98636