### PR TITLE
Avoid waiting forever in deeply broken tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1224,7 +1224,7 @@ public final class InternalTestCluster extends TestCluster {
                 .prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes(Integer.toString(expectedNodes.size()))
-                .get()
+                .get(TimeValue.timeValueSeconds(40))
                 .isTimedOut()
         );
         try {

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -10,6 +10,7 @@ package org.elasticsearch.test;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteComponentTemplateAction;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteComposableIndexTemplateAction;
@@ -18,6 +19,9 @@ import org.elasticsearch.action.admin.indices.template.get.GetComposableIndexTem
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.datastreams.DeleteDataStreamAction;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
@@ -32,6 +36,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
@@ -206,13 +211,31 @@ public abstract class TestCluster implements Closeable {
             if (repositories.length == 0) {
                 repositories = new String[] { "*" };
             }
-            for (String repository : repositories) {
-                try {
-                    client().admin().cluster().prepareDeleteRepository(repository).execute().actionGet();
-                } catch (RepositoryMissingException ex) {
-                    // ignore
+            final var future = new PlainActionFuture<Void>();
+            try (var listeners = new RefCountingListener(future)) {
+                for (String repository : repositories) {
+                    ActionListener.run(
+                        listeners.acquire(),
+                        l -> client().admin().cluster().prepareDeleteRepository(repository).execute(new ActionListener<>() {
+                            @Override
+                            public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                                l.onResponse(null);
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                if (e instanceof RepositoryMissingException) {
+                                    // ignore
+                                    l.onResponse(null);
+                                } else {
+                                    l.onFailure(e);
+                                }
+                            }
+                        })
+                    );
                 }
             }
+            future.actionGet(30, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Today if we break something really badly, internal-cluster tests may
wait forever (hitting the suite timeout) rather than failing more
promptly. This commit bounds the waits at two of the places where
previously we would get stuck.