### PR TITLE
[Profiling] Mark executables without a name

### DIFF
--- a/docs/changelog/98884.yaml
+++ b/docs/changelog/98884.yaml
@@ -1,0 +1,5 @@
+pr: 98884
+summary: "[Profiling] Mark executables without a name"
+area: Application
+type: bug
+issues: []


### PR DESCRIPTION
Previously the get stacktraces API has assumed that all executable documents have a file name. In rare circumstances this might not be true (to be investigated separately). In this commit we treat these executables by marking them as "missing" which allows the UI to still display flamegraphs (previously it was failing with `Could not load data` as the get stacktraces API returned HTTP 500).