### PR TITLE
Add settings registration for Java modules through SPI

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -371,7 +371,11 @@ module org.elasticsearch.server {
 
     exports org.elasticsearch.action.datastreams.lifecycle;
     exports org.elasticsearch.action.downsample;
-    exports org.elasticsearch.plugins.internal to org.elasticsearch.metering, org.elasticsearch.settings.secure, org.elasticsearch.serverless.constants;
+    exports org.elasticsearch.plugins.internal
+        to
+            org.elasticsearch.metering,
+            org.elasticsearch.settings.secure,
+            org.elasticsearch.serverless.constants;
 
     provides java.util.spi.CalendarDataProvider with org.elasticsearch.common.time.IsoCalendarDataProvider;
     provides org.elasticsearch.xcontent.ErrorOnUnknown with org.elasticsearch.common.xcontent.SuggestingErrorOnUnknown;

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -371,7 +371,7 @@ module org.elasticsearch.server {
 
     exports org.elasticsearch.action.datastreams.lifecycle;
     exports org.elasticsearch.action.downsample;
-    exports org.elasticsearch.plugins.internal to org.elasticsearch.metering, org.elasticsearch.settings.secure;
+    exports org.elasticsearch.plugins.internal to org.elasticsearch.metering, org.elasticsearch.settings.secure, org.elasticsearch.serverless.constants;
 
     provides java.util.spi.CalendarDataProvider with org.elasticsearch.common.time.IsoCalendarDataProvider;
     provides org.elasticsearch.xcontent.ErrorOnUnknown with org.elasticsearch.common.xcontent.SuggestingErrorOnUnknown;
@@ -386,6 +386,7 @@ module org.elasticsearch.server {
     uses org.elasticsearch.node.internal.TerminationHandlerProvider;
     uses org.elasticsearch.internal.VersionExtension;
     uses org.elasticsearch.internal.BuildExtension;
+    uses org.elasticsearch.plugins.internal.SettingsExtension;
 
     provides org.apache.lucene.codecs.PostingsFormat
         with

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -182,6 +182,7 @@ import org.elasticsearch.plugins.TracerPlugin;
 import org.elasticsearch.plugins.internal.DocumentParsingObserver;
 import org.elasticsearch.plugins.internal.DocumentParsingObserverPlugin;
 import org.elasticsearch.plugins.internal.ReloadAwarePlugin;
+import org.elasticsearch.plugins.internal.SettingsExtension;
 import org.elasticsearch.readiness.ReadinessService;
 import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -462,6 +463,7 @@ public class Node implements Closeable {
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());
             }
+            SettingsExtension.load().forEach(e -> additionalSettings.addAll(e.getSettings()));
             client = new NodeClient(settings, threadPool);
 
             final ScriptModule scriptModule = new ScriptModule(settings, pluginsService.filterPlugins(ScriptPlugin.class));

--- a/server/src/main/java/org/elasticsearch/plugins/internal/SettingsExtension.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/SettingsExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins.internal;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * An SPI interface for registering Settings.
+ *
+ * This is an alternative to {@link Plugin#getSettings()} allowing
+ * any Java module to include registered settings.
+ */
+public interface SettingsExtension {
+    List<Setting<?>> getSettings();
+
+    /**
+     * Loads a single BuildExtension, or returns {@code null} if none are found.
+     */
+    static List<SettingsExtension> load() {
+        var loader = ServiceLoader.load(SettingsExtension.class);
+        return loader.stream().map(p -> p.get()).toList();
+    }
+}


### PR DESCRIPTION
Currently plugins register settings through Plugin.getSettings. For easier breakdown of the codebase, it would be nice to allow arbitrary Java modules to register settings. This commit adds an internal SettingsExtension SPI which acts just like Plugin.getSettings but from a purely static context.