### PR TITLE
[Profiling] Abort index creation on outdated index

### DIFF
--- a/docs/changelog/98864.yaml
+++ b/docs/changelog/98864.yaml
@@ -1,0 +1,5 @@
+pr: 98864
+summary: "[Profiling] Abort index creation on outdated index"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/AbstractProfilingPersistenceManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/AbstractProfilingPersistenceManager.java
@@ -21,22 +21,14 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.cluster.health.ClusterIndexHealth;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.gateway.GatewayService;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
 
 import java.io.Closeable;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
@@ -44,22 +36,26 @@ import java.util.function.BiConsumer;
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
-public abstract class AbstractProfilingPersistenceManager<T extends AbstractProfilingPersistenceManager.ProfilingIndexAbstraction>
-    implements
-        ClusterStateListener,
-        Closeable {
+abstract class AbstractProfilingPersistenceManager<T extends ProfilingIndexAbstraction> implements ClusterStateListener, Closeable {
     protected final Logger logger = LogManager.getLogger(getClass());
 
     private final AtomicBoolean inProgress = new AtomicBoolean(false);
     private final ClusterService clusterService;
     protected final ThreadPool threadPool;
     protected final Client client;
+    private final IndexStateResolver indexStateResolver;
     private volatile boolean templatesEnabled;
 
-    public AbstractProfilingPersistenceManager(ThreadPool threadPool, Client client, ClusterService clusterService) {
+    AbstractProfilingPersistenceManager(
+        ThreadPool threadPool,
+        Client client,
+        ClusterService clusterService,
+        IndexStateResolver indexStateResolver
+    ) {
         this.threadPool = threadPool;
         this.client = client;
         this.clusterService = clusterService;
+        this.indexStateResolver = indexStateResolver;
     }
 
     public void initialize() {
@@ -95,7 +91,7 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
             return;
         }
 
-        if (isAllResourcesCreated(event, clusterService.getSettings()) == false) {
+        if (areAllIndexTemplatesCreated(event, clusterService.getSettings()) == false) {
             logger.trace("Skipping index creation; not all required resources are present yet");
             return;
         }
@@ -109,26 +105,20 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         try (var refs = new RefCountingRunnable(() -> inProgress.set(false))) {
             ClusterState clusterState = event.state();
             for (T index : getManagedIndices()) {
-                IndexState<T> state = getIndexState(clusterState, index);
+                IndexState<T> state = indexStateResolver.getIndexState(clusterState, index);
                 if (state.getStatus().actionable) {
                     onIndexState(clusterState, state, ActionListener.releasing(refs.acquire()));
+                } else if (state.getStatus() == IndexStatus.TOO_OLD) {
+                    logger.info("Aborting index creation as index [{}] is considered too old.", index);
+                    return;
                 }
             }
         }
     }
 
-    protected boolean isAllResourcesCreated(ClusterChangedEvent event, Settings settings) {
+    protected boolean areAllIndexTemplatesCreated(ClusterChangedEvent event, Settings settings) {
         return ProfilingIndexTemplateRegistry.isAllResourcesCreated(event.state(), settings);
     }
-
-    /**
-     * Extracts the appropriate index metadata for a given index from the cluster state.
-     *
-     * @param state Current cluster state. Never <code>null</code>.
-     * @param index An index for which to retrieve index metadata. Never <code>null</code>.
-     * @return The corresponding index metadata or <code>null</code> if there are none.
-     */
-    protected abstract IndexMetadata indexMetadata(ClusterState state, T index);
 
     /**
      * @return An iterable of all indices that are managed by this instance.
@@ -147,78 +137,6 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
         IndexState<T> indexState,
         ActionListener<? super ActionResponse> listener
     );
-
-    private IndexState<T> getIndexState(ClusterState state, T index) {
-        IndexMetadata metadata = indexMetadata(state, index);
-        if (metadata == null) {
-            return new IndexState<>(index, null, Status.NEEDS_CREATION);
-        }
-        if (metadata.getState() == IndexMetadata.State.CLOSE) {
-            logger.warn(
-                "Index [{}] is closed. This is likely to prevent Universal Profiling from functioning correctly",
-                metadata.getIndex()
-            );
-            return new IndexState<>(index, metadata.getIndex(), Status.CLOSED);
-        }
-        final IndexRoutingTable routingTable = state.getRoutingTable().index(metadata.getIndex());
-        ClusterHealthStatus indexHealth = new ClusterIndexHealth(metadata, routingTable).getStatus();
-        if (indexHealth == ClusterHealthStatus.RED) {
-            logger.trace("Index [{}] health status is RED, any pending mapping upgrades will wait until this changes", metadata.getIndex());
-            return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
-        }
-        MappingMetadata mapping = metadata.mapping();
-        if (mapping != null) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> meta = (Map<String, Object>) mapping.sourceAsMap().get("_meta");
-            int currentIndexVersion;
-            int currentTemplateVersion;
-            if (meta == null) {
-                logger.debug("Missing _meta field in mapping of index [{}], assuming initial version.", metadata.getIndex());
-                currentIndexVersion = 1;
-                currentTemplateVersion = 1;
-            } else {
-                // we are extra defensive and treat any unexpected values as an unhealthy index which we won't touch.
-                currentIndexVersion = getVersionField(metadata.getIndex(), meta, "index-version");
-                currentTemplateVersion = getVersionField(metadata.getIndex(), meta, "index-template-version");
-                if (currentIndexVersion == -1 || currentTemplateVersion == -1) {
-                    return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
-                }
-            }
-            if (index.getVersion() > currentIndexVersion) {
-                return new IndexState<>(index, metadata.getIndex(), Status.NEEDS_VERSION_BUMP);
-            } else if (getIndexTemplateVersion() > currentTemplateVersion) {
-                // if there are no migrations we can consider the index up-to-date even if the index template version does not match.
-                List<Migration> pendingMigrations = index.getMigrations(currentTemplateVersion);
-                if (pendingMigrations.isEmpty()) {
-                    logger.trace(
-                        "Index [{}] with index template version [{}] (current is [{}]) is up-to-date (no pending migrations).",
-                        metadata.getIndex(),
-                        currentTemplateVersion,
-                        getIndexTemplateVersion()
-                    );
-                    return new IndexState<>(index, metadata.getIndex(), Status.UP_TO_DATE);
-                }
-                logger.trace(
-                    "Index [{}] with index template version [{}] (current is [{}])  has [{}] pending migrations.",
-                    metadata.getIndex(),
-                    currentTemplateVersion,
-                    getIndexTemplateVersion(),
-                    pendingMigrations.size()
-                );
-                return new IndexState<>(index, metadata.getIndex(), Status.NEEDS_MAPPINGS_UPDATE, pendingMigrations);
-            } else {
-                return new IndexState<>(index, metadata.getIndex(), Status.UP_TO_DATE);
-            }
-        } else {
-            logger.warn("No mapping found for existing index [{}]. Index cannot be migrated.", metadata.getIndex());
-            return new IndexState<>(index, metadata.getIndex(), Status.UNHEALTHY);
-        }
-    }
-
-    // overridable for testing
-    protected int getIndexTemplateVersion() {
-        return ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION;
-    }
 
     protected final void applyMigrations(IndexState<T> indexState, ActionListener<? super ActionResponse> listener) {
         String writeIndex = indexState.getWriteIndex().getName();
@@ -281,81 +199,5 @@ public abstract class AbstractProfilingPersistenceManager<T extends AbstractProf
                 }
             }, consumer);
         });
-    }
-
-    private int getVersionField(Index index, Map<String, Object> meta, String fieldName) {
-        Object value = meta.get(fieldName);
-        if (value instanceof Integer) {
-            return (int) value;
-        }
-        if (value == null) {
-            logger.warn("Metadata version field [{}] of index [{}] is empty.", fieldName, index);
-            return -1;
-        }
-        logger.warn("Metadata version field [{}] of index [{}] is [{}] (expected an integer).", fieldName, index, value);
-        return -1;
-    }
-
-    protected static final class IndexState<T extends ProfilingIndexAbstraction> {
-        private final T index;
-        private final Index writeIndex;
-        private final Status status;
-        private final List<Migration> pendingMigrations;
-
-        IndexState(T index, Index writeIndex, Status status) {
-            this(index, writeIndex, status, null);
-        }
-
-        IndexState(T index, Index writeIndex, Status status, List<Migration> pendingMigrations) {
-            this.index = index;
-            this.writeIndex = writeIndex;
-            this.status = status;
-            this.pendingMigrations = pendingMigrations;
-        }
-
-        public T getIndex() {
-            return index;
-        }
-
-        public Index getWriteIndex() {
-            return writeIndex;
-        }
-
-        public Status getStatus() {
-            return status;
-        }
-
-        public List<Migration> getPendingMigrations() {
-            return pendingMigrations;
-        }
-    }
-
-    enum Status {
-        CLOSED(false),
-        UNHEALTHY(false),
-        NEEDS_CREATION(true),
-        NEEDS_VERSION_BUMP(true),
-        UP_TO_DATE(false),
-        NEEDS_MAPPINGS_UPDATE(true);
-
-        /**
-         * Whether a status is for informational purposes only or whether it should be acted upon and may change cluster state.
-         */
-        private final boolean actionable;
-
-        Status(boolean actionable) {
-            this.actionable = actionable;
-        }
-    }
-
-    /**
-     * An index that is used by Universal Profiling.
-     */
-    interface ProfilingIndexAbstraction {
-        String getName();
-
-        int getVersion();
-
-        List<Migration> getMigrations(int currentIndexTemplateVersion);
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
@@ -33,18 +33,21 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
         private boolean profilingEnabled;
         private boolean resourceManagementEnabled;
         private boolean resourcesCreated;
+        private boolean anyResourceTooOld;
 
         public Response(StreamInput in) throws IOException {
             super(in);
             profilingEnabled = in.readBoolean();
             resourceManagementEnabled = in.readBoolean();
             resourcesCreated = in.readBoolean();
+            anyResourceTooOld = in.readBoolean();
         }
 
-        public Response(boolean profilingEnabled, boolean resourceManagementEnabled, boolean resourcesCreated) {
+        public Response(boolean profilingEnabled, boolean resourceManagementEnabled, boolean resourcesCreated, boolean anyResourceTooOld) {
             this.profilingEnabled = profilingEnabled;
             this.resourceManagementEnabled = resourceManagementEnabled;
             this.resourcesCreated = resourcesCreated;
+            this.anyResourceTooOld = anyResourceTooOld;
         }
 
         @Override
@@ -52,7 +55,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             builder.startObject();
             builder.startObject("profiling").field("enabled", profilingEnabled).endObject();
             builder.startObject("resource_management").field("enabled", resourceManagementEnabled).endObject();
-            builder.startObject("resources").field("created", resourcesCreated).endObject();
+            builder.startObject("resources").field("created", resourcesCreated).field("too_old", anyResourceTooOld).endObject();
             builder.endObject();
             return builder;
         }
@@ -62,6 +65,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             out.writeBoolean(profilingEnabled);
             out.writeBoolean(resourceManagementEnabled);
             out.writeBoolean(resourcesCreated);
+            out.writeBoolean(anyResourceTooOld);
         }
 
         @Override
@@ -71,12 +75,13 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             Response response = (Response) o;
             return profilingEnabled == response.profilingEnabled
                 && resourceManagementEnabled == response.resourceManagementEnabled
-                && resourcesCreated == response.resourcesCreated;
+                && resourcesCreated == response.resourcesCreated
+                && anyResourceTooOld == response.anyResourceTooOld;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated);
+            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, anyResourceTooOld);
         }
 
         @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
@@ -33,21 +33,21 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
         private boolean profilingEnabled;
         private boolean resourceManagementEnabled;
         private boolean resourcesCreated;
-        private boolean anyResourceTooOld;
+        private boolean pre891Data;
 
         public Response(StreamInput in) throws IOException {
             super(in);
             profilingEnabled = in.readBoolean();
             resourceManagementEnabled = in.readBoolean();
             resourcesCreated = in.readBoolean();
-            anyResourceTooOld = in.readBoolean();
+            pre891Data = in.readBoolean();
         }
 
-        public Response(boolean profilingEnabled, boolean resourceManagementEnabled, boolean resourcesCreated, boolean anyResourceTooOld) {
+        public Response(boolean profilingEnabled, boolean resourceManagementEnabled, boolean resourcesCreated, boolean pre891Data) {
             this.profilingEnabled = profilingEnabled;
             this.resourceManagementEnabled = resourceManagementEnabled;
             this.resourcesCreated = resourcesCreated;
-            this.anyResourceTooOld = anyResourceTooOld;
+            this.pre891Data = pre891Data;
         }
 
         @Override
@@ -55,7 +55,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             builder.startObject();
             builder.startObject("profiling").field("enabled", profilingEnabled).endObject();
             builder.startObject("resource_management").field("enabled", resourceManagementEnabled).endObject();
-            builder.startObject("resources").field("created", resourcesCreated).field("too_old", anyResourceTooOld).endObject();
+            builder.startObject("resources").field("created", resourcesCreated).field("pre_8_9_1_data", pre891Data).endObject();
             builder.endObject();
             return builder;
         }
@@ -65,7 +65,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             out.writeBoolean(profilingEnabled);
             out.writeBoolean(resourceManagementEnabled);
             out.writeBoolean(resourcesCreated);
-            out.writeBoolean(anyResourceTooOld);
+            out.writeBoolean(pre891Data);
         }
 
         @Override
@@ -76,12 +76,12 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             return profilingEnabled == response.profilingEnabled
                 && resourceManagementEnabled == response.resourceManagementEnabled
                 && resourcesCreated == response.resourcesCreated
-                && anyResourceTooOld == response.anyResourceTooOld;
+                && pre891Data == response.pre891Data;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, anyResourceTooOld);
+            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, pre891Data);
         }
 
         @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexState.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexState.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.index.Index;
+
+import java.util.List;
+
+final class IndexState<T extends ProfilingIndexAbstraction> {
+    private final T index;
+    private final Index writeIndex;
+    private final IndexStatus status;
+    private final List<Migration> pendingMigrations;
+
+    IndexState(T index, Index writeIndex, IndexStatus status) {
+        this(index, writeIndex, status, null);
+    }
+
+    IndexState(T index, Index writeIndex, IndexStatus status, List<Migration> pendingMigrations) {
+        this.index = index;
+        this.writeIndex = writeIndex;
+        this.status = status;
+        this.pendingMigrations = pendingMigrations;
+    }
+
+    public T getIndex() {
+        return index;
+    }
+
+    public Index getWriteIndex() {
+        return writeIndex;
+    }
+
+    public IndexStatus getStatus() {
+        return status;
+    }
+
+    public List<Migration> getPendingMigrations() {
+        return pendingMigrations;
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexStateResolver.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexStateResolver.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterIndexHealth;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
+
+import java.util.List;
+import java.util.Map;
+
+class IndexStateResolver {
+    private static final Logger logger = LogManager.getLogger(IndexStateResolver.class);
+
+    private volatile boolean checkOutdatedIndices;
+
+    IndexStateResolver(boolean checkOutdatedIndices) {
+        this.checkOutdatedIndices = checkOutdatedIndices;
+    }
+
+    public void setCheckOutdatedIndices(boolean checkOutdatedIndices) {
+        this.checkOutdatedIndices = checkOutdatedIndices;
+    }
+
+    public <T extends ProfilingIndexAbstraction> IndexState<T> getIndexState(ClusterState state, T index) {
+        IndexMetadata metadata = index.indexMetadata(state);
+        if (metadata == null) {
+            return new IndexState<>(index, null, IndexStatus.NEEDS_CREATION);
+        }
+        if (metadata.getState() == IndexMetadata.State.CLOSE) {
+            logger.warn(
+                "Index [{}] is closed. This is likely to prevent Universal Profiling from functioning correctly",
+                metadata.getIndex()
+            );
+            return new IndexState<>(index, metadata.getIndex(), IndexStatus.CLOSED);
+        }
+        final IndexRoutingTable routingTable = state.getRoutingTable().index(metadata.getIndex());
+        ClusterHealthStatus indexHealth = new ClusterIndexHealth(metadata, routingTable).getStatus();
+        if (indexHealth == ClusterHealthStatus.RED) {
+            logger.trace("Index [{}] health status is RED, any pending mapping upgrades will wait until this changes", metadata.getIndex());
+            return new IndexState<>(index, metadata.getIndex(), IndexStatus.UNHEALTHY);
+        }
+        if (checkOutdatedIndices && metadata.getCreationVersion().before(IndexVersion.V_8_9_1)) {
+            logger.trace(
+                "Index [{}] has been created before version 8.9.1 and must be deleted before proceeding with the upgrade.",
+                metadata.getIndex()
+            );
+            return new IndexState<>(index, metadata.getIndex(), IndexStatus.TOO_OLD);
+        }
+        MappingMetadata mapping = metadata.mapping();
+        if (mapping != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> meta = (Map<String, Object>) mapping.sourceAsMap().get("_meta");
+            int currentIndexVersion;
+            int currentTemplateVersion;
+            if (meta == null) {
+                logger.debug("Missing _meta field in mapping of index [{}], assuming initial version.", metadata.getIndex());
+                currentIndexVersion = 1;
+                currentTemplateVersion = 1;
+            } else {
+                // we are extra defensive and treat any unexpected values as an unhealthy index which we won't touch.
+                currentIndexVersion = getVersionField(metadata.getIndex(), meta, "index-version");
+                currentTemplateVersion = getVersionField(metadata.getIndex(), meta, "index-template-version");
+                if (currentIndexVersion == -1 || currentTemplateVersion == -1) {
+                    return new IndexState<>(index, metadata.getIndex(), IndexStatus.UNHEALTHY);
+                }
+            }
+            if (index.getVersion() > currentIndexVersion) {
+                return new IndexState<>(index, metadata.getIndex(), IndexStatus.NEEDS_VERSION_BUMP);
+            } else if (getIndexTemplateVersion() > currentTemplateVersion) {
+                // if there are no migrations we can consider the index up-to-date even if the index template version does not match.
+                List<Migration> pendingMigrations = index.getMigrations(currentTemplateVersion);
+                if (pendingMigrations.isEmpty()) {
+                    logger.trace(
+                        "Index [{}] with index template version [{}] (current is [{}]) is up-to-date (no pending migrations).",
+                        metadata.getIndex(),
+                        currentTemplateVersion,
+                        getIndexTemplateVersion()
+                    );
+                    return new IndexState<>(index, metadata.getIndex(), IndexStatus.UP_TO_DATE);
+                }
+                logger.trace(
+                    "Index [{}] with index template version [{}] (current is [{}])  has [{}] pending migrations.",
+                    metadata.getIndex(),
+                    currentTemplateVersion,
+                    getIndexTemplateVersion(),
+                    pendingMigrations.size()
+                );
+                return new IndexState<>(index, metadata.getIndex(), IndexStatus.NEEDS_MAPPINGS_UPDATE, pendingMigrations);
+            } else {
+                return new IndexState<>(index, metadata.getIndex(), IndexStatus.UP_TO_DATE);
+            }
+        } else {
+            logger.warn("No mapping found for existing index [{}]. Index cannot be migrated.", metadata.getIndex());
+            return new IndexState<>(index, metadata.getIndex(), IndexStatus.UNHEALTHY);
+        }
+    }
+
+    private int getVersionField(Index index, Map<String, Object> meta, String fieldName) {
+        Object value = meta.get(fieldName);
+        if (value instanceof Integer) {
+            return (int) value;
+        }
+        if (value == null) {
+            logger.warn("Metadata version field [{}] of index [{}] is empty.", fieldName, index);
+            return -1;
+        }
+        logger.warn("Metadata version field [{}] of index [{}] is [{}] (expected an integer).", fieldName, index, value);
+        return -1;
+    }
+
+    // overridable for testing
+    protected int getIndexTemplateVersion() {
+        return ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION;
+    }
+
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexStatus.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+enum IndexStatus {
+    CLOSED(false),
+    UNHEALTHY(false),
+    TOO_OLD(false),
+    NEEDS_CREATION(true),
+    NEEDS_VERSION_BUMP(true),
+    UP_TO_DATE(false),
+    NEEDS_MAPPINGS_UPDATE(true);
+
+    /**
+     * Whether a status is for informational purposes only or whether it should be acted upon and may change cluster state.
+     */
+    public final boolean actionable;
+
+    IndexStatus(boolean actionable) {
+        this.actionable = actionable;
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexAbstraction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexAbstraction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+
+import java.util.List;
+
+/**
+ * An index that is used by Universal Profiling.
+ */
+interface ProfilingIndexAbstraction {
+    String getName();
+
+    int getVersion();
+
+    List<Migration> getMigrations(int currentIndexTemplateVersion);
+
+    /**
+     * Extracts the appropriate index metadata for a given index from the cluster state.
+     *
+     * @param state Current cluster state. Never <code>null</code>.
+     * @return The corresponding index metadata or <code>null</code> if there are none.
+     */
+    IndexMetadata indexMetadata(ClusterState state);
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -62,10 +62,10 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
         boolean dataStreamsCreated = ProfilingDataStreamManager.isAllResourcesCreated(state, indexStateResolver);
         boolean resourcesCreated = templatesCreated && indicesCreated && dataStreamsCreated;
 
-        boolean indicesTooOld = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
-        boolean dataStreamsTooOld = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
-        boolean anyTooOld = indicesTooOld || dataStreamsTooOld;
-        listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyTooOld));
+        boolean indicesPre891 = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
+        boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
+        boolean anyPre891Data = indicesPre891 || dataStreamsPre891;
+        listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data));
     }
 
     private boolean getValue(ClusterState state, Setting<Boolean> setting) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatusAction.Request, GetStatusAction.Response> {
-
     @Inject
     public TransportGetStatusAction(
         TransportService transportService,
@@ -53,10 +52,20 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
         ClusterState state,
         ActionListener<GetStatusAction.Response> listener
     ) {
+        IndexStateResolver indexStateResolver = new IndexStateResolver(getValue(state, ProfilingPlugin.PROFILING_CHECK_OUTDATED_INDICES));
+
         boolean pluginEnabled = getValue(state, XPackSettings.PROFILING_ENABLED);
         boolean resourceManagementEnabled = getValue(state, ProfilingPlugin.PROFILING_TEMPLATES_ENABLED);
-        boolean resourcesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state, clusterService.getSettings());
-        listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated));
+
+        boolean templatesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state, clusterService.getSettings());
+        boolean indicesCreated = ProfilingIndexManager.isAllResourcesCreated(state, indexStateResolver);
+        boolean dataStreamsCreated = ProfilingDataStreamManager.isAllResourcesCreated(state, indexStateResolver);
+        boolean resourcesCreated = templatesCreated && indicesCreated && dataStreamsCreated;
+
+        boolean indicesTooOld = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
+        boolean dataStreamsTooOld = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
+        boolean anyTooOld = indicesTooOld || dataStreamsTooOld;
+        listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyTooOld));
     }
 
     private boolean getValue(ClusterState state, Setting<Boolean> setting) {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexManagerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexManagerTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 
@@ -60,7 +61,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -73,6 +76,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
     private VerifyingClient client;
     private List<ProfilingIndexManager.ProfilingIndex> managedIndices;
     private int indexTemplateVersion;
+    private IndexStateResolver indexStateResolver;
 
     @Before
     public void createRegistryAndClient() {
@@ -82,20 +86,21 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
         managedIndices = ProfilingIndexManager.PROFILING_INDICES;
         indexTemplateVersion = ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION;
-        indexManager = new ProfilingIndexManager(threadPool, client, clusterService) {
+        indexStateResolver = new IndexStateResolver(true) {
             @Override
-            protected boolean isAllResourcesCreated(ClusterChangedEvent event, Settings settings) {
+            protected int getIndexTemplateVersion() {
+                return indexTemplateVersion;
+            }
+        };
+        indexManager = new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver) {
+            @Override
+            protected boolean areAllIndexTemplatesCreated(ClusterChangedEvent event, Settings settings) {
                 return templatesCreated.get();
             }
 
             @Override
             protected Iterable<ProfilingIndex> getManagedIndices() {
                 return managedIndices;
-            }
-
-            @Override
-            protected int getIndexTemplateVersion() {
-                return indexTemplateVersion;
             }
         };
         indexManager.setTemplatesEnabled(true);
@@ -161,6 +166,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
             List.of(existingIndex.withVersion(0)),
             nodes,
             IndexMetadata.State.OPEN,
+            IndexVersion.current(),
             false
         );
 
@@ -171,6 +177,62 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         // should not create the index because a newer generation with the correct version exists
         assertBusy(() -> assertThat(calledTimes.get(), equalTo(ProfilingIndexManager.PROFILING_INDICES.size() - 1)));
 
+        calledTimes.set(0);
+    }
+
+    public void testThatOutdatedIndexIsDetectedIfCheckEnabled() throws Exception {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+        templatesCreated.set(true);
+
+        ProfilingIndexManager.ProfilingIndex existingIndex = randomFrom(ProfilingIndexManager.PROFILING_INDICES);
+        ClusterChangedEvent event = createClusterChangedEvent(
+            List.of(existingIndex.withVersion(0)),
+            nodes,
+            IndexMetadata.State.OPEN,
+            // This is an outdated version that requires indices to be deleted upon migration
+            IndexVersion.V_8_8_2,
+            true
+        );
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+
+        client.setVerifier((action, request, listener) -> verifyIndexInstalled(calledTimes, action, request, listener));
+        indexManager.clusterChanged(event);
+        // should not create this index because the one that has changed is too old. Depending on the point at which the index is
+        // evaluated, other indices may have already been created.
+        assertBusy(
+            () -> assertThat(
+                calledTimes.get(),
+                allOf(greaterThanOrEqualTo(0), Matchers.lessThan(ProfilingIndexManager.PROFILING_INDICES.size()))
+            )
+        );
+        calledTimes.set(0);
+    }
+
+    public void testThatOutdatedIndexIsIgnoredIfCheckDisabled() throws Exception {
+        // disable the check
+        indexStateResolver.setCheckOutdatedIndices(false);
+
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+        templatesCreated.set(true);
+
+        ProfilingIndexManager.ProfilingIndex existingIndex = randomFrom(ProfilingIndexManager.PROFILING_INDICES);
+        ClusterChangedEvent event = createClusterChangedEvent(
+            List.of(existingIndex),
+            nodes,
+            IndexMetadata.State.OPEN,
+            IndexVersion.V_8_8_2,
+            true
+        );
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+
+        client.setVerifier((action, request, listener) -> verifyIndexInstalled(calledTimes, action, request, listener));
+        indexManager.clusterChanged(event);
+        // should create all indices but consider the current one up-to-date
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(ProfilingIndexManager.PROFILING_INDICES.size() - 1)));
         calledTimes.set(0);
     }
 
@@ -185,6 +247,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
             List.of(existingIndex.withVersion(0)),
             nodes,
             IndexMetadata.State.CLOSE,
+            IndexVersion.current(),
             true
         );
 
@@ -401,16 +464,17 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         Iterable<ProfilingIndexManager.ProfilingIndex> existingIndices,
         DiscoveryNodes nodes
     ) {
-        return createClusterChangedEvent(existingIndices, nodes, IndexMetadata.State.OPEN, true);
+        return createClusterChangedEvent(existingIndices, nodes, IndexMetadata.State.OPEN, IndexVersion.current(), true);
     }
 
     private ClusterChangedEvent createClusterChangedEvent(
         Iterable<ProfilingIndexManager.ProfilingIndex> existingIndices,
         DiscoveryNodes nodes,
         IndexMetadata.State state,
+        IndexVersion indexVersion,
         boolean allShardsAssigned
     ) {
-        ClusterState cs = createClusterState(Settings.EMPTY, existingIndices, nodes, state, allShardsAssigned);
+        ClusterState cs = createClusterState(Settings.EMPTY, existingIndices, nodes, state, indexVersion, allShardsAssigned);
         ClusterChangedEvent realEvent = new ClusterChangedEvent(
             "created-from-test",
             cs,
@@ -427,6 +491,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
         Iterable<ProfilingIndexManager.ProfilingIndex> existingIndices,
         DiscoveryNodes nodes,
         IndexMetadata.State state,
+        IndexVersion indexVersion,
         boolean allShardsAssigned
     ) {
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
@@ -436,7 +501,7 @@ public class ProfilingIndexManagerTests extends ESTestCase {
             Index index = new Index(indexName, indexName);
             IndexMetadata.Builder builder = new IndexMetadata.Builder(indexName);
             builder.state(state);
-            builder.settings(indexSettings(IndexVersion.current(), 1, 1).put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID()));
+            builder.settings(indexSettings(indexVersion, 1, 1).put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID()));
             builder.putMapping(
                 new MappingMetadata(
                     MapperService.SINGLE_MAPPING_NAME,


### PR DESCRIPTION
Profiling-related indices that have been created in versions before 8.9.1 are incompatible with later versions. Therefore, the Universal Profiling upgrade documentation states that indices must be deleted on upgrade. However, if the user forgets to do this, the cluster is in an inconsistent state as some indices can be created in the new format but others cannot because they conflict with existing indices in the old format. This leads to a situation where the upgrade appears to have worked but ultimately writes will fail for non-obvious reasons.

With this commit we introduce the following changes:

1. We detect that an outdated index is present and then stop creating new indices.
2. We tighten the status check for the `resources.created` flag and not only include index templates and ILM policies but also indices and data streams. Consequently, this flag remains `false` if not all indices / data streams have been created, thus allowing the UI to detect this state.
3. We introduce a new flag `resources.pre_8_9_1_data` in the status API that is true iff Elasticsearch has detected that there is at least one outdated index or data stream present. This allows the UI to flag that specific condition and instruct the user to delete their profiling-related indices and data streams as required by the upgrade instructions.