### PR TITLE
Cap the DSL recorded errors to 1000 chars

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleErrorStore.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleErrorStore.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.datastreams.lifecycle;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 
 import java.util.List;
@@ -24,6 +25,7 @@ import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
  */
 public class DataStreamLifecycleErrorStore {
 
+    public static final int MAX_ERROR_MESSAGE_LENGTH = 1000;
     private final ConcurrentMap<String, String> indexNameToError = new ConcurrentHashMap<>();
 
     /**
@@ -31,10 +33,12 @@ public class DataStreamLifecycleErrorStore {
      * If an error was already recorded for the provided index this will override that error.
      */
     public void recordError(String indexName, Exception e) {
-        indexNameToError.put(indexName, org.elasticsearch.common.Strings.toString(((builder, params) -> {
+        String exceptionToString = Strings.toString(((builder, params) -> {
             ElasticsearchException.generateThrowableXContent(builder, EMPTY_PARAMS, e);
             return builder;
-        })));
+        }));
+        String recordedError = Strings.substring(exceptionToString, 0, MAX_ERROR_MESSAGE_LENGTH);
+        indexNameToError.put(indexName, recordedError);
     }
 
     /**

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleErrorStoreTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleErrorStoreTests.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleErrorStore.MAX_ERROR_MESSAGE_LENGTH;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -67,5 +68,12 @@ public class DataStreamLifecycleErrorStoreTests extends ESTestCase {
             errorStore.getAllIndices(),
             containsInAnyOrder(Stream.iterate(2, i -> i + 1).limit(8).map(i -> "test" + i).toArray(String[]::new))
         );
+    }
+
+    public void testRecordedErrorIsMaxOneThousandChars() {
+        NullPointerException exceptionWithLongMessage = new NullPointerException(randomAlphaOfLength(2000));
+        errorStore.recordError("test", exceptionWithLongMessage);
+        assertThat(errorStore.getError("test"), is(notNullValue()));
+        assertThat(errorStore.getError("test").length(), is(MAX_ERROR_MESSAGE_LENGTH));
     }
 }


### PR DESCRIPTION
We've seen very large generated exceptions (>5MB). 
As the Data Stream Lifecycle error store is in-memory 
this caps the recorded error message for each index to 
1000 chars.
