### PR TITLE
Add downsampling parser support for PUT _lifecycle API

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/20_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/20_basic.yml
@@ -70,7 +70,7 @@ setup:
             "downsampling": [
               {
                 "after": "10d",
-                 "fixed_interval": "1h"
+                "fixed_interval": "1h"
               },
               {
                 "after": "100d",
@@ -90,9 +90,17 @@ setup:
   - match: { data_streams.0.name: data-stream-with-lifecycle }
   - match: { data_streams.0.lifecycle.data_retention: '30d' }
   - match: { data_streams.0.lifecycle.enabled: false}
+  - match: { data_streams.0.lifecycle.downsampling.0.after: '10d'}
+  - match: { data_streams.0.lifecycle.downsampling.0.fixed_interval: '1h'}
+  - match: { data_streams.0.lifecycle.downsampling.1.after: '100d'}
+  - match: { data_streams.0.lifecycle.downsampling.1.fixed_interval: '10h'}
   - match: { data_streams.1.name: simple-data-stream1 }
   - match: { data_streams.1.lifecycle.data_retention: '30d' }
   - match: { data_streams.1.lifecycle.enabled: false}
+  - match: { data_streams.1.lifecycle.downsampling.0.after: '10d'}
+  - match: { data_streams.1.lifecycle.downsampling.0.fixed_interval: '1h'}
+  - match: { data_streams.1.lifecycle.downsampling.1.after: '100d'}
+  - match: { data_streams.1.lifecycle.downsampling.1.fixed_interval: '10h'}
 
 ---
 "Enable lifecycle":

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/20_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/20_basic.yml
@@ -1,8 +1,8 @@
 setup:
   - skip:
       features: allowed_warnings
-      version: " - 8.9.99"
-      reason: "Data stream lifecycles only supported in 8.10+"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycles only supported in 8.11+"
   - do:
       allowed_warnings:
         - "index template [my-lifecycle] has index patterns [data-stream-with-lifecycle] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-lifecycle] will take precedence during new index creation"
@@ -65,9 +65,22 @@ setup:
   - do:
       indices.put_data_lifecycle:
         name: "*"
-        body:
-          data_retention: '30d'
-          enabled: false
+        body: >
+          {
+            "downsampling": [
+              {
+                "after": "10d",
+                 "fixed_interval": "1h"
+              },
+              {
+                "after": "100d",
+                "fixed_interval": "10h"
+              }
+            ],
+            "data_retention": "30d",
+            "enabled": false
+          }
+
   - is_true: acknowledged
 
   - do:


### PR DESCRIPTION
This adds parsing support for the donwsampling configuration
in the `PUT _data_stream/target/_lifecycle` API

Documentation will be added in a follow-up (and marked as >feature)