### PR TITLE
Don't wrap the IndexSearcher in SignificantTermsAggregatorTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -124,7 +124,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
-                IndexSearcher searcher = newSearcher(reader);
+                IndexSearcher searcher = newSearcher(reader, false);
 
                 // Search "odd"
                 SignificantStringTerms terms = searchAndReduce(
@@ -233,7 +233,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
             randomSamplerAggregationBuilder.subAggregation(sigAgg);
 
             try (DirectoryReader reader = DirectoryReader.open(w)) {
-                IndexSearcher searcher = newSearcher(reader);
+                IndexSearcher searcher = newSearcher(reader, false);
 
                 // Match all so background and foreground should be the same size
                 // randomly select the query, but both should hit the same docs, which is all of them.
@@ -283,7 +283,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
-                IndexSearcher searcher = newSearcher(reader);
+                IndexSearcher searcher = newSearcher(reader, false);
 
                 // Search "odd"
                 SignificantLongTerms terms = searchAndReduce(
@@ -331,7 +331,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
-                IndexSearcher searcher = newSearcher(reader);
+                IndexSearcher searcher = newSearcher(reader, false);
 
                 // Search "odd"
                 SignificantTerms terms = searchAndReduce(
@@ -409,7 +409,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
-                IndexSearcher searcher = newSearcher(reader);
+                IndexSearcher searcher = newSearcher(reader, false);
 
                 SignificantTerms evenTerms = searchAndReduce(
                     searcher,
@@ -461,7 +461,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
-                IndexSearcher searcher = newSearcher(reader);
+                IndexSearcher searcher = newSearcher(reader, false);
 
                 SignificantTerms evenTerms = searchAndReduce(
                     searcher,


### PR DESCRIPTION
another failure if this sage, we need to prevent wrapping of the Index reader.

relates https://github.com/elastic/elasticsearch/issues/98789