### PR TITLE
Simplify Field Caps logic further

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/CCSFieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/CCSFieldCapabilitiesIT.java
@@ -66,7 +66,7 @@ public class CCSFieldCapabilitiesIT extends AbstractMultiClustersTestCase {
             .setIndexFilter(new ExceptionOnRewriteQueryBuilder())
             .get();
         assertThat(response.getIndices()[0], equalTo(localIndex));
-        assertThat(response.getFailedIndices()[0], equalTo("remote_cluster:*"));
+        assertThat(response.getFailedIndicesCount(), equalTo(1));
         FieldCapabilitiesFailure failure = response.getFailures()
             .stream()
             .filter(f -> Arrays.asList(f.getIndices()).contains("remote_cluster:*"))
@@ -95,7 +95,7 @@ public class CCSFieldCapabilitiesIT extends AbstractMultiClustersTestCase {
             .setIndexFilter(new ExceptionOnRewriteQueryBuilder())
             .get();
         assertThat(Arrays.asList(response.getIndices()), containsInAnyOrder(localIndex, "remote_cluster:okay_remote_index"));
-        assertThat(response.getFailedIndices()[0], equalTo("remote_cluster:" + remoteErrorIndex));
+        assertThat(response.getFailedIndicesCount(), equalTo(1));
         failure = response.getFailures()
             .stream()
             .filter(f -> Arrays.asList(f.getIndices()).contains("remote_cluster:" + remoteErrorIndex))

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -421,7 +421,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             .setIndexFilter(new ExceptionOnRewriteQueryBuilder())
             .get();
         assertEquals(1, response.getFailures().size());
-        assertEquals(2, response.getFailedIndices().length);
+        assertEquals(2, response.getFailedIndicesCount());
         assertThat(response.getFailures().get(0).getIndices(), arrayContainingInAnyOrder("index1-error", "index2-error"));
         Exception failure = response.getFailures().get(0).getException();
         assertEquals(IllegalArgumentException.class, failure.getClass());

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -276,7 +276,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         builder.field(SEARCHABLE_FIELD.getPreferredName(), isSearchable);
         builder.field(AGGREGATABLE_FIELD.getPreferredName(), isAggregatable);
         if (isDimension) {
-            builder.field(TIME_SERIES_DIMENSION_FIELD.getPreferredName(), isDimension);
+            builder.field(TIME_SERIES_DIMENSION_FIELD.getPreferredName(), true);
         }
         if (metricType != null) {
             builder.field(TIME_SERIES_METRIC_FIELD.getPreferredName(), metricType);
@@ -315,7 +315,6 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         return PARSER.parse(parser, name);
     }
 
-    @SuppressWarnings("unchecked")
     private static final InstantiatingObjectParser<FieldCapabilities, String> PARSER;
 
     static {
@@ -471,10 +470,6 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
     @Override
     public String toString() {
         return Strings.toString(this);
-    }
-
-    static FieldCapabilities buildBasic(String field, String type, String[] indices) {
-        return new FieldCapabilities(field, type, false, false, false, false, null, indices, null, null, null, null, Map.of());
     }
 
     static class Builder {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -58,11 +58,8 @@ class FieldCapabilitiesFetcher {
     ) throws IOException {
         final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         final IndexShard indexShard = indexService.getShard(shardId.getId());
-        if (alwaysMatches(indexFilter)) {
-            // no need to open a searcher if we aren't filtering
-            return doFetch(task, shardId, fieldPatterns, filters, fieldTypes, indexFilter, nowInMillis, runtimeFields, indexService, null);
-        }
-        try (Engine.Searcher searcher = indexShard.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE)) {
+        // no need to open a searcher if we aren't filtering
+        try (Engine.Searcher searcher = alwaysMatches(indexFilter) ? null : indexShard.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE)) {
             return doFetch(
                 task,
                 shardId,

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -81,8 +81,8 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
             out.writeMap(responseMap, StreamOutput::writeString, (valueOut, fc) -> fc.writeTo(valueOut));
         }
 
-        List<FieldCapabilitiesIndexResponse> getResponses() {
-            return indices.stream().map(index -> new FieldCapabilitiesIndexResponse(index, indexMappingHash, responseMap, true)).toList();
+        Stream<FieldCapabilitiesIndexResponse> getResponses() {
+            return indices.stream().map(index -> new FieldCapabilitiesIndexResponse(index, indexMappingHash, responseMap, true));
         }
     }
 
@@ -92,7 +92,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
         }
         final List<FieldCapabilitiesIndexResponse> ungroupedList = input.readList(FieldCapabilitiesIndexResponse::new);
         final List<GroupByMappingHash> groups = input.readList(GroupByMappingHash::new);
-        return Stream.concat(ungroupedList.stream(), groups.stream().flatMap(g -> g.getResponses().stream())).toList();
+        return Stream.concat(ungroupedList.stream(), groups.stream().flatMap(GroupByMappingHash::getResponses)).toList();
     }
 
     static void writeList(StreamOutput output, List<FieldCapabilitiesIndexResponse> responses) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -143,12 +143,16 @@ class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesReque
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("shards[");
         Strings.collectionToDelimitedStringWithLimit(shardIds, ",", "", "", 1024, stringBuilder);
+        return completeDescription(stringBuilder, fields, filters, allowedTypes);
+    }
+
+    static String completeDescription(StringBuilder stringBuilder, String[] fields, String[] filters, String[] allowedTypes) {
         stringBuilder.append("], fields[");
         Strings.collectionToDelimitedStringWithLimit(Arrays.asList(fields), ",", "", "", 1024, stringBuilder);
         stringBuilder.append("], filters[");
-        stringBuilder.append(Strings.collectionToDelimitedString(Arrays.asList(filters), ","));
+        Strings.collectionToDelimitedString(Arrays.asList(filters), ",", "", "", stringBuilder);
         stringBuilder.append("], types[");
-        stringBuilder.append(Strings.collectionToDelimitedString(Arrays.asList(allowedTypes), ","));
+        Strings.collectionToDelimitedString(Arrays.asList(allowedTypes), ",", "", "", stringBuilder);
         stringBuilder.append("]");
         return stringBuilder.toString();
     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -264,14 +264,7 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder("indices[");
         Strings.collectionToDelimitedStringWithLimit(Arrays.asList(indices), ",", "", "", 1024, stringBuilder);
-        stringBuilder.append("], fields[");
-        Strings.collectionToDelimitedStringWithLimit(Arrays.asList(fields), ",", "", "", 1024, stringBuilder);
-        stringBuilder.append("], filters[");
-        stringBuilder.append(Strings.collectionToDelimitedString(Arrays.asList(filters), ","));
-        stringBuilder.append("], types[");
-        stringBuilder.append(Strings.collectionToDelimitedString(Arrays.asList(types), ","));
-        stringBuilder.append("]");
-        return stringBuilder.toString();
+        return FieldCapabilitiesNodeRequest.completeDescription(stringBuilder, fields, filters, types);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -91,8 +91,13 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
     /**
      * Get the concrete list of indices that failed
      */
-    public String[] getFailedIndices() {
-        return this.failures.stream().map(FieldCapabilitiesFailure::getIndices).flatMap(s -> Arrays.stream(s)).toArray(String[]::new);
+    public int getFailedIndicesCount() {
+        int count = 0;
+        for (FieldCapabilitiesFailure fieldCapabilitiesFailure : this.failures) {
+            int length = fieldCapabilitiesFailure.getIndices().length;
+            count += length;
+        }
+        return count;
     }
 
     /**
@@ -166,7 +171,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
                 ? Iterators.concat(
                     Iterators.single(
                         (ToXContent) (b, p) -> b.endObject()
-                            .field(FAILED_INDICES_FIELD.getPreferredName(), getFailedIndices().length)
+                            .field(FAILED_INDICES_FIELD.getPreferredName(), getFailedIndicesCount())
                             .field(FAILURES_FIELD.getPreferredName())
                             .startArray()
                     ),


### PR DESCRIPTION
Lots of memory savings here. Stop using streams in some spots, remove intermediate collections of stream to list where unnecessary and some other obvious cleanups.
