### PR TITLE
[8.10] Delete extra space from exception message (#98516)

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
@@ -48,7 +48,7 @@ public final class LicenseUtils {
             "Current license is non-compliant for "
                 + product.getName()
                 + ". Current license is {}. "
-                + " This feature requires an active trial, platinum or enterprise license.",
+                + "This feature requires an active trial, platinum or enterprise license.",
             RestStatus.FORBIDDEN,
             licenseStatus
         );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Delete extra space from exception message (#98516)](https://github.com/elastic/elasticsearch/pull/98516)

<!--- Backport version: 8.9.9 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)