### PR TITLE
randomReadAndSlice also verify clones keeps position

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -146,9 +146,10 @@ public class ESIndexInputTestCase extends ESTestCase {
                             @Override
                             protected void doRun() throws Exception {
                                 final IndexInput clone;
-                                final int readStart = between(0, length);
+                                final boolean keepPosition = randomBoolean();
+                                final int readStart = keepPosition ? (int) indexInput.getFilePointer() : between(0, length);
                                 final int readEnd = between(readStart, length);
-                                if (randomBoolean()) {
+                                if (keepPosition || randomBoolean()) {
                                     clone = indexInput.clone();
                                 } else {
                                     final int sliceEnd = between(readEnd, length);
@@ -157,7 +158,9 @@ public class ESIndexInputTestCase extends ESTestCase {
                                 }
                                 startLatch.countDown();
                                 startLatch.await();
-                                clone.seek(readStart);
+                                if (keepPosition == false) {
+                                    clone.seek(readStart);
+                                }
                                 final byte[] cloneResult = randomReadAndSlice(clone, readEnd);
                                 if (randomBoolean()) {
                                     clone.close();


### PR DESCRIPTION
randomReadAndSlice now randomly keeps the cloned IndexInput's position, checking that clone of index inputs also copies the position.