### PR TITLE
ESQL: Opt in to regenerating docs

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -56,7 +56,6 @@ sourceSets.main.java {
 
 tasks.getByName('test') {
   dependsOn 'cleanGeneratedDocs'
-  finalizedBy 'copyGeneratedDocs'
 }
 
 tasks.register('cleanGeneratedDocs', Delete) {


### PR DESCRIPTION
Instead of regenerating the docs on every build we want to opt in with a command like `./gradlew x-pack:plugin:esql:copyGeneratedDocs`. The trouble is that the docs generation work isn't entirely idempotent. So, at least for now, let's not regenerate on every build.
