### PR TITLE
Add pipeline for qualitygates

### DIFF
--- a/.buildkite/pipelines/quality-gates/elasticsearch-tests.yaml
+++ b/.buildkite/pipelines/quality-gates/elasticsearch-tests.yaml
@@ -1,0 +1,10 @@
+env:
+  ENVIRONMENT: ${ENVIRONMENT?}
+
+steps:
+  - label: ":pipeline::grey_question::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    env:
+      QG_PIPELINE_LOCATION: ".buildkite/pipelines/quality-gates"
+    command: "make run-environment-tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/quality-gate-seedling:0.0.2"

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -1,0 +1,10 @@
+steps:
+  - label: ":pipeline::kibana::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Elasticsearch specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::kibana::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Enterprise Search specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -1,0 +1,30 @@
+steps:
+  - label: ":pipeline::kibana::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Elasticsearch specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::kibana::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Enterprise Search specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::kibana::seedling: Trigger Observability Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Observability specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::fleet::seedling: Trigger Fleet Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Fleet specific Elasticsearch tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::lock::seedling: Trigger Security Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Security specific Elasticsearch tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::lock::seedling: Trigger Control Plane Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Security specific Elasticsearch tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
@@ -1,0 +1,10 @@
+steps:
+  - label: ":pipeline::kibana::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Elasticsearch specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
+
+  - label: ":pipeline::kibana::seedling: Trigger Elasticsearch Tests for ${ENVIRONMENT}"
+    command: echo "replace me with Enterprise Search specific tests"
+    agent:
+      image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -269,3 +269,45 @@ spec:
           branch: lucene_snapshot
           cronline: "0 9,12,15,18 * * * America/New_York"
           message: "Runs tests against lucene_snapshot branch several times per day"
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: elasticsearch-tests-pipeline
+  description: Definition of the elasticsearch pipeline
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-tests
+spec:
+  type: buildkite-pipeline
+  owner: group:elasticsearch-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elasticsearch-tests
+      description: Pipeline that tests the service integration in various environments
+    spec:
+      repository: elastic/elasticsearch
+      pipeline_file: ./.buildkite/pipelines/quality-gates/pipeline.elasticsearch-tests.yaml
+      provider_settings:
+        trigger_mode: none
+      teams:
+        elasticsearch-team:
+          access_level: MANAGE_BUILD_AND_READ
+        enterprise-search:
+          access_level: BUILD_AND_READ
+        cloud-observability:
+          access_level: BUILD_AND_READ
+        control-plane-serverless:
+          access_level: BUILD_AND_READ
+        security-engineering-productivity:
+          access_level: BUILD_AND_READ
+        fleet:
+          access_level: BUILD_AND_READ
+        cloud-tooling:
+          access_level: BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
Head start on [quality gates!](https://docs.elastic.dev/serverless/qualitygates) Adds a simple bk pipeline that will be triggered by gpctl during promotion.  Follows the matrix titled, "Elasticsearch Release required testing" laid out in the [Serverless - end-to-end release workflow for single-tenant applications](https://docs.google.com/document/d/15rx2Z-soL20An0nBUcXX0o_HHf1OU_IgrHXgz20NndI/edit) doc.

If you're on this review its because your team name is in the matrix.


The [GPCTL trigger](https://github.com/elastic/serverless-gitops/pull/636) will not merge until there is a periodic release mechanism available.  Teams will be able to add to this and run them from buildkite until a custom release cadence is available and the trigger has merged.

