### PR TITLE
Add ESQL worker threadpool

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
@@ -35,22 +35,20 @@ import java.util.concurrent.Executor;
 public class DriverTaskRunner {
     public static final String ACTION_NAME = "internal:data/read/esql/compute";
     private final TransportService transportService;
-    private final Executor executor;
 
     public DriverTaskRunner(TransportService transportService, String executorName) {
         this.transportService = transportService;
-        this.executor = transportService.getThreadPool().executor(executorName);
-        transportService.registerRequestHandler(ACTION_NAME, executorName, DriverRequest::new, new DriverRequestHandler(executor));
+        transportService.registerRequestHandler(ACTION_NAME, executorName, DriverRequest::new, new DriverRequestHandler());
     }
 
-    public void executeDrivers(Task parentTask, List<Driver> drivers, ActionListener<Void> listener) {
+    public void executeDrivers(Task parentTask, List<Driver> drivers, Executor executor, ActionListener<Void> listener) {
         var runner = new DriverRunner() {
             @Override
             protected void start(Driver driver, ActionListener<Void> driverListener) {
                 transportService.sendChildRequest(
                     transportService.getLocalNode(),
                     ACTION_NAME,
-                    new DriverRequest(driver),
+                    new DriverRequest(driver, executor),
                     parentTask,
                     TransportRequestOptions.EMPTY,
                     TransportResponseHandler.empty(executor, driverListener)
@@ -62,9 +60,11 @@ public class DriverTaskRunner {
 
     private static class DriverRequest extends ActionRequest {
         private final Driver driver;
+        private final Executor executor;
 
-        DriverRequest(Driver driver) {
+        DriverRequest(Driver driver, Executor executor) {
             this.driver = driver;
+            this.executor = executor;
         }
 
         DriverRequest(StreamInput in) {
@@ -107,11 +107,16 @@ public class DriverTaskRunner {
         }
     }
 
-    private record DriverRequestHandler(Executor executor) implements TransportRequestHandler<DriverRequest> {
+    private record DriverRequestHandler() implements TransportRequestHandler<DriverRequest> {
         @Override
         public void messageReceived(DriverRequest request, TransportChannel channel, Task task) {
             var listener = new ChannelActionListener<TransportResponse.Empty>(channel);
-            Driver.start(executor, request.driver, Driver.DEFAULT_MAX_ITERATIONS, listener.map(unused -> TransportResponse.Empty.INSTANCE));
+            Driver.start(
+                request.executor,
+                request.driver,
+                Driver.DEFAULT_MAX_ITERATIONS,
+                listener.map(unused -> TransportResponse.Empty.INSTANCE)
+            );
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -77,6 +77,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_THREAD_POOL_NAME;
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
 
 /**
  * Computes the result of a {@link PhysicalPlan}.
@@ -260,7 +261,12 @@ public class ComputeService {
             listener.onFailure(e);
             return;
         }
-        driverRunner.executeDrivers(task, drivers, ActionListener.releaseAfter(listener, () -> Releasables.close(drivers)));
+        driverRunner.executeDrivers(
+            task,
+            drivers,
+            transportService.getThreadPool().executor(ESQL_WORKER_THREAD_POOL_NAME),
+            ActionListener.releaseAfter(listener, () -> Releasables.close(drivers))
+        );
     }
 
     private void acquireSearchContexts(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -72,6 +72,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
     public static final TransportVersion TRANSPORT_MINIMUM_VERSION = TransportVersion.V_8_8_0;
 
     public static final String ESQL_THREAD_POOL_NAME = "esql";
+    public static final String ESQL_WORKER_THREAD_POOL_NAME = "esql_worker";
 
     public static final Setting<Integer> QUERY_RESULT_TRUNCATION_MAX_SIZE = Setting.intSetting(
         "esql.query.result_truncation_max_size",
@@ -168,9 +169,19 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
             new FixedExecutorBuilder(
                 settings,
                 ESQL_THREAD_POOL_NAME,
+                allocatedProcessors,
+                1000,
+                ESQL_THREAD_POOL_NAME,
+                EsExecutors.TaskTrackingConfig.DEFAULT
+            ),
+            // TODO: Maybe have two types of threadpools for workers: one for CPU-bound and one for I/O-bound tasks.
+            // And we should also reduce the number of threads of the CPU-bound threadpool to allocatedProcessors.
+            new FixedExecutorBuilder(
+                settings,
+                ESQL_WORKER_THREAD_POOL_NAME,
                 ThreadPool.searchOrGetThreadPoolSize(allocatedProcessors),
                 1000,
-                "esql",
+                ESQL_WORKER_THREAD_POOL_NAME,
                 EsExecutors.TaskTrackingConfig.DEFAULT
             )
         );


### PR DESCRIPTION
Currently, we use a single threadpool for both compute and coordination tasks in ESQL. The compute tasks are anticipated to be intensive, whereas coordination tasks are expected to be short-lived. Importantly, compute tasks can be throttled and rescheduled if coordination tasks aren't scheduled timely due to the presence of long-lived compute tasks. Rescheduling a compute task in ESQL can be expensive due to the potential need to re-initialize certain Lucene structures.

Rather than introducing a new coordination threadpool, this PR introduces a new worker threadpool for compute tasks exclusively, and maintains the current threadpool as the coordination threadpool.