### PR TITLE
ESQL: Add ability to perform date math

### DIFF
--- a/docs/changelog/97409.yaml
+++ b/docs/changelog/97409.yaml
@@ -1,0 +1,5 @@
+pr: 97409
+summary: Trim stored fields for `_id` field in tsdb
+area: TSDB
+type: enhancement
+issues: []

--- a/docs/changelog/97972.yaml
+++ b/docs/changelog/97972.yaml
@@ -1,0 +1,6 @@
+pr: 97972
+summary: Automatically flatten objects when subobjects:false
+area: Mapping
+type: enhancement
+issues:
+ - 88934

--- a/docs/changelog/98808.yaml
+++ b/docs/changelog/98808.yaml
@@ -1,0 +1,6 @@
+pr: 98808
+summary: Set default index mode for `TimeSeries` to `null`
+area: Aggregations
+type: enhancement
+issues:
+ - 97429

--- a/docs/changelog/98844.yaml
+++ b/docs/changelog/98844.yaml
@@ -1,0 +1,5 @@
+pr: 98844
+summary: Add accessors required to recreate `TransformStats` object from the fields
+area: Transform
+type: enhancement
+issues: []

--- a/docs/changelog/98848.yaml
+++ b/docs/changelog/98848.yaml
@@ -1,0 +1,6 @@
+pr: 98848
+summary: "ESQL: Add ability to perform date math"
+area: ES|QL
+type: enhancement
+issues:
+ - 98402

--- a/docs/reference/settings/security-hash-settings.asciidoc
+++ b/docs/reference/settings/security-hash-settings.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[hashing-settings]]
-==== User cache and password hash algorithms
+=== User cache and password hash algorithms
 
 Certain realms store user credentials in memory. To limit exposure
 to credential theft and mitigate credential compromise, the cache only stores

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -2609,7 +2609,7 @@ setting, this would be `transport.profiles.$PROFILE.xpack.security.ssl.key`.
 
 [discrete]
 [[ip-filtering-settings]]
-==== IP filtering settings
+=== IP filtering settings
 You can configure the following settings for <<ip-filtering,IP filtering>>.
 
 `xpack.security.transport.filter.allow`::
@@ -2635,5 +2635,14 @@ List of IP addresses to allow for this profile.
 `transport.profiles.$PROFILE.xpack.security.filter.deny`::
 (<<dynamic-cluster-setting,Dynamic>>)
 List of IP addresses to deny for this profile.
+
+// TODO: fix the link to new page of API key based remote clusters
+`xpack.security.remote_cluster.filter.allow`::
+(<<dynamic-cluster-setting,Dynamic>>)
+beta:[] List of IP addresses to allow just for the remote cluster server.
+
+`xpack.security.remote_cluster.filter.deny`::
+(<<dynamic-cluster-setting,Dynamic>>)
+beta:[] List of IP addresses to deny just for the remote cluster server.
 
 include::security-hash-settings.asciidoc[]

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/FlatteningXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/FlatteningXContentParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xcontent;
+
+import java.io.IOException;
+
+/**
+ * A subclass of XContentSubParser that provides the functionality to flatten
+ * the field names by prefixing them with the provided parent name.
+ */
+public class FlatteningXContentParser extends XContentSubParser {
+    private final String parentName;
+    private static final char DELIMITER = '.';
+
+    /**
+     * Constructs a FlatteningXContentParser with the given parent name and wraps an existing XContentParser.
+     *
+     * @param parser The XContentParser to be wrapped and extended with flattening functionality.
+     * @param parentName The parent name to be used as a prefix for immediate children.
+     */
+    public FlatteningXContentParser(XContentParser parser, String parentName) {
+        super(parser);
+        this.parentName = parentName;
+    }
+
+    /**
+     * Retrieves the name of the current field being parsed. If the current parsing level is 1,
+     * the returned field name will be constructed by prepending the parent name to the
+     * delegate's currentFieldName, otherwise just delegate.
+     *
+     * @return The current field name, potentially modified by prepending the parent name as a prefix.
+     * @throws IOException If an I/O error occurs during parsing.
+     */
+    @Override
+    public String currentName() throws IOException {
+        if (level() == 1) {
+            return new StringBuilder(parentName).append(DELIMITER).append(delegate().currentName()).toString();
+        }
+        return delegate().currentName();
+    }
+}

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentSubParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentSubParser.java
@@ -77,4 +77,8 @@ public class XContentSubParser extends FilterXContentParserWrapper {
             }
         }
     }
+
+    int level() {
+        return level;
+    }
 }

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -475,6 +475,41 @@ public class XContentParserTests extends ESTestCase {
         }
     }
 
+    public void testFlatteningParserObject() throws IOException {
+        String content = """
+            {
+              "parent": {
+                "child1" : 1,
+                "child2": {
+                  "grandChild" : 1
+                },
+                "child3" : 1
+              }
+            }
+            """;
+        XContentParser parser = createParser(JsonXContent.jsonXContent, content);
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+        assertEquals("parent", parser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        XContentParser subParser = new FlatteningXContentParser(parser, parser.currentName());
+        assertEquals(XContentParser.Token.FIELD_NAME, subParser.nextToken());
+        assertEquals("parent.child1", subParser.currentName());
+        assertEquals(XContentParser.Token.VALUE_NUMBER, subParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, subParser.nextToken());
+        String secondChildName = subParser.currentName();
+        assertEquals("parent.child2", secondChildName);
+        assertEquals(XContentParser.Token.START_OBJECT, subParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, subParser.nextToken());
+        assertEquals("grandChild", subParser.currentName());
+        assertEquals(XContentParser.Token.VALUE_NUMBER, subParser.nextToken());
+        assertEquals(XContentParser.Token.END_OBJECT, subParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, subParser.nextToken());
+        assertEquals("parent.child3", subParser.currentName());
+        assertEquals(XContentParser.Token.VALUE_NUMBER, subParser.nextToken());
+
+    }
+
     public void testSubParserArray() throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         int numberOfArrayElements = randomInt(10);

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -416,6 +416,37 @@ nested fields:
                             time_series_metric: gauge
 
 ---
+"Synthetic source":
+  - skip:
+      version: " - 8.9.99"
+      reason: "Synthetic source shows up in the mapping in 8.10 and on"
+
+  - do:
+      indices.create:
+        index: tsdb-synthetic
+        body:
+          settings:
+            number_of_replicas: 0
+            mode: time_series
+            routing_path: [field1]
+            time_series:
+              start_time: 2000-01-01T00:00:00Z
+              end_time: 2099-12-31T23:59:59Z
+          mappings:
+            properties:
+              field1:
+                type: keyword
+                time_series_dimension: true
+              field2:
+                type: long
+                time_series_metric: gauge
+
+  - do:
+      indices.get_mapping: {}
+
+  - match: {tsdb-synthetic.mappings._source.mode: synthetic}
+
+---
 regular source:
   - skip:
       version: " - 8.6.99"

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreClusterStateListener.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreClusterStateListener.java
@@ -43,7 +43,7 @@ public class RestoreClusterStateListener {
         ActionListener<RestoreSnapshotResponse> listener,
         ThreadContext threadContext
     ) {
-        final String uuid = response.getUuid();
+        final String uuid = response.uuid();
         final DiscoveryNode localNode = clusterService.localNode();
         ClusterStateObserver.waitForState(clusterService, threadContext, new RestoreListener(listener, localNode) {
             @Override
@@ -66,7 +66,7 @@ public class RestoreClusterStateListener {
                 ClusterStateObserver.waitForState(clusterService, threadContext, new RestoreListener(listener, localNode) {
                     @Override
                     public void onNewClusterState(ClusterState state) {
-                        logger.debug("restore of [{}] completed", response.getSnapshot().getSnapshotId());
+                        logger.debug("restore of [{}] completed", response.snapshot().getSnapshotId());
                         listener.onResponse(new RestoreSnapshotResponse(restoreInfo));
                     }
                 }, clusterState -> restoreInProgress(clusterState, uuid) == null, null, logger);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -71,7 +71,7 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
         final ActionListener<RestoreSnapshotResponse> listener
     ) {
         restoreService.restoreSnapshot(request, listener.delegateFailure((delegatedListener, restoreCompletionResponse) -> {
-            if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {
+            if (restoreCompletionResponse.restoreInfo() == null && request.waitForCompletion()) {
                 RestoreClusterStateListener.createAndRegisterListener(
                     clusterService,
                     restoreCompletionResponse,
@@ -79,7 +79,7 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
                     threadPool.getThreadContext()
                 );
             } else {
-                delegatedListener.onResponse(new RestoreSnapshotResponse(restoreCompletionResponse.getRestoreInfo()));
+                delegatedListener.onResponse(new RestoreSnapshotResponse(restoreCompletionResponse.restoreInfo()));
             }
         }));
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2608,6 +2608,7 @@ public class InternalEngine extends Engine {
         iwc.setSoftDeletesField(Lucene.SOFT_DELETES_FIELD);
         mergePolicy = new RecoverySourcePruneMergePolicy(
             SourceFieldMapper.RECOVERY_SOURCE_NAME,
+            engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES,
             softDeletesPolicy::getRetentionQuery,
             new SoftDeletesRetentionMergePolicy(
                 Lucene.SOFT_DELETES_FIELD,

--- a/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
+import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.search.internal.FilterStoredFieldVisitor;
 
 import java.io.IOException;
@@ -39,18 +40,27 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
-    RecoverySourcePruneMergePolicy(String recoverySourceField, Supplier<Query> retainSourceQuerySupplier, MergePolicy in) {
+    RecoverySourcePruneMergePolicy(
+        String recoverySourceField,
+        boolean pruneIdField,
+        Supplier<Query> retainSourceQuerySupplier,
+        MergePolicy in
+    ) {
         super(in, toWrap -> new OneMerge(toWrap.segments) {
             @Override
             public CodecReader wrapForMerge(CodecReader reader) throws IOException {
                 CodecReader wrapped = toWrap.wrapForMerge(reader);
-                return wrapReader(recoverySourceField, wrapped, retainSourceQuerySupplier);
+                return wrapReader(recoverySourceField, pruneIdField, wrapped, retainSourceQuerySupplier);
             }
         });
     }
 
-    private static CodecReader wrapReader(String recoverySourceField, CodecReader reader, Supplier<Query> retainSourceQuerySupplier)
-        throws IOException {
+    private static CodecReader wrapReader(
+        String recoverySourceField,
+        boolean pruneIdField,
+        CodecReader reader,
+        Supplier<Query> retainSourceQuerySupplier
+    ) throws IOException {
         NumericDocValues recoverySource = reader.getNumericDocValues(recoverySourceField);
         if (recoverySource == null || recoverySource.nextDoc() == DocIdSetIterator.NO_MORE_DOCS) {
             return reader; // early terminate - nothing to do here since non of the docs has a recovery source anymore.
@@ -66,20 +76,22 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             if (recoverySourceToKeep.cardinality() == reader.maxDoc()) {
                 return reader; // keep all source
             }
-            return new SourcePruningFilterCodecReader(recoverySourceField, reader, recoverySourceToKeep);
+            return new SourcePruningFilterCodecReader(recoverySourceField, pruneIdField, reader, recoverySourceToKeep);
         } else {
-            return new SourcePruningFilterCodecReader(recoverySourceField, reader, null);
+            return new SourcePruningFilterCodecReader(recoverySourceField, pruneIdField, reader, null);
         }
     }
 
     private static class SourcePruningFilterCodecReader extends FilterCodecReader {
         private final BitSet recoverySourceToKeep;
         private final String recoverySourceField;
+        private final boolean pruneIdField;
 
-        SourcePruningFilterCodecReader(String recoverySourceField, CodecReader reader, BitSet recoverySourceToKeep) {
+        SourcePruningFilterCodecReader(String recoverySourceField, boolean pruneIdField, CodecReader reader, BitSet recoverySourceToKeep) {
             super(reader);
             this.recoverySourceField = recoverySourceField;
             this.recoverySourceToKeep = recoverySourceToKeep;
+            this.pruneIdField = pruneIdField;
         }
 
         @Override
@@ -125,7 +137,12 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
 
         @Override
         public StoredFieldsReader getFieldsReader() {
-            return new RecoverySourcePruningStoredFieldsReader(super.getFieldsReader(), recoverySourceToKeep, recoverySourceField);
+            return new RecoverySourcePruningStoredFieldsReader(
+                super.getFieldsReader(),
+                recoverySourceToKeep,
+                recoverySourceField,
+                pruneIdField
+            );
         }
 
         @Override
@@ -212,11 +229,18 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
 
             private final BitSet recoverySourceToKeep;
             private final String recoverySourceField;
+            private final boolean pruneIdField;
 
-            RecoverySourcePruningStoredFieldsReader(StoredFieldsReader in, BitSet recoverySourceToKeep, String recoverySourceField) {
+            RecoverySourcePruningStoredFieldsReader(
+                StoredFieldsReader in,
+                BitSet recoverySourceToKeep,
+                String recoverySourceField,
+                boolean pruneIdField
+            ) {
                 super(in);
                 this.recoverySourceToKeep = recoverySourceToKeep;
                 this.recoverySourceField = Objects.requireNonNull(recoverySourceField);
+                this.pruneIdField = pruneIdField;
             }
 
             @Override
@@ -230,6 +254,9 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
                             if (recoverySourceField.equals(fieldInfo.name)) {
                                 return Status.NO;
                             }
+                            if (pruneIdField && IdFieldMapper.NAME.equals(fieldInfo.name)) {
+                                return Status.NO;
+                            }
                             return super.needsField(fieldInfo);
                         }
                     });
@@ -238,12 +265,17 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
 
             @Override
             public StoredFieldsReader getMergeInstance() {
-                return new RecoverySourcePruningStoredFieldsReader(in.getMergeInstance(), recoverySourceToKeep, recoverySourceField);
+                return new RecoverySourcePruningStoredFieldsReader(
+                    in.getMergeInstance(),
+                    recoverySourceToKeep,
+                    recoverySourceField,
+                    pruneIdField
+                );
             }
 
             @Override
             public StoredFieldsReader clone() {
-                return new RecoverySourcePruningStoredFieldsReader(in.clone(), recoverySourceToKeep, recoverySourceField);
+                return new RecoverySourcePruningStoredFieldsReader(in.clone(), recoverySourceToKeep, recoverySourceField, pruneIdField);
             }
 
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
 
 import java.util.List;
 
@@ -30,16 +31,28 @@ public class DocumentMapper {
         );
         MetadataFieldMapper[] metadata = mapperService.getMetadataMappers().values().toArray(new MetadataFieldMapper[0]);
         Mapping mapping = new Mapping(root, metadata, null);
-        return new DocumentMapper(mapperService.documentParser(), mapping, mapping.toCompressedXContent());
+        return new DocumentMapper(mapperService.documentParser(), mapping, mapping.toCompressedXContent(), IndexVersion.current());
     }
 
-    DocumentMapper(DocumentParser documentParser, Mapping mapping, CompressedXContent source) {
+    DocumentMapper(DocumentParser documentParser, Mapping mapping, CompressedXContent source, IndexVersion version) {
         this.documentParser = documentParser;
         this.type = mapping.getRoot().name();
         this.mappingLookup = MappingLookup.fromMapping(mapping);
         this.mappingSource = source;
-        assert mapping.toCompressedXContent().equals(source)
+
+        assert mapping.toCompressedXContent().equals(source) || isSyntheticSourceMalformed(source, version)
             : "provided source [" + source + "] differs from mapping [" + mapping.toCompressedXContent() + "]";
+    }
+
+    /**
+     * Indexes built at v.8.7 were missing an explicit entry for synthetic_source.
+     * This got restored in v.8.10 to avoid confusion. The change is only restricted to mapping printout, it has no
+     * functional effect as the synthetic source already applies.
+     */
+    boolean isSyntheticSourceMalformed(CompressedXContent source, IndexVersion version) {
+        return sourceMapper().isSynthetic()
+            && source.string().contains("\"_source\":{\"mode\":\"synthetic\"}") == false
+            && version.onOrBefore(IndexVersion.V_8_10_0);
     }
 
     public Mapping mapping() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.xcontent.FilterXContentParserWrapper;
+import org.elasticsearch.xcontent.FlatteningXContentParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -442,6 +443,20 @@ public abstract class DocumentParserContext {
             @Override
             public LuceneDocument doc() {
                 return doc;
+            }
+        };
+    }
+
+    /**
+     * Return a context for flattening subobjects
+     * @param fieldName   the name of the field to be flattened
+     */
+    public final DocumentParserContext createFlattenContext(String fieldName) {
+        XContentParser flatteningParser = new FlatteningXContentParser(parser(), fieldName);
+        return new Wrapper(this.parent(), this) {
+            @Override
+            public XContentParser parser() {
+                return flatteningParser;
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.routing.IndexRouting;
+import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Responsible for loading the _id from stored fields or for TSDB synthesizing the _id from the routing, _tsid and @timestamp fields.
+ */
+public sealed interface IdLoader permits IdLoader.TsIdLoader, IdLoader.StoredIdLoader {
+
+    /**
+     * @return returns an {@link IdLoader} instance the loads the _id from stored field.
+     */
+    static IdLoader fromLeafStoredFieldLoader() {
+        return new StoredIdLoader();
+    }
+
+    /**
+     * @return returns an {@link IdLoader} instance that syn synthesizes _id from routing, _tsid and @timestamp fields.
+     */
+    static IdLoader createTsIdLoader(IndexRouting.ExtractFromSource indexRouting, List<String> routingPaths) {
+        return new TsIdLoader(indexRouting, routingPaths);
+    }
+
+    Leaf leaf(LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf) throws IOException;
+
+    /**
+     * Returns a leaf instance for a leaf reader that returns the _id for segment level doc ids.
+     */
+    sealed interface Leaf permits StoredLeaf, TsIdLeaf {
+
+        /**
+         * @param subDocId The segment level doc id for which the return the _id
+         * @return the _id for the provided subDocId
+         */
+        String getId(int subDocId);
+
+    }
+
+    final class TsIdLoader implements IdLoader {
+
+        private final IndexRouting.ExtractFromSource indexRouting;
+        private final List<String> routingPaths;
+
+        TsIdLoader(IndexRouting.ExtractFromSource indexRouting, List<String> routingPaths) {
+            this.routingPaths = routingPaths;
+            this.indexRouting = indexRouting;
+        }
+
+        public IdLoader.Leaf leaf(LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf) throws IOException {
+            IndexRouting.ExtractFromSource.Builder[] builders = new IndexRouting.ExtractFromSource.Builder[docIdsInLeaf.length];
+            for (int i = 0; i < builders.length; i++) {
+                builders[i] = indexRouting.builder();
+            }
+
+            for (String routingField : routingPaths) {
+                // Routing field must always be keyword fields, so it is ok to use SortedSetDocValues directly here.
+                SortedSetDocValues dv = DocValues.getSortedSet(reader, routingField);
+                for (int i = 0; i < docIdsInLeaf.length; i++) {
+                    int docId = docIdsInLeaf[i];
+                    var builder = builders[i];
+                    if (dv.advanceExact(docId)) {
+                        for (int j = 0; j < dv.docValueCount(); j++) {
+                            BytesRef routingValue = dv.lookupOrd(dv.nextOrd());
+                            builder.addMatching(routingField, routingValue);
+                        }
+                    }
+                }
+            }
+
+            String[] ids = new String[docIdsInLeaf.length];
+            // Each document always has exactly one tsid and one timestamp:
+            SortedDocValues tsIdDocValues = DocValues.getSorted(reader, TimeSeriesIdFieldMapper.NAME);
+            SortedNumericDocValues timestampDocValues = DocValues.getSortedNumeric(reader, DataStream.TIMESTAMP_FIELD_NAME);
+            for (int i = 0; i < docIdsInLeaf.length; i++) {
+                int docId = docIdsInLeaf[i];
+
+                boolean found = tsIdDocValues.advanceExact(docId);
+                assert found;
+                BytesRef tsid = tsIdDocValues.lookupOrd(tsIdDocValues.ordValue());
+                found = timestampDocValues.advanceExact(docId);
+                assert found;
+                assert timestampDocValues.docValueCount() == 1;
+                long timestamp = timestampDocValues.nextValue();
+
+                var routingBuilder = builders[i];
+                ids[i] = TsidExtractingIdFieldMapper.createId(false, routingBuilder, tsid, timestamp, new byte[16]);
+            }
+            return new TsIdLeaf(docIdsInLeaf, ids);
+        }
+    }
+
+    final class StoredIdLoader implements IdLoader {
+
+        public StoredIdLoader() {}
+
+        @Override
+        public Leaf leaf(LeafStoredFieldLoader loader, LeafReader reader, int[] docIdsInLeaf) throws IOException {
+            return new StoredLeaf(loader);
+        }
+    }
+
+    final class TsIdLeaf implements Leaf {
+
+        private final String[] ids;
+        private final int[] docIdsInLeaf;
+
+        private int idx = -1;
+
+        TsIdLeaf(int[] docIdsInLeaf, String[] ids) {
+            this.ids = ids;
+            this.docIdsInLeaf = docIdsInLeaf;
+        }
+
+        public String getId(int subDocId) {
+            idx++;
+            if (docIdsInLeaf[idx] != subDocId) {
+                throw new IllegalArgumentException(
+                    "expected to be called with [" + docIdsInLeaf[idx] + "] but was called with " + subDocId + " instead"
+                );
+            }
+            return ids[idx];
+        }
+    }
+
+    final class StoredLeaf implements Leaf {
+
+        private final LeafStoredFieldLoader loader;
+
+        StoredLeaf(LeafStoredFieldLoader loader) {
+            this.loader = loader;
+        }
+
+        @Override
+        public String getId(int subDocId) {
+            return loader.id();
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -348,13 +348,15 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             Mapping newMapping = parseMapping(mapping.type(), mapping.source());
             final CompressedXContent currentSource = this.mapper.mappingSource();
             final CompressedXContent newSource = newMapping.toCompressedXContent();
-            if (Objects.equals(currentSource, newSource) == false) {
+            if (Objects.equals(currentSource, newSource) == false
+                && mapper.isSyntheticSourceMalformed(currentSource, indexVersionCreated) == false) {
                 throw new IllegalStateException(
                     "expected current mapping [" + currentSource + "] to be the same as new mapping [" + newSource + "]"
                 );
             }
         }
         return true;
+
     }
 
     public void merge(IndexMetadata indexMetadata, MergeReason reason) {
@@ -386,7 +388,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason, CompressedXContent mappingSource) {
-        DocumentMapper newMapper = new DocumentMapper(documentParser, mapping, mappingSource);
+        DocumentMapper newMapper = new DocumentMapper(documentParser, mapping, mappingSource, indexVersionCreated);
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
     }

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -17,14 +17,17 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -814,5 +817,15 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public SourceLoader newSourceLoader() {
         return searchExecutionContext.newSourceLoader(request.isForceSyntheticSource());
+    }
+
+    @Override
+    public IdLoader newIdLoader() {
+        if (indexService.getIndexSettings().getMode() == IndexMode.TIME_SERIES) {
+            var indexRouting = (IndexRouting.ExtractFromSource) indexService.getIndexSettings().getIndexRouting();
+            return IdLoader.createTsIdLoader(indexRouting, indexService.getMetadata().getRoutingPaths());
+        } else {
+            return IdLoader.fromLeafStoredFieldLoader();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.search.LeafNestedDocuments;
 import org.elasticsearch.search.NestedDocuments;
@@ -110,6 +111,7 @@ public class FetchPhase {
         storedFieldsSpec = storedFieldsSpec.merge(new StoredFieldsSpec(false, false, sourceLoader.requiredStoredFields()));
 
         StoredFieldLoader storedFieldLoader = profiler.storedFields(StoredFieldLoader.fromSpec(storedFieldsSpec));
+        IdLoader idLoader = context.newIdLoader();
         boolean requiresSource = storedFieldsSpec.requiresSource();
 
         NestedDocuments nestedDocuments = context.getSearchExecutionContext().getNestedDocuments();
@@ -120,6 +122,7 @@ public class FetchPhase {
             LeafNestedDocuments leafNestedDocuments;
             LeafStoredFieldLoader leafStoredFieldLoader;
             SourceLoader.Leaf leafSourceLoader;
+            IdLoader.Leaf leafIdLoader;
 
             @Override
             protected void setNextReader(LeafReaderContext ctx, int[] docsInLeaf) throws IOException {
@@ -128,6 +131,7 @@ public class FetchPhase {
                 this.leafNestedDocuments = nestedDocuments.getLeafNestedDocuments(ctx);
                 this.leafStoredFieldLoader = storedFieldLoader.getLoader(ctx, docsInLeaf);
                 this.leafSourceLoader = sourceLoader.leaf(ctx.reader(), docsInLeaf);
+                this.leafIdLoader = idLoader.leaf(leafStoredFieldLoader, ctx.reader(), docsInLeaf);
                 fieldLookupProvider.setNextReader(ctx);
                 for (FetchSubPhaseProcessor processor : processors) {
                     processor.setNextReader(ctx);
@@ -150,7 +154,8 @@ public class FetchPhase {
                     leafStoredFieldLoader,
                     doc,
                     ctx,
-                    leafSourceLoader
+                    leafSourceLoader,
+                    leafIdLoader
                 );
                 sourceProvider.source = hit.source();
                 fieldLookupProvider.storedFields = hit.loadedFields();
@@ -194,10 +199,19 @@ public class FetchPhase {
         LeafStoredFieldLoader leafStoredFieldLoader,
         int docId,
         LeafReaderContext subReaderContext,
-        SourceLoader.Leaf sourceLoader
+        SourceLoader.Leaf sourceLoader,
+        IdLoader.Leaf idLoader
     ) throws IOException {
         if (nestedDocuments.advance(docId - subReaderContext.docBase) == null) {
-            return prepareNonNestedHitContext(requiresSource, profiler, leafStoredFieldLoader, docId, subReaderContext, sourceLoader);
+            return prepareNonNestedHitContext(
+                requiresSource,
+                profiler,
+                leafStoredFieldLoader,
+                docId,
+                subReaderContext,
+                sourceLoader,
+                idLoader
+            );
         } else {
             return prepareNestedHitContext(
                 context,
@@ -224,18 +238,20 @@ public class FetchPhase {
         LeafStoredFieldLoader leafStoredFieldLoader,
         int docId,
         LeafReaderContext subReaderContext,
-        SourceLoader.Leaf sourceLoader
+        SourceLoader.Leaf sourceLoader,
+        IdLoader.Leaf idLoader
     ) throws IOException {
         int subDocId = docId - subReaderContext.docBase;
 
         leafStoredFieldLoader.advanceTo(subDocId);
 
-        if (leafStoredFieldLoader.id() == null) {
+        String id = idLoader.getId(subDocId);
+        if (id == null) {
             SearchHit hit = new SearchHit(docId, null);
             Source source = Source.lazy(lazyStoredSourceLoader(profiler, subReaderContext, subDocId));
             return new HitContext(hit, subReaderContext, subDocId, Map.of(), source);
         } else {
-            SearchHit hit = new SearchHit(docId, leafStoredFieldLoader.id());
+            SearchHit hit = new SearchHit(docId, id);
             Source source;
             if (requiresSource) {
                 Timer timer = profiler.startLoadingSource();

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -481,5 +482,10 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public SourceLoader newSourceLoader() {
         return in.newSourceLoader();
+    }
+
+    @Override
+    public IdLoader newIdLoader() {
+        return in.newIdLoader();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -17,6 +17,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardException;
@@ -398,4 +399,6 @@ public abstract class SearchContext implements Releasable {
      * Build something to load source {@code _source}.
      */
     public abstract SourceLoader newSourceLoader();
+
+    public abstract IdLoader newIdLoader();
 }

--- a/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -546,6 +547,11 @@ public class RankSearchContext extends SearchContext {
 
     @Override
     public SourceLoader newSourceLoader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IdLoader newIdLoader() {
         throw new UnsupportedOperationException();
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -754,29 +754,7 @@ public class RestoreService implements ClusterStateApplier {
         }
     }
 
-    public static final class RestoreCompletionResponse {
-        private final String uuid;
-        private final Snapshot snapshot;
-        private final RestoreInfo restoreInfo;
-
-        private RestoreCompletionResponse(final String uuid, final Snapshot snapshot, final RestoreInfo restoreInfo) {
-            this.uuid = uuid;
-            this.snapshot = snapshot;
-            this.restoreInfo = restoreInfo;
-        }
-
-        public String getUuid() {
-            return uuid;
-        }
-
-        public Snapshot getSnapshot() {
-            return snapshot;
-        }
-
-        public RestoreInfo getRestoreInfo() {
-            return restoreInfo;
-        }
-    }
+    public record RestoreCompletionResponse(String uuid, Snapshot snapshot, RestoreInfo restoreInfo) {}
 
     public static class RestoreInProgressUpdater implements RoutingChangesObserver {
         // Map of RestoreUUID to a of changes to the shards' restore statuses
@@ -1055,7 +1033,12 @@ public class RestoreService implements ClusterStateApplier {
                 boolean changed = false;
                 for (RestoreInProgress.Entry entry : currentState.custom(RestoreInProgress.TYPE, RestoreInProgress.EMPTY)) {
                     if (entry.state().completed()) {
-                        logger.log(entry.quiet() ? Level.DEBUG : Level.INFO, "completed restore of snapshot [{}]", entry.snapshot());
+                        logger.log(
+                            entry.quiet() ? Level.DEBUG : Level.INFO,
+                            "completed restore of snapshot [{}] with state [{}]",
+                            entry.snapshot(),
+                            entry.state()
+                        );
                         changed = true;
                     } else {
                         restoreInProgressBuilder.add(entry);

--- a/server/src/main/java/org/elasticsearch/transport/DeflateTransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/DeflateTransportDecompressor.java
@@ -10,30 +10,21 @@ package org.elasticsearch.transport;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.util.PageCacheRecycler;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-public class DeflateTransportDecompressor implements TransportDecompressor {
+public class DeflateTransportDecompressor extends TransportDecompressor {
 
     private final Inflater inflater;
-    private final Recycler<BytesRef> recycler;
-    private final ArrayDeque<Recycler.V<BytesRef>> pages;
-    private int pageOffset = 0;
-    private int pageLength = 0;
-    private boolean hasSkippedHeader = false;
 
     public DeflateTransportDecompressor(Recycler<BytesRef> recycler) {
-        this.recycler = recycler;
+        super(recycler);
         inflater = new Inflater(true);
-        pages = new ArrayDeque<>(4);
     }
 
     @Override
@@ -53,14 +44,7 @@ public class DeflateTransportDecompressor implements TransportDecompressor {
             bytesConsumed += ref.length;
             boolean continueInflating = true;
             while (continueInflating) {
-                final boolean isNewPage = pageOffset == pageLength;
-                if (isNewPage) {
-                    Recycler.V<BytesRef> newPage = recycler.obtain();
-                    pageOffset = 0;
-                    pageLength = newPage.v().length;
-                    assert newPage.v().length > 0;
-                    pages.add(newPage);
-                }
+                final boolean isNewPage = maybeAddNewPage();
                 final Recycler.V<BytesRef> page = pages.getLast();
 
                 BytesRef output = page.v();
@@ -97,28 +81,6 @@ public class DeflateTransportDecompressor implements TransportDecompressor {
     }
 
     @Override
-    public ReleasableBytesReference pollDecompressedPage(boolean isEOS) {
-        if (pages.isEmpty()) {
-            return null;
-        } else if (pages.size() == 1) {
-            if (isEOS) {
-                assert isEOS();
-                Recycler.V<BytesRef> page = pages.pollFirst();
-                BytesArray delegate = new BytesArray(page.v().bytes, page.v().offset, pageOffset);
-                ReleasableBytesReference reference = new ReleasableBytesReference(delegate, page);
-                pageLength = 0;
-                pageOffset = 0;
-                return reference;
-            } else {
-                return null;
-            }
-        } else {
-            Recycler.V<BytesRef> page = pages.pollFirst();
-            return new ReleasableBytesReference(new BytesArray(page.v()), page);
-        }
-    }
-
-    @Override
     public Compression.Scheme getScheme() {
         return Compression.Scheme.DEFLATE;
     }
@@ -126,8 +88,6 @@ public class DeflateTransportDecompressor implements TransportDecompressor {
     @Override
     public void close() {
         inflater.end();
-        for (Recycler.V<BytesRef> page : pages) {
-            page.close();
-        }
+        super.close();
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/Lz4TransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/Lz4TransportDecompressor.java
@@ -26,18 +26,15 @@ import net.jpountz.lz4.LZ4Exception;
 import net.jpountz.lz4.LZ4FastDecompressor;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.recycler.Recycler;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Locale;
 
 /**
- * This file is forked from the https://netty.io project. In particular it forks the following file
+ * This file is forked from the https://netty.io project. In particular, it forks the following file
  * io.netty.handler.codec.compression.Lz4FrameDecoder.
  *
  * It modifies the original netty code to operate on byte arrays opposed to ByteBufs.
@@ -46,7 +43,7 @@ import java.util.Locale;
  *
  * This class is necessary as Netty is not a dependency in Elasticsearch server module.
  */
-public class Lz4TransportDecompressor implements TransportDecompressor {
+public class Lz4TransportDecompressor extends TransportDecompressor {
 
     private static final ThreadLocal<byte[]> DECOMPRESSED = ThreadLocal.withInitial(() -> BytesRef.EMPTY_BYTES);
     private static final ThreadLocal<byte[]> COMPRESSED = ThreadLocal.withInitial(() -> BytesRef.EMPTY_BYTES);
@@ -68,9 +65,7 @@ public class Lz4TransportDecompressor implements TransportDecompressor {
      */
     static final int COMPRESSION_LEVEL_BASE = 10;
 
-    static final int MIN_BLOCK_SIZE = 64;
     static final int MAX_BLOCK_SIZE = 1 << COMPRESSION_LEVEL_BASE + 0x0F;   // 32 M
-    static final int DEFAULT_BLOCK_SIZE = 1 << 16;  // 64 KB
 
     static final int BLOCK_TYPE_NON_COMPRESSED = 0x10;
     static final int BLOCK_TYPE_COMPRESSED = 0x20;
@@ -104,37 +99,9 @@ public class Lz4TransportDecompressor implements TransportDecompressor {
      */
     private int decompressedLength;
 
-    private final Recycler<BytesRef> recycler;
-    private final ArrayDeque<Recycler.V<BytesRef>> pages;
-    private int pageOffset = 0;
-    private int pageLength = 0;
-    private boolean hasSkippedESHeader = false;
-
     public Lz4TransportDecompressor(Recycler<BytesRef> recycler) {
+        super(recycler);
         this.decompressor = Compression.Scheme.lz4Decompressor();
-        this.recycler = recycler;
-        this.pages = new ArrayDeque<>(4);
-    }
-
-    @Override
-    public ReleasableBytesReference pollDecompressedPage(boolean isEOS) {
-        if (pages.isEmpty()) {
-            return null;
-        } else if (pages.size() == 1) {
-            if (isEOS) {
-                Recycler.V<BytesRef> page = pages.pollFirst();
-                BytesArray delegate = new BytesArray(page.v().bytes, page.v().offset, pageOffset);
-                ReleasableBytesReference reference = new ReleasableBytesReference(delegate, page);
-                pageLength = 0;
-                pageOffset = 0;
-                return reference;
-            } else {
-                return null;
-            }
-        } else {
-            Recycler.V<BytesRef> page = pages.pollFirst();
-            return new ReleasableBytesReference(new BytesArray(page.v()), page);
-        }
     }
 
     @Override
@@ -143,17 +110,10 @@ public class Lz4TransportDecompressor implements TransportDecompressor {
     }
 
     @Override
-    public void close() {
-        for (Recycler.V<BytesRef> page : pages) {
-            page.close();
-        }
-    }
-
-    @Override
     public int decompress(BytesReference bytesReference) throws IOException {
         int bytesConsumed = 0;
-        if (hasSkippedESHeader == false) {
-            hasSkippedESHeader = true;
+        if (hasSkippedHeader == false) {
+            hasSkippedHeader = true;
             int esHeaderLength = Compression.Scheme.HEADER_LENGTH;
             bytesReference = bytesReference.slice(esHeaderLength, bytesReference.length() - esHeaderLength);
             bytesConsumed += esHeaderLength;
@@ -292,16 +252,8 @@ public class Lz4TransportDecompressor implements TransportDecompressor {
                         int bytesToCopy = decompressedLength;
                         int uncompressedOffset = 0;
                         while (bytesToCopy > 0) {
-                            final boolean isNewPage = pageOffset == pageLength;
-                            if (isNewPage) {
-                                Recycler.V<BytesRef> newPage = recycler.obtain();
-                                pageOffset = 0;
-                                pageLength = newPage.v().length;
-                                assert newPage.v().length > 0;
-                                pages.add(newPage);
-                            }
+                            maybeAddNewPage();
                             final Recycler.V<BytesRef> page = pages.getLast();
-
                             int toCopy = Math.min(bytesToCopy, pageLength - pageOffset);
                             System.arraycopy(decompressed, uncompressedOffset, page.v().bytes, page.v().offset + pageOffset, toCopy);
                             pageOffset += toCopy;

--- a/server/src/main/java/org/elasticsearch/transport/TransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportDecompressor.java
@@ -9,14 +9,28 @@
 package org.elasticsearch.transport;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.core.Releasable;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 
-public interface TransportDecompressor extends Releasable {
+public abstract class TransportDecompressor implements Releasable {
+
+    protected int pageOffset = 0;
+    protected int pageLength = 0;
+    protected boolean hasSkippedHeader = false;
+
+    protected final ArrayDeque<Recycler.V<BytesRef>> pages = new ArrayDeque<>(4);
+
+    private final Recycler<BytesRef> recycler;
+
+    protected TransportDecompressor(Recycler<BytesRef> recycler) {
+        this.recycler = recycler;
+    }
 
     /**
      * Decompress the provided bytes
@@ -24,16 +38,33 @@ public interface TransportDecompressor extends Releasable {
      * @param bytesReference to decompress
      * @return number of compressed bytes consumed
      */
-    int decompress(BytesReference bytesReference) throws IOException;
+    public abstract int decompress(BytesReference bytesReference) throws IOException;
 
-    ReleasableBytesReference pollDecompressedPage(boolean isEOS);
+    public ReleasableBytesReference pollDecompressedPage(boolean isEOS) {
+        if (pages.isEmpty()) {
+            return null;
+        } else if (pages.size() == 1) {
+            if (isEOS) {
+                return pollLastPage();
+            } else {
+                return null;
+            }
+        } else {
+            Recycler.V<BytesRef> page = pages.pollFirst();
+            return new ReleasableBytesReference(new BytesArray(page.v()), page);
+        }
+    }
 
-    Compression.Scheme getScheme();
+    public abstract Compression.Scheme getScheme();
 
     @Override
-    void close();
+    public void close() {
+        for (Recycler.V<BytesRef> page : pages) {
+            page.close();
+        }
+    }
 
-    static TransportDecompressor getDecompressor(Recycler<BytesRef> recycler, BytesReference bytes) throws IOException {
+    static TransportDecompressor getDecompressor(Recycler<BytesRef> recycler, BytesReference bytes) {
         if (bytes.length() < Compression.Scheme.HEADER_LENGTH) {
             return null;
         }
@@ -45,6 +76,27 @@ public interface TransportDecompressor extends Releasable {
         } else {
             throw createIllegalState(bytes);
         }
+    }
+
+    protected ReleasableBytesReference pollLastPage() {
+        Recycler.V<BytesRef> page = pages.pollFirst();
+        BytesArray delegate = new BytesArray(page.v().bytes, page.v().offset, pageOffset);
+        ReleasableBytesReference reference = new ReleasableBytesReference(delegate, page);
+        pageLength = 0;
+        pageOffset = 0;
+        return reference;
+    }
+
+    protected boolean maybeAddNewPage() {
+        if (pageOffset == pageLength) {
+            Recycler.V<BytesRef> newPage = recycler.obtain();
+            pageOffset = 0;
+            pageLength = newPage.v().length;
+            assert newPage.v().length > 0;
+            pages.add(newPage);
+            return true;
+        }
+        return false;
     }
 
     private static IllegalStateException createIllegalState(BytesReference bytes) {

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -32,6 +32,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.NullInfoStream;
 import org.apache.lucene.util.InfoStream;
+import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -43,9 +44,11 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
     public void testPruneAll() throws IOException {
         try (Directory dir = newDirectory()) {
+            boolean pruneIdField = randomBoolean();
             IndexWriterConfig iwc = newIndexWriterConfig();
             RecoverySourcePruneMergePolicy mp = new RecoverySourcePruneMergePolicy(
                 "extra_source",
+                pruneIdField,
                 MatchNoDocsQuery::new,
                 newLogMergePolicy()
             );
@@ -56,6 +59,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         writer.flush();
                     }
                     Document doc = new Document();
+                    doc.add(new StoredField(IdFieldMapper.NAME, "_id"));
                     doc.add(new StoredField("source", "hello world"));
                     doc.add(new StoredField("extra_source", "hello world"));
                     doc.add(new NumericDocValuesField("extra_source", 1));
@@ -66,8 +70,14 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
                     for (int i = 0; i < reader.maxDoc(); i++) {
                         Document document = reader.document(i);
-                        assertEquals(1, document.getFields().size());
-                        assertEquals("source", document.getFields().get(0).name());
+                        if (pruneIdField) {
+                            assertEquals(1, document.getFields().size());
+                            assertEquals("source", document.getFields().get(0).name());
+                        } else {
+                            assertEquals(2, document.getFields().size());
+                            assertEquals(IdFieldMapper.NAME, document.getFields().get(0).name());
+                            assertEquals("source", document.getFields().get(1).name());
+                        }
                     }
                     assertEquals(1, reader.leaves().size());
                     LeafReader leafReader = reader.leaves().get(0).reader();
@@ -111,9 +121,15 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
 
     public void testPruneSome() throws IOException {
         try (Directory dir = newDirectory()) {
+            boolean pruneIdField = randomBoolean();
             IndexWriterConfig iwc = newIndexWriterConfig();
             iwc.setMergePolicy(
-                new RecoverySourcePruneMergePolicy("extra_source", () -> new TermQuery(new Term("even", "true")), iwc.getMergePolicy())
+                new RecoverySourcePruneMergePolicy(
+                    "extra_source",
+                    pruneIdField,
+                    () -> new TermQuery(new Term("even", "true")),
+                    iwc.getMergePolicy()
+                )
             );
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
                 for (int i = 0; i < 20; i++) {
@@ -121,6 +137,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         writer.flush();
                     }
                     Document doc = new Document();
+                    doc.add(new StoredField(IdFieldMapper.NAME, "_id"));
                     doc.add(new StringField("even", Boolean.toString(i % 2 == 0), Field.Store.YES));
                     doc.add(new StoredField("source", "hello world"));
                     doc.add(new StoredField("extra_source", "hello world"));
@@ -138,12 +155,13 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
                         Set<String> collect = document.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
                         assertTrue(collect.contains("source"));
                         assertTrue(collect.contains("even"));
-                        if (collect.size() == 3) {
+                        if (collect.size() == 4) {
                             assertTrue(collect.contains("extra_source"));
+                            assertTrue(collect.contains(IdFieldMapper.NAME));
                             assertEquals("true", document.getField("even").stringValue());
                             assertEquals(i, extra_source.nextDoc());
                         } else {
-                            assertEquals(2, document.getFields().size());
+                            assertEquals(pruneIdField ? 2 : 3, document.getFields().size());
                         }
                     }
                     assertEquals(DocIdSetIterator.NO_MORE_DOCS, extra_source.nextDoc());
@@ -155,7 +173,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
     public void testPruneNone() throws IOException {
         try (Directory dir = newDirectory()) {
             IndexWriterConfig iwc = newIndexWriterConfig();
-            iwc.setMergePolicy(new RecoverySourcePruneMergePolicy("extra_source", () -> new MatchAllDocsQuery(), iwc.getMergePolicy()));
+            iwc.setMergePolicy(new RecoverySourcePruneMergePolicy("extra_source", false, MatchAllDocsQuery::new, iwc.getMergePolicy()));
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
                 for (int i = 0; i < 20; i++) {
                     if (i > 0 && randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -69,7 +69,7 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         assertThat(stage1.mappers().getMapper("obj1.prop1"), nullValue());
         // but merged should
         DocumentParser documentParser = new DocumentParser(null, null, () -> DocumentParsingObserver.EMPTY_INSTANCE);
-        DocumentMapper mergedMapper = new DocumentMapper(documentParser, merged, merged.toCompressedXContent());
+        DocumentMapper mergedMapper = new DocumentMapper(documentParser, merged, merged.toCompressedXContent(), IndexVersion.current());
         assertThat(mergedMapper.mappers().getMapper("age"), notNullValue());
         assertThat(mergedMapper.mappers().getMapper("obj1.prop1"), notNullValue());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.CompositeFieldScript;
@@ -2580,7 +2581,12 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
         // merge without going through toXContent and reparsing, otherwise the potential leaf path issue gets fixed on its own
         Mapping newMapping = MapperService.mergeMappings(mapperService.documentMapper(), mapping, MapperService.MergeReason.MAPPING_UPDATE);
-        DocumentMapper newDocMapper = new DocumentMapper(mapperService.documentParser(), newMapping, newMapping.toCompressedXContent());
+        DocumentMapper newDocMapper = new DocumentMapper(
+            mapperService.documentParser(),
+            newMapping,
+            newMapping.toCompressedXContent(),
+            IndexVersion.current()
+        );
         ParsedDocument doc2 = newDocMapper.parse(source("""
             {
               "foo" : {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.LatLonPoint;
+import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -2001,7 +2003,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(
             mapping(b -> b.startObject("metrics.service").field("type", "object").field("subobjects", false).endObject())
         );
-        DocumentParsingException err = expectThrows(DocumentParsingException.class, () -> mapper.parse(source("""
+        ParsedDocument doc = mapper.parse(source("""
             {
               "metrics": {
                 "service": {
@@ -2011,18 +2013,23 @@ public class DocumentParserTests extends MapperServiceTestCase {
                 }
               }
             }
-            """)));
-        assertEquals(
-            "[4:16] Tried to add subobject [time] to object [metrics.service] which does not support subobjects",
-            err.getMessage()
-        );
+            """));
+        Mapping mappingsUpdate = doc.dynamicMappingsUpdate();
+        assertNotNull(mappingsUpdate);
+        Mapper metricsMapper = mappingsUpdate.getRoot().getMapper("metrics");
+        assertNotNull(metricsMapper);
+        Mapper serviceMapper = ((ObjectMapper) metricsMapper).getMapper("service");
+        assertNotNull(serviceMapper);
+        assertNull(((ObjectMapper) serviceMapper).getMapper("time"));
+        assertNotNull(((ObjectMapper) serviceMapper).getMapper("time.max"));
+        assertNotNull(doc.rootDoc().getField("metrics.service.time.max"));
     }
 
     public void testSubobjectsFalseWithInnerDottedObject() throws Exception {
         DocumentMapper mapper = createDocumentMapper(
             mapping(b -> b.startObject("metrics.service").field("type", "object").field("subobjects", false).endObject())
         );
-        DocumentParsingException err = expectThrows(DocumentParsingException.class, () -> mapper.parse(source("""
+        ParsedDocument doc = mapper.parse(source("""
             {
               "metrics": {
                 "service": {
@@ -2032,25 +2039,16 @@ public class DocumentParserTests extends MapperServiceTestCase {
                 }
               }
             }
-            """)));
-        assertEquals(
-            "[4:26] Tried to add subobject [test.with.dots] to object [metrics.service] which does not support subobjects",
-            err.getMessage()
-        );
-    }
+            """));
+        Mapping mappingsUpdate = doc.dynamicMappingsUpdate();
 
-    public void testSubobjectsFalseRootWithInnerObject() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(mappingNoSubobjects(xContentBuilder -> {}));
-        DocumentParsingException err = expectThrows(DocumentParsingException.class, () -> mapper.parse(source("""
-            {
-              "metrics": {
-                "service": {
-                  "time.max" : 10
-                }
-              }
-            }
-            """)));
-        assertEquals("[2:14] Tried to add subobject [metrics] to object [_doc] which does not support subobjects", err.getMessage());
+        assertNotNull(mappingsUpdate);
+        Mapper metricsMapper = mappingsUpdate.getRoot().getMapper("metrics");
+        assertNotNull(metricsMapper);
+        Mapper serviceMapper = ((ObjectMapper) metricsMapper).getMapper("service");
+        assertNotNull(serviceMapper);
+        assertNotNull(((ObjectMapper) serviceMapper).getMapper("test.with.dots.max"));
+        assertNotNull(doc.rootDoc().getField("metrics.service.test.with.dots.max"));
     }
 
     public void testSubobjectsFalseRoot() throws Exception {
@@ -2190,16 +2188,25 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(
             mapping(b -> b.startObject("metrics").field("type", "object").field("subobjects", false).endObject())
         );
-        DocumentParsingException err = expectThrows(DocumentParsingException.class, () -> mapper.parse(source("""
+        ParsedDocument parsedDocument = mapper.parse(source("""
             {
               "metrics.service.time": [
                 {
-                  "max" : 1000
+                  "max" : 1
+                },
+                {
+                  "max" : 2
                 }
               ]
             }
-            """)));
-        assertEquals("[3:5] Tried to add subobject [service.time] to object [metrics] which does not support subobjects", err.getMessage());
+            """));
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields("metrics.service.time.max");
+        assertEquals(2, fields.size());
+        String[] fieldStrings = fields.stream().map(Object::toString).toArray(String[]::new);
+        assertArrayEquals(
+            new String[] { "LongField <metrics.service.time.max:1>", "LongField <metrics.service.time.max:2>" },
+            fieldStrings
+        );
     }
 
     public void testSubobjectsFalseParseGeoPoint() throws Exception {
@@ -2415,6 +2422,49 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNotNull(doc.dynamicMappingsUpdate());
     }
 
+    public void testRuntimeSubfieldsWithObjectsAndSubobjectsFalse() throws IOException {
+
+        // Create mappings with a runtime field called 'obj' that produces two subfields,
+        // 'obj.foo' and 'obj.bar'
+
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("subobjects", false);
+            b.startObject("runtime");
+            b.startObject("obj").field("type", "test-composite").endObject();
+            b.endObject();
+        }));
+
+        // Incoming documents should not create mappings for 'obj.foo' fields, as they will
+        // be shadowed by the runtime fields; but other subfields are fine and should be
+        // indexed
+
+        ParsedDocument doc = mapper.parse(source(b -> {
+            b.startObject("obj");
+            b.field("foo", "ignored");
+            b.field("baz", "indexed");
+            b.field("bar", "ignored");
+            b.startObject("sub");
+            b.startObject("foo").field("bar", "baz");
+            b.endObject();
+            b.endObject();
+            b.endObject();
+            b.startObject("sub");
+            b.startObject("foo").field("bar", "baz");
+            b.endObject();
+            b.endObject();
+        }));
+
+        assertNull(doc.rootDoc().getField("obj.foo"));
+        assertNotNull(doc.rootDoc().getField("obj.baz"));
+        assertNull(doc.rootDoc().getField("obj.bar"));
+        assertNotNull(doc.rootDoc().getField("obj.sub.foo.bar"));
+        assertNotNull(doc.rootDoc().getField("sub.foo.bar"));
+        assertNotNull(doc.dynamicMappingsUpdate());
+        assertNotNull(doc.dynamicMappingsUpdate().getRoot().getMapper("obj.baz"));
+        assertNotNull(doc.dynamicMappingsUpdate().getRoot().getMapper("obj.sub.foo.bar"));
+        assertNotNull(doc.dynamicMappingsUpdate().getRoot().getMapper("sub.foo.bar"));
+    }
+
     public void testDynamicFalseMatchesRoutingPath() throws IOException {
         DocumentMapper mapper = createMapperService(
             Settings.builder()
@@ -2572,6 +2622,551 @@ public class DocumentParserTests extends MapperServiceTestCase {
         }
         sb.append("foo");
         docMapper2.parse(source(b -> { b.field(sb.toString(), 10); }));
+    }
+
+    public void testSubobjectsFalseDocWithInnerObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(
+            mapping(b -> b.startObject("metrics.service").field("type", "object").field("subobjects", false).endObject())
+        );
+        // service cannot hold subobjects, yet incoming docs may have objects in it, which are treated as if flat paths were provided
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": {
+                "service": {
+                  "time" : {
+                    "max" : 10,
+                    "min" : 1
+                  }
+                },
+                "object" : {
+                  "field" : 5000
+                }
+              }
+            }
+            """));
+        assertNull(parsedDocument.rootDoc().getField("metrics.service.time"));
+        for (String s : Arrays.asList("metrics.service.time.max", "metrics.service.time.min", "metrics.object.field")) {
+            assertThat(parsedDocument.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+        ObjectMapper metrics = (ObjectMapper) parsedDocument.dynamicMappingsUpdate().getRoot().getMapper("metrics");
+        assertEquals(2, metrics.mappers.size());
+        ObjectMapper object = (ObjectMapper) metrics.getMapper("object");
+        assertThat(object.getMapper("field"), instanceOf(NumberFieldMapper.class));
+        ObjectMapper service = (ObjectMapper) metrics.getMapper("service");
+        assertNull(service.getMapper("time"));
+        assertThat(service.getMapper("time.max"), instanceOf(NumberFieldMapper.class));
+        assertThat(service.getMapper("time.min"), instanceOf(NumberFieldMapper.class));
+    }
+
+    public void testSubobjectsFalseRootWithInnerObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("subobjects", false);
+            b.startObject("properties");
+            {
+                b.startObject("host.name");
+                b.field("type", "keyword");
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        // the root cannot hold subobjects, yet incoming docs may have objects in it, which means that no intermediate objects are mapped
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "host" : {
+                "name" : "localhost",
+                "id" : "test"
+              },
+              "time" : 10,
+              "time.max" : 1000,
+              "time.min" : 1
+            }
+            """));
+        assertThat(parsedDocument.rootDoc().getField("host.name"), instanceOf(KeywordFieldMapper.KeywordField.class));
+        assertThat(parsedDocument.rootDoc().getField("host.id"), instanceOf(Field.class));
+        for (String s : Arrays.asList("time", "time.min", "time.max")) {
+            assertThat(parsedDocument.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(4, root.mappers.size());
+        assertThat(root.getMapper("host.id"), instanceOf(TextFieldMapper.class));
+        for (String s : Arrays.asList("time", "time.min", "time.max")) {
+            assertThat(root.getMapper(s), instanceOf(NumberFieldMapper.class));
+        }
+    }
+
+    public void testSubobjectsFalseRootAndChildWithInnerObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mappingNoSubobjects(xContentBuilder -> {}));
+        ParsedDocument doc = mapper.parse(source("""
+            {
+              "time" : {
+                "measured" : 10,
+                "range" : {
+                    "max" : 500,
+                    "min" : 1
+                },
+                "all.time.high": 499
+              }
+            }
+            """));
+
+        Mapping mappingsUpdate = doc.dynamicMappingsUpdate();
+        assertNotNull(mappingsUpdate);
+        assertNull(mappingsUpdate.getRoot().getMapper("time"));
+        assertNull(mappingsUpdate.getRoot().getMapper("time.range"));
+        for (String s : Arrays.asList("time.measured", "time.range.min", "time.range.max", "time.all.time.high")) {
+            assertThat(doc.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+        for (String s : Arrays.asList("time.measured", "time.range.min", "time.range.max", "time.all.time.high")) {
+            assertThat(mappingsUpdate.getRoot().getMapper(s), instanceOf(NumberFieldMapper.class));
+        }
+    }
+
+    public void testSubobjectsFalseRootAndChildWithInnerObjectAndDottedNames() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mappingNoSubobjects(xContentBuilder -> {}));
+        ParsedDocument doc = mapper.parse(source("""
+            {
+              "time.foo" : {
+                "measured" : 10,
+                "old.measure" : 9,
+                "range.values" : {
+                    "max" : 500,
+                    "min" : 1,
+                    "legacy.min": 2
+                }
+              }
+            }
+            """));
+        for (String s : Arrays.asList(
+            "time.foo.measured",
+            "time.foo.old.measure",
+            "time.foo.range.values.min",
+            "time.foo.range.values.max",
+            "time.foo.range.values.legacy.min"
+        )) {
+            assertThat(doc.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+
+        Mapping mappingsUpdate = doc.dynamicMappingsUpdate();
+        assertNotNull(mappingsUpdate);
+
+        for (String s : Arrays.asList(
+            "time.foo.measured",
+            "time.foo.old.measure",
+            "time.foo.range.values.min",
+            "time.foo.range.values.max",
+            "time.foo.range.values.legacy.min"
+        )) {
+            assertThat(mappingsUpdate.getRoot().getMapper(s), instanceOf(NumberFieldMapper.class));
+        }
+
+    }
+
+    public void testSubobjectsFalseRootMixedPaths() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.field("subobjects", false);
+            b.startObject("properties");
+            {
+                b.startObject("service.host.name");
+                b.field("type", "keyword");
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        // the root cannot hold subobjects, yet incoming docs may have objects in it. This verifies that different ways of
+        // specifying the same path in a document are treated in the same way
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "service.time" : 100,
+              "service" : {
+                "time" : {
+                  "min" : 1
+                },
+                "time.max" : 1000,
+                "host" : {
+                  "name" : "localhost"
+                }
+              },
+              "service.time.avg" : 500
+            }
+            """));
+
+        assertThat(parsedDocument.rootDoc().getField("service.host.name"), instanceOf(KeywordFieldMapper.KeywordField.class));
+        for (String s : Arrays.asList("service.time", "service.time.min", "service.time.max", "service.time.avg")) {
+            assertThat(parsedDocument.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+        assertNotNull(parsedDocument.dynamicMappingsUpdate());
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(4, root.mappers.size());
+        for (String s : Arrays.asList("service.time", "service.time.min", "service.time.max", "service.time.avg")) {
+            assertThat(root.getMapper(s), instanceOf(NumberFieldMapper.class));
+        }
+    }
+
+    public void testSubobjectsFalseDocWithInnerObjectsNullValues() throws Exception {
+        // null values are handled separately while parsing hence we want to make sure that the field paths are propagated correctly
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
+                {
+                    b.startObject("service.time");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                {
+                    b.startObject("service.time.max");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                {
+                    b.startObject("service.time.min");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                {
+                    b.startObject("service.time.avg");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": {
+                "service.time" : null,
+                "service": {
+                  "time" : {
+                    "min" : null
+                  },
+                  "time.max" : null
+                },
+                "service.time.avg" : null
+              }
+            }
+            """));
+
+        for (String s : Arrays.asList(
+            "metrics.service.time",
+            "metrics.service.time.min",
+            "metrics.service.time.max",
+            "metrics.service.time.avg"
+        )) {
+            assertThat(parsedDocument.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+        assertNull(parsedDocument.dynamicMappingsUpdate());
+    }
+
+    public void testSubobjectsFalseDocsWithInnerObjectMappedAsFieldThatCanParseNativalyObjects() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
+                {
+                    b.startObject("service.location");
+                    b.field("type", "geo_point");
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": {
+                "service.location" : {
+                    "lat": 41.12,
+                    "lon": -71.34
+                  }
+              }
+            }
+            """));
+        IndexableField location = parsedDocument.rootDoc().getField("metrics.service.location");
+        assertNotNull(location);
+        assertNull(parsedDocument.rootDoc().getField("metrics.service.location.lat"));
+        assertNull(parsedDocument.rootDoc().getField("metrics.service.location.lon"));
+        assertTrue(location instanceof LatLonPoint);
+        Mapper locationMapper = mapper.mappers().getMapper("metrics.service.location");
+        assertNotNull(locationMapper);
+        assertTrue(locationMapper instanceof GeoPointFieldMapper);
+    }
+
+    public void testSubobjectsFalseDocsWithInnerObjectMappedAsNonObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
+                {
+                    b.startObject("service.time");
+                    b.field("type", "long");
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": {
+                "service.time" : {
+                  "min" : 1
+                }
+              }
+            }
+            """));
+        assertThat(parsedDocument.rootDoc().getField("metrics.service.time.min"), instanceOf(LongField.class));
+        assertNotNull(parsedDocument.dynamicMappingsUpdate());
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(1, root.mappers.size());
+        ObjectMapper metrics = (ObjectMapper) root.getMapper("metrics");
+        assertNotNull(metrics);
+        assertThat((FieldMapper) metrics.getMapper("service.time.min"), instanceOf(NumberFieldMapper.class));
+    }
+
+    public void testSubobjectsFalseDocsWithMultipleInnerObjectMappedAsNonObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
+                {
+                    b.startObject("service.time");
+                    b.field("type", "long");
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": {
+                "service.time" : {
+                  "current" : {
+                    "min" : 1,
+                    "max" : 10
+                  }
+                }
+              }
+            }
+            """));
+        assertNull(parsedDocument.rootDoc().getField("metrics.service.time"));
+        assertThat(parsedDocument.rootDoc().getField("metrics.service.time.current.min"), instanceOf(LongField.class));
+        assertThat(parsedDocument.rootDoc().getField("metrics.service.time.current.max"), instanceOf(LongField.class));
+        assertNotNull(parsedDocument.dynamicMappingsUpdate());
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(1, root.mappers.size());
+        Mapper metrics = root.getMapper("metrics");
+        assertNotNull(metrics);
+        assertThat(((ObjectMapper) metrics).getMapper("service.time.current.min"), instanceOf(NumberFieldMapper.class));
+        assertThat(((ObjectMapper) metrics).getMapper("service.time.current.max"), instanceOf(NumberFieldMapper.class));
+    }
+
+    public void testSubobjectsFalseDocsWithInnerObjectThatCanBeParsedNatively() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
+                {
+                    b.startObject("service.location");
+                    b.field("type", "geo_point");
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": {
+                "service.location" : {
+                  "lat" : 42.3,
+                  "lon" : 71.2
+                }
+              }
+            }
+            """));
+        assertNull(parsedDocument.rootDoc().getField("metrics.service.location.lat"));
+        assertNull(parsedDocument.rootDoc().getField("metrics.service.location.lon"));
+        assertThat(parsedDocument.rootDoc().getField("metrics.service.location"), instanceOf(LatLonPoint.class));
+        assertThat(mapper.mappers().getMapper("metrics.service.location"), instanceOf(GeoPointFieldMapper.class));
+    }
+
+    public void testSubobjectsFalseArrayOfObjectsMixedPaths() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(
+            mapping(b -> b.startObject("metrics").field("type", "object").field("subobjects", false).endObject())
+        );
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics": [
+                {
+                  "service" : {
+                    "time" : {
+                      "max" : 1000
+                    }
+                  }
+                },
+                {
+                  "service.time" : {
+                    "min" : 1
+                  }
+                },
+                {
+                  "service.time" : 100
+                },
+                {
+                  "service" : {
+                    "time.avg" : 500
+                  }
+                }
+              ]
+            }
+            """));
+
+        for (String s : Arrays.asList(
+            "metrics.service.time",
+            "metrics.service.time.min",
+            "metrics.service.time.max",
+            "metrics.service.time.avg"
+        )) {
+            assertThat(parsedDocument.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+
+        assertNotNull(parsedDocument.dynamicMappingsUpdate());
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(1, root.mappers.size());
+        ObjectMapper metrics = (ObjectMapper) root.getMapper("metrics");
+        assertEquals(4, metrics.mappers.size());
+        for (String s : Arrays.asList("service.time", "service.time.min", "service.time.max", "service.time.avg")) {
+            assertThat(metrics.getMapper(s), instanceOf(NumberFieldMapper.class));
+        }
+    }
+
+    public void testSubobjectsFalseArrayMixedContent() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(
+            mapping(b -> b.startObject("metrics").field("type", "object").field("subobjects", false).endObject())
+        );
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "metrics.service.time": [
+                1,
+                {
+                  "max" : 2
+                }
+              ]
+            }
+            """));
+
+        for (String s : Arrays.asList("metrics.service.time", "metrics.service.time.max")) {
+            assertThat(parsedDocument.rootDoc().getField(s), instanceOf(LongField.class));
+        }
+
+        assertNotNull(parsedDocument.dynamicMappingsUpdate());
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(1, root.mappers.size());
+        ObjectMapper metrics = (ObjectMapper) root.getMapper("metrics");
+        assertEquals(2, metrics.mappers.size());
+        for (String s : Arrays.asList("service.time", "service.time.max")) {
+            assertThat(metrics.getMapper(s), instanceOf(NumberFieldMapper.class));
+        }
+    }
+
+    public void testSubobjectsFalseDocsWithGeoPointFromDynamicTemplate() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> {
+            b.startArray("dynamic_templates");
+            {
+                b.startObject();
+                b.startObject("location");
+                {
+                    b.field("match", "location");
+                    b.startObject("mapping");
+                    {
+                        b.field("type", "geo_point");
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+                b.endObject();
+            }
+            b.endArray();
+            b.field("subobjects", false);
+
+        }));
+
+        ParsedDocument parsedDocument = mapper.parse(source("""
+            {
+              "location" : {
+                "lat": 41.12,
+                "lon": -71.34
+              }
+            }
+            """));
+
+        assertThat(parsedDocument.rootDoc().getField("location"), instanceOf(LatLonPoint.class));
+        RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
+        assertEquals(1, root.mappers.size());
+        assertThat(root.getMapper("location"), instanceOf(GeoPointFieldMapper.class));
+        assertNotNull(parsedDocument.dynamicMappingsUpdate());
+    }
+
+    public void testSubobjectsFalseIngestDifferentObjectsRepresentation() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mappingNoSubobjects(b -> {}));
+
+        ParsedDocument doc1 = mapper.parse(new SourceToParse("1", new BytesArray("""
+            {
+              "foo": {
+                "bar": {
+                  "baz" : {
+                    "max" : 10,
+                    "min" : 1
+                  }
+                }
+              }
+            }
+            """), XContentType.JSON));
+        ParsedDocument doc2 = mapper.parse(new SourceToParse("2", new BytesArray("""
+            {
+              "foo": {
+                "bar.baz" : {
+                  "max" : 10,
+                  "min" : 1
+                }
+              }
+            }
+            """), XContentType.JSON));
+        ParsedDocument doc3 = mapper.parse(new SourceToParse("3", new BytesArray("""
+            {
+              "foo.bar.baz": {
+                "max" : 10,
+                "min" : 1
+              }
+            }
+            """), XContentType.JSON));
+        ParsedDocument doc4 = mapper.parse(new SourceToParse("4", new BytesArray("""
+            {
+              "foo.bar.baz.max" : 10,
+              "foo.bar.baz.min" : 1
+            }
+            """), XContentType.JSON));
+
+        for (ParsedDocument doc : Arrays.asList(doc1, doc2, doc3, doc4)) {
+            assertNotNull(doc.dynamicMappingsUpdate());
+            for (String s : Arrays.asList("foo.bar.baz.max", "foo.bar.baz.min")) {
+                assertThat(doc.rootDoc().getField(s), instanceOf(LongField.class));
+                assertThat(doc.dynamicMappingsUpdate().getRoot().getMapper(s), instanceOf(NumberFieldMapper.class));
+
+            }
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
@@ -68,6 +68,7 @@ public class IdLoaderTests extends ESTestCase {
         prepareIndexReader(indexAndForceMerge(routing, docs), verify);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98865")
     public void testSynthesizeIdMultipleSegments() throws Exception {
         var routingPaths = List.of("dim1");
         var routing = createRouting(routingPaths);

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.routing.IndexRouting;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class IdLoaderTests extends ESTestCase {
+
+    public void testSynthesizeIdSimple() throws Exception {
+        var routingPaths = List.of("dim1");
+        var routing = createRouting(routingPaths);
+        var idLoader = IdLoader.createTsIdLoader(routing, routingPaths);
+
+        long startTime = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-01-01T00:00:00Z");
+        List<Doc> docs = List.of(
+            new Doc(startTime, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "xxx"))),
+            new Doc(startTime + 1, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime + 2, List.of(new Dimension("dim1", "bbb"), new Dimension("dim2", "xxx")))
+        );
+        CheckedConsumer<IndexReader, IOException> verify = indexReader -> {
+            assertThat(indexReader.leaves(), hasSize(1));
+            LeafReader leafReader = indexReader.leaves().get(0).reader();
+            assertThat(leafReader.numDocs(), equalTo(3));
+            var leaf = idLoader.leaf(null, leafReader, new int[] { 0, 1, 2 });
+            assertThat(leaf.getId(0), equalTo(expectedId(routing, docs.get(0))));
+            assertThat(leaf.getId(1), equalTo(expectedId(routing, docs.get(1))));
+            assertThat(leaf.getId(2), equalTo(expectedId(routing, docs.get(2))));
+        };
+        prepareIndexReader(indexAndForceMerge(routing, docs), verify);
+    }
+
+    public void testSynthesizeIdMultipleSegments() throws Exception {
+        var routingPaths = List.of("dim1");
+        var routing = createRouting(routingPaths);
+        var idLoader = IdLoader.createTsIdLoader(routing, routingPaths);
+
+        long startTime = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-01-01T00:00:00Z");
+        List<Doc> docs1 = List.of(
+            new Doc(startTime, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "xxx"))),
+            new Doc(startTime - 1, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "xxx"))),
+            new Doc(startTime - 2, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "xxx"))),
+            new Doc(startTime - 3, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "xxx")))
+        );
+        List<Doc> docs2 = List.of(
+            new Doc(startTime, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime - 1, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime - 2, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime - 3, List.of(new Dimension("dim1", "aaa"), new Dimension("dim2", "yyy")))
+        );
+        List<Doc> docs3 = List.of(
+            new Doc(startTime, List.of(new Dimension("dim1", "bbb"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime - 1, List.of(new Dimension("dim1", "bbb"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime - 2, List.of(new Dimension("dim1", "bbb"), new Dimension("dim2", "yyy"))),
+            new Doc(startTime - 3, List.of(new Dimension("dim1", "bbb"), new Dimension("dim2", "yyy")))
+        );
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex = writer -> {
+            for (Doc doc : docs1) {
+                indexDoc(routing, writer, doc);
+            }
+            writer.flush();
+            for (Doc doc : docs2) {
+                indexDoc(routing, writer, doc);
+            }
+            writer.flush();
+            for (Doc doc : docs3) {
+                indexDoc(routing, writer, doc);
+            }
+            writer.flush();
+        };
+        CheckedConsumer<IndexReader, IOException> verify = indexReader -> {
+            assertThat(indexReader.leaves(), hasSize(3));
+            {
+                LeafReader leafReader = indexReader.leaves().get(0).reader();
+                assertThat(leafReader.numDocs(), equalTo(docs1.size()));
+                var leaf = idLoader.leaf(null, leafReader, IntStream.range(0, docs1.size()).toArray());
+                for (int i = 0; i < docs1.size(); i++) {
+                    assertThat(leaf.getId(i), equalTo(expectedId(routing, docs1.get(i))));
+                }
+            }
+            {
+                LeafReader leafReader = indexReader.leaves().get(1).reader();
+                assertThat(leafReader.numDocs(), equalTo(docs2.size()));
+                var leaf = idLoader.leaf(null, leafReader, new int[] { 0, 3 });
+                assertThat(leaf.getId(0), equalTo(expectedId(routing, docs2.get(0))));
+                assertThat(leaf.getId(3), equalTo(expectedId(routing, docs2.get(3))));
+            }
+            {
+                LeafReader leafReader = indexReader.leaves().get(2).reader();
+                assertThat(leafReader.numDocs(), equalTo(docs3.size()));
+                var leaf = idLoader.leaf(null, leafReader, new int[] { 1, 2 });
+                assertThat(leaf.getId(1), equalTo(expectedId(routing, docs3.get(1))));
+                assertThat(leaf.getId(2), equalTo(expectedId(routing, docs3.get(2))));
+            }
+            {
+                LeafReader leafReader = indexReader.leaves().get(2).reader();
+                assertThat(leafReader.numDocs(), equalTo(docs3.size()));
+                var leaf = idLoader.leaf(null, leafReader, new int[] { 3 });
+                expectThrows(IllegalArgumentException.class, () -> leaf.getId(0));
+            }
+        };
+        prepareIndexReader(buildIndex, verify);
+    }
+
+    public void testSynthesizeIdRandom() throws Exception {
+        var routingPaths = List.of("dim1");
+        var routing = createRouting(routingPaths);
+        var idLoader = IdLoader.createTsIdLoader(routing, routingPaths);
+
+        long startTime = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-01-01T00:00:00Z");
+        Set<String> expectedIDs = new HashSet<>();
+        List<Doc> randomDocs = new ArrayList<>();
+        int numberOfTimeSeries = randomIntBetween(8, 64);
+        for (int i = 0; i < numberOfTimeSeries; i++) {
+            int numberOfDimensions = randomIntBetween(1, 6);
+            List<Dimension> dimensions = new ArrayList<>(numberOfDimensions);
+            for (int j = 1; j <= numberOfDimensions; j++) {
+                String fieldName = "dim" + j;
+                Object value;
+                if (j == 5) {
+                    value = randomLongBetween(1, 20);
+                } else {
+                    value = randomAlphaOfLength(4);
+                }
+                dimensions.add(new Dimension(fieldName, value));
+            }
+            int numberOfSamples = randomIntBetween(1, 16);
+            for (int j = 0; j < numberOfSamples; j++) {
+                Doc doc = new Doc(startTime++, dimensions);
+                randomDocs.add(doc);
+                expectedIDs.add(expectedId(routing, doc));
+            }
+        }
+        CheckedConsumer<IndexReader, IOException> verify = indexReader -> {
+            assertThat(indexReader.leaves(), hasSize(1));
+            LeafReader leafReader = indexReader.leaves().get(0).reader();
+            assertThat(leafReader.numDocs(), equalTo(randomDocs.size()));
+            var leaf = idLoader.leaf(null, leafReader, IntStream.range(0, randomDocs.size()).toArray());
+            for (int i = 0; i < randomDocs.size(); i++) {
+                String actualId = leaf.getId(i);
+                assertTrue("docId=" + i + " id=" + actualId, expectedIDs.remove(actualId));
+            }
+        };
+        prepareIndexReader(indexAndForceMerge(routing, randomDocs), verify);
+        assertThat(expectedIDs, empty());
+    }
+
+    private static CheckedConsumer<RandomIndexWriter, IOException> indexAndForceMerge(
+        IndexRouting.ExtractFromSource routing,
+        List<Doc> docs
+    ) {
+        return writer -> {
+            for (Doc doc : docs) {
+                indexDoc(routing, writer, doc);
+            }
+            writer.forceMerge(1);
+        };
+    }
+
+    private void prepareIndexReader(
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        CheckedConsumer<IndexReader, IOException> verify
+    ) throws IOException {
+        try (Directory directory = newDirectory()) {
+            IndexWriterConfig config = LuceneTestCase.newIndexWriterConfig(random(), new MockAnalyzer(random()));
+            Sort sort = new Sort(
+                new SortField(TimeSeriesIdFieldMapper.NAME, SortField.Type.STRING, false),
+                new SortedNumericSortField(DataStreamTimestampFieldMapper.DEFAULT_PATH, SortField.Type.LONG, true)
+            );
+            config.setIndexSort(sort);
+            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory, config);
+            buildIndex.accept(indexWriter);
+            indexWriter.close();
+
+            try (DirectoryReader indexReader = DirectoryReader.open(directory);) {
+                verify.accept(indexReader);
+            }
+        }
+    }
+
+    private static void indexDoc(IndexRouting.ExtractFromSource routing, RandomIndexWriter iw, Doc doc) throws IOException {
+        final TimeSeriesIdFieldMapper.TimeSeriesIdBuilder builder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(routing.builder());
+
+        final List<IndexableField> fields = new ArrayList<>();
+        fields.add(new SortedNumericDocValuesField(DataStreamTimestampFieldMapper.DEFAULT_PATH, doc.timestamp));
+        fields.add(new LongPoint(DataStreamTimestampFieldMapper.DEFAULT_PATH, doc.timestamp));
+        for (Dimension dimension : doc.dimensions) {
+            if (dimension.value instanceof Number n) {
+                builder.addLong(dimension.field, n.longValue());
+                fields.add(new SortedNumericDocValuesField(dimension.field, ((Number) dimension.value).longValue()));
+            } else {
+                builder.addString(dimension.field, dimension.value.toString());
+                fields.add(new SortedSetDocValuesField(dimension.field, new BytesRef(dimension.value.toString())));
+            }
+        }
+        BytesRef tsid = builder.build().toBytesRef();
+        fields.add(new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, tsid));
+        iw.addDocument(fields);
+    }
+
+    private static String expectedId(IndexRouting.ExtractFromSource routing, Doc doc) throws IOException {
+        var routingBuilder = routing.builder();
+        var timeSeriesIdBuilder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(routingBuilder);
+        for (Dimension dimension : doc.dimensions) {
+            if (dimension.value instanceof Number n) {
+                timeSeriesIdBuilder.addLong(dimension.field, n.longValue());
+            } else {
+                timeSeriesIdBuilder.addString(dimension.field, dimension.value.toString());
+            }
+        }
+        return TsidExtractingIdFieldMapper.createId(
+            false,
+            routingBuilder,
+            timeSeriesIdBuilder.build().toBytesRef(),
+            doc.timestamp,
+            new byte[16]
+        );
+    }
+
+    private static IndexRouting.ExtractFromSource createRouting(List<String> routingPaths) {
+        var settings = indexSettings(IndexVersion.current(), 2, 1).put(IndexSettings.MODE.getKey(), "time_series")
+            .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2000-01-01T00:00:00.000Z")
+            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2001-01-01T00:00:00.000Z")
+            .putList(IndexMetadata.INDEX_ROUTING_PATH.getKey(), routingPaths)
+            .build();
+        var indexMetadata = IndexMetadata.builder("index").settings(settings).build();
+        return (IndexRouting.ExtractFromSource) IndexRouting.fromIndexMetadata(indexMetadata);
+    }
+
+    record Doc(long timestamp, List<Dimension> dimensions) {}
+
+    record Dimension(String field, Object value) {}
+
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -226,5 +227,15 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
         mapper = mapperService.documentMapper().sourceMapper();
         assertFalse(mapper.enabled());
         assertFalse(mapper.isSynthetic());
+    }
+
+    public void testSyntheticSourceInTimeSeries() throws IOException {
+        XContentBuilder mapping = fieldMapping(b -> {
+            b.field("type", "keyword");
+            b.field("time_series_dimension", true);
+        });
+        DocumentMapper mapper = createTimeSeriesModeDocumentMapper(mapping);
+        assertTrue(mapper.sourceMapper().isSynthetic());
+        assertEquals("{\"_source\":{\"mode\":\"synthetic\"}}", mapper.sourceMapper().toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.cache.IndexCache;
 import org.elasticsearch.index.cache.query.QueryCache;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -52,6 +53,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -406,6 +408,109 @@ public class DefaultSearchContextTests extends ESTestCase {
             readerContext.close();
         } finally {
             threadPool.shutdown();
+        }
+    }
+
+    public void testNewIdLoader() throws Exception {
+        try (DefaultSearchContext context = createDefaultSearchContext(Settings.EMPTY)) {
+            assertThat(context.newIdLoader(), instanceOf(IdLoader.StoredIdLoader.class));
+            context.indexShard().getThreadPool().shutdown();
+        }
+    }
+
+    public void testNewIdLoaderWithTsdb() throws Exception {
+        Settings settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), "time_series")
+            .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2000-01-01T00:00:00.000Z")
+            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2001-01-01T00:00:00.000Z")
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field")
+            .build();
+        try (DefaultSearchContext context = createDefaultSearchContext(settings)) {
+            assertThat(context.newIdLoader(), instanceOf(IdLoader.TsIdLoader.class));
+            context.indexShard().getThreadPool().shutdown();
+        }
+    }
+
+    private DefaultSearchContext createDefaultSearchContext(Settings providedIndexSettings) throws IOException {
+        TimeValue timeout = new TimeValue(randomIntBetween(1, 100));
+        ShardSearchRequest shardSearchRequest = mock(ShardSearchRequest.class);
+        when(shardSearchRequest.searchType()).thenReturn(SearchType.DEFAULT);
+        ShardId shardId = new ShardId("index", UUID.randomUUID().toString(), 1);
+        when(shardSearchRequest.shardId()).thenReturn(shardId);
+        when(shardSearchRequest.shardRequestIndex()).thenReturn(shardId.id());
+        when(shardSearchRequest.numberOfShards()).thenReturn(2);
+
+        ThreadPool threadPool = new TestThreadPool(this.getClass().getName());
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.getThreadPool()).thenReturn(threadPool);
+
+        Settings settings = indexSettings(IndexVersion.current(), 2, 1).put(providedIndexSettings).build();
+
+        IndexService indexService = mock(IndexService.class);
+        IndexCache indexCache = mock(IndexCache.class);
+        QueryCache queryCache = mock(QueryCache.class);
+        when(indexCache.query()).thenReturn(queryCache);
+        when(indexService.cache()).thenReturn(indexCache);
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(indexService.newSearchExecutionContext(eq(shardId.id()), eq(shardId.id()), any(), any(), nullable(String.class), any()))
+            .thenReturn(searchExecutionContext);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.hasNested()).thenReturn(randomBoolean());
+        when(indexService.mapperService()).thenReturn(mapperService);
+
+        IndexMetadata indexMetadata = IndexMetadata.builder("index").settings(settings).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+        when(indexService.getIndexSettings()).thenReturn(indexSettings);
+        when(indexService.getMetadata()).thenReturn(indexMetadata);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        when(searchExecutionContext.getIndexSettings()).thenReturn(indexSettings);
+        when(searchExecutionContext.indexVersionCreated()).thenReturn(indexSettings.getIndexVersionCreated());
+
+        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            final Supplier<Engine.SearcherSupplier> searcherSupplier = () -> new Engine.SearcherSupplier(Function.identity()) {
+                @Override
+                protected void doClose() {}
+
+                @Override
+                protected Engine.Searcher acquireSearcherInternal(String source) {
+                    try {
+                        IndexReader reader = w.getReader();
+                        return new Engine.Searcher(
+                            "test",
+                            reader,
+                            IndexSearcher.getDefaultSimilarity(),
+                            IndexSearcher.getDefaultQueryCache(),
+                            IndexSearcher.getDefaultQueryCachingPolicy(),
+                            reader
+                        );
+                    } catch (IOException exc) {
+                        throw new AssertionError(exc);
+                    }
+                }
+            };
+
+            SearchShardTarget target = new SearchShardTarget("node", shardId, null);
+
+            ReaderContext readerContext = new ReaderContext(
+                newContextId(),
+                indexService,
+                indexShard,
+                searcherSupplier.get(),
+                randomNonNegativeLong(),
+                false
+            );
+            return new DefaultSearchContext(
+                readerContext,
+                shardSearchRequest,
+                target,
+                null,
+                timeout,
+                null,
+                false,
+                null,
+                randomInt(),
+                randomInt()
+            );
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -82,6 +82,7 @@ import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -435,6 +436,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         when(indexShard.indexSettings()).thenReturn(indexSettings);
         when(ctx.indexShard()).thenReturn(indexShard);
         when(ctx.newSourceLoader()).thenAnswer(inv -> searchExecutionContext.newSourceLoader(false));
+        when(ctx.newIdLoader()).thenReturn(IdLoader.fromLeafStoredFieldLoader());
         return new SubSearchContext(ctx);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
+import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -564,5 +565,10 @@ public class TestSearchContext extends SearchContext {
     @Override
     public SourceLoader newSourceLoader() {
         return searchExecutionContext.newSourceLoader(false);
+    }
+
+    @Override
+    public IdLoader newIdLoader() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -3,9 +3,9 @@
 == Restricting connections with IP filtering
 
 You can apply IP filtering to application clients, node clients, or transport
-clients, in addition to other nodes that are attempting to join the cluster.
+clients, remote cluster clients, in addition to other nodes that are attempting to join the cluster.
 
-If a node's IP address is on the blacklist, the {es} {security-features} allow
+If a node's IP address is on the denylist, the {es} {security-features} allow
 the connection to {es} but it is be dropped immediately and no requests are
 processed.
 
@@ -25,7 +25,8 @@ You configure IP filtering by specifying the `xpack.security.transport.filter.al
 `xpack.security.transport.filter.deny` settings in `elasticsearch.yml`. Allow rules
 take precedence over the deny rules.
 
-IMPORTANT: Unless explicitly specified, `xpack.security.http.filter.*` settings default to
+IMPORTANT: Unless explicitly specified, `xpack.security.http.filter.*` and
+`xpack.security.remote_cluster.filter.*` settings default to
 the corresponding `xpack.security.transport.filter.*` setting's value.
 
 [source,yaml]
@@ -111,8 +112,32 @@ xpack.security.http.filter.deny: _all
 --------------------------------------------------
 
 [discrete]
+=== Remote cluster (API key based model) filtering
+
+beta::[]
+
+If other clusters connect <<remote-clusters-api-key,using API key
+authentication>> for {ccs} or {ccr}, you may want to have different IP filtering
+for the remote cluster server interface.
+
+[source,yaml]
+--------------------------------------------------
+xpack.security.remote_cluster.filter.allow: 192.168.1.0/8
+xpack.security.remote_cluster.filter.deny: 192.168.0.0/16
+xpack.security.transport.filter.allow: localhost
+xpack.security.transport.filter.deny: '*.google.com'
+xpack.security.http.filter.allow: 172.16.0.0/16
+xpack.security.http.filter.deny: _all
+--------------------------------------------------
+
+NOTE: Whether IP filtering for remote cluster is enabled is controlled by
+`xpack.security.transport.filter.enabled` as well. This means filtering for
+the remote cluster and transport interfaces must be enabled or disabled together.
+But the exact allow and deny lists can be different between them.
+
+[discrete]
 [[dynamic-ip-filtering]]
-==== Dynamically updating IP filter settings
+=== Dynamically updating IP filter settings
 
 In case of running in an environment with highly dynamic IP addresses like cloud
 based hosting, it is very hard to know the IP addresses upfront when provisioning

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -831,10 +831,10 @@ public abstract class CcrIntegTestCase extends ESTestCase {
     ) {
         final var future = new PlainActionFuture<RestoreInfo>();
         restoreService.restoreSnapshot(restoreSnapshotRequest, future.delegateFailure((delegate, restoreCompletionResponse) -> {
-            assertNull(restoreCompletionResponse.getRestoreInfo());
+            assertNull(restoreCompletionResponse.restoreInfo());
             // this would only be non-null if the restore was a no-op, but that would be a test bug
-            final Snapshot snapshot = restoreCompletionResponse.getSnapshot();
-            final String uuid = restoreCompletionResponse.getUuid();
+            final Snapshot snapshot = restoreCompletionResponse.snapshot();
+            final String uuid = restoreCompletionResponse.uuid();
             final ClusterStateListener clusterStateListener = new ClusterStateListener() {
                 @Override
                 public void clusterChanged(ClusterChangedEvent changedEvent) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.action.util.PageParams;
@@ -157,8 +158,8 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
     public static class Response extends BaseTasksResponse implements ToXContentObject {
         private final QueryPage<TransformStats> transformsStats;
 
-        public Response(List<TransformStats> transformStateAndStats, long count) {
-            this(new QueryPage<>(transformStateAndStats, count, TransformField.TRANSFORMS));
+        public Response(List<TransformStats> transformStateAndStats) {
+            this(new QueryPage<>(transformStateAndStats, transformStateAndStats.size(), TransformField.TRANSFORMS));
         }
 
         public Response(
@@ -170,7 +171,7 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
             this(new QueryPage<>(transformStateAndStats, count, TransformField.TRANSFORMS), taskFailures, nodeFailures);
         }
 
-        private Response(QueryPage<TransformStats> transformsStats) {
+        public Response(QueryPage<TransformStats> transformsStats) {
             this(transformsStats, Collections.emptyList(), Collections.emptyList());
         }
 
@@ -194,6 +195,10 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
 
         public long getCount() {
             return transformsStats.count();
+        }
+
+        public ParseField getResultsField() {
+            return transformsStats.getResultsField();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformStats.java
@@ -200,6 +200,10 @@ public class TransformStats implements Writeable, ToXContentObject {
         return checkpointingInfo;
     }
 
+    public TransformHealth getHealth() {
+        return health;
+    }
+
     @Override
     public String toString() {
         return Strings.toString(this);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -453,3 +453,93 @@ emp_no:integer  |  birth_date:datetime       | birth_month:keyword
 10049           |  null                      | null
 10050           |  1958-05-21T00:00:00.000Z  | May
 ;
+
+datePlusPeriod
+row dt = to_dt("2100-01-01T01:01:01.000Z")
+| eval plus = dt + 4 years + 3 months + 2 weeks + 1 day;
+
+dt:datetime              |plus:datetime
+2100-01-01T01:01:01.000Z |2104-04-16T01:01:01.000Z
+;
+ 
+datePlusDuration
+row dt = to_dt("2100-01-01T00:00:00.000Z")
+| eval plus = dt + 1 hour + 1 minute + 1 second + 1 milliseconds;
+
+dt:datetime              |plus:datetime
+2100-01-01T00:00:00.000Z |2100-01-01T01:01:01.001Z
+;
+
+dateMinusPeriod
+row dt = to_dt("2104-04-16T01:01:01.000Z")
+| eval minus = dt - 4 years - 3 months - 2 weeks - 1 day;
+
+dt:datetime              |minus:datetime
+2104-04-16T01:01:01.000Z |2100-01-01T01:01:01.000Z
+;
+ 
+dateMinusDuration
+row dt = to_dt("2100-01-01T01:01:01.001Z")
+| eval minus = dt - 1 hour - 1 minute - 1 second - 1 milliseconds;
+
+dt:datetime              |minus:datetime
+2100-01-01T01:01:01.001Z |2100-01-01T00:00:00.000Z
+;
+
+datePlusPeriodAndDuration
+row dt = to_dt("2100-01-01T00:00:00.000Z")
+| eval plus = dt + 4 years + 3 months + 2 weeks + 1 day + 1 hour + 1 minute + 1 second + 1 milliseconds;
+
+dt:datetime              |plus:datetime
+2100-01-01T00:00:00.000Z |2104-04-16T01:01:01.001Z
+;
+
+dateMinusPeriodAndDuration
+row dt = to_dt("2104-04-16T01:01:01.001Z")
+| eval minus = dt - 4 years - 3 months - 2 weeks - 1 day - 1 hour - 1 minute - 1 second - 1 milliseconds;
+
+dt:datetime              |minus:datetime
+2104-04-16T01:01:01.001Z |2100-01-01T00:00:00.000Z
+;
+
+datePlusPeriodMinusDuration
+row dt = to_dt("2100-01-01T01:01:01.001Z")
+| eval plus = dt + 4 years + 3 months + 2 weeks + 1 day - 1 hour - 1 minute - 1 second - 1 milliseconds;
+
+dt:datetime              |plus:datetime
+2100-01-01T01:01:01.001Z |2104-04-16T00:00:00.000Z
+;
+
+datePlusDurationMinusPeriod
+row dt = to_dt("2104-04-16T00:00:00.000Z")
+| eval plus = dt - 4 years - 3 months - 2 weeks - 1 day + 1 hour + 1 minute + 1 second + 1 milliseconds;
+
+dt:datetime              |plus:datetime
+2104-04-16T00:00:00.000Z |2100-01-01T01:01:01.001Z
+;
+
+fieldDateMathSimple
+from employees
+| eval bd = birth_date + 1 year - 1 millisecond
+| keep birth_date, bd
+| limit 5;
+
+birth_date:datetime      |bd:datetime           
+1953-09-02T00:00:00.000Z |1954-09-01T23:59:59.999Z
+1964-06-02T00:00:00.000Z |1965-06-01T23:59:59.999Z
+1959-12-03T00:00:00.000Z |1960-12-02T23:59:59.999Z
+1954-05-01T00:00:00.000Z |1955-04-30T23:59:59.999Z
+1955-01-21T00:00:00.000Z |1956-01-20T23:59:59.999Z
+;
+
+fieldDateMath
+from employees
+| eval bd = birth_date + 1 year - 1 millisecond
+| eval bd = date_trunc(1 day, bd)
+| eval bd = bd + 1 day - 1 year
+| where birth_date != bd
+| stats c = count(bd);
+
+c:long
+0
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -518,6 +518,18 @@ dt:datetime              |plus:datetime
 2104-04-16T00:00:00.000Z |2100-01-01T01:01:01.001Z
 ;
 
+dateMathOverflow
+row dt = to_dt(9223372036854775807)
+| eval plus = dt + 1 day
+| keep plus;  
+
+warning:Line 2:15: evaluation of [dt + 1 day] failed, treating result as null. Only first 20 failures recorded.
+warning:java.lang.ArithmeticException: long overflow
+
+plus:datetime      
+null           
+;
+
 fieldDateMathSimple
 from employees
 | eval bd = birth_date + 1 year - 1 millisecond
@@ -542,4 +554,27 @@ from employees
 
 c:long
 0
+;
+
+filteringWithDateMath
+from employees
+| where birth_date < to_dt("2023-08-25T11:25:41.052Z") - 70 years
+| keep birth_date;
+
+birth_date:datetime       
+1953-04-20T00:00:00.000Z
+1952-04-19T00:00:00.000Z
+1953-01-23T00:00:00.000Z
+1952-12-24T00:00:00.000Z
+1952-07-08T00:00:00.000Z
+1953-04-03T00:00:00.000Z
+1953-02-08T00:00:00.000Z
+1953-07-28T00:00:00.000Z
+1952-08-06T00:00:00.000Z
+1952-11-13T00:00:00.000Z
+1953-01-07T00:00:00.000Z
+1952-05-15T00:00:00.000Z
+1952-06-13T00:00:00.000Z
+1952-02-27T00:00:00.000Z
+1953-04-21T00:00:00.000Z
 ;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddDatetimesEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddDatetimesEvaluator.java
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
+
+import java.lang.ArithmeticException;
+import java.lang.Override;
+import java.lang.String;
+import java.time.DateTimeException;
+import java.time.temporal.TemporalAmount;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Add}.
+ * This class is generated. Do not edit it.
+ */
+public final class AddDatetimesEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator datetime;
+
+  private final TemporalAmount temporalAmount;
+
+  public AddDatetimesEvaluator(Source source, EvalOperator.ExpressionEvaluator datetime,
+      TemporalAmount temporalAmount) {
+    this.warnings = new Warnings(source);
+    this.datetime = datetime;
+    this.temporalAmount = temporalAmount;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    Block datetimeUncastBlock = datetime.eval(page);
+    if (datetimeUncastBlock.areAllValuesNull()) {
+      return Block.constantNullBlock(page.getPositionCount());
+    }
+    LongBlock datetimeBlock = (LongBlock) datetimeUncastBlock;
+    LongVector datetimeVector = datetimeBlock.asVector();
+    if (datetimeVector == null) {
+      return eval(page.getPositionCount(), datetimeBlock);
+    }
+    return eval(page.getPositionCount(), datetimeVector);
+  }
+
+  public LongBlock eval(int positionCount, LongBlock datetimeBlock) {
+    LongBlock.Builder result = LongBlock.newBlockBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      if (datetimeBlock.isNull(p) || datetimeBlock.getValueCount(p) != 1) {
+        result.appendNull();
+        continue position;
+      }
+      try {
+        result.appendLong(Add.processDatetimes(datetimeBlock.getLong(datetimeBlock.getFirstValueIndex(p)), temporalAmount));
+      } catch (ArithmeticException | DateTimeException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
+    }
+    return result.build();
+  }
+
+  public LongBlock eval(int positionCount, LongVector datetimeVector) {
+    LongBlock.Builder result = LongBlock.newBlockBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      try {
+        result.appendLong(Add.processDatetimes(datetimeVector.getLong(p), temporalAmount));
+      } catch (ArithmeticException | DateTimeException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
+    }
+    return result.build();
+  }
+
+  @Override
+  public String toString() {
+    return "AddDatetimesEvaluator[" + "datetime=" + datetime + ", temporalAmount=" + temporalAmount + "]";
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/SubDatetimesEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/SubDatetimesEvaluator.java
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
+
+import java.lang.ArithmeticException;
+import java.lang.Override;
+import java.lang.String;
+import java.time.DateTimeException;
+import java.time.temporal.TemporalAmount;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Sub}.
+ * This class is generated. Do not edit it.
+ */
+public final class SubDatetimesEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator datetime;
+
+  private final TemporalAmount temporalAmount;
+
+  public SubDatetimesEvaluator(Source source, EvalOperator.ExpressionEvaluator datetime,
+      TemporalAmount temporalAmount) {
+    this.warnings = new Warnings(source);
+    this.datetime = datetime;
+    this.temporalAmount = temporalAmount;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    Block datetimeUncastBlock = datetime.eval(page);
+    if (datetimeUncastBlock.areAllValuesNull()) {
+      return Block.constantNullBlock(page.getPositionCount());
+    }
+    LongBlock datetimeBlock = (LongBlock) datetimeUncastBlock;
+    LongVector datetimeVector = datetimeBlock.asVector();
+    if (datetimeVector == null) {
+      return eval(page.getPositionCount(), datetimeBlock);
+    }
+    return eval(page.getPositionCount(), datetimeVector);
+  }
+
+  public LongBlock eval(int positionCount, LongBlock datetimeBlock) {
+    LongBlock.Builder result = LongBlock.newBlockBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      if (datetimeBlock.isNull(p) || datetimeBlock.getValueCount(p) != 1) {
+        result.appendNull();
+        continue position;
+      }
+      try {
+        result.appendLong(Sub.processDatetimes(datetimeBlock.getLong(datetimeBlock.getFirstValueIndex(p)), temporalAmount));
+      } catch (ArithmeticException | DateTimeException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
+    }
+    return result.build();
+  }
+
+  public LongBlock eval(int positionCount, LongVector datetimeVector) {
+    LongBlock.Builder result = LongBlock.newBlockBuilder(positionCount);
+    position: for (int p = 0; p < positionCount; p++) {
+      try {
+        result.appendLong(Sub.processDatetimes(datetimeVector.getLong(p), temporalAmount));
+      } catch (ArithmeticException | DateTimeException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
+    }
+    return result.build();
+  }
+
+  @Override
+  public String toString() {
+    return "SubDatetimesEvaluator[" + "datetime=" + datetime + ", temporalAmount=" + temporalAmount + "]";
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateTrunc.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateTrunc.java
@@ -15,11 +15,9 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Expression;
-import org.elasticsearch.xpack.ql.expression.TypeResolutions;
 import org.elasticsearch.xpack.ql.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
-import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
 import java.time.Duration;
@@ -30,6 +28,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.isTemporalAmount;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.isDate;
@@ -57,28 +56,15 @@ public class DateTrunc extends BinaryDateTimeFunction implements EvaluatorMapper
             return resolution;
         }
 
-        return isInterval(interval(), sourceText(), SECOND);
+        return isType(interval(), EsqlDataTypes::isTemporalAmount, sourceText(), SECOND, "dateperiod", "timeduration");
     }
 
     // TODO: drop check once 8.11 is released
     private TypeResolution argumentTypesAreSwapped() {
-        DataType leftType = left().dataType();
-        DataType rightType = right().dataType();
-        if (leftType == DataTypes.DATETIME && (rightType == EsqlDataTypes.DATE_PERIOD || rightType == EsqlDataTypes.TIME_DURATION)) {
+        if (left().dataType() == DataTypes.DATETIME && (isTemporalAmount(right().dataType()))) {
             return new TypeResolution(format(null, "function definition has been updated, please swap arguments in [{}]", sourceText()));
         }
         return TypeResolution.TYPE_RESOLVED;
-    }
-
-    private static TypeResolution isInterval(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
-        return isType(
-            e,
-            dt -> dt == EsqlDataTypes.DATE_PERIOD || dt == EsqlDataTypes.TIME_DURATION,
-            operationName,
-            paramOrd,
-            "dateperiod",
-            "timeduration"
-        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Add.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Add.java
@@ -8,15 +8,21 @@
 package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
 
 import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
+import java.time.DateTimeException;
+import java.time.temporal.TemporalAmount;
+
 import static org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.EsqlArithmeticOperation.OperationSymbol.ADD;
+import static org.elasticsearch.xpack.ql.type.DateUtils.asDateTime;
+import static org.elasticsearch.xpack.ql.type.DateUtils.asMillis;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAddExact;
 
-public class Add extends EsqlArithmeticOperation implements BinaryComparisonInversible {
+public class Add extends DateTimeArithmeticOperation implements BinaryComparisonInversible {
 
     public Add(Source source, Expression left, Expression right) {
         super(
@@ -27,7 +33,8 @@ public class Add extends EsqlArithmeticOperation implements BinaryComparisonInve
             AddIntsEvaluator::new,
             AddLongsEvaluator::new,
             AddUnsignedLongsEvaluator::new,
-            (s, l, r) -> new AddDoublesEvaluator(l, r)
+            (s, l, r) -> new AddDoublesEvaluator(l, r),
+            AddDatetimesEvaluator::new
         );
     }
 
@@ -74,5 +81,10 @@ public class Add extends EsqlArithmeticOperation implements BinaryComparisonInve
     @Evaluator(extraName = "Doubles")
     static double processDoubles(double lhs, double rhs) {
         return lhs + rhs;
+    }
+
+    @Evaluator(extraName = "Datetimes", warnExceptions = { ArithmeticException.class, DateTimeException.class })
+    static long processDatetimes(long datetime, @Fixed TemporalAmount temporalAmount) {
+        return asMillis(asDateTime(datetime, DEFAULT_TZ).plus(temporalAmount));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
+
+import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
+import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.type.DateUtils;
+
+import java.time.ZoneId;
+import java.time.temporal.TemporalAmount;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+
+abstract class DateTimeArithmeticOperation extends EsqlArithmeticOperation {
+
+    interface DatetimeArithmeticEvaluator extends TriFunction<Source, ExpressionEvaluator, TemporalAmount, ExpressionEvaluator> {};
+
+    protected static final ZoneId DEFAULT_TZ = DateUtils.UTC;
+
+    private final DatetimeArithmeticEvaluator datetimes;
+
+    DateTimeArithmeticOperation(
+        Source source,
+        Expression left,
+        Expression right,
+        OperationSymbol op,
+        ArithmeticEvaluator ints,
+        ArithmeticEvaluator longs,
+        ArithmeticEvaluator ulongs,
+        ArithmeticEvaluator doubles,
+        DatetimeArithmeticEvaluator datetimes
+    ) {
+        super(source, left, right, op, ints, longs, ulongs, doubles);
+        this.datetimes = datetimes;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        DataType leftType = left().dataType();
+        DataType rightType = right().dataType();
+        if (EsqlDataTypes.isDateTime(leftType) || EsqlDataTypes.isDateTime(rightType)) {
+            Expression dateTime = argumentOfType(dt -> dt == DataTypes.DATETIME);
+            Expression nonDateTime = argumentOfType(dt -> dt != DataTypes.DATETIME);
+            if (dateTime == null || nonDateTime == null || EsqlDataTypes.isTemporalAmount(nonDateTime.dataType()) == false) {
+                return new TypeResolution(
+                    format(null, "[{}] has arguments with incompatible types [{}] and [{}]", symbol(), leftType, rightType)
+                );
+            }
+            return TypeResolution.TYPE_RESOLVED;
+        }
+        return super.resolveType();
+    }
+
+    @Override
+    public Supplier<ExpressionEvaluator> toEvaluator(Function<Expression, Supplier<ExpressionEvaluator>> toEvaluator) {
+        return dataType() == DataTypes.DATETIME
+            ? () -> datetimes.apply(
+                source(),
+                toEvaluator.apply(argumentOfType(dt -> dt == DataTypes.DATETIME)).get(),
+                (TemporalAmount) argumentOfType(EsqlDataTypes::isTemporalAmount).fold()
+            )
+            : super.toEvaluator(toEvaluator);
+    }
+
+    private Expression argumentOfType(Predicate<DataType> filter) {
+        return filter.test(left().dataType()) ? left() : filter.test(right().dataType()) ? right() : null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/EsqlArithmeticOperation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/EsqlArithmeticOperation.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 
 import java.io.IOException;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.ql.type.DataTypes.DOUBLE;
@@ -110,9 +111,7 @@ abstract class EsqlArithmeticOperation extends ArithmeticOperation implements Ev
     }
 
     @Override
-    public final Supplier<ExpressionEvaluator> toEvaluator(
-        java.util.function.Function<Expression, Supplier<ExpressionEvaluator>> toEvaluator
-    ) {
+    public Supplier<ExpressionEvaluator> toEvaluator(Function<Expression, Supplier<ExpressionEvaluator>> toEvaluator) {
         var commonType = dataType();
         var leftType = left().dataType();
         if (leftType.isNumeric()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
@@ -10,8 +10,11 @@ package org.elasticsearch.xpack.esql.type;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.ql.type.DataTypeRegistry;
+import org.elasticsearch.xpack.ql.type.DataTypes;
 
 import java.util.Collection;
+
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.isTemporalAmount;
 
 public class EsqlDataTypeRegistry implements DataTypeRegistry {
 
@@ -51,6 +54,9 @@ public class EsqlDataTypeRegistry implements DataTypeRegistry {
 
     @Override
     public DataType commonType(DataType left, DataType right) {
+        if (left == DataTypes.DATETIME && isTemporalAmount(right) || isTemporalAmount(left) && right == DataTypes.DATETIME) {
+            return DataTypes.DATETIME;
+        }
         return DataTypeConverter.commonType(left, right);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -137,6 +137,14 @@ public final class EsqlDataTypes {
         return t != OBJECT && t != NESTED;
     }
 
+    public static boolean isDateTime(DataType t) {
+        return DataTypes.isDateTime(t) || isTemporalAmount(t);
+    }
+
+    public static boolean isTemporalAmount(DataType t) {
+        return t == DATE_PERIOD || t == TIME_DURATION;
+    }
+
     /**
      * Supported types that can be contained in a block.
      */

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/DateUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/DateUtils.java
@@ -52,6 +52,14 @@ public final class DateUtils {
         return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC);
     }
 
+    public static ZonedDateTime asDateTime(long millis, ZoneId zoneId) {
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), zoneId);
+    }
+
+    public static long asMillis(ZonedDateTime zonedDateTime) {
+        return zonedDateTime.toInstant().toEpochMilli();
+    }
+
     /**
      * Parses the given string into a DateTime using UTC as a default timezone.
      */

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
@@ -166,7 +166,7 @@ public class JwkSetLoader implements Releasable {
         );
         // Filter JWK(s) vs signature algorithms. Only keep JWKs with a matching alg. Only keep algs with a matching JWK.
         final JwksAlgs jwksAlgsPkc = JwkValidateUtil.filterJwksAndAlgorithms(jwksPkc, allowedJwksAlgsPkc);
-        logger.info(
+        logger.debug(
             "Usable PKC: JWKs=[{}] algorithms=[{}] sha256=[{}]",
             jwksAlgsPkc.jwks().size(),
             String.join(",", jwksAlgsPkc.algs()),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkValidateUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkValidateUtil.java
@@ -32,32 +32,44 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Utilities for JWK Validation.
  */
 public class JwkValidateUtil {
-    private static final Logger LOGGER = LogManager.getLogger(JwkValidateUtil.class);
+    private static final Logger logger = LogManager.getLogger(JwkValidateUtil.class);
 
     // Static method for unit testing. No need to construct a complete RealmConfig with all settings.
     static JwkSetLoader.JwksAlgs filterJwksAndAlgorithms(final List<JWK> jwks, final List<String> algs) throws SettingsException {
-        LOGGER.trace("JWKs [" + jwks.size() + "] and Algorithms [" + String.join(",", algs) + "] before filters.");
+        try (JwtUtil.TraceBuffer tracer = new JwtUtil.TraceBuffer(logger)) {
+            tracer.append("Filtering [{}] JWKs for the following algorithms [{}].", jwks.size(), String.join(",", algs));
 
-        final Predicate<JWK> keyUsePredicate = j -> ((j.getKeyUse() == null) || (KeyUse.SIGNATURE.equals(j.getKeyUse())));
-        final List<JWK> jwksSig = jwks.stream().filter(keyUsePredicate).toList();
-        LOGGER.trace("JWKs [" + jwksSig.size() + "] after KeyUse [SIGNATURE||null] filter.");
+            final Predicate<JWK> keyUsePredicate = j -> ((j.getKeyUse() == null) || (KeyUse.SIGNATURE.equals(j.getKeyUse())));
+            final List<JWK> jwksSig = jwks.stream().filter(keyUsePredicate).toList();
+            tracer.append("[{}] remaining JWKs after KeyUse [SIGNATURE] filter.", jwksSig.size());
 
-        final Predicate<JWK> keyOpPredicate = j -> ((j.getKeyOperations() == null) || (j.getKeyOperations().contains(KeyOperation.VERIFY)));
-        final List<JWK> jwksVerify = jwksSig.stream().filter(keyOpPredicate).toList();
-        LOGGER.trace("JWKs [" + jwksVerify.size() + " after KeyOperation [VERIFY||null] filter.");
+            final Predicate<JWK> keyOpPredicate = j -> ((j.getKeyOperations() == null)
+                || (j.getKeyOperations().contains(KeyOperation.VERIFY)));
+            final List<JWK> jwksVerify = jwksSig.stream().filter(keyOpPredicate).toList();
+            tracer.append("[{}] remaining JWKs after KeyOperation [VERIFY] filter.", jwksVerify.size());
 
-        final List<JWK> jwksFiltered = jwksVerify.stream().filter(j -> (algs.stream().anyMatch(a -> isMatch(j, a)))).toList();
-        LOGGER.trace("JWKs [" + jwksFiltered.size() + "] after Algorithms [" + String.join(",", algs) + "] filter.");
+            final List<JWK> jwksFiltered = jwksVerify.stream().filter(j -> (algs.stream().anyMatch(a -> isMatch(j, a, tracer)))).toList();
+            tracer.append("[{}] remaining JWKs after algorithms name filter.", jwksFiltered.size());
 
-        final List<String> algsFiltered = algs.stream().filter(a -> (jwksFiltered.stream().anyMatch(j -> isMatch(j, a)))).toList();
-        LOGGER.trace("Algorithms [" + String.join(",", algsFiltered) + "] after remaining JWKs [" + jwksFiltered.size() + "] filter.");
+            final List<String> algsFiltered = algs.stream()
+                .filter(a -> (jwksFiltered.stream().anyMatch(j -> isMatch(j, a, tracer))))
+                .toList();
+            tracer.append(
+                "[{}] remaining JWKs after configured algorithms [{}] filter.",
+                jwksFiltered.size(),
+                String.join(",", algsFiltered)
+            );
 
-        return new JwkSetLoader.JwksAlgs(jwksFiltered, algsFiltered);
+            return new JwkSetLoader.JwksAlgs(jwksFiltered, algsFiltered);
+        }
     }
 
     /**
@@ -68,14 +80,14 @@ public class JwkValidateUtil {
      * @param algorithm Algorithm string of value HS256, HS384, HS512, RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, or ES512.
      * @return True if JWT type and strength match both requirements for the signature algorithm.
      */
-    static boolean isMatch(final JWK jwk, final String algorithm) {
+    static boolean isMatch(final JWK jwk, final String algorithm, JwtUtil.TraceBuffer tracer) {
         try {
             if ((JwtRealmSettings.SUPPORTED_SIGNATURE_ALGORITHMS_HMAC.contains(algorithm)) && (jwk instanceof OctetSequenceKey jwkHmac)) {
                 final int bits = jwkHmac.size();
                 final int min = MACSigner.getMinRequiredSecretLength(JWSAlgorithm.parse(algorithm));
                 final boolean isMatch = bits >= min;
                 if (isMatch == false) {
-                    LOGGER.trace("HMAC JWK [" + bits + "] bits too small for algorithm [" + algorithm + "] minimum [" + min + "].");
+                    tracer.append("HMAC JWK [" + bits + "] bits too small for algorithm [" + algorithm + "] minimum [" + min + "].");
                 }
                 return isMatch;
             } else if ((JwtRealmSettings.SUPPORTED_SIGNATURE_ALGORITHMS_RSA.contains(algorithm)) && (jwk instanceof RSAKey jwkRsa)) {
@@ -83,7 +95,7 @@ public class JwkValidateUtil {
                 final int min = RSAKeyGenerator.MIN_KEY_SIZE_BITS;
                 final boolean isMatch = bits >= min;
                 if (isMatch == false) {
-                    LOGGER.trace("RSA JWK [" + bits + "] bits too small for algorithm [" + algorithm + "] minimum [" + min + "].");
+                    tracer.append("RSA JWK [" + bits + "] bits too small for algorithm [" + algorithm + "] minimum [" + min + "].");
                 }
                 return isMatch;
             } else if ((JwtRealmSettings.SUPPORTED_SIGNATURE_ALGORITHMS_EC.contains(algorithm)) && (jwk instanceof ECKey jwkEc)) {
@@ -91,12 +103,20 @@ public class JwkValidateUtil {
                 final Set<Curve> allowed = Curve.forJWSAlgorithm(JWSAlgorithm.parse(algorithm));
                 final boolean isMatch = allowed.contains(curve);
                 if (isMatch == false) {
-                    LOGGER.trace("EC JWK [" + curve + "] curve not allowed for algorithm [" + algorithm + "] allowed " + allowed + ".");
+                    tracer.append("EC JWK [" + curve + "] curve not allowed for algorithm [" + algorithm + "] allowed " + allowed + ".");
                 }
                 return isMatch;
             }
         } catch (Exception e) {
-            LOGGER.trace("Unexpected exception", e);
+            Supplier<String> message = () -> format(
+                "Unexpected exception while matching JWK with kid [%s] to it's algorithm requirement.",
+                jwk.getKeyID()
+            );
+            if (logger.isTraceEnabled()) {
+                logger.trace(message.get(), e);
+            } else {
+                logger.debug(message.get());
+            }
         }
         return false;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtAuthenticator.java
@@ -70,8 +70,8 @@ public class JwtAuthenticator implements Releasable {
         final JWTClaimsSet jwtClaimsSet = jwtAuthenticationToken.getJWTClaimsSet();
         final JWSHeader jwsHeader = signedJWT.getHeader();
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
+        if (logger.isTraceEnabled()) {
+            logger.trace(
                 "Realm [{}] successfully parsed JWT token [{}] with header [{}] and claimSet [{}]",
                 realmConfig.name(),
                 tokenPrincipal,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtSignatureValidator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtSignatureValidator.java
@@ -17,6 +17,7 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.OctetSequenceKey;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
 
 import org.apache.logging.log4j.LogManager;
@@ -39,6 +40,7 @@ import org.elasticsearch.xpack.core.ssl.SSLService;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public interface JwtSignatureValidator extends Releasable {
@@ -274,26 +276,33 @@ public interface JwtSignatureValidator extends Releasable {
                 validateSignature(signedJWT, jwksAlgs.jwks());
                 listener.onResponse(null);
             } catch (Exception primaryException) {
-                logger.debug(
-                    () -> org.elasticsearch.core.Strings.format(
-                        "Signature verification failed for JWT [%s] reloading JWKSet (was: #[%s] JWKs, #[%s] algs, sha256=[%s])",
-                        tokenPrincipal,
-                        jwksAlgs.jwks().size(),
-                        jwksAlgs.algs().size(),
-                        MessageDigests.toHexString(contentAndJwksAlgs.sha256())
-                    ),
-                    primaryException
+                String message = org.elasticsearch.core.Strings.format(
+                    "Signature verification failed for JWT token [%s] against JWK set with sha256=[%s].",
+                    tokenPrincipal,
+                    MessageDigests.toHexString(contentAndJwksAlgs.sha256())
                 );
 
+                if (logger.isTraceEnabled()) {
+                    logger.trace(message, primaryException);
+                } else {
+                    logger.debug(message + " Cause: " + primaryException.getMessage());
+                }
+
+                logger.debug("Attempting to reload JWK set with sha256=[{}]", MessageDigests.toHexString(contentAndJwksAlgs.sha256()));
                 jwkSetLoader.reload(ActionListener.wrap(ignore -> {
                     final JwkSetLoader.ContentAndJwksAlgs maybeUpdatedContentAndJwksAlgs = jwkSetLoader.getContentAndJwksAlgs();
                     if (Arrays.equals(maybeUpdatedContentAndJwksAlgs.sha256(), initialJwksVersion)) {
                         logger.debug(
                             "No change in reloaded JWK set with sha256=[{}] will not retry signature verification",
-                            MessageDigests.toHexString(jwkSetLoader.getContentAndJwksAlgs().sha256())
+                            MessageDigests.toHexString(maybeUpdatedContentAndJwksAlgs.sha256())
                         );
                         listener.onFailure(primaryException);
                         return;
+                    } else {
+                        logger.debug(
+                            "Successful reload of JWK set. Now with sha256=[{}]",
+                            MessageDigests.toHexString(maybeUpdatedContentAndJwksAlgs.sha256())
+                        );
                     }
 
                     // If all PKC JWKs were replaced, all PKC JWT cache entries need to be invalidated.
@@ -342,66 +351,86 @@ public interface JwtSignatureValidator extends Releasable {
      * @throws Exception Error if JWKs fail to validate the Signed JWT.
      */
     default void validateSignature(final SignedJWT jwt, final List<JWK> jwks) throws Exception {
+
         assert jwks != null : "Verify requires a non-null JWK list";
         if (jwks.isEmpty()) {
-            throw new ElasticsearchException("Verify requires a non-empty JWK list");
-        }
-        final String id = jwt.getHeader().getKeyID();
-        final JWSAlgorithm alg = jwt.getHeader().getAlgorithm();
-        logger.trace("JWKs [{}], JWT KID [{}], and JWT Algorithm [{}] before filters.", jwks.size(), id, alg.getName());
-
-        // If JWT has optional kid header, and realm JWKs have optional kid attribute, any mismatches JWT.kid vs JWK.kid can be ignored.
-        // Keep any JWKs if JWK optional kid attribute is missing. Keep all JWKs if JWT optional kid header is missing.
-        final List<JWK> jwksKid = jwks.stream().filter(j -> ((id == null) || (j.getKeyID() == null) || (id.equals(j.getKeyID())))).toList();
-        logger.trace("JWKs [{}] after KID [{}](|null) filter.", jwksKid.size(), id);
-
-        // JWT has mandatory alg header. If realm JWKs have optional alg attribute, any mismatches JWT.alg vs JWK.alg can be ignored.
-        // Keep any JWKs if JWK optional alg attribute is missing.
-        final List<JWK> jwksAlg = jwksKid.stream().filter(j -> (j.getAlgorithm() == null) || (alg.equals(j.getAlgorithm()))).toList();
-        logger.trace("JWKs [{}] after Algorithm [{}](|null) filter.", jwksAlg.size(), alg.getName());
-
-        // PKC Example: Realm has five PKC JWKs RSA-2048, RSA-3072, EC-P256, EC-P384, and EC-P512. JWT alg allows ignoring some.
-        // - If JWT alg is RS256, only RSA-2048 and RSA-3072 are valid for a JWT RS256 signature. Ignore three EC JWKs.
-        // - If JWT alg is ES512, only EC-P512 is valid for a JWT ES512 signature. Ignore four JWKs (two RSA, two EC).
-        // - If JWT alg is ES384, only EC-P384 is valid for a JWT ES384 signature. Ignore four JWKs (two RSA, two EC).
-        // - If JWT alg is ES256, only EC-P256 is valid for a JWT ES256 signature. Ignore four JWKs (two RSA, two EC).
-        //
-        // HMAC Example: Realm has six HMAC JWKs of bit lengths 256, 320, 384, 400, 512, and 1000. JWT alg allows ignoring some.
-        // - If JWT alg is HS256, all are valid for a JWT HS256 signature. Don't ignore any HMAC JWKs.
-        // - If JWT alg is HS384, only 384, 400, 512, and 1000 are valid for a JWT HS384 signature. Ignore two HMAC JWKs.
-        // - If JWT alg is HS512, only 512 and 1000 are valid for a JWT HS512 signature. Ignore four HMAC JWKs.
-        final List<JWK> jwksStrength = jwksAlg.stream().filter(j -> JwkValidateUtil.isMatch(j, alg.getName())).toList();
-        logger.debug("JWKs [{}] after Algorithm [{}] match filter.", jwksStrength.size(), alg);
-
-        // No JWKs passed the kid, alg, and strength checks, so nothing left to use in verifying the JWT signature
-        if (jwksStrength.isEmpty()) {
-            throw new ElasticsearchException("Verify failed because all " + jwks.size() + " provided JWKs were filtered.");
+            throw new ElasticsearchException("Signature verification was not attempted since there are not any JWKs available.");
         }
 
-        for (final JWK jwk : jwksStrength) {
-            if (jwt.verify(createJwsVerifier(jwk))) {
-                logger.trace(
-                    "JWT signature validation succeeded with JWK kty=[{}], jwtAlg=[{}], jwtKid=[{}], use=[{}], ops=[{}]",
-                    jwk.getKeyType(),
-                    jwk.getAlgorithm(),
-                    jwk.getKeyID(),
-                    jwk.getKeyUse(),
-                    jwk.getKeyOperations()
-                );
-                return;
-            } else {
-                logger.trace(
-                    "JWT signature validation failed with JWK kty=[{}], jwtAlg=[{}], jwtKid=[{}], use=[{}], ops={}",
-                    jwk.getKeyType(),
-                    jwk.getAlgorithm(),
-                    jwk.getKeyID(),
-                    jwk.getKeyUse(),
-                    jwk.getKeyOperations() == null ? "[null]" : jwk.getKeyOperations()
+        try (JwtUtil.TraceBuffer tracer = new JwtUtil.TraceBuffer(logger)) {
+            final String id = jwt.getHeader().getKeyID();
+            final JWSAlgorithm alg = jwt.getHeader().getAlgorithm();
+
+            tracer.append("Filtering [{}] possible JWKs to verifying signature for JWT [{}].", jwks.size(), getSafePrintableJWT(jwt));
+
+            // If JWT has optional kid header, and realm JWKs have optional kid attribute, any mismatches JWT.kid vs JWK.kid can be ignored.
+            // Keep any JWKs if JWK optional kid attribute is missing. Keep all JWKs if JWT optional kid header is missing.
+            final List<JWK> jwksKid = jwks.stream()
+                .filter(j -> ((id == null) || (j.getKeyID() == null) || (id.equals(j.getKeyID()))))
+                .toList();
+            tracer.append("[{}] JWKs remain after filtering for KID [{}].", jwksKid.size(), id);
+
+            // JWT has mandatory alg header. If realm JWKs have optional alg attribute, any mismatches JWT.alg vs JWK.alg can be ignored.
+            // Keep any JWKs if JWK optional alg attribute is missing.
+            final List<JWK> jwksAlg = jwksKid.stream().filter(j -> (j.getAlgorithm() == null) || (alg.equals(j.getAlgorithm()))).toList();
+            tracer.append("[{}] algorithms remain after filtering for algorithm name [{}].", jwksAlg.size(), alg.getName());
+
+            // PKC Example: Realm has five PKC JWKs RSA-2048, RSA-3072, EC-P256, EC-P384, and EC-P512. JWT alg allows ignoring some.
+            // - If JWT alg is RS256, only RSA-2048 and RSA-3072 are valid for a JWT RS256 signature. Ignore three EC JWKs.
+            // - If JWT alg is ES512, only EC-P512 is valid for a JWT ES512 signature. Ignore four JWKs (two RSA, two EC).
+            // - If JWT alg is ES384, only EC-P384 is valid for a JWT ES384 signature. Ignore four JWKs (two RSA, two EC).
+            // - If JWT alg is ES256, only EC-P256 is valid for a JWT ES256 signature. Ignore four JWKs (two RSA, two EC).
+            //
+            // HMAC Example: Realm has six HMAC JWKs of bit lengths 256, 320, 384, 400, 512, and 1000. JWT alg allows ignoring some.
+            // - If JWT alg is HS256, all are valid for a JWT HS256 signature. Don't ignore any HMAC JWKs.
+            // - If JWT alg is HS384, only 384, 400, 512, and 1000 are valid for a JWT HS384 signature. Ignore two HMAC JWKs.
+            // - If JWT alg is HS512, only 512 and 1000 are valid for a JWT HS512 signature. Ignore four HMAC JWKs.
+            final List<JWK> jwksConfigured = jwksAlg.stream().filter(j -> JwkValidateUtil.isMatch(j, alg.getName(), tracer)).toList();
+            tracer.append("[{}] JWKs remain after filtering for configured algorithms.", jwksConfigured.size());
+            tracer.flush();
+
+            // No JWKs passed the kid, alg, and strength checks, so nothing left to use in verifying the JWT signature
+            if (jwksConfigured.isEmpty()) {
+                throw new ElasticsearchException(
+                    "Signature verification was not attempted since there are not any JWKs "
+                        + "available after filtering for incompatible keys."
                 );
             }
-        }
 
-        throw new ElasticsearchException("Verify failed using " + jwksStrength.size() + " of " + jwks.size() + " provided JWKs.");
+            int attempt = 0;
+            int maxAttempts = jwksConfigured.size();
+            tracer.append("Attempting to verify signature for JWT [{}] against [{}] possible JWKs.", getSafePrintableJWT(jwt), maxAttempts);
+            for (final JWK jwk : jwksConfigured) {
+                attempt++;
+                if (jwt.verify(createJwsVerifier(jwk))) {
+                    tracer.append(
+                        "Attempt [{}/{}] -> JWT signature verification succeeded with jwk/kid=[{}], jwk/alg=[{}], jwk/kty=[{}], "
+                            + "jwk/use=[{}], jwk/key_ops=[{}]",
+                        attempt,
+                        maxAttempts,
+                        jwk.getKeyID(),
+                        jwk.getAlgorithm(),
+                        jwk.getKeyType(),
+                        jwk.getKeyUse(),
+                        jwk.getKeyOperations()
+                    );
+                    return;
+                } else {
+                    tracer.append(
+                        "Attempt [{}/{}] -> JWT signature verification failed with jwk/kid=[{}], jwk/alg=[{}], jwk/kty=[{}], jwk/use=[{}], "
+                            + "jwk/key_ops=[{}]",
+                        attempt,
+                        maxAttempts,
+                        jwk.getKeyID(),
+                        jwk.getAlgorithm(),
+                        jwk.getKeyType(),
+                        jwk.getKeyUse(),
+                        jwk.getKeyOperations()
+                    );
+                }
+            }
+            throw new ElasticsearchException("JWT [" + getSafePrintableJWT(jwt).get() + "] signature verification failed.");
+        }
     }
 
     default JWSVerifier createJwsVerifier(final JWK jwk) throws JOSEException {
@@ -428,4 +457,16 @@ public interface JwtSignatureValidator extends Releasable {
     interface PkcJwkSetReloadNotifier {
         void reloaded();
     }
+
+    /**
+     * @param jwt The signed JWT
+     * @return A print safe supplier to describe a JWT that redacts the signature. While the signature is not generally sensitive,
+     * we don't want to leak the entire JWT to the log to avoid a possible replay.
+     */
+    private Supplier<String> getSafePrintableJWT(SignedJWT jwt) {
+        Base64URL[] parts = jwt.getParsedParts();
+        assert parts.length == 3;
+        return () -> parts[0].toString() + "." + parts[1].toString() + ".<redacted>";
+    }
+
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
@@ -33,6 +33,7 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.SettingsException;
@@ -54,6 +55,10 @@ import java.security.MessageDigest;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -137,7 +142,8 @@ public class JwtUtil {
     public static void validateClientAuthentication(
         final JwtRealmSettings.ClientAuthenticationType type,
         final SecureString expectedSecret,
-        final SecureString actualSecret
+        final SecureString actualSecret,
+        final String tokenPrincipal
     ) throws Exception {
         switch (type) {
             case SHARED_SECRET:
@@ -146,14 +152,18 @@ public class JwtUtil {
                 } else if (expectedSecret.equals(actualSecret) == false) {
                     throw new Exception("Rejected client. Authentication type is [" + type + "] and secret did not match.");
                 }
-                LOGGER.trace("Accepted client. Authentication type is [{}] and secret matched.", type);
+                LOGGER.trace("Accepted client for token [{}]. Authentication type is [{}] and secret matched.", tokenPrincipal, type);
                 break;
             case NONE:
             default:
                 if (Strings.hasText(actualSecret)) {
-                    LOGGER.debug("Accepted client. Authentication type [{}]. Secret is present but ignored.", type);
+                    LOGGER.trace(
+                        "Accepted client for token [{}]. Authentication type [{}]. Secret is present but ignored.",
+                        tokenPrincipal,
+                        type
+                    );
                 } else {
-                    LOGGER.trace("Accepted client. Authentication type [{}].", type);
+                    LOGGER.trace("Accepted client for token [{}]. Authentication type [{}].", tokenPrincipal, type);
                 }
                 break;
         }
@@ -337,5 +347,45 @@ public class JwtUtil {
         final MessageDigest messageDigest = MessageDigests.sha256();
         messageDigest.update(charSequence.toString().getBytes(StandardCharsets.UTF_8));
         return messageDigest.digest();
+    }
+
+    /**
+     * Helper class to consolidate multiple trace level statements to a single trace statement with lazy evaluation.
+     * If trace level is not enabled, then no work is performed. This class is not threadsafe and is not intended for a long lifecycle.
+     */
+    public static class TraceBuffer implements AutoCloseable {
+        private final Logger logger;
+        private final List<Object> params = new ArrayList<>();
+        private final StringBuilder builder = new StringBuilder();
+        boolean closed = false;
+
+        public TraceBuffer(Logger logger) {
+            this.logger = logger;
+        }
+
+        public void append(String s, Object... args) {
+            assert closed == false;
+            if (logger.isTraceEnabled()) {
+                builder.append(s).append(" ");
+                List<Object> resolved = Arrays.stream(args).map(x -> (x instanceof Supplier) ? ((Supplier<?>) x).get() : x).toList();
+                params.addAll(resolved);
+            }
+        }
+
+        @SuppressLoggerChecks(reason = "builds the tracer dynamically")
+        public void flush() {
+            assert closed == false;
+            if (logger.isTraceEnabled() && builder.isEmpty() == false) {
+                logger.trace(builder.toString(), params.toArray());
+                params.clear();
+                builder.setLength(0); // does not guarantee contents available for GC, don't overly reuse a single instance of this class
+            }
+        }
+
+        @Override
+        public void close() {
+            flush();
+            closed = true;
+        }
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -118,9 +118,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
             task.getCheckpointingInfo(
                 transformCheckpointService,
                 ActionListener.wrap(
-                    checkpointingInfo -> listener.onResponse(
-                        new Response(Collections.singletonList(deriveStats(task, checkpointingInfo)), 1L)
-                    ),
+                    checkpointingInfo -> listener.onResponse(new Response(Collections.singletonList(deriveStats(task, checkpointingInfo)))),
                     e -> {
                         logger.warn("Failed to retrieve checkpointing info for transform [" + task.getTransformId() + "]", e);
                         listener.onResponse(
@@ -135,7 +133,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                 )
             );
         } else {
-            listener.onResponse(new Response(Collections.emptyList(), 0L));
+            listener.onResponse(new Response(Collections.emptyList()));
         }
     }
 
@@ -204,12 +202,12 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                     request.setNodes(transformNodeAssignments.getExecutorNodes().toArray(new String[0]));
                     super.doExecute(task, request, doExecuteListener);
                 } else {
-                    doExecuteListener.onResponse(new Response(Collections.emptyList(), 0L));
+                    doExecuteListener.onResponse(new Response(Collections.emptyList()));
                 }
             }, e -> {
                 // If the index to search, or the individual config is not there, just return empty
                 if (e instanceof ResourceNotFoundException) {
-                    finalListener.onResponse(new Response(Collections.emptyList(), 0L));
+                    finalListener.onResponse(new Response(Collections.emptyList()));
                 } else {
                     finalListener.onFailure(e);
                 }


### PR DESCRIPTION
This adds the ability to perform date math: allow date types be updated with a time span (a duration or a period).

Ex. : `row n = now() | eval then = n - 1 year + 2 minutes`

Closes #98402.