### PR TITLE
Revert "Kibana system index does not allow user templates to affect it (#98696)"

### DIFF
--- a/docs/changelog/98888.yaml
+++ b/docs/changelog/98888.yaml
@@ -1,0 +1,5 @@
+pr: 98888
+summary: Revert "Kibana system index does not allow user templates to affect it"
+area: Infra/Core
+type: bug
+issues: []

--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -27,6 +27,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         .setAliasName(".kibana")
         .setType(Type.EXTERNAL_UNMANAGED)
         .setAllowedElasticProductOrigins(KIBANA_PRODUCT_ORIGIN)
+        .setAllowsTemplates()
         .build();
 
     public static final SystemIndexDescriptor REPORTING_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
@@ -120,10 +120,10 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
     static final int EXTERNAL_UNMANAGED_FLAG_VALUE = 4;
     static final String ASSOCIATED_INDEX_NAME = ".my-associated-idx";
 
-    public static final SystemIndexDescriptor ALLOW_TEMPLATES_MOCK_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
-        .setIndexPattern(".allow_templates_*")
-        .setDescription("A system index that allows user templates")
-        .setAliasName(".allow_templates")
+    public static final SystemIndexDescriptor KIBANA_MOCK_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
+        .setIndexPattern(".kibana_*")
+        .setDescription("Kibana saved objects system index")
+        .setAliasName(".kibana")
         .setType(SystemIndexDescriptor.Type.EXTERNAL_UNMANAGED)
         .setAllowedElasticProductOrigins(Collections.emptyList())
         .setAllowedElasticProductOrigins(Collections.singletonList(ORIGIN))
@@ -281,13 +281,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
 
         @Override
         public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-            return Arrays.asList(
-                INTERNAL_MANAGED,
-                INTERNAL_UNMANAGED,
-                EXTERNAL_MANAGED,
-                EXTERNAL_UNMANAGED,
-                ALLOW_TEMPLATES_MOCK_INDEX_DESCRIPTOR
-            );
+            return Arrays.asList(INTERNAL_MANAGED, INTERNAL_UNMANAGED, EXTERNAL_MANAGED, EXTERNAL_UNMANAGED, KIBANA_MOCK_INDEX_DESCRIPTOR);
         }
 
         @Override

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -358,8 +358,8 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     }
 
     public void testMigrateWithTemplatesV1() throws Exception {
-        // this should pass for both, the first allows templates, the second INTERNAL_UNMANAGED doesn't match the template
-        migrateWithTemplatesV1(".allow_templates", ALLOW_TEMPLATES_MOCK_INDEX_DESCRIPTOR, INTERNAL_UNMANAGED);
+        // this should pass for both, kibana allows templates, the unmanaged doesn't match the template
+        migrateWithTemplatesV1(".kibana", KIBANA_MOCK_INDEX_DESCRIPTOR, INTERNAL_UNMANAGED);
 
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(
@@ -442,8 +442,8 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     }
 
     public void testMigrateWithTemplatesV2() throws Exception {
-        // this should pass for both, the first allows templates, the second INTERNAL_UNMANAGED doesn't match the template
-        migrateWithTemplatesV2(".allow_templates", ALLOW_TEMPLATES_MOCK_INDEX_DESCRIPTOR, INTERNAL_UNMANAGED);
+        // this should pass for both, kibana allows templates, the unmanaged doesn't match the template
+        migrateWithTemplatesV2(".kibana", KIBANA_MOCK_INDEX_DESCRIPTOR, INTERNAL_UNMANAGED);
 
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -174,8 +174,9 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     private final boolean isNetNew;
 
     /**
-     * Defaults to false as we typically don't want to apply user defined templates on system indices, since they may have unexpected
-     * behaviour when upgrading Elasticsearch versions.
+     * We typically don't want to apply user defined templates on system indices, since they may have unexpected
+     * behaviour when upgrading Elasticsearch versions. Currently, only the .kibana_ indices use templates, so we
+     * are making this property by default as false.
      */
     private final boolean allowsTemplates;
 
@@ -207,7 +208,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
      *                                     indices
      * @param priorSystemIndexDescriptors A list of system index descriptors that describe the same index in a way that is compatible with
      *                                    older versions of Elasticsearch
-     * @param allowsTemplates if this system index descriptor allows templates to affect its settings
+     * @param allowsTemplates if this system index descriptor allows templates to affect its settings (e.g. .kibana_ indices)
      */
     protected SystemIndexDescriptor(
         String indexPattern,

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -379,7 +379,7 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
         String newIndexName = migrationInfo.getNextIndexName();
 
         /**
-         * This is on for all system indices except when the system index explicitly opts out
+         * This should be on for all System indices except for .kibana_ indices. See allowsTemplates in KibanaPlugin.java for more info.
          */
         if (migrationInfo.allowsTemplates() == false) {
             final String v2template = MetadataIndexTemplateService.findV2Template(clusterState.metadata(), newIndexName, false);


### PR DESCRIPTION
## Summary

This reverts commit 22393215e7c2d049b0325b74f258f070150d5551.

This change caused the Kibana compatibility test (7.17.x <-> 8.x.x) to fail (https://buildkite.com/elastic/kibana-7-dot-17-es-8-dot-11-forward-compatibility/builds/9#018a2868-e94d-4741-a96d-2bedbc991d1c). The reason for this failure is that we still rely on an index template for one of the `.kibana_` prefixed indices in 7.17, specifically `.kibana_security_session_1`. After discussing in Slack, we've decided that it's safer to revert this change rather than backporting [this PR](https://github.com/elastic/kibana/pull/134900) that removed the dependency on the index template to 7.17.

We can revisit and re-implement this change once 7.17 reaches its End of Life.

cc @rudolf @gwbrown 
