### PR TITLE
Fix minimum version for SingleValueQuery

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.esql.plugin;
 
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.internal.Client;
@@ -65,11 +64,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class EsqlPlugin extends Plugin implements ActionPlugin {
-    /**
-     * The first version for ESQL. It's actual value is certainly wrong and will need to be
-     * updated when we merge.
-     */
-    public static final TransportVersion TRANSPORT_MINIMUM_VERSION = TransportVersion.V_8_8_0;
 
     public static final String ESQL_THREAD_POOL_NAME = "esql";
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.ql.querydsl.query.Query;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -166,7 +165,7 @@ public class SingleValueQuery extends Query {
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return EsqlPlugin.TRANSPORT_MINIMUM_VERSION;
+            return TransportVersion.V_8_500_065; // This is 8.11 - the first version of ESQL
         }
 
         @Override


### PR DESCRIPTION
The minimum supported version of SingleValueQuery should be updated to 8.11.