### PR TITLE
Add a way to filter the health overview logs

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -189,7 +189,7 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
         }
 
         final Map<String, Object> result = new HashMap<>();
-        // This flag is used to filter this log lines for analysis
+        // This flag is used to filter this log line for analysis
         result.put("elasticsearch.health_overview", true);
 
         // overall status

--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -189,18 +189,20 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
         }
 
         final Map<String, Object> result = new HashMap<>();
+        // This flag is used to filter this log lines for analysis
+        result.put("elasticsearch.health_overview", true);
 
         // overall status
         final HealthStatus status = HealthStatus.merge(indicatorResults.stream().map(HealthIndicatorResult::status));
         result.put(String.format(Locale.ROOT, "%s.overall.status", HEALTH_FIELD_PREFIX), status.xContentValue());
 
         // top-level status for each indicator
-        indicatorResults.forEach((indicatorResult) -> {
-            result.put(
+        indicatorResults.forEach(
+            (indicatorResult) -> result.put(
                 String.format(Locale.ROOT, "%s.%s.status", HEALTH_FIELD_PREFIX, indicatorResult.name()),
                 indicatorResult.status().xContentValue()
-            );
-        });
+            )
+        );
 
         return result;
     }
@@ -209,7 +211,7 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
      * Handle the result of the Health Service getHealth call
      */
     // default visibility for testing purposes
-    final ActionListener<List<HealthIndicatorResult>> resultsListener = new ActionListener<List<HealthIndicatorResult>>() {
+    final ActionListener<List<HealthIndicatorResult>> resultsListener = new ActionListener<>() {
         @Override
         public void onResponse(List<HealthIndicatorResult> healthIndicatorResults) {
             try {

--- a/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
@@ -45,6 +45,7 @@ import static org.elasticsearch.health.HealthStatus.GREEN;
 import static org.elasticsearch.health.HealthStatus.YELLOW;
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -101,7 +102,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
 
         Map<String, Object> loggerResults = HealthPeriodicLogger.convertToLoggedFields(results);
 
-        assertThat(loggerResults.size(), equalTo(results.size() + 1));
+        assertThat(loggerResults.size(), equalTo(results.size() + 2));
 
         // test indicator status
         assertThat(loggerResults.get(makeHealthStatusString("network_latency")), equalTo("green"));
@@ -110,6 +111,9 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
 
         // test calculated overall status
         assertThat(loggerResults.get(makeHealthStatusString("overall")), equalTo(overallStatus.xContentValue()));
+
+        // test the flag the signals that this is the status overview
+        assertThat(loggerResults.get("elasticsearch.health_overview"), is(true));
 
         // test empty results
         {


### PR DESCRIPTION
The health periodic logger exposes through the logs an overview of the status of each health indicator. In order to be able to filter effectively and count this log lines, we would like to add an extra flag. The json will look like this:

```
"elasticsearch": {
      "health_overview": true,
      "health": {
        "disk": {
          "status": "green"
        },
        "shards_availability": {
          "status": "green"
        },
        "repository_integrity": {
          "status": "green"
        },
        "slm": {
          "status": "green"
        },
        "master_is_stable": {
          "status": "green"
        },
        "ilm": {
          "status": "green"
        },
        "shards_capacity": {
          "status": "green"
        },
        "overall": {
          "status": "green"
        }
      }
    }
```


