### PR TITLE
ESQL: Shrink ordinals

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.IntBlock;
 
 import java.util.Arrays;
 
@@ -140,11 +140,11 @@ public class MultivalueDedupeBytesRef {
     }
 
     /**
-     * Dedupe values and build a {@link LongBlock} suitable for passing
+     * Dedupe values and build a {@link IntBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(BytesRefHash hash) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
@@ -152,7 +152,7 @@ public class MultivalueDedupeBytesRef {
             switch (count) {
                 case 0 -> {
                     sawNull = true;
-                    builder.appendLong(0);
+                    builder.appendInt(0);
                 }
                 case 1 -> {
                     BytesRef v = block.getBytesRef(first, work[0]);
@@ -312,7 +312,7 @@ public class MultivalueDedupeBytesRef {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(BytesRefHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -327,7 +327,7 @@ public class MultivalueDedupeBytesRef {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(BytesRefHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -383,7 +383,7 @@ public class MultivalueDedupeBytesRef {
         }
     }
 
-    private void hash(LongBlock.Builder builder, BytesRefHash hash, BytesRef v) {
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
@@ -13,7 +13,7 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.IntBlock;
 
 import java.util.Arrays;
 
@@ -137,11 +137,11 @@ public class MultivalueDedupeDouble {
     }
 
     /**
-     * Dedupe values and build a {@link LongBlock} suitable for passing
+     * Dedupe values and build a {@link IntBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(LongHash hash) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
@@ -149,7 +149,7 @@ public class MultivalueDedupeDouble {
             switch (count) {
                 case 0 -> {
                     sawNull = true;
-                    builder.appendLong(0);
+                    builder.appendInt(0);
                 }
                 case 1 -> {
                     double v = block.getDouble(first);
@@ -301,7 +301,7 @@ public class MultivalueDedupeDouble {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -316,7 +316,7 @@ public class MultivalueDedupeDouble {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -361,7 +361,7 @@ public class MultivalueDedupeDouble {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(LongBlock.Builder builder, LongHash hash, double v) {
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v))));
+    private void hash(IntBlock.Builder builder, LongHash hash, double v) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v)))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntBlock;
-import org.elasticsearch.compute.data.LongBlock;
 
 import java.util.Arrays;
 
@@ -137,11 +136,11 @@ public class MultivalueDedupeInt {
     }
 
     /**
-     * Dedupe values and build a {@link LongBlock} suitable for passing
+     * Dedupe values and build a {@link IntBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(LongHash hash) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
@@ -149,7 +148,7 @@ public class MultivalueDedupeInt {
             switch (count) {
                 case 0 -> {
                     sawNull = true;
-                    builder.appendLong(0);
+                    builder.appendInt(0);
                 }
                 case 1 -> {
                     int v = block.getInt(first);
@@ -301,7 +300,7 @@ public class MultivalueDedupeInt {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -316,7 +315,7 @@ public class MultivalueDedupeInt {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -361,7 +360,7 @@ public class MultivalueDedupeInt {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(LongBlock.Builder builder, LongHash hash, int v) {
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+    private void hash(IntBlock.Builder builder, LongHash hash, int v) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 
 import java.util.Arrays;
@@ -137,11 +138,11 @@ public class MultivalueDedupeLong {
     }
 
     /**
-     * Dedupe values and build a {@link LongBlock} suitable for passing
+     * Dedupe values and build a {@link IntBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(LongHash hash) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
@@ -149,7 +150,7 @@ public class MultivalueDedupeLong {
             switch (count) {
                 case 0 -> {
                     sawNull = true;
-                    builder.appendLong(0);
+                    builder.appendInt(0);
                 }
                 case 1 -> {
                     long v = block.getLong(first);
@@ -301,7 +302,7 @@ public class MultivalueDedupeLong {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -316,7 +317,7 @@ public class MultivalueDedupeLong {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
             hash(builder, hash, work[0]);
             return;
@@ -361,7 +362,7 @@ public class MultivalueDedupeLong {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(LongBlock.Builder builder, LongHash hash, long v) {
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+    private void hash(IntBlock.Builder builder, LongHash hash, long v) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanGroupingAggregatorFunction.java
@@ -14,9 +14,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -63,11 +62,11 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -79,32 +78,32 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, BooleanBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, BooleanBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -116,14 +115,14 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, BooleanVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, BooleanVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctBooleanAggregator.combine(state, groupId, values.getBoolean(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, BooleanBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, BooleanBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -131,7 +130,7 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -144,7 +143,7 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, BooleanVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, BooleanVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -152,21 +151,21 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         CountDistinctBooleanAggregator.combine(state, groupId, values.getBoolean(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BooleanVector fbit = page.<BooleanBlock>getBlock(channels.get(0)).asVector();
     BooleanVector tbit = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert fbit.getPositionCount() == tbit.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctBooleanAggregator.combineIntermediate(state, groupId, fbit.getBoolean(groupPosition + positionOffset), tbit.getBoolean(groupPosition + positionOffset));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
@@ -15,9 +15,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -66,11 +65,11 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -82,33 +81,33 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, BytesRefBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefBlock values) {
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -120,15 +119,15 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, BytesRefVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, BytesRefVector values) {
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctBytesRefAggregator.combine(state, groupId, values.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, BytesRefBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, BytesRefBlock values) {
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -137,7 +136,7 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -150,7 +149,7 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, BytesRefVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, BytesRefVector values) {
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -159,20 +158,20 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         CountDistinctBytesRefAggregator.combine(state, groupId, values.getBytesRef(groupPosition + positionOffset, scratch));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctBytesRefAggregator.combineIntermediate(state, groupId, hll.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
@@ -17,9 +17,8 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -68,11 +67,11 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -84,32 +83,32 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -121,14 +120,14 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -136,7 +135,7 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -149,7 +148,7 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -157,20 +156,20 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         CountDistinctDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctDoubleAggregator.combineIntermediate(state, groupId, hll.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
@@ -17,8 +17,6 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -67,11 +65,11 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -83,32 +81,32 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -120,14 +118,14 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctIntAggregator.combine(state, groupId, values.getInt(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -135,7 +133,7 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -148,7 +146,7 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -156,20 +154,20 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         CountDistinctIntAggregator.combine(state, groupId, values.getInt(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctIntAggregator.combineIntermediate(state, groupId, hll.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -66,11 +67,11 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -82,32 +83,32 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -119,14 +120,14 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctLongAggregator.combine(state, groupId, values.getLong(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -134,7 +135,7 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -147,7 +148,7 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -155,20 +156,20 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         CountDistinctLongAggregator.combine(state, groupId, values.getLong(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       CountDistinctLongAggregator.combineIntermediate(state, groupId, hll.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
@@ -16,9 +16,8 @@ import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -61,11 +60,11 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -77,32 +76,32 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -114,14 +113,14 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), values.getDouble(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -129,7 +128,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -142,7 +141,7 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -150,21 +149,21 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), values.getDouble(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     DoubleVector max = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert max.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, MaxDoubleAggregator.combine(state.getOrDefault(groupId), max.getDouble(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
@@ -16,8 +16,6 @@ import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -60,11 +58,11 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -76,32 +74,32 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -113,14 +111,14 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), values.getInt(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -128,7 +126,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -141,7 +139,7 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -149,21 +147,21 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), values.getInt(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     IntVector max = page.<IntBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert max.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, MaxIntAggregator.combine(state.getOrDefault(groupId), max.getInt(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -59,11 +60,11 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -75,32 +76,32 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -112,14 +113,14 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), values.getLong(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -127,7 +128,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -140,7 +141,7 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -148,21 +149,21 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), values.getLong(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector max = page.<LongBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert max.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, MaxLongAggregator.combine(state.getOrDefault(groupId), max.getLong(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
@@ -17,9 +17,8 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -65,11 +64,11 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -81,32 +80,32 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -118,14 +117,14 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -133,7 +132,7 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -146,7 +145,7 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -154,20 +153,20 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntGroupingAggregatorFunction.java
@@ -17,8 +17,6 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -64,11 +62,11 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -80,32 +78,32 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -117,14 +115,14 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       MedianAbsoluteDeviationIntAggregator.combine(state, groupId, values.getInt(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -132,7 +130,7 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -145,7 +143,7 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -153,20 +151,20 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         MedianAbsoluteDeviationIntAggregator.combine(state, groupId, values.getInt(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       MedianAbsoluteDeviationIntAggregator.combineIntermediate(state, groupId, quart.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongGroupingAggregatorFunction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -63,11 +64,11 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -79,32 +80,32 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -116,14 +117,14 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       MedianAbsoluteDeviationLongAggregator.combine(state, groupId, values.getLong(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -131,7 +132,7 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -144,7 +145,7 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -152,20 +153,20 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         MedianAbsoluteDeviationLongAggregator.combine(state, groupId, values.getLong(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       MedianAbsoluteDeviationLongAggregator.combineIntermediate(state, groupId, quart.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
@@ -16,8 +16,6 @@ import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -60,11 +58,11 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -76,32 +74,32 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -113,14 +111,14 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), values.getInt(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -128,7 +126,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -141,7 +139,7 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -149,21 +147,21 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), values.getInt(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     IntVector min = page.<IntBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert min.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, MinIntAggregator.combine(state.getOrDefault(groupId), min.getInt(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -59,11 +60,11 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -75,32 +76,32 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -112,14 +113,14 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), values.getLong(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -127,7 +128,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -140,7 +141,7 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -148,21 +149,21 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), values.getLong(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector min = page.<LongBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert min.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, MinLongAggregator.combine(state.getOrDefault(groupId), min.getLong(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
@@ -17,9 +17,8 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -68,11 +67,11 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -84,32 +83,32 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -121,14 +120,14 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       PercentileDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -136,7 +135,7 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -149,7 +148,7 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -157,20 +156,20 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         PercentileDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunction.java
@@ -17,8 +17,6 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -67,11 +65,11 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -83,32 +81,32 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -120,14 +118,14 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       PercentileIntAggregator.combine(state, groupId, values.getInt(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -135,7 +133,7 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -148,7 +146,7 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -156,20 +154,20 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         PercentileIntAggregator.combine(state, groupId, values.getInt(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       PercentileIntAggregator.combineIntermediate(state, groupId, quart.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongGroupingAggregatorFunction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -66,11 +67,11 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -82,32 +83,32 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -119,14 +120,14 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       PercentileLongAggregator.combine(state, groupId, values.getLong(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -134,7 +135,7 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -147,7 +148,7 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -155,20 +156,20 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         PercentileLongAggregator.combine(state, groupId, values.getLong(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
     BytesRef scratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       PercentileLongAggregator.combineIntermediate(state, groupId, quart.getBytesRef(groupPosition + positionOffset, scratch));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleGroupingAggregatorFunction.java
@@ -16,9 +16,8 @@ import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -66,11 +65,11 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -82,32 +81,32 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -119,14 +118,14 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       SumDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -134,7 +133,7 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -147,7 +146,7 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, DoubleVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, DoubleVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -155,14 +154,14 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         SumDoubleAggregator.combine(state, groupId, values.getDouble(groupPosition + positionOffset));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     DoubleVector value = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
@@ -170,7 +169,7 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(2)).asVector();
     assert value.getPositionCount() == delta.getPositionCount() && value.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       SumDoubleAggregator.combineIntermediate(state, groupId, value.getDouble(groupPosition + positionOffset), delta.getDouble(groupPosition + positionOffset), seen.getBoolean(groupPosition + positionOffset));
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
@@ -60,11 +60,11 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -76,32 +76,32 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -113,14 +113,14 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), values.getInt(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -128,7 +128,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -141,7 +141,7 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, IntVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, IntVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -149,21 +149,21 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), values.getInt(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector sum = page.<LongBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert sum.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, SumIntAggregator.combine(state.getOrDefault(groupId), sum.getLong(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -59,11 +60,11 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
       state.enableGroupIdTracking(seenGroupIds);
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
         }
       };
     }
@@ -75,32 +76,32 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
       }
       return new GroupingAggregatorFunction.AddInput() {
         @Override
-        public void add(int positionOffset, LongBlock groupIds) {
+        public void add(int positionOffset, IntBlock groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
 
         @Override
-        public void add(int positionOffset, LongVector groupIds) {
+        public void add(int positionOffset, IntVector groupIds) {
           addRawInput(positionOffset, groupIds, valuesBlock);
         }
       };
     }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
-      public void add(int positionOffset, LongBlock groupIds) {
+      public void add(int positionOffset, IntBlock groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
 
       @Override
-      public void add(int positionOffset, LongVector groupIds) {
+      public void add(int positionOffset, IntVector groupIds) {
         addRawInput(positionOffset, groupIds, valuesVector);
       }
     };
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (values.isNull(groupPosition + positionOffset)) {
         continue;
       }
@@ -112,14 +113,14 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
     }
   }
 
-  private void addRawInput(int positionOffset, LongVector groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntVector groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       state.set(groupId, SumLongAggregator.combine(state.getOrDefault(groupId), values.getLong(groupPosition + positionOffset)));
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongBlock values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongBlock values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -127,7 +128,7 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         if (values.isNull(groupPosition + positionOffset)) {
           continue;
         }
@@ -140,7 +141,7 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
     }
   }
 
-  private void addRawInput(int positionOffset, LongBlock groups, LongVector values) {
+  private void addRawInput(int positionOffset, IntBlock groups, LongVector values) {
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
         continue;
@@ -148,21 +149,21 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
       int groupStart = groups.getFirstValueIndex(groupPosition);
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
-        int groupId = Math.toIntExact(groups.getLong(g));
+        int groupId = Math.toIntExact(groups.getInt(g));
         state.set(groupId, SumLongAggregator.combine(state.getOrDefault(groupId), values.getLong(groupPosition + positionOffset)));
       }
     }
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, LongVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector sum = page.<LongBlock>getBlock(channels.get(0)).asVector();
     BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
     assert sum.getPositionCount() == seen.getPositionCount();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
-      int groupId = Math.toIntExact(groups.getLong(groupPosition));
+      int groupId = Math.toIntExact(groups.getInt(groupPosition));
       if (seen.getBoolean(groupPosition + positionOffset)) {
         state.set(groupId, SumLongAggregator.combine(state.getOrDefault(groupId), sum.getLong(groupPosition + positionOffset)));
       }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregator.java
@@ -9,9 +9,8 @@ package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
@@ -42,12 +41,12 @@ public class GroupingAggregator implements Releasable {
         if (mode.isInputPartial()) {
             return new GroupingAggregatorFunction.AddInput() {
                 @Override
-                public void add(int positionOffset, LongBlock groupIds) {
+                public void add(int positionOffset, IntBlock groupIds) {
                     throw new IllegalStateException("Intermediate group id must not have nulls");
                 }
 
                 @Override
-                public void add(int positionOffset, LongVector groupIds) {
+                public void add(int positionOffset, IntVector groupIds) {
                     aggregatorFunction.addIntermediateInput(positionOffset, groupIds, page);
                 }
             };

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunction.java
@@ -8,9 +8,8 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.core.Releasable;
@@ -48,14 +47,14 @@ public interface GroupingAggregatorFunction extends Releasable {
          * @param groupIds {@link Block} of group id, some of which may be null
          *                 or multivalued
          */
-        void add(int positionOffset, LongBlock groupIds);
+        void add(int positionOffset, IntBlock groupIds);
 
         /**
          * Send a batch of group ids to the aggregator. The {@code groupIds}
          * may be offset from the start of the block to allow for sending chunks
          * of group ids.
          * <p>
-         *     See {@link #add(int, LongBlock)} for discussion on the offset. This
+         *     See {@link #add(int, IntBlock)} for discussion on the offset. This
          *     method can only be called with blocks contained in a {@link Vector}
          *     which only allows a single value per position.
          * </p>
@@ -64,7 +63,7 @@ public interface GroupingAggregatorFunction extends Releasable {
          * @param groupIds {@link Vector} of group id, some of which may be null
          *                 or multivalued
          */
-        void add(int positionOffset, LongVector groupIds);
+        void add(int positionOffset, IntVector groupIds);
     }
 
     /**
@@ -79,7 +78,7 @@ public interface GroupingAggregatorFunction extends Releasable {
     /**
      * Add data produced by {@link #evaluateIntermediate}.
      */
-    void addIntermediateInput(int positionOffset, LongVector groupIdVector, Page page);
+    void addIntermediateInput(int positionOffset, IntVector groupIdVector, Page page);
 
     /**
      * Add the position-th row from the intermediate output of the given aggregator function to the groupId

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -12,10 +12,9 @@ import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.IntArrayVector;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongArrayVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.MultivalueDedupeBoolean;
 
@@ -46,15 +45,15 @@ final class BooleanBlockHash extends BlockHash {
         }
     }
 
-    private LongVector add(BooleanVector vector) {
-        long[] groups = new long[vector.getPositionCount()];
+    private IntVector add(BooleanVector vector) {
+        int[] groups = new int[vector.getPositionCount()];
         for (int i = 0; i < vector.getPositionCount(); i++) {
             groups[i] = MultivalueDedupeBoolean.hashOrd(everSeen, vector.getBoolean(i));
         }
-        return new LongArrayVector(groups, groups.length);
+        return new IntArrayVector(groups, groups.length);
     }
 
-    private LongBlock add(BooleanBlock block) {
+    private IntBlock add(BooleanBlock block) {
         return new MultivalueDedupeBoolean(block).hash(everSeen);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -20,10 +20,9 @@ import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.BytesRefArrayVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntArrayVector;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongArrayVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeBytesRef;
@@ -63,15 +62,15 @@ final class BytesRefBlockHash extends BlockHash {
         }
     }
 
-    private LongVector add(BytesRefVector vector) {
-        long[] groups = new long[vector.getPositionCount()];
+    private IntVector add(BytesRefVector vector) {
+        int[] groups = new int[vector.getPositionCount()];
         for (int i = 0; i < vector.getPositionCount(); i++) {
-            groups[i] = hashOrdToGroupNullReserved(bytesRefHash.add(vector.getBytesRef(i, bytes)));
+            groups[i] = Math.toIntExact(hashOrdToGroupNullReserved(bytesRefHash.add(vector.getBytesRef(i, bytes))));
         }
-        return new LongArrayVector(groups, vector.getPositionCount());
+        return new IntArrayVector(groups, vector.getPositionCount());
     }
 
-    private LongBlock add(BytesRefBlock block) {
+    private IntBlock add(BytesRefBlock block) {
         MultivalueDedupe.HashResult result = new MultivalueDedupeBytesRef(block).hash(bytesRefHash);
         seenNull |= result.sawNull();
         return result.ords();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -17,10 +17,9 @@ import org.elasticsearch.compute.data.DoubleArrayBlock;
 import org.elasticsearch.compute.data.DoubleArrayVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.IntArrayVector;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongArrayVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeDouble;
@@ -59,15 +58,15 @@ final class DoubleBlockHash extends BlockHash {
         }
     }
 
-    private LongVector add(DoubleVector vector) {
-        long[] groups = new long[vector.getPositionCount()];
+    private IntVector add(DoubleVector vector) {
+        int[] groups = new int[vector.getPositionCount()];
         for (int i = 0; i < vector.getPositionCount(); i++) {
-            groups[i] = hashOrdToGroupNullReserved(longHash.add(Double.doubleToLongBits(vector.getDouble(i))));
+            groups[i] = Math.toIntExact(hashOrdToGroupNullReserved(longHash.add(Double.doubleToLongBits(vector.getDouble(i)))));
         }
-        return new LongArrayVector(groups, groups.length);
+        return new IntArrayVector(groups, groups.length);
     }
 
-    private LongBlock add(DoubleBlock block) {
+    private IntBlock add(DoubleBlock block) {
         MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hash(longHash);
         seenNull |= result.sawNull();
         return result.ords();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -17,9 +17,6 @@ import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongArrayVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeInt;
@@ -57,15 +54,15 @@ final class IntBlockHash extends BlockHash {
         }
     }
 
-    private LongVector add(IntVector vector) {
-        long[] groups = new long[vector.getPositionCount()];
+    private IntVector add(IntVector vector) {
+        int[] groups = new int[vector.getPositionCount()];
         for (int i = 0; i < vector.getPositionCount(); i++) {
-            groups[i] = hashOrdToGroupNullReserved(longHash.add(vector.getInt(i)));
+            groups[i] = Math.toIntExact(hashOrdToGroupNullReserved(longHash.add(vector.getInt(i))));
         }
-        return new LongArrayVector(groups, groups.length);
+        return new IntArrayVector(groups, groups.length);
     }
 
-    private LongBlock add(IntBlock block) {
+    private IntBlock add(IntBlock block) {
         MultivalueDedupe.HashResult result = new MultivalueDedupeInt(block).hash(longHash);
         seenNull |= result.sawNull();
         return result.ords();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntArrayVector;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongArrayBlock;
 import org.elasticsearch.compute.data.LongArrayVector;
@@ -56,15 +58,15 @@ final class LongBlockHash extends BlockHash {
         }
     }
 
-    private LongVector add(LongVector vector) {
-        long[] groups = new long[vector.getPositionCount()];
+    private IntVector add(LongVector vector) {
+        int[] groups = new int[vector.getPositionCount()];
         for (int i = 0; i < vector.getPositionCount(); i++) {
-            groups[i] = hashOrdToGroupNullReserved(longHash.add(vector.getLong(i)));
+            groups[i] = Math.toIntExact(hashOrdToGroupNullReserved(longHash.add(vector.getLong(i))));
         }
-        return new LongArrayVector(groups, groups.length);
+        return new IntArrayVector(groups, groups.length);
     }
 
-    private LongBlock add(LongBlock block) {
+    private IntBlock add(LongBlock block) {
         MultivalueDedupe.HashResult result = new MultivalueDedupeLong(block).hash(longHash);
         seenNull |= result.sawNull();
         return result.ords();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -85,7 +85,7 @@ final class PackedValuesBlockHash extends BlockHash {
 
         int position;
         int count;
-        long bufferedGroup;
+        int bufferedGroup;
 
         AddWork(Page page, GroupingAggregatorFunction.AddInput addInput, int batchSize) {
             super(emitBatchSize, addInput);
@@ -124,7 +124,7 @@ final class PackedValuesBlockHash extends BlockHash {
                 switch (count) {
                     case 0 -> throw new IllegalStateException("didn't find any values");
                     case 1 -> {
-                        ords.appendLong(bufferedGroup);
+                        ords.appendInt(bufferedGroup);
                         addedValue(position);
                     }
                     default -> ords.endPositionEntry();
@@ -171,18 +171,18 @@ final class PackedValuesBlockHash extends BlockHash {
         }
 
         private void addBytes() {
-            long group = hashOrdToGroup(bytesRefHash.add(bytes.get()));
+            int group = Math.toIntExact(hashOrdToGroup(bytesRefHash.add(bytes.get())));
             switch (count) {
                 case 0 -> bufferedGroup = group;
                 case 1 -> {
                     ords.beginPositionEntry();
-                    ords.appendLong(bufferedGroup);
+                    ords.appendInt(bufferedGroup);
                     addedValueInMultivaluePosition(position);
-                    ords.appendLong(group);
+                    ords.appendInt(group);
                     addedValueInMultivaluePosition(position);
                 }
                 default -> {
-                    ords.appendLong(group);
+                    ords.appendInt(group);
                     addedValueInMultivaluePosition(position);
                 }
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/BlockOrdinalsReader.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/BlockOrdinalsReader.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.compute.lucene;
 
 import org.apache.lucene.index.SortedSetDocValues;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
 
 import java.io.IOException;
 
@@ -22,9 +22,9 @@ public final class BlockOrdinalsReader {
         this.creationThread = Thread.currentThread();
     }
 
-    public LongBlock readOrdinals(IntVector docs) throws IOException {
+    public IntBlock readOrdinals(IntVector docs) throws IOException {
         final int positionCount = docs.getPositionCount();
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(positionCount);
+        IntBlock.Builder builder = IntBlock.newBlockBuilder(positionCount);
         for (int p = 0; p < positionCount; p++) {
             int doc = docs.getInt(p);
             if (false == sortedSetDocValues.advanceExact(doc)) {
@@ -32,13 +32,14 @@ public final class BlockOrdinalsReader {
                 continue;
             }
             int count = sortedSetDocValues.docValueCount();
+            // TODO don't come this way if there are a zillion ords on the field
             if (count == 1) {
-                builder.appendLong(sortedSetDocValues.nextOrd());
+                builder.appendInt(Math.toIntExact(sortedSetDocValues.nextOrd()));
                 continue;
             }
             builder.beginPositionEntry();
             for (int i = 0; i < count; i++) {
-                builder.appendLong(sortedSetDocValues.nextOrd());
+                builder.appendInt(Math.toIntExact(sortedSetDocValues.nextOrd()));
             }
             builder.endPositionEntry();
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -14,9 +14,8 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 
@@ -97,8 +96,8 @@ public class HashAggregationOperator implements Operator {
 
         blockHash.add(wrapPage(page), new GroupingAggregatorFunction.AddInput() {
             @Override
-            public void add(int positionOffset, LongBlock groupIds) {
-                LongVector groupIdsVector = groupIds.asVector();
+            public void add(int positionOffset, IntBlock groupIds) {
+                IntVector groupIdsVector = groupIds.asVector();
                 if (groupIdsVector != null) {
                     add(positionOffset, groupIdsVector);
                 } else {
@@ -109,7 +108,7 @@ public class HashAggregationOperator implements Operator {
             }
 
             @Override
-            public void add(int positionOffset, LongVector groupIds) {
+            public void add(int positionOffset, IntVector groupIds) {
                 for (GroupingAggregatorFunction.AddInput p : prepared) {
                     p.add(positionOffset, groupIds);
                 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
@@ -125,7 +125,7 @@ public final class MultivalueDedupe {
     /**
      * Result of calling "hash" on a multivalue dedupe.
      */
-    public record HashResult(LongBlock ords, boolean sawNull) {}
+    public record HashResult(IntBlock ords, boolean sawNull) {}
 
     /**
      * Build a {@link BatchEncoder} which deduplicates values at each position

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -24,8 +24,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DocBlock;
 import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.BlockOrdinalsReader;
 import org.elasticsearch.compute.lucene.ValueSourceInfo;
@@ -338,7 +338,7 @@ public class OrdinalsGroupingOperator implements Operator {
                 if (BlockOrdinalsReader.canReuse(currentReader, docs.getInt(0)) == false) {
                     currentReader = new BlockOrdinalsReader(withOrdinals.ordinalsValues(leafReaderContext));
                 }
-                final LongBlock ordinals = currentReader.readOrdinals(docs);
+                final IntBlock ordinals = currentReader.readOrdinals(docs);
                 for (int p = 0; p < ordinals.getPositionCount(); p++) {
                     if (ordinals.isNull(p)) {
                         continue;
@@ -346,7 +346,7 @@ public class OrdinalsGroupingOperator implements Operator {
                     int start = ordinals.getFirstValueIndex(p);
                     int end = start + ordinals.getValueCount(p);
                     for (int i = start; i < end; i++) {
-                        long ord = ordinals.getLong(i);
+                        long ord = ordinals.getInt(i);
                         visitedOrds.set(ord);
                     }
                 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -16,16 +16,21 @@ import org.elasticsearch.common.util.LongHash;
 $endif$
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
-$if(long)$
+$if(int)$
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+
+$elseif(long)$
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 
 $else$
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.$Type$Block;
-import org.elasticsearch.compute.data.LongBlock;
-$endif$
+import org.elasticsearch.compute.data.IntBlock;
 
+$endif$
 import java.util.Arrays;
 
 /**
@@ -173,7 +178,7 @@ $endif$
     }
 
     /**
-     * Dedupe values and build a {@link LongBlock} suitable for passing
+     * Dedupe values and build a {@link IntBlock} suitable for passing
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
 $if(BytesRef)$
@@ -181,7 +186,7 @@ $if(BytesRef)$
 $else$
     public MultivalueDedupe.HashResult hash(LongHash hash) {
 $endif$
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
@@ -189,7 +194,7 @@ $endif$
             switch (count) {
                 case 0 -> {
                     sawNull = true;
-                    builder.appendLong(0);
+                    builder.appendInt(0);
                 }
                 case 1 -> {
 $if(BytesRef)$
@@ -389,9 +394,9 @@ $endif$
      * Writes an already deduplicated {@link #work} to a hash.
      */
 $if(BytesRef)$
-    private void hashUniquedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(BytesRefHash hash, IntBlock.Builder builder) {
 $else$
-    private void hashUniquedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
 $endif$
         if (w == 1) {
             hash(builder, hash, work[0]);
@@ -408,9 +413,9 @@ $endif$
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
 $if(BytesRef)$
-    private void hashSortedWork(BytesRefHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(BytesRefHash hash, IntBlock.Builder builder) {
 $else$
-    private void hashSortedWork(LongHash hash, LongBlock.Builder builder) {
+    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
 $endif$
         if (w == 1) {
             hash(builder, hash, work[0]);
@@ -485,14 +490,14 @@ $if(BytesRef)$
 $endif$
 
 $if(BytesRef)$
-    private void hash(LongBlock.Builder builder, BytesRefHash hash, BytesRef v) {
+    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
 $else$
-    private void hash(LongBlock.Builder builder, LongHash hash, $type$ v) {
+    private void hash(IntBlock.Builder builder, LongHash hash, $type$ v) {
 $endif$
 $if(double)$
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v))));
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v)))));
 $else$
-        builder.appendLong(BlockHash.hashOrdToGroupNullReserved(hash.add(v)));
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
 $endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.HashAggregationOperator;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -68,11 +67,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block);
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:INT], entries=3, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 0L, 1L, 2L, 0L, 1L, 2L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 0, 1, 2, 0, 1, 2);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 3)));
         } else {
             assertThat(ordsAndKeys.description, equalTo("IntBlockHash{channel=0, entries=3, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L);
+            assertOrds(ordsAndKeys.ords, 1, 2, 3, 1, 2, 3, 1, 2, 3);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(1, 4)));
         }
         assertKeys(ordsAndKeys.keys, 1, 2, 3);
@@ -88,11 +87,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(builder.build());
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:INT], entries=3, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 1L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 1);
             assertKeys(ordsAndKeys.keys, 0, null, 2);
         } else {
             assertThat(ordsAndKeys.description, equalTo("IntBlockHash{channel=0, entries=2, seenNull=true}"));
-            assertOrds(ordsAndKeys.ords, 1L, 0L, 2L, 0L);
+            assertOrds(ordsAndKeys.ords, 1, 0, 2, 0);
             assertKeys(ordsAndKeys.keys, null, 0, 2);
         }
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 3)));
@@ -125,24 +124,24 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:INT], entries=4, size="));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0 },
-                new long[] { 0, 1 },
-                new long[] { 2, 0 },
-                new long[] { 2 },
-                new long[] { 3 },
-                new long[] { 2, 1, 0 }
+                new int[] { 0 },
+                new int[] { 0, 1 },
+                new int[] { 2, 0 },
+                new int[] { 2 },
+                new int[] { 3 },
+                new int[] { 2, 1, 0 }
             );
             assertKeys(ordsAndKeys.keys, 1, 2, 3, null);
         } else {
             assertThat(ordsAndKeys.description, equalTo("IntBlockHash{channel=0, entries=3, seenNull=true}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 1 },
-                new long[] { 1, 2 },
-                new long[] { 3, 1 },
-                new long[] { 3 },
-                new long[] { 0 },
-                new long[] { 3, 2, 1 }
+                new int[] { 1 },
+                new int[] { 1, 2 },
+                new int[] { 3, 1 },
+                new int[] { 3 },
+                new int[] { 0 },
+                new int[] { 3, 2, 1 }
             );
             assertKeys(ordsAndKeys.keys, null, 1, 2, 3);
         }
@@ -156,11 +155,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block);
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG], entries=4, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 0L, 2L, 1L, 3L, 2L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 0, 2, 1, 3, 2);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 4)));
         } else {
             assertThat(ordsAndKeys.description, equalTo("LongBlockHash{channel=0, entries=4, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 1L, 2L, 3L, 1L, 3L, 2L, 4L, 3L);
+            assertOrds(ordsAndKeys.ords, 1, 2, 3, 1, 3, 2, 4, 3);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(1, 5)));
         }
         assertKeys(ordsAndKeys.keys, 2L, 1L, 4L, 3L);
@@ -176,11 +175,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(builder.build());
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG], entries=3, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 1L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 1);
             assertKeys(ordsAndKeys.keys, 0L, null, 2L);
         } else {
             assertThat(ordsAndKeys.description, equalTo("LongBlockHash{channel=0, entries=2, seenNull=true}"));
-            assertOrds(ordsAndKeys.ords, 1L, 0L, 2L, 0L);
+            assertOrds(ordsAndKeys.ords, 1, 0, 2, 0);
             assertKeys(ordsAndKeys.keys, null, 0L, 2L);
         }
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 3)));
@@ -213,24 +212,24 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG], entries=4, size="));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0 },
-                new long[] { 0, 1, 2 },
-                new long[] { 0 },
-                new long[] { 2 },
-                new long[] { 3 },
-                new long[] { 2, 1, 0 }
+                new int[] { 0 },
+                new int[] { 0, 1, 2 },
+                new int[] { 0 },
+                new int[] { 2 },
+                new int[] { 3 },
+                new int[] { 2, 1, 0 }
             );
             assertKeys(ordsAndKeys.keys, 1L, 2L, 3L, null);
         } else {
             assertThat(ordsAndKeys.description, equalTo("LongBlockHash{channel=0, entries=3, seenNull=true}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 1 },
-                new long[] { 1, 2, 3 },
-                new long[] { 1 },
-                new long[] { 3 },
-                new long[] { 0 },
-                new long[] { 3, 2, 1 }
+                new int[] { 1 },
+                new int[] { 1, 2, 3 },
+                new int[] { 1 },
+                new int[] { 3 },
+                new int[] { 0 },
+                new int[] { 3, 2, 1 }
             );
             assertKeys(ordsAndKeys.keys, null, 1L, 2L, 3L);
         }
@@ -244,11 +243,11 @@ public class BlockHashTests extends ESTestCase {
 
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:DOUBLE], entries=4, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 0L, 2L, 1L, 3L, 2L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 0, 2, 1, 3, 2);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 4)));
         } else {
             assertThat(ordsAndKeys.description, equalTo("DoubleBlockHash{channel=0, entries=4, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 1L, 2L, 3L, 1L, 3L, 2L, 4L, 3L);
+            assertOrds(ordsAndKeys.ords, 1, 2, 3, 1, 3, 2, 4, 3);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(1, 5)));
         }
         assertKeys(ordsAndKeys.keys, 2.0, 1.0, 4.0, 3.0);
@@ -264,11 +263,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(builder.build());
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:DOUBLE], entries=3, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 1L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 1);
             assertKeys(ordsAndKeys.keys, 0.0, null, 2.0);
         } else {
             assertThat(ordsAndKeys.description, equalTo("DoubleBlockHash{channel=0, entries=2, seenNull=true}"));
-            assertOrds(ordsAndKeys.ords, 1L, 0L, 2L, 0L);
+            assertOrds(ordsAndKeys.ords, 1, 0, 2, 0);
             assertKeys(ordsAndKeys.keys, null, 0.0, 2.0);
         }
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 3)));
@@ -300,24 +299,24 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:DOUBLE], entries=4, size="));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0 },
-                new long[] { 1, 2 },
-                new long[] { 2, 1 },
-                new long[] { 0 },
-                new long[] { 3 },
-                new long[] { 0, 1 }
+                new int[] { 0 },
+                new int[] { 1, 2 },
+                new int[] { 2, 1 },
+                new int[] { 0 },
+                new int[] { 3 },
+                new int[] { 0, 1 }
             );
             assertKeys(ordsAndKeys.keys, 1.0, 2.0, 3.0, null);
         } else {
             assertThat(ordsAndKeys.description, equalTo("DoubleBlockHash{channel=0, entries=3, seenNull=true}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 1 },
-                new long[] { 2, 3 },
-                new long[] { 3, 2 },
-                new long[] { 1 },
-                new long[] { 0 },
-                new long[] { 1, 2 }
+                new int[] { 1 },
+                new int[] { 2, 3 },
+                new int[] { 3, 2 },
+                new int[] { 1 },
+                new int[] { 0 },
+                new int[] { 1, 2 }
             );
             assertKeys(ordsAndKeys.keys, null, 1.0, 2.0, 3.0);
         }
@@ -339,12 +338,12 @@ public class BlockHashTests extends ESTestCase {
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BYTES_REF], entries=4, size="));
             assertThat(ordsAndKeys.description, endsWith("b}"));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 0L, 2L, 1L, 3L, 2L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 0, 2, 1, 3, 2);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 4)));
         } else {
             assertThat(ordsAndKeys.description, startsWith("BytesRefBlockHash{channel=0, entries=4, size="));
             assertThat(ordsAndKeys.description, endsWith("b, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 1L, 2L, 3L, 1L, 3L, 2L, 4L, 3L);
+            assertOrds(ordsAndKeys.ords, 1, 2, 3, 1, 3, 2, 4, 3);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(1, 5)));
         }
         assertKeys(ordsAndKeys.keys, "item-2", "item-1", "item-4", "item-3");
@@ -361,12 +360,12 @@ public class BlockHashTests extends ESTestCase {
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BYTES_REF], entries=3, size="));
             assertThat(ordsAndKeys.description, endsWith("b}"));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 1L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 1);
             assertKeys(ordsAndKeys.keys, "cat", null, "dog");
         } else {
             assertThat(ordsAndKeys.description, startsWith("BytesRefBlockHash{channel=0, entries=2, size="));
             assertThat(ordsAndKeys.description, endsWith("b, seenNull=true}"));
-            assertOrds(ordsAndKeys.ords, 1L, 0L, 2L, 0L);
+            assertOrds(ordsAndKeys.ords, 1, 0, 2, 0);
             assertKeys(ordsAndKeys.keys, null, "cat", "dog");
         }
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 3)));
@@ -400,12 +399,12 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, endsWith("b}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0 },
-                new long[] { 0, 1 },
-                new long[] { 1, 2 },
-                new long[] { 2, 1 },
-                new long[] { 3 },
-                new long[] { 2, 1 }
+                new int[] { 0 },
+                new int[] { 0, 1 },
+                new int[] { 1, 2 },
+                new int[] { 2, 1 },
+                new int[] { 3 },
+                new int[] { 2, 1 }
             );
             assertKeys(ordsAndKeys.keys, "foo", "bar", "bort", null);
         } else {
@@ -413,12 +412,12 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, endsWith("b, seenNull=true}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 1 },
-                new long[] { 1, 2 },
-                new long[] { 2, 3 },
-                new long[] { 3, 2 },
-                new long[] { 0 },
-                new long[] { 3, 2 }
+                new int[] { 1 },
+                new int[] { 1, 2 },
+                new int[] { 2, 3 },
+                new int[] { 3, 2 },
+                new int[] { 0 },
+                new int[] { 3, 2 }
             );
             assertKeys(ordsAndKeys.keys, null, "foo", "bar", "bort");
         }
@@ -432,11 +431,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block);
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=2, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 1L, 1L, 1L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 1, 1, 1);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 2)));
         } else {
             assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=true, seenTrue=true, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 1L, 2L, 2L, 2L, 2L);
+            assertOrds(ordsAndKeys.ords, 1, 2, 2, 2, 2);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(1, 3)));
         }
         assertKeys(ordsAndKeys.keys, false, true);
@@ -449,12 +448,12 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block);
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=2, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 1L, 0L, 0L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 1, 0, 0);
             assertKeys(ordsAndKeys.keys, true, false);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 2)));
         } else {
             assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=true, seenTrue=true, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 2L, 1L, 1L, 2L, 2L);
+            assertOrds(ordsAndKeys.ords, 2, 1, 1, 2, 2);
             assertKeys(ordsAndKeys.keys, false, true);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(1, 3)));
         }
@@ -467,12 +466,12 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block);
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=1, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 0L, 0L, 0L);
+            assertOrds(ordsAndKeys.ords, 0, 0, 0, 0);
             assertKeys(ordsAndKeys.keys, true);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(0).build()));
         } else {
             assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=false, seenTrue=true, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 2L, 2L, 2L, 2L);
+            assertOrds(ordsAndKeys.ords, 2, 2, 2, 2);
             assertKeys(ordsAndKeys.keys, true);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(2).build()));
         }
@@ -485,11 +484,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block);
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=1, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 0L, 0L, 0L);
+            assertOrds(ordsAndKeys.ords, 0, 0, 0, 0);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(0).build()));
         } else {
             assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=true, seenTrue=false, seenNull=false}"));
-            assertOrds(ordsAndKeys.ords, 1L, 1L, 1L, 1L);
+            assertOrds(ordsAndKeys.ords, 1, 1, 1, 1);
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(1).build()));
         }
         assertKeys(ordsAndKeys.keys, false);
@@ -505,11 +504,11 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(builder.build());
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=3, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 1L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 1);
             assertKeys(ordsAndKeys.keys, false, null, true);
         } else {
             assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=true, seenTrue=true, seenNull=true}"));
-            assertOrds(ordsAndKeys.ords, 1L, 0L, 2L, 0L);
+            assertOrds(ordsAndKeys.ords, 1, 0, 2, 0);
             assertKeys(ordsAndKeys.keys, null, false, true);
         }
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 3)));
@@ -541,24 +540,24 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=3, size="));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0 },
-                new long[] { 0, 1 },
-                new long[] { 0, 1 },  // Order is not preserved
-                new long[] { 1 },
-                new long[] { 2 },
-                new long[] { 0, 1 }
+                new int[] { 0 },
+                new int[] { 0, 1 },
+                new int[] { 0, 1 },  // Order is not preserved
+                new int[] { 1 },
+                new int[] { 2 },
+                new int[] { 0, 1 }
             );
             assertKeys(ordsAndKeys.keys, false, true, null);
         } else {
             assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=true, seenTrue=true, seenNull=true}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 1 },
-                new long[] { 1, 2 },
-                new long[] { 1, 2 },  // Order is not preserved
-                new long[] { 2 },
-                new long[] { 0 },
-                new long[] { 1, 2 }
+                new int[] { 1 },
+                new int[] { 1, 2 },
+                new int[] { 1, 2 },  // Order is not preserved
+                new int[] { 2 },
+                new int[] { 0 },
+                new int[] { 1, 2 }
             );
             assertKeys(ordsAndKeys.keys, null, false, true);
         }
@@ -579,7 +578,7 @@ public class BlockHashTests extends ESTestCase {
                 ? startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:LONG], entries=4, size=")
                 : equalTo("LongLongBlockHash{channels=[0,1], entries=4}")
         );
-        assertOrds(ordsAndKeys.ords, 0L, 1L, 0L, 2L, 3L, 2L);
+        assertOrds(ordsAndKeys.ords, 0, 1, 0, 2, 3, 2);
         assertKeys(ordsAndKeys.keys, expectedKeys);
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 4)));
     }
@@ -627,15 +626,15 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:LONG], entries=10, size="));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 0, 2 },
-                new long[] { 0, 1 },
-                new long[] { 0 },
-                new long[] { 4 },
-                new long[] { 5 },
-                new long[] { 0 },
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 6, 0, 7, 2, 8, 9 }
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 0, 2 },
+                new int[] { 0, 1 },
+                new int[] { 0 },
+                new int[] { 4 },
+                new int[] { 5 },
+                new int[] { 0 },
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 6, 0, 7, 2, 8, 9 }
             );
             assertKeys(
                 ordsAndKeys.keys,
@@ -656,15 +655,15 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, equalTo("LongLongBlockHash{channels=[0,1], entries=8}"));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 0, 2 },
-                new long[] { 0, 1 },
-                new long[] { 0 },
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 0, 2 },
+                new int[] { 0, 1 },
+                new int[] { 0 },
                 null,
                 null,
-                new long[] { 0 },
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 4, 0, 5, 2, 6, 7 }
+                new int[] { 0 },
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 4, 0, 5, 2, 6, 7 }
             );
             assertKeys(
                 ordsAndKeys.keys,
@@ -701,7 +700,7 @@ public class BlockHashTests extends ESTestCase {
                     ? startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:LONG], entries=" + expectedEntries[0] + ", size=")
                     : equalTo("LongLongBlockHash{channels=[0,1], entries=" + expectedEntries[0] + "}")
             );
-            assertOrds(ordsAndKeys.ords, LongStream.range(start, expectedEntries[0]).toArray());
+            assertOrds(ordsAndKeys.ords, IntStream.range(start, expectedEntries[0]).toArray());
             assertKeys(
                 ordsAndKeys.keys,
                 IntStream.range(0, expectedEntries[0])
@@ -724,7 +723,7 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block1, block2);
         assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:INT, 1:LONG], entries=4, size="));
         assertThat(ordsAndKeys.description, endsWith("b}"));
-        assertOrds(ordsAndKeys.ords, 0L, 1L, 0L, 2L, 3L, 2L);
+        assertOrds(ordsAndKeys.ords, 0, 1, 0, 2, 3, 2);
         assertKeys(ordsAndKeys.keys, expectedKeys);
     }
 
@@ -737,7 +736,7 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block1, block2);
         assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:DOUBLE], entries=4, size="));
         assertThat(ordsAndKeys.description, endsWith("b}"));
-        assertOrds(ordsAndKeys.ords, 0L, 1L, 0L, 2L, 3L, 2L);
+        assertOrds(ordsAndKeys.ords, 0, 1, 0, 2, 3, 2);
         assertKeys(ordsAndKeys.keys, expectedKeys);
     }
 
@@ -755,7 +754,7 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(block1, block2);
         assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:INT, 1:BOOLEAN], entries=4, size="));
         assertThat(ordsAndKeys.description, endsWith("b}"));
-        assertOrds(ordsAndKeys.ords, 0L, 1L, 0L, 2L, 3L, 2L);
+        assertOrds(ordsAndKeys.ords, 0, 1, 0, 2, 3, 2);
         assertKeys(ordsAndKeys.keys, expectedKeys);
     }
 
@@ -776,7 +775,7 @@ public class BlockHashTests extends ESTestCase {
         OrdsAndKeys ordsAndKeys = hash(b1.build(), b2.build());
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:LONG], entries=5, size="));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 3L, 4L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 3, 4);
             assertKeys(
                 ordsAndKeys.keys,
                 new Object[][] {
@@ -789,7 +788,7 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 5)));
         } else {
             assertThat(ordsAndKeys.description, equalTo("LongLongBlockHash{channels=[0,1], entries=2}"));
-            assertOrds(ordsAndKeys.ords, 0L, null, 1L, null, null);
+            assertOrds(ordsAndKeys.ords, 0, null, 1, null, null);
             assertKeys(ordsAndKeys.keys, new Object[][] { new Object[] { 1L, 0L }, new Object[] { 0L, 1L } });
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 2)));
         }
@@ -822,7 +821,7 @@ public class BlockHashTests extends ESTestCase {
             )
         );
         assertThat(ordsAndKeys.description, endsWith("b}"));
-        assertOrds(ordsAndKeys.ords, 0L, 1L, 0L, 2L, 3L, 2L);
+        assertOrds(ordsAndKeys.ords, 0, 1, 0, 2, 3, 2);
         assertKeys(ordsAndKeys.keys, expectedKeys);
         assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 4)));
     }
@@ -845,7 +844,7 @@ public class BlockHashTests extends ESTestCase {
         if (forcePackedHash) {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:BYTES_REF], entries=5, size="));
             assertThat(ordsAndKeys.description, endsWith("b}"));
-            assertOrds(ordsAndKeys.ords, 0L, 1L, 2L, 3L, 4L);
+            assertOrds(ordsAndKeys.ords, 0, 1, 2, 3, 4);
             assertKeys(
                 ordsAndKeys.keys,
                 new Object[][] {
@@ -862,7 +861,7 @@ public class BlockHashTests extends ESTestCase {
                 startsWith("BytesRefLongBlockHash{keys=[BytesRefKey[channel=1], LongKey[channel=0]], entries=2, size=")
             );
             assertThat(ordsAndKeys.description, endsWith("b}"));
-            assertOrds(ordsAndKeys.ords, 0L, null, 1L, null, null);
+            assertOrds(ordsAndKeys.ords, 0, null, 1, null, null);
             assertKeys(ordsAndKeys.keys, new Object[][] { new Object[] { 1L, "cat" }, new Object[] { 0L, "dog" } });
             assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.range(0, 2)));
         }
@@ -911,15 +910,15 @@ public class BlockHashTests extends ESTestCase {
             assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:BYTES_REF], entries=10, size="));
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 0, 2 },
-                new long[] { 0, 1 },
-                new long[] { 0 },
-                new long[] { 4 },
-                new long[] { 5 },
-                new long[] { 0 },
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 6, 0, 7, 2, 8, 9 }
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 0, 2 },
+                new int[] { 0, 1 },
+                new int[] { 0 },
+                new int[] { 4 },
+                new int[] { 5 },
+                new int[] { 0 },
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 6, 0, 7, 2, 8, 9 }
             );
             assertKeys(
                 ordsAndKeys.keys,
@@ -943,15 +942,15 @@ public class BlockHashTests extends ESTestCase {
             );
             assertOrds(
                 ordsAndKeys.ords,
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 0, 1 },
-                new long[] { 0, 2 },
-                new long[] { 0 },
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 0, 1 },
+                new int[] { 0, 2 },
+                new int[] { 0 },
                 null,
                 null,
-                new long[] { 0 },
-                new long[] { 0, 1, 2, 3 },
-                new long[] { 4, 5, 6, 0, 1, 7 }
+                new int[] { 0 },
+                new int[] { 0, 1, 2, 3 },
+                new int[] { 4, 5, 6, 0, 1, 7 }
             );
             assertKeys(
                 ordsAndKeys.keys,
@@ -990,7 +989,7 @@ public class BlockHashTests extends ESTestCase {
                         "BytesRefLongBlockHash{keys=[BytesRefKey[channel=1], LongKey[channel=0]], entries=" + expectedEntries[0] + ", size="
                     )
             );
-            assertOrds(ordsAndKeys.ords, LongStream.range(start, expectedEntries[0]).toArray());
+            assertOrds(ordsAndKeys.ords, IntStream.range(start, expectedEntries[0]).toArray());
             assertKeys(
                 ordsAndKeys.keys,
                 IntStream.range(0, expectedEntries[0])
@@ -1007,7 +1006,7 @@ public class BlockHashTests extends ESTestCase {
         assertThat("misconfigured test", expectedEntries[0], greaterThan(0));
     }
 
-    record OrdsAndKeys(String description, int positionOffset, LongBlock ords, Block[] keys, IntVector nonEmpty) {}
+    record OrdsAndKeys(String description, int positionOffset, IntBlock ords, Block[] keys, IntVector nonEmpty) {}
 
     /**
      * Hash some values into a single block of group ids. If the hash produces
@@ -1042,7 +1041,7 @@ public class BlockHashTests extends ESTestCase {
     static void hash(boolean collectKeys, BlockHash blockHash, Consumer<OrdsAndKeys> callback, Block... values) {
         blockHash.add(new Page(values), new GroupingAggregatorFunction.AddInput() {
             @Override
-            public void add(int positionOffset, LongBlock groupIds) {
+            public void add(int positionOffset, IntBlock groupIds) {
                 OrdsAndKeys result = new OrdsAndKeys(
                     blockHash.toString(),
                     positionOffset,
@@ -1051,9 +1050,9 @@ public class BlockHashTests extends ESTestCase {
                     blockHash.nonEmpty()
                 );
 
-                Set<Long> allowedOrds = new HashSet<>();
+                Set<Integer> allowedOrds = new HashSet<>();
                 for (int p = 0; p < result.nonEmpty.getPositionCount(); p++) {
-                    allowedOrds.add(Long.valueOf(result.nonEmpty.getInt(p)));
+                    allowedOrds.add(result.nonEmpty.getInt(p));
                 }
                 for (int p = 0; p < result.ords.getPositionCount(); p++) {
                     if (result.ords.isNull(p)) {
@@ -1062,7 +1061,7 @@ public class BlockHashTests extends ESTestCase {
                     int start = result.ords.getFirstValueIndex(p);
                     int end = start + result.ords.getValueCount(p);
                     for (int i = start; i < end; i++) {
-                        long ord = result.ords.getLong(i);
+                        int ord = result.ords.getInt(i);
                         if (false == allowedOrds.contains(ord)) {
                             fail("ord is not allowed " + ord);
                         }
@@ -1072,17 +1071,17 @@ public class BlockHashTests extends ESTestCase {
             }
 
             @Override
-            public void add(int positionOffset, LongVector groupIds) {
+            public void add(int positionOffset, IntVector groupIds) {
                 add(positionOffset, groupIds.asBlock());
             }
         });
     }
 
-    private void assertOrds(LongBlock ordsBlock, Long... expectedOrds) {
-        assertOrds(ordsBlock, Arrays.stream(expectedOrds).map(l -> l == null ? null : new long[] { l }).toArray(long[][]::new));
+    private void assertOrds(IntBlock ordsBlock, Integer... expectedOrds) {
+        assertOrds(ordsBlock, Arrays.stream(expectedOrds).map(l -> l == null ? null : new int[] { l }).toArray(int[][]::new));
     }
 
-    private void assertOrds(LongBlock ordsBlock, long[]... expectedOrds) {
+    private void assertOrds(IntBlock ordsBlock, int[]... expectedOrds) {
         assertEquals(expectedOrds.length, ordsBlock.getPositionCount());
         for (int p = 0; p < expectedOrds.length; p++) {
             int start = ordsBlock.getFirstValueIndex(p);
@@ -1096,16 +1095,16 @@ public class BlockHashTests extends ESTestCase {
                         if (i != 0) {
                             error.append(", ");
                         }
-                        error.append(ordsBlock.getLong(start + i));
+                        error.append(ordsBlock.getInt(start + i));
                     }
                     fail(error.append("]").toString());
                 }
                 continue;
             }
             assertFalse(p + ": expected not null", ordsBlock.isNull(p));
-            long[] actual = new long[count];
+            int[] actual = new int[count];
             for (int i = 0; i < count; i++) {
-                actual[i] = ordsBlock.getLong(start + i);
+                actual[i] = ordsBlock.getInt(start + i);
             }
             assertThat("position " + p, actual, equalTo(expectedOrds[p]));
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
@@ -252,7 +252,7 @@ public class MultivalueDedupeTests extends ESTestCase {
         if (previousValues.contains(true)) {
             everSeen[2] = true;
         }
-        LongBlock hashes = new MultivalueDedupeBoolean((BooleanBlock) b.block()).hash(everSeen);
+        IntBlock hashes = new MultivalueDedupeBoolean((BooleanBlock) b.block()).hash(everSeen);
         List<Boolean> hashedValues = new ArrayList<>();
         if (everSeen[1]) {
             hashedValues.add(false);
@@ -297,7 +297,7 @@ public class MultivalueDedupeTests extends ESTestCase {
 
     private void assertHash(
         BasicBlockTests.RandomBlock b,
-        LongBlock hashes,
+        IntBlock hashes,
         long hashSize,
         Set<? extends Object> previousValues,
         LongFunction<Object> lookup
@@ -311,13 +311,13 @@ public class MultivalueDedupeTests extends ESTestCase {
             List<Object> v = b.values().get(p);
             if (v == null) {
                 assertThat(count, equalTo(1));
-                assertThat(hashes.getLong(start), equalTo(0L));
+                assertThat(hashes.getInt(start), equalTo(0));
                 return;
             }
             List<Object> actualValues = new ArrayList<>(count);
             int end = start + count;
             for (int i = start; i < end; i++) {
-                actualValues.add(lookup.apply(hashes.getLong(i) - 1));
+                actualValues.add(lookup.apply(hashes.getInt(i) - 1));
             }
             assertThat(actualValues, containsInAnyOrder(v.stream().collect(Collectors.toSet()).stream().sorted().toArray()));
             allValues.addAll(v);


### PR DESCRIPTION
This uses `int`s for the ordinals representing ESQL's grouping keys instead of `long`s. At this point we don't have support for massive numbers of groups and it's folly to pretend we can by using such massive ordinals. One day, we might want `long` back in certainly places to support huge ordinals. But when that day comes, we'll have a better sense of how to use them. In the mean time, let's use the smaller type.
