### PR TITLE
Perform reduce with InternalAggregations#topLevelReduce in AggregatorTestCase

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -134,7 +134,7 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
      * Return the internal {@link DoubleHistogram} sketch for this metric.
      */
     public DoubleHistogram getState() {
-        return state;
+        return state == null ? EMPTY_HISTOGRAM_ZERO_DIGITS : state;
     }
 
     /**
@@ -207,7 +207,7 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        DoubleHistogram state = this.state != null ? this.state : EMPTY_HISTOGRAM_ZERO_DIGITS;
+        DoubleHistogram state = getState();
         if (keyed) {
             builder.startObject(CommonFields.VALUES.getPreferredName());
             for (int i = 0; i < keys.length; ++i) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -114,7 +114,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
      * Return the internal {@link TDigestState} sketch for this metric.
      */
     public TDigestState getState() {
-        return state;
+        return state == null ? EMPTY_HISTOGRAM : state;
     }
 
     /**
@@ -185,7 +185,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        TDigestState state = this.state != null ? this.state : EMPTY_HISTOGRAM;
+        TDigestState state = getState();
         if (keyed) {
             builder.startObject(CommonFields.VALUES.getPreferredName());
             for (int i = 0; i < keys.length; ++i) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregatorTests.java
@@ -49,9 +49,7 @@ public class HDRPercentileRanksAggregatorTests extends AggregatorTestCase {
         try (IndexReader reader = new MultiReader()) {
             IndexSearcher searcher = newSearcher(reader);
             PercentileRanks ranks = searchAndReduce(searcher, new AggTestConfig(aggBuilder, fieldType));
-            Percentile rank = ranks.iterator().next();
-            assertEquals(Double.NaN, rank.getPercent(), 0d);
-            assertEquals(0.5, rank.getValue(), 0d);
+            assertFalse(ranks.iterator().hasNext());
             assertFalse(AggregationInspectionHelper.hasValue((InternalHDRPercentileRanks) ranks));
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
@@ -56,7 +56,7 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
         testCase(new MatchAllDocsQuery(), iw -> {
             // Intentionally not writing any docs
         }, hdr -> {
-            assertEquals(0L, hdr.state.getTotalCount());
+            assertEquals(0L, hdr.getState().getTotalCount());
             assertFalse(AggregationInspectionHelper.hasValue(hdr));
         });
     }
@@ -94,7 +94,7 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 1)));
         }, hdr -> {
-            assertEquals(0L, hdr.state.getTotalCount());
+            assertEquals(0L, hdr.getState().getTotalCount());
             assertFalse(AggregationInspectionHelper.hasValue(hdr));
         });
     }
@@ -106,7 +106,7 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 20)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 10)));
         }, hdr -> {
-            assertEquals(4L, hdr.state.getTotalCount());
+            assertEquals(4L, hdr.getState().getTotalCount());
             double approximation = 0.05d;
             assertEquals(10.0d, hdr.percentile(25), approximation);
             assertEquals(20.0d, hdr.percentile(50), approximation);
@@ -123,7 +123,7 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 20)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 10)));
         }, hdr -> {
-            assertEquals(4L, hdr.state.getTotalCount());
+            assertEquals(4L, hdr.getState().getTotalCount());
             double approximation = 0.05d;
             assertEquals(10.0d, hdr.percentile(25), approximation);
             assertEquals(20.0d, hdr.percentile(50), approximation);
@@ -142,13 +142,13 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
         };
 
         testCase(LongPoint.newRangeQuery("row", 0, 2), docs, hdr -> {
-            assertEquals(2L, hdr.state.getTotalCount());
+            assertEquals(2L, hdr.getState().getTotalCount());
             assertEquals(10.0d, hdr.percentile(randomDoubleBetween(1, 50, true)), 0.05d);
             assertTrue(AggregationInspectionHelper.hasValue(hdr));
         });
 
         testCase(LongPoint.newRangeQuery("row", 5, 10), docs, hdr -> {
-            assertEquals(0L, hdr.state.getTotalCount());
+            assertEquals(0L, hdr.getState().getTotalCount());
             assertFalse(AggregationInspectionHelper.hasValue(hdr));
         });
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
@@ -56,7 +56,7 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
         testCase(new MatchAllDocsQuery(), iw -> {
             // Intentionally not writing any docs
         }, tdigest -> {
-            assertEquals(0L, tdigest.state.size());
+            assertEquals(0L, tdigest.getState().size());
             assertFalse(AggregationInspectionHelper.hasValue(tdigest));
         });
     }
@@ -66,7 +66,7 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 1)));
         }, tdigest -> {
-            assertEquals(0L, tdigest.state.size());
+            assertEquals(0L, tdigest.getState().size());
             assertFalse(AggregationInspectionHelper.hasValue(tdigest));
         });
     }
@@ -81,8 +81,8 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 1)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 0)));
         }, tdigest -> {
-            assertEquals(7L, tdigest.state.size());
-            assertEquals(7L, tdigest.state.centroidCount());
+            assertEquals(7L, tdigest.getState().size());
+            assertEquals(7L, tdigest.getState().centroidCount());
             assertEquals(4.0d, tdigest.percentile(75), 0.0d);
             assertEquals("4.0", tdigest.percentileAsString(75));
             assertEquals(2.0d, tdigest.percentile(50), 0.0d);
@@ -103,8 +103,8 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 0)));
         }, tdigest -> {
-            assertEquals(tdigest.state.size(), 7L);
-            assertEquals(tdigest.state.centroidCount(), 7L);
+            assertEquals(tdigest.getState().size(), 7L);
+            assertEquals(tdigest.getState().centroidCount(), 7L);
             assertEquals(8.0d, tdigest.percentile(100), 0.0d);
             assertEquals("8.0", tdigest.percentileAsString(100));
             assertEquals(4.0d, tdigest.percentile(75), 0.0d);
@@ -131,8 +131,8 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
         };
 
         testCase(LongPoint.newRangeQuery("row", 1, 4), docs, tdigest -> {
-            assertEquals(4L, tdigest.state.size());
-            assertEquals(4L, tdigest.state.centroidCount());
+            assertEquals(4L, tdigest.getState().size());
+            assertEquals(4L, tdigest.getState().centroidCount());
             assertEquals(2.0d, tdigest.percentile(100), 0.0d);
             assertEquals(1.0d, tdigest.percentile(50), 0.0d);
             assertEquals(0.75d, tdigest.percentile(25), 0.0d);
@@ -140,8 +140,8 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
         });
 
         testCase(LongPoint.newRangeQuery("row", 100, 110), docs, tdigest -> {
-            assertEquals(0L, tdigest.state.size());
-            assertEquals(0L, tdigest.state.centroidCount());
+            assertEquals(0L, tdigest.getState().size());
+            assertEquals(0L, tdigest.getState().centroidCount());
             assertFalse(AggregationInspectionHelper.hasValue(tdigest));
         });
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -99,8 +99,6 @@ import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
-import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -121,7 +119,6 @@ import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuil
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.metrics.MultiValueAggregation;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.AggregationContext.ProductionAggregationContext;
@@ -257,14 +254,21 @@ public abstract class AggregatorTestCase extends ESTestCase {
         return createAggregator(aggregationBuilder, createAggregationContext(searcher, new MatchAllDocsQuery(), fieldTypes));
     }
 
+    protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder, AggregationContext context)
+        throws IOException {
+        return createAggregator(new AggregatorFactories.Builder().addAggregator(aggregationBuilder), context);
+    }
+
     /**
      * Deprecated - this will be made private in a future update
      */
     @Deprecated
-    protected <A extends Aggregator> A createAggregator(AggregationBuilder builder, AggregationContext context) throws IOException {
-        QueryRewriteContext rewriteContext = new QueryRewriteContext(parserConfig(), null, context::nowInMillis);
+    protected <A extends Aggregator> A createAggregator(AggregatorFactories.Builder builder, AggregationContext context)
+        throws IOException {
+        Aggregator[] aggregators = builder.build(context, null).createTopLevelAggregators();
+        assertThat(aggregators.length, equalTo(1));
         @SuppressWarnings("unchecked")
-        A aggregator = (A) Rewriteable.rewrite(builder, rewriteContext, true).build(context, null).create(null, CardinalityUpperBound.ONE);
+        A aggregator = (A) aggregators[0];
         return aggregator;
     }
 
@@ -501,7 +505,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         AggTestConfig aggTestConfig
     ) throws IOException {
         Query query = aggTestConfig.query();
-        AggregationBuilder builder = aggTestConfig.builder();
+        AggregatorFactories.Builder builder = new AggregatorFactories.Builder().addAggregator(aggTestConfig.builder());
         int maxBucket = aggTestConfig.maxBuckets();
         boolean splitLeavesIntoSeparateAggregators = aggTestConfig.splitLeavesIntoSeparateAggregators();
         boolean shouldBeCached = aggTestConfig.shouldBeCached();
@@ -613,7 +617,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     () -> false,
                     builder
                 );
-                A reduced = (A) internalAggs.get(0).reduce(toReduce, reduceContext);
+                A reduced = (A) doReduce(toReduce, reduceContext);
                 internalAggs = new ArrayList<>(internalAggs.subList(r, toReduceSize));
                 internalAggs.add(reduced);
                 assertRoundTrip(internalAggs);
@@ -629,30 +633,36 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 getMockScriptService(),
                 () -> false,
                 builder,
-                reduceBucketConsumer,
-                pipelines
+                reduceBucketConsumer
             );
 
             @SuppressWarnings("unchecked")
-            A internalAgg = (A) internalAggs.get(0).reduce(internalAggs, reduceContext);
+            A internalAgg = (A) doReduce(internalAggs, reduceContext);
             assertRoundTrip(internalAgg);
 
             // materialize any parent pipelines
             internalAgg = (A) internalAgg.reducePipelines(internalAgg, reduceContext, pipelines);
 
-            // materialize any sibling pipelines at top level
-            for (PipelineAggregator pipelineAggregator : pipelines.aggregators()) {
-                internalAgg = (A) pipelineAggregator.reduce(internalAgg, reduceContext);
-            }
             doAssertReducedMultiBucketConsumer(internalAgg, reduceBucketConsumer);
             assertRoundTrip(internalAgg);
-            if (builder instanceof ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) {
-                verifyMetricNames((ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) builder, internalAgg);
+            if (aggTestConfig.builder instanceof ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) {
+                verifyMetricNames((ValuesSourceAggregationBuilder.MetricsAggregationBuilder<?>) aggTestConfig.builder, internalAgg);
             }
             return internalAgg;
         } finally {
             Releasables.close(breakerService);
         }
+    }
+
+    private InternalAggregation doReduce(List<InternalAggregation> aggregators, AggregationReduceContext reduceContext) {
+        final List<InternalAggregations> internalAggregations = new ArrayList<>(aggregators.size());
+        for (InternalAggregation aggregator : aggregators) {
+            internalAggregations.add(InternalAggregations.from(List.of(aggregator)));
+        }
+        InternalAggregations aggregations = InternalAggregations.topLevelReduce(internalAggregations, reduceContext);
+        List<InternalAggregation> reduced = aggregations.copyResults();
+        assertThat(reduced.size(), equalTo(1));
+        return reduced.get(0);
     }
 
     protected void doAssertReducedMultiBucketConsumer(Aggregation agg, MultiBucketConsumerService.MultiBucketConsumer bucketConsumer) {
@@ -753,7 +763,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
      * creates a single {@link Aggregator} so we can get consistent debug info.
      */
     protected <R extends InternalAggregation> void debugTestCase(
-        AggregationBuilder builder,
+        AggregationBuilder aggregationBuilder,
         Query query,
         IndexSearcher searcher,
         TriConsumer<R, Class<? extends Aggregator>, Map<String, Map<String, Object>>> verify,
@@ -766,25 +776,25 @@ public abstract class AggregatorTestCase extends ESTestCase {
             createIndexSettings(),
             searcher.rewrite(query),
             breakerService,
-            builder.bytesToPreallocate(),
+            aggregationBuilder.bytesToPreallocate(),
             DEFAULT_MAX_BUCKETS,
-            builder.isInSortOrderExecutionRequired(),
+            aggregationBuilder.isInSortOrderExecutionRequired(),
             fieldTypes
         );
+        AggregatorFactories.Builder builder = new AggregatorFactories.Builder().addAggregator(aggregationBuilder);
         try {
             Aggregator aggregator = createAggregator(builder, context);
             aggregator.preCollection();
             searcher.search(context.query(), aggregator.asCollector());
             InternalAggregation r = aggregator.buildTopLevel();
-            r = r.reduce(
+            r = doReduce(
                 List.of(r),
                 new AggregationReduceContext.ForFinal(
                     context.bigArrays(),
                     getMockScriptService(),
                     () -> false,
                     builder,
-                    new MultiBucketConsumer(context.maxBuckets(), context.breaker()),
-                    builder.buildPipelineTree()
+                    new MultiBucketConsumer(context.maxBuckets(), context.breaker())
                 )
             );
             @SuppressWarnings("unchecked") // We'll get a cast error in the test if we're wrong here and that is ok
@@ -793,7 +803,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             Map<String, Map<String, Object>> debug = new HashMap<>();
             collectDebugInfo("", aggregator, debug);
             verify.apply(result, aggregator.getClass(), debug);
-            verifyOutputFieldNames(builder, result);
+            verifyOutputFieldNames(aggregationBuilder, result);
         } finally {
             Releasables.close(context);
         }


### PR DESCRIPTION
In order to make AggregatorTestCase similar to how aggregations are run on production, lets use InternalAggregations#topLevelReduce as this is the code path we are using. There are some side effects in histogram aggregations as if they are empty, the state now is null.

relates https://github.com/elastic/elasticsearch/issues/98672