### PR TITLE
Make Maps.deepEquals handle nested maps that contain array values

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -151,9 +151,20 @@ public class Maps {
         if (left == null || right == null || left.size() != right.size()) {
             return false;
         }
-        return left.entrySet()
-            .stream()
-            .allMatch(e -> right.containsKey(e.getKey()) && Objects.deepEquals(e.getValue(), right.get(e.getKey())));
+
+        for (Map.Entry<K, V> e : left.entrySet()) {
+            if (right.containsKey(e.getKey()) == false) {
+                return false;
+            }
+
+            V v1 = e.getValue();
+            V v2 = right.get(e.getKey());
+            if (Objects.deepEquals(v1, v2) == false) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -159,7 +159,16 @@ public class Maps {
 
             V v1 = e.getValue();
             V v2 = right.get(e.getKey());
-            if (Objects.deepEquals(v1, v2) == false) {
+            if (v1 instanceof Map && v2 instanceof Map) {
+                // if the values are both maps, then recursively compare them with Maps.deepEquals
+                @SuppressWarnings("unchecked")
+                Map<Object, Object> m1 = (Map<Object, Object>) v1;
+                @SuppressWarnings("unchecked")
+                Map<Object, Object> m2 = (Map<Object, Object>) v2;
+                if (Maps.deepEquals(m1, m2) == false) {
+                    return false;
+                }
+            } else if (Objects.deepEquals(v1, v2) == false) {
                 return false;
             }
         }

--- a/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
@@ -99,7 +99,7 @@ public class MapsTests extends ESTestCase {
         assertMapEntriesAndImmutability(map, entries);
     }
 
-    public void testDeepEquals() {
+    public void testDeepEqualsMapsWithArrayValues() {
         final Supplier<String> keyGenerator = () -> randomAlphaOfLengthBetween(1, 5);
         final Supplier<int[]> arrayValueGenerator = () -> random().ints(randomInt(5)).toArray();
         final Map<String, int[]> map = randomMap(randomInt(5), keyGenerator, arrayValueGenerator);
@@ -125,7 +125,7 @@ public class MapsTests extends ESTestCase {
         assertFalse(Maps.deepEquals(map, mapModified));
     }
 
-    public void testDeepEqualsMapsSimple() {
+    public void testDeepEqualsMapsWithMapValuesSimple() {
         Map<String, Map<String, int[]>> m1 = Map.of("a", Map.of("b", new int[] { 1 }));
         Map<String, Map<String, int[]>> m2 = Map.of("a", Map.of("b", new int[] { 1 }));
         assertTrue(Maps.deepEquals(m1, m2));

--- a/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
@@ -99,6 +99,30 @@ public class MapsTests extends ESTestCase {
         assertMapEntriesAndImmutability(map, entries);
     }
 
+    public void testDeepEqualsMapsWithSimpleValues() {
+        final Supplier<String> keyGenerator = () -> randomAlphaOfLengthBetween(1, 5);
+        final Supplier<Integer> valueGenerator = () -> randomInt(5);
+        final Map<String, Integer> map = randomMap(randomInt(5), keyGenerator, valueGenerator);
+        final Map<String, Integer> mapCopy = new HashMap<>(map);
+
+        assertTrue(Maps.deepEquals(map, mapCopy));
+
+        final Map<String, Integer> mapModified = mapCopy;
+        if (mapModified.isEmpty()) {
+            mapModified.put(keyGenerator.get(), valueGenerator.get());
+        } else {
+            if (randomBoolean()) {
+                final String randomKey = mapModified.keySet().toArray(new String[0])[randomInt(mapModified.size() - 1)];
+                final int value = mapModified.get(randomKey);
+                mapModified.put(randomKey, randomValueOtherThanMany((v) -> v.equals(value), valueGenerator));
+            } else {
+                mapModified.put(randomValueOtherThanMany(mapModified::containsKey, keyGenerator), valueGenerator.get());
+            }
+        }
+
+        assertFalse(Maps.deepEquals(map, mapModified));
+    }
+
     public void testDeepEqualsMapsWithArrayValues() {
         final Supplier<String> keyGenerator = () -> randomAlphaOfLengthBetween(1, 5);
         final Supplier<int[]> arrayValueGenerator = () -> random().ints(randomInt(5)).toArray();

--- a/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
@@ -125,6 +125,12 @@ public class MapsTests extends ESTestCase {
         assertFalse(Maps.deepEquals(map, mapModified));
     }
 
+    public void testDeepEqualsMapsSimple() {
+        Map<String, Map<String, int[]>> m1 = Map.of("a", Map.of("b", new int[] { 1 }));
+        Map<String, Map<String, int[]>> m2 = Map.of("a", Map.of("b", new int[] { 1 }));
+        assertTrue(Maps.deepEquals(m1, m2));
+    }
+
     public void testCollectToUnmodifiableSortedMap() {
         SortedMap<String, String> canadianProvinces = Stream.of(
             new Tuple<>("ON", "Ontario"),


### PR DESCRIPTION
A reminder before we start, because there are details we forget sometimes:

```
    public static void main(String[] args) {
        int[] a = { 1, 2, 3 };
        int[] b = Arrays.copyOf(a, 3);
        System.out.println((a != b) && (a.equals(b) == false) && (Arrays.equals(a, b)));
    }
```
The above will print `true` -- the arrays are not `==`, nor are they `.equals` (which is easy to forget), but they are definitely `Arrays.equals` to each other.

-----

`Map#equals` is expected to do `Object#equals` comparisons on values, but that doesn't do the 'right' thing for equivalent arrays.

`Maps.deepEquals` is a handy utility method to check that maps are deeply equal, and it handles the case of equivalent array values correctly (by invoking `Objects.deepEquals` on values, which'll call `Arrays.deepEquals`). That means that we can do working comparisons in the 'expected' way on maps that may contain array values.

However, `Maps.deepEquals` does not handle the nested maps case, so if you have (for example) a `Map<String, Map<String, int[]>>` then you're back to square one.

This pull request updates `Maps.deepEquals` to handle the nested maps case by adding a recursive call to `Maps.deepEquals` when the values being compared are both maps.

-----

Related to #97210, which would like to use `Maps.deepEquals` for comparing arbitrarily nested maps that might contain arrays.