### PR TITLE
Fix autoexpand during node replace

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -278,6 +278,20 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     }
 
     /**
+     * Check if a node with provided name exists
+     *
+     * @return {@code true} node identified with provided name exists or {@code false} otherwise
+     */
+    public boolean hasByName(String name) {
+        for (DiscoveryNode node : nodes.values()) {
+            if (node.getName().equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns the version of the node with the oldest version in the cluster that is not a client node
      *
      * If there are no non-client nodes, Version.CURRENT will be returned.

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -100,6 +100,16 @@ public class NodeShutdownAllocationDecider extends AllocationDecider {
                     node.getId()
                 );
             case REPLACE:
+                if (allocation.nodes().hasByName(thisNodeShutdownMetadata.getTargetNodeName()) == false) {
+                    return allocation.decision(
+                        Decision.YES,
+                        NAME,
+                        "node [%s] is preparing to be removed from the cluster, but replacement is not yet present",
+                        node.getId()
+                    );
+                } else {
+                    return allocation.decision(Decision.NO, NAME, "node [%s] is preparing for removal from the cluster", node.getId());
+                }
             case REMOVE:
                 return allocation.decision(Decision.NO, NAME, "node [%s] is preparing for removal from the cluster", node.getId());
             default:

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.EmptyClusterInfoService;
@@ -19,8 +20,10 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -37,6 +40,9 @@ import java.util.Collections;
 import java.util.HashMap;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.hamcrest.Matchers.equalTo;
 
 public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase {
@@ -85,25 +91,18 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             .nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_B).add(NODE_C).build())
             .build();
 
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        RoutingAllocation allocation = createRoutingAllocation(state);
         DiscoveryNode node = randomFrom(NODE_A, NODE_B, NODE_C);
         RoutingNode routingNode = new RoutingNode(node.getId(), node, shard);
-        allocation.debugDecision(true);
 
-        Decision decision = decider.canAllocate(shard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS.getExplanation()));
-
-        decision = decider.canRemain(shard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS.getExplanation()));
+        assertThat(decider.canAllocate(shard, routingNode, allocation), equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS));
+        assertThat(decider.canRemain(shard, routingNode, allocation), equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS));
     }
 
     public void testCanForceAllocate() {
-        ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(NODE_A.getId(), NODE_B.getName());
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(NODE_A.getId(), NODE_A, shard);
-        allocation.debugDecision(true);
 
         ShardRouting assignedShard = ShardRouting.newUnassigned(
             new ShardId("myindex", "myindex", 0),
@@ -114,39 +113,33 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
         assignedShard = assignedShard.initialize(NODE_A.getId(), null, 1);
         assignedShard = assignedShard.moveToStarted();
 
-        Decision decision = decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.NO));
-        assertThat(
-            decision.getExplanation(),
-            equalTo("shard is not on the source of a node replacement relocated to the replacement target")
+        assertThatDecision(
+            decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation),
+            Decision.Type.NO,
+            "shard is not on the source of a node replacement relocated to the replacement target"
         );
 
         routingNode = new RoutingNode(NODE_B.getId(), NODE_B, assignedShard);
 
-        decision = decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(
-            decision.getExplanation(),
-            equalTo(
-                "node [" + NODE_A.getId() + "] is being replaced by node [" + NODE_B.getId() + "], and can be force vacated to the target"
-            )
+        assertThatDecision(
+            decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation),
+            Decision.Type.YES,
+            "node [" + NODE_A.getId() + "] is being replaced by node [" + NODE_B.getId() + "], and can be force vacated to the target"
         );
 
         routingNode = new RoutingNode(NODE_C.getId(), NODE_C, assignedShard);
 
-        decision = decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.NO));
-        assertThat(
-            decision.getExplanation(),
-            equalTo("shard is not on the source of a node replacement relocated to the replacement target")
+        assertThatDecision(
+            decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation),
+            Decision.Type.NO,
+            "shard is not on the source of a node replacement relocated to the replacement target"
         );
     }
 
     public void testCannotRemainOnReplacedNode() {
-        ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(NODE_A.getId(), NODE_B.getName());
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(NODE_A.getId(), NODE_A, shard);
-        allocation.debugDecision(true);
 
         Decision decision = decider.canRemain(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.NO));
@@ -169,62 +162,303 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
     }
 
     public void testCanAllocateToNeitherSourceNorTarget() {
-        ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(NODE_A.getId(), NODE_B.getName());
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(NODE_A.getId(), NODE_A, shard);
-        allocation.debugDecision(true);
 
         ShardRouting testShard = this.shard;
         if (randomBoolean()) {
             testShard = shard.initialize(NODE_C.getId(), null, 1);
             testShard = testShard.moveToStarted();
         }
-        Decision decision = decider.canAllocate(testShard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.NO));
-        assertThat(
-            decision.getExplanation(),
-            equalTo("node [" + NODE_A.getId() + "] is being replaced by [" + NODE_B.getName() + "], so no data may be allocated to it")
+        assertThatDecision(
+            decider.canAllocate(testShard, routingNode, allocation),
+            Decision.Type.NO,
+            "node [" + NODE_A.getId() + "] is being replaced by [" + NODE_B.getName() + "], so no data may be allocated to it"
         );
 
         routingNode = new RoutingNode(NODE_B.getId(), NODE_B, testShard);
 
-        decision = decider.canAllocate(testShard, routingNode, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.NO));
-        assertThat(
-            decision.getExplanation(),
-            equalTo(
-                "node ["
-                    + NODE_B.getId()
-                    + "] is replacing the vacating node ["
-                    + NODE_A.getId()
-                    + "], only data currently allocated "
-                    + "to the source node may be allocated to it until the replacement is complete"
-            )
+        assertThatDecision(
+            decider.canAllocate(testShard, routingNode, allocation),
+            Decision.Type.NO,
+            "node ["
+                + NODE_B.getId()
+                + "] is replacing the vacating node ["
+                + NODE_A.getId()
+                + "], only data currently allocated "
+                + "to the source node may be allocated to it until the replacement is complete"
         );
 
         routingNode = new RoutingNode(NODE_C.getId(), NODE_C, testShard);
 
-        decision = decider.canAllocate(testShard, routingNode, allocation);
+        Decision decision = decider.canAllocate(testShard, routingNode, allocation);
         assertThat(decision.getExplanation(), decision.type(), equalTo(Decision.Type.YES));
         assertThat(decision.getExplanation(), containsString("neither the source nor target node are part of an ongoing node replacement"));
     }
 
-    private ClusterState prepareState(ClusterState initialState, String sourceNodeId, String targetNodeName) {
-        final SingleNodeShutdownMetadata nodeShutdownMetadata = SingleNodeShutdownMetadata.builder()
-            .setNodeId(sourceNodeId)
-            .setTargetNodeName(targetNodeName)
-            .setType(SingleNodeShutdownMetadata.Type.REPLACE)
-            .setReason(this.getTestName())
-            .setStartedAtMillis(1L)
-            .build();
-        NodesShutdownMetadata nodesShutdownMetadata = new NodesShutdownMetadata(new HashMap<>()).putSingleNodeMetadata(
-            nodeShutdownMetadata
-        );
-        return ClusterState.builder(initialState)
-            .nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_B).add(NODE_C).build())
-            .metadata(
-                Metadata.builder().put(IndexMetadata.builder(indexMetadata)).putCustom(NodesShutdownMetadata.TYPE, nodesShutdownMetadata)
+    public void testShouldNotAutoExpandReplicasDuringUnrelatedNodeReplacement() {
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(idxName)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                    .build()
             )
             .build();
+        ShardId shardId = new ShardId(indexMetadata.getIndex(), 0);
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_C).build())
+            .metadata(
+                Metadata.builder()
+                    .put(IndexMetadata.builder(indexMetadata))
+                    .putCustom(NodesShutdownMetadata.TYPE, createNodeShutdownReplacementMetadata(NODE_A.getId(), NODE_B.getName()))
+            )
+            .routingTable(
+                RoutingTable.builder()
+                    .add(
+                        IndexRoutingTable.builder(indexMetadata.getIndex())
+                            .addShard(newShardRouting(shardId, NODE_C.getId(), true, STARTED))
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+
+        // before replacement node has joined
+        {
+            RoutingAllocation allocation = createRoutingAllocation(state);
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_A, allocation),
+                Decision.Type.NO,
+                "node [" + NODE_A.getId() + "] is being replaced by [" + NODE_B.getId() + "], shards cannot auto expand to be on it"
+            );
+            assertThat(allocation.nodes().hasByName(NODE_B.getName()), equalTo(false));
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_B, allocation),
+                Decision.Type.NO,
+                "node ["
+                    + NODE_B.getId()
+                    + "] is a node replacement target for node ["
+                    + NODE_A.getId()
+                    + "], "
+                    + "shards cannot auto expand to be on it until the replacement is complete"
+
+            );
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_C, allocation),
+                Decision.Type.YES,
+                "node is not part of a node replacement, so shards may be auto expanded onto it"
+            );
+        }
+
+        state = ClusterState.builder(state).nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_B).add(NODE_C).build()).build();
+
+        // after replacement node has joined
+        {
+            RoutingAllocation allocation = createRoutingAllocation(state);
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_A, allocation),
+                Decision.Type.NO,
+                "node [" + NODE_A.getId() + "] is being replaced by [" + NODE_B.getId() + "], shards cannot auto expand to be on it"
+            );
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_B, allocation),
+                Decision.Type.NO,
+                "node ["
+                    + NODE_B.getId()
+                    + "] is a node replacement target for node ["
+                    + NODE_A.getId()
+                    + "], "
+                    + "shards cannot auto expand to be on it until the replacement is complete"
+
+            );
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_C, allocation),
+                Decision.Type.YES,
+                "node is not part of a node replacement, so shards may be auto expanded onto it"
+            );
+        }
+    }
+
+    public void testShouldNotContractAutoExpandReplicasDuringNodeReplacement() {
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(idxName)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                    .build()
+            )
+            .build();
+        ShardId shardId = new ShardId(indexMetadata.getIndex(), 0);
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_C).build())
+            .metadata(Metadata.builder().put(IndexMetadata.builder(indexMetadata)))
+            .routingTable(
+                RoutingTable.builder()
+                    .add(
+                        IndexRoutingTable.builder(indexMetadata.getIndex())
+                            .addShard(newShardRouting(shardId, NODE_A.getId(), true, STARTED))
+                            .addShard(newShardRouting(shardId, NODE_C.getId(), false, STARTED))
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+
+        // index is already allocated on both nodes
+        {
+            RoutingAllocation allocation = createRoutingAllocation(state);
+            assertThat(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_A, allocation),
+                equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS)
+            );
+            assertThat("node-b has not joined yet", allocation.nodes().hasByName(NODE_B.getName()), equalTo(false));
+            assertThat(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_C, allocation),
+                equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS)
+            );
+        }
+
+        // when registering node replacement
+        state = ClusterState.builder(state)
+            .metadata(
+                Metadata.builder(state.metadata())
+                    .putCustom(NodesShutdownMetadata.TYPE, createNodeShutdownReplacementMetadata(NODE_A.getId(), NODE_B.getName()))
+                    .build()
+            )
+            .build();
+        {
+            RoutingAllocation allocation = createRoutingAllocation(state);
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_A, allocation),
+                Decision.Type.YES,
+                "node ["
+                    + NODE_A.getId()
+                    + "] is being replaced by ["
+                    + NODE_B.getId()
+                    + "], shards can auto expand to be on it "
+                    + "while replacement node has not joined the cluster"
+            );
+            assertThat("node-b has not joined yet", allocation.nodes().hasByName(NODE_B.getName()), equalTo(false));
+            assertThatDecision(
+                decider.shouldAutoExpandToNode(indexMetadata, NODE_C, allocation),
+                Decision.Type.YES,
+                "node is not part of a node replacement, so shards may be auto expanded onto it"
+            );
+        }
+
+        // when starting node replacement
+        state = ClusterState.builder(state).nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_B).add(NODE_C).build()).build();
+        {
+            RoutingAllocation allocation = createRoutingAllocation(state);
+            assertThatDecision(
+                decider.canAllocate(
+                    allocation.routingNodes().node(NODE_A.getId()).getByShardId(shardId),
+                    allocation.routingNodes().node(NODE_B.getId()),
+                    allocation
+                ),
+                Decision.Type.YES,
+                "node [" + NODE_B.getId() + "] is replacing node [" + NODE_A.getId() + "], and may receive shards from it"
+            );
+            assertThatAutoExpandReplicasDidNotContract(indexMetadata, allocation);
+        }
+
+        // when index is relocating
+        state = ClusterState.builder(state)
+            .routingTable(
+                RoutingTable.builder()
+                    .add(
+                        IndexRoutingTable.builder(indexMetadata.getIndex())
+                            .addShard(newShardRouting(shardId, NODE_A.getId(), NODE_B.getId(), true, RELOCATING))
+                            .addShard(newShardRouting(shardId, NODE_C.getId(), false, STARTED))
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+        assertThatAutoExpandReplicasDidNotContract(indexMetadata, createRoutingAllocation(state));
+
+        // when index is relocated
+        state = ClusterState.builder(state)
+            .routingTable(
+                RoutingTable.builder()
+                    .add(
+                        IndexRoutingTable.builder(indexMetadata.getIndex())
+                            .addShard(newShardRouting(shardId, NODE_B.getId(), true, STARTED))
+                            .addShard(newShardRouting(shardId, NODE_C.getId(), false, STARTED))
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+        assertThatAutoExpandReplicasDidNotContract(indexMetadata, createRoutingAllocation(state));
+
+        // when source node is removed
+        state = ClusterState.builder(state).nodes(DiscoveryNodes.builder().add(NODE_B).add(NODE_C).build()).build();
+        assertThatAutoExpandReplicasDidNotContract(indexMetadata, createRoutingAllocation(state));
+    }
+
+    private void assertThatAutoExpandReplicasDidNotContract(IndexMetadata indexMetadata, RoutingAllocation allocation) {
+        assertThatDecision(
+            decider.shouldAutoExpandToNode(indexMetadata, NODE_A, allocation),
+            Decision.Type.NO,
+            "node [" + NODE_A.getId() + "] is being replaced by [" + NODE_B.getId() + "], shards cannot auto expand to be on it"
+        );
+        assertThatDecision(
+            decider.shouldAutoExpandToNode(indexMetadata, NODE_B, allocation),
+            Decision.Type.YES,
+            "node ["
+                + NODE_B.getId()
+                + "] is a node replacement target for node ["
+                + NODE_A.getId()
+                + "], "
+                + "shard can auto expand to it as it was already present on the source node"
+        );
+        assertThatDecision(
+            decider.shouldAutoExpandToNode(indexMetadata, NODE_C, allocation),
+            Decision.Type.YES,
+            "none of the ongoing node replacements relate to the allocation of this shard"
+        );
+    }
+
+    private ClusterState prepareState(String sourceNodeId, String targetNodeName) {
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_B).add(NODE_C).build())
+            .metadata(
+                Metadata.builder()
+                    .put(IndexMetadata.builder(indexMetadata))
+                    .putCustom(NodesShutdownMetadata.TYPE, createNodeShutdownReplacementMetadata(sourceNodeId, targetNodeName))
+            )
+            .build();
+    }
+
+    private NodesShutdownMetadata createNodeShutdownReplacementMetadata(String sourceNodeId, String targetNodeName) {
+        return new NodesShutdownMetadata(new HashMap<>()).putSingleNodeMetadata(
+            SingleNodeShutdownMetadata.builder()
+                .setNodeId(sourceNodeId)
+                .setTargetNodeName(targetNodeName)
+                .setType(SingleNodeShutdownMetadata.Type.REPLACE)
+                .setReason(this.getTestName())
+                .setStartedAtMillis(1L)
+                .build()
+        );
+    }
+
+    private RoutingAllocation createRoutingAllocation(ClusterState state) {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        allocation.debugDecision(true);
+        return allocation;
+    }
+
+    private static void assertThatDecision(Decision decision, Decision.Type type, String explanation) {
+        assertThat(decision.type(), equalTo(type));
+        assertThat(decision.getExplanation(), equalTo(explanation));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
@@ -39,10 +39,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
@@ -202,6 +202,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
         IndexMetadata indexMetadata = IndexMetadata.builder(idxName)
             .settings(
                 Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
@@ -289,6 +290,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
         IndexMetadata indexMetadata = IndexMetadata.builder(idxName)
             .settings(
                 Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
@@ -424,7 +426,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
         assertThatDecision(
             decider.shouldAutoExpandToNode(indexMetadata, NODE_C, allocation),
             Decision.Type.YES,
-            "none of the ongoing node replacements relate to the allocation of this shard"
+            "node is not part of a node replacement, so shards may be auto expanded onto it"
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -140,14 +140,14 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(
-            decision.getExplanation(),
-            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster")
-        );
+        assertThat(decision.getExplanation(), equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster"));
     }
 
     public void testCanAutoExpandToNodeThatIsNotShuttingDown() {
-        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE), "other-node-id");
+        ClusterState state = prepareState(
+            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE),
+            "other-node-id"
+        );
         RoutingAllocation allocation = createRoutingAllocation(state);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
@@ -173,10 +173,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         // should auto-expand when no shutdown
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, createRoutingAllocation(state));
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(
-            decision.getExplanation(),
-            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster")
-        );
+        assertThat(decision.getExplanation(), equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster"));
 
         // should auto-expand to source when shutdown/replacement entry is registered and node replacement has not started
         NodesShutdownMetadata shutdown = createNodesShutdownMetadata(SingleNodeShutdownMetadata.Type.REPLACE, DATA_NODE.getId());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -147,7 +147,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testCanAutoExpandToNodeThatIsNotShuttingDown() {
-        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE));
+        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE), "other-node-id");
         RoutingAllocation allocation = createRoutingAllocation(state);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
@@ -156,7 +156,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testCannotAutoExpandToRemovingNode() {
-        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE));
+        ClusterState state = prepareState(SingleNodeShutdownMetadata.Type.REMOVE);
         RoutingAllocation allocation = createRoutingAllocation(state);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
@@ -197,7 +197,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         assertThatDecision(
             decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, createRoutingAllocation(state)),
             Decision.Type.NO,
-            "node [" + DATA_NODE.getId() + "] is preparing to be removed from the cluster"
+            "node [" + DATA_NODE.getId() + "] is preparing for removal from the cluster"
         );
         decision = decider.shouldAutoExpandToNode(indexMetadata, replacementNode, createRoutingAllocation(state));
         assertThat(decision.type(), equalTo(Decision.Type.YES));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.EmptyClusterInfoService;
@@ -77,13 +78,9 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         .build();
 
     public void testCanAllocateShardsToRestartingNode() {
-        ClusterState state = prepareState(
-            service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            SingleNodeShutdownMetadata.Type.RESTART
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(SingleNodeShutdownMetadata.Type.RESTART);
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
-        allocation.debugDecision(true);
 
         Decision decision = decider.canAllocate(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
@@ -94,13 +91,9 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testCannotAllocateShardsToRemovingNode() {
-        ClusterState state = prepareState(
-            service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE));
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
-        allocation.debugDecision(true);
 
         Decision decision = decider.canAllocate(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.NO));
@@ -108,13 +101,9 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testShardsCanRemainOnRestartingNode() {
-        ClusterState state = prepareState(
-            service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            SingleNodeShutdownMetadata.Type.RESTART
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(SingleNodeShutdownMetadata.Type.RESTART);
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
-        allocation.debugDecision(true);
 
         Decision decision = decider.canRemain(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
@@ -125,13 +114,9 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testShardsCannotRemainOnRemovingNode() {
-        ClusterState state = prepareState(
-            service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE));
+        RoutingAllocation allocation = createRoutingAllocation(state);
         RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
-        allocation.debugDecision(true);
 
         Decision decision = decider.canRemain(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.NO));
@@ -139,12 +124,8 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testCanAutoExpandToRestartingNode() {
-        ClusterState state = prepareState(
-            service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            SingleNodeShutdownMetadata.Type.RESTART
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
-        allocation.debugDecision(true);
+        ClusterState state = prepareState(SingleNodeShutdownMetadata.Type.RESTART);
+        RoutingAllocation allocation = createRoutingAllocation(state);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
@@ -154,11 +135,20 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         );
     }
 
-    public void testCanAutoExpandToNodeThatIsNotShuttingDown() {
-        ClusterState state = service.reroute(ClusterState.EMPTY_STATE, "initial state");
+    public void testCanAutoExpandToNodeIfNoNodesShuttingDown() {
+        RoutingAllocation allocation = createRoutingAllocation(ClusterState.EMPTY_STATE);
 
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
-        allocation.debugDecision(true);
+        Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
+        assertThat(decision.type(), equalTo(Decision.Type.YES));
+        assertThat(
+            decision.getExplanation(),
+            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster")
+        );
+    }
+
+    public void testCanAutoExpandToNodeThatIsNotShuttingDown() {
+        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE));
+        RoutingAllocation allocation = createRoutingAllocation(state);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
@@ -166,35 +156,93 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testCannotAutoExpandToRemovingNode() {
-        ClusterState state = prepareState(
-            service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
-        allocation.debugDecision(true);
+        ClusterState state = prepareState(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE));
+        RoutingAllocation allocation = createRoutingAllocation(state);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.NO));
         assertThat(decision.getExplanation(), equalTo("node [" + DATA_NODE.getId() + "] is preparing for removal from the cluster"));
     }
 
-    private ClusterState prepareState(ClusterState initialState, SingleNodeShutdownMetadata.Type shutdownType) {
-        final String targetNodeName = shutdownType == SingleNodeShutdownMetadata.Type.REPLACE ? randomAlphaOfLengthBetween(10, 20) : null;
-        final SingleNodeShutdownMetadata nodeShutdownMetadata = SingleNodeShutdownMetadata.builder()
-            .setNodeId(DATA_NODE.getId())
-            .setType(shutdownType)
-            .setReason(this.getTestName())
-            .setStartedAtMillis(1L)
-            .setTargetNodeName(targetNodeName)
+    public void testAutoExpandDuringNodeReplacement() {
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(DATA_NODE).build())
+            .metadata(Metadata.builder().put(IndexMetadata.builder(indexMetadata)))
             .build();
-        NodesShutdownMetadata nodesShutdownMetadata = new NodesShutdownMetadata(new HashMap<>()).putSingleNodeMetadata(
-            nodeShutdownMetadata
+
+        // should auto-expand when no shutdown
+        Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, createRoutingAllocation(state));
+        assertThat(decision.type(), equalTo(Decision.Type.YES));
+        assertThat(
+            decision.getExplanation(),
+            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster")
         );
-        return ClusterState.builder(initialState)
+
+        // should auto-expand to source when shutdown/replacement entry is registered and node replacement has not started
+        NodesShutdownMetadata shutdown = createNodesShutdownMetadata(SingleNodeShutdownMetadata.Type.REPLACE, DATA_NODE.getId());
+        state = ClusterState.builder(state)
+            .metadata(Metadata.builder(state.metadata()).putCustom(NodesShutdownMetadata.TYPE, shutdown).build())
+            .build();
+        assertThatDecision(
+            decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, createRoutingAllocation(state)),
+            Decision.Type.YES,
+            "node [" + DATA_NODE.getId() + "] is preparing to be removed from the cluster, but replacement is not yet present"
+        );
+
+        // should auto-expand to replacement when node replacement has started
+        String replacementName = shutdown.getAllNodeMetadataMap().get(DATA_NODE.getId()).getTargetNodeName();
+        DiscoveryNode replacementNode = newNode(replacementName, "node-data-1", Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
+        state = ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.getNodes()).add(replacementNode).build()).build();
+
+        assertThatDecision(
+            decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, createRoutingAllocation(state)),
+            Decision.Type.NO,
+            "node [" + DATA_NODE.getId() + "] is preparing to be removed from the cluster"
+        );
+        decision = decider.shouldAutoExpandToNode(indexMetadata, replacementNode, createRoutingAllocation(state));
+        assertThat(decision.type(), equalTo(Decision.Type.YES));
+        assertThat(
+            decision.getExplanation(),
+            equalTo("node [" + replacementNode.getId() + "] is not preparing for removal from the cluster")
+        );
+    }
+
+    private ClusterState prepareState(SingleNodeShutdownMetadata.Type shutdownType) {
+        return prepareState(shutdownType, DATA_NODE.getId());
+    }
+
+    private ClusterState prepareState(SingleNodeShutdownMetadata.Type shutdownType, String nodeId) {
+        return ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(DATA_NODE).build())
             .metadata(
-                Metadata.builder().put(IndexMetadata.builder(indexMetadata)).putCustom(NodesShutdownMetadata.TYPE, nodesShutdownMetadata)
+                Metadata.builder()
+                    .put(IndexMetadata.builder(indexMetadata))
+                    .putCustom(NodesShutdownMetadata.TYPE, createNodesShutdownMetadata(shutdownType, nodeId))
             )
             .build();
+    }
+
+    private NodesShutdownMetadata createNodesShutdownMetadata(SingleNodeShutdownMetadata.Type shutdownType, String nodeId) {
+        final String targetNodeName = shutdownType == SingleNodeShutdownMetadata.Type.REPLACE ? randomAlphaOfLengthBetween(10, 20) : null;
+        return new NodesShutdownMetadata(new HashMap<>()).putSingleNodeMetadata(
+            SingleNodeShutdownMetadata.builder()
+                .setNodeId(nodeId)
+                .setType(shutdownType)
+                .setReason(this.getTestName())
+                .setStartedAtMillis(1L)
+                .setTargetNodeName(targetNodeName)
+                .build()
+        );
+    }
+
+    private RoutingAllocation createRoutingAllocation(ClusterState state) {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        allocation.debugDecision(true);
+        return allocation;
+    }
+
+    private static void assertThatDecision(Decision decision, Decision.Type type, String explanation) {
+        assertThat(decision.type(), equalTo(type));
+        assertThat(decision.getExplanation(), equalTo(explanation));
     }
 }


### PR DESCRIPTION
Backport of PR https://github.com/elastic/elasticsearch/pull/96281 amended for 7.17.x. As a reviewer, it may be a good idea to compare the diff of this PR with the diff of this PR.

Tried to be as least intrusive to the allocation decision explanations of 7.17.x as possible.

Closes #89527
