### PR TITLE
[8.9] Run VectorTileRestIT#testPartialResult only on snapshot builds (#98825)

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -14,6 +14,7 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -930,6 +931,7 @@ public class VectorTileRestIT extends ESRestTestCase {
     }
 
     public void testPartialResult() throws Exception {
+        assumeTrue("[error_query] is only available in snapshot builds", Build.current().isSnapshot());
         final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
         mvtRequest.setJsonEntity("""
             {

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -931,7 +931,7 @@ public class VectorTileRestIT extends ESRestTestCase {
     }
 
     public void testPartialResult() throws Exception {
-        assumeTrue("[error_query] is only available in snapshot builds", Build.current().isSnapshot());
+        assumeTrue("[error_query] is only available in snapshot builds", Build.CURRENT.isSnapshot());
         final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
         mvtRequest.setJsonEntity("""
             {


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Run VectorTileRestIT#testPartialResult only on snapshot builds (#98825)