### PR TITLE
fix UnsignedLong field range query gt "0" can get the result equal to 0

### DIFF
--- a/docs/changelog/98843.yaml
+++ b/docs/changelog/98843.yaml
@@ -1,0 +1,5 @@
+pr: 98843
+summary: Fix UnsignedLong field range query gt "0" can get the result equal to 0
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -460,8 +460,8 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             }
             String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
             final BigDecimal bigDecimalValue = new BigDecimal(stringValue);  // throws an exception if it is an improper number
-            if (bigDecimalValue.compareTo(BigDecimal.ZERO) <= 0) {
-                return 0L; // for values <=0, set lowerTerm to 0
+            if (bigDecimalValue.compareTo(BigDecimal.ZERO) < 0) {
+                return 0L; // for values < 0, set lowerTerm to 0
             }
             int c = bigDecimalValue.compareTo(BIGDECIMAL_2_64_MINUS_ONE);
             if (c > 0 || (c == 0 && include == false)) {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
@@ -125,6 +125,7 @@ public class UnsignedLongFieldTypeTests extends FieldTypeTestCase {
         assertEquals(0L, parseLowerRangeTerm(0L, true).longValue());
         assertEquals(0L, parseLowerRangeTerm("0", true).longValue());
         assertEquals(0L, parseLowerRangeTerm("0.0", true).longValue());
+        assertEquals(1L, parseLowerRangeTerm("0", false).longValue());
         assertEquals(1L, parseLowerRangeTerm("0.5", true).longValue());
         assertEquals(9223372036854775807L, parseLowerRangeTerm(9223372036854775806L, false).longValue());
         assertEquals(9223372036854775807L, parseLowerRangeTerm(9223372036854775807L, true).longValue());


### PR DESCRIPTION
fix UnsignedLong field range query gt "0" can get the result equal to 0

reproduce step
```js
PUT /test
{
  "settings": {
    "number_of_shards": 1
  },
  "mappings": {
    "properties": {
      "age": { "type": "unsigned_long" }
    }
  }
}

POST /test/_doc
{
  "age": 0
}

GET /test/_search
{
  "query": {
    "range": {
      "age": {
        "gt": "0"
      }
    }
  }
}
```

result:
```json
{
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "test",
        "_type" : "_doc",
        "_id" : "IQ9fJ4oBlwqQDSgR8uji",
        "_score" : 1.0,
        "_source" : {
          "age" : 0
        }
      }
    ]
  }
}
```
