### PR TITLE
Allow explain data stream lifecycle to accept a data stream.

### DIFF
--- a/docs/changelog/98811.yaml
+++ b/docs/changelog/98811.yaml
@@ -1,0 +1,5 @@
+pr: 98811
+summary: Allow explain data stream lifecycle to accept a data stream
+area: Data streams
+type: enhancement
+issues: []

--- a/docs/reference/data-streams/lifecycle/apis/explain-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/explain-lifecycle.asciidoc
@@ -29,13 +29,13 @@ execution.
 ==== {api-path-parms-title}
 
 `<target>`::
-(Required, string) Comma-separated list of indices.
+(Required, string) Comma-separated list of indices or data streams.
 
 [[data-streams-explain-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
 `include_defaults`::
-  (Optional, Boolean) Includes default configurations related to the lifecycle of the target index.
+  (Optional, Boolean) Includes default configurations related to the lifecycle of the target.
   Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
@@ -43,7 +43,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 [[data-streams-explain-lifecycle-example]]
 ==== {api-examples-title}
 
-The following example retrieves the lifecycle state of the index `.ds-metrics-2023.03.22-000001`:
+If you want to retrieve the lifecycle state of all the backing indices of a data stream, you can use the data stream name.
+For simplicity, the following example retrieves the lifecycle state of one backing index `.ds-metrics-2023.03.22-000001`:
 
 [source,console]
 --------------------------------------------------

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -163,6 +163,38 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
             assertThat(conditions.get(RolloverConditions.MAX_DOCS_FIELD.getPreferredName()).value(), is(1L));
             assertThat(conditions.get(RolloverConditions.MIN_DOCS_FIELD.getPreferredName()).value(), is(1L));
         }
+
+        {
+            // Let's also explain using the data stream name
+            ExplainDataStreamLifecycleAction.Request explainIndicesRequest = new ExplainDataStreamLifecycleAction.Request(
+                new String[] { dataStreamName }
+            );
+            ExplainDataStreamLifecycleAction.Response response = client().execute(
+                ExplainDataStreamLifecycleAction.INSTANCE,
+                explainIndicesRequest
+            ).actionGet();
+            assertThat(response.getIndices().size(), is(2));
+            for (ExplainIndexDataStreamLifecycle explainIndex : response.getIndices()) {
+                assertThat(explainIndex.isManagedByLifecycle(), is(true));
+                assertThat(explainIndex.getIndexCreationDate(), notNullValue());
+                assertThat(explainIndex.getLifecycle(), notNullValue());
+                assertThat(explainIndex.getLifecycle().getEffectiveDataRetention(), nullValue());
+
+                if (explainIndex.getIndex().equals(DataStream.getDefaultBackingIndexName(dataStreamName, 1))) {
+                    // first generation index was rolled over
+                    assertThat(explainIndex.getIndex(), is(DataStream.getDefaultBackingIndexName(dataStreamName, 1)));
+                    assertThat(explainIndex.getRolloverDate(), notNullValue());
+                    assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), notNullValue());
+                    assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), notNullValue());
+                } else {
+                    // the write index has not been rolled over yet
+                    assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), nullValue());
+                    assertThat(explainIndex.getIndex(), is(DataStream.getDefaultBackingIndexName(dataStreamName, 2)));
+                    assertThat(explainIndex.getRolloverDate(), nullValue());
+                    assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), nullValue());
+                }
+            }
+        }
     }
 
     public void testExplainLifecycleForIndicesWithErrors() throws Exception {

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/ExplainDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/ExplainDataStreamLifecycleAction.java
@@ -67,6 +67,11 @@ public class ExplainDataStreamLifecycleAction extends ActionType<ExplainDataStre
             return null;
         }
 
+        @Override
+        public boolean includeDataStreams() {
+            return true;
+        }
+
         public Request(StreamInput in) throws IOException {
             super(in);
             this.names = in.readOptionalStringArray();


### PR DESCRIPTION
Currently the `GET target/_lifecycle/explain` API only works for indices. In this PR we extend this behaviour to allow the target to be a data stream so we can get the overview lifecycle status for all the backing indices of a data stream.

