### PR TITLE
async-search is_partial=true when any shard search fails or times out

### DIFF
--- a/docs/changelog/98913.yaml
+++ b/docs/changelog/98913.yaml
@@ -1,0 +1,6 @@
+pr: 98913
+summary: Async-search is_partial=true when any shard search fails or times out
+area: Search
+type: bug
+issues:
+ - 98725

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -445,6 +445,21 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         }
     }
 
+    /**
+     * If this is a CCS search all the underlying Cluster search states will be evaluated.
+     * If it is a local-only search, the shards info and timedOut field of the SearchResponse will be examined.
+     *
+     * @return true if the search has partial results due to either failed shards, the search is still running
+     * or a search timed out.
+     */
+    public boolean hasPartialResults() {
+        if (clusters.hasClusterObjects()) {
+            return clusters.hasPartialResults();
+        } else {
+            return getFailedShards() > 0 || isTimedOut();
+        }
+    }
+
     @Override
     public String toString() {
         return Strings.toString(this);
@@ -729,6 +744,10 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         }
 
         /**
+         * This method should NOT be called for local-only, non-CCS searches. In that case,
+         * the Clusters object has no useful info and the _shards section of the SearchResponse
+         * should be used. Call the {@link SearchResponse#hasPartialResults} method instead.
+         *
          * @return true if any underlying Cluster objects have PARTIAL, SKIPPED, FAILED or RUNNING status.
          *              or any Cluster is marked as timedOut.
          */

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -299,6 +299,7 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertNull(response.getSearchResponse());
         assertNotNull(response.getFailure());
         assertFalse(response.isRunning());
+        assertTrue(response.isPartial());
         Exception exc = response.getFailure();
         assertThat(exc.getMessage(), containsString("error while executing search"));
         assertThat(exc.getCause().getMessage(), containsString("no such index"));
@@ -311,6 +312,7 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         AsyncSearchResponse response = submitAsyncSearch(request);
         assertNotNull(response.getSearchResponse());
         assertTrue(response.isRunning());
+        assertTrue(response.isPartial());
         assertThat(response.getSearchResponse().getTotalShards(), equalTo(numShards));
         assertThat(response.getSearchResponse().getSuccessfulShards(), equalTo(0));
         assertThat(response.getSearchResponse().getFailedShards(), equalTo(0));
@@ -318,12 +320,14 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         response = getAsyncSearch(response.getId());
         assertNotNull(response.getSearchResponse());
         assertTrue(response.isRunning());
+        assertTrue(response.isPartial());
         assertThat(response.getSearchResponse().getTotalShards(), equalTo(numShards));
         assertThat(response.getSearchResponse().getSuccessfulShards(), equalTo(0));
         assertThat(response.getSearchResponse().getFailedShards(), equalTo(0));
 
         AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
         assertTrue(statusResponse.isRunning());
+        assertTrue(statusResponse.isPartial());
         assertEquals(numShards, statusResponse.getTotalShards());
         assertEquals(0, statusResponse.getSuccessfulShards());
         assertEquals(0, statusResponse.getSkippedShards());

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -313,7 +313,11 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
                 } else {
                     assertThat(newResponse.status(), equalTo(RestStatus.OK));
                     assertNotNull(newResponse.getSearchResponse());
-                    assertFalse(newResponse.isPartial());
+                    if (numFailures > 0) {
+                        assertTrue(newResponse.isPartial());
+                    } else {
+                        assertFalse(newResponse.isPartial());
+                    }
                     assertThat(newResponse.status(), equalTo(RestStatus.OK));
                     assertThat(newResponse.getSearchResponse().getTotalShards(), equalTo(numShards));
                     assertThat(newResponse.getSearchResponse().getShardFailures().length, equalTo(numFailures));

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -119,15 +119,8 @@ class MutableSearchResponse {
 
         this.responseHeaders = threadContext.getResponseHeaders();
         this.finalResponse = response;
-        this.isPartial = isPartialResponse(response);
+        this.isPartial = response.hasPartialResults();
         this.frozen = true;
-    }
-
-    private boolean isPartialResponse(SearchResponse response) {
-        if (response.getClusters() == null) {
-            return true;
-        }
-        return response.getClusters().hasPartialResults();
     }
 
     /**

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchSingleNodeTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchSingleNodeTests.java
@@ -99,7 +99,7 @@ public class AsyncSearchSingleNodeTests extends ESSingleNodeTestCase {
         AsyncSearchResponse asyncSearchResponse = client().execute(SubmitAsyncSearchAction.INSTANCE, submitAsyncSearchRequest).actionGet();
 
         assertFalse(asyncSearchResponse.isRunning());
-        assertFalse(asyncSearchResponse.isPartial());
+        assertTrue(asyncSearchResponse.isPartial());
         assertNull(asyncSearchResponse.getFailure());
         SearchResponse searchResponse = asyncSearchResponse.getSearchResponse();
         assertEquals(10, searchResponse.getTotalShards());

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
@@ -310,7 +310,15 @@ public class AsyncSearchTaskTests extends ESTestCase {
         ((AsyncSearchTask.Listener) task.getProgressListener()).onResponse(
             newSearchResponse(totalShards, totalShards - numFetchFailures, numSkippedShards, shardSearchFailures)
         );
-        assertCompletionListeners(task, totalShards, totalShards - numFetchFailures, numSkippedShards, numFetchFailures, false, false);
+        assertCompletionListeners(
+            task,
+            totalShards,
+            totalShards - numFetchFailures,
+            numSkippedShards,
+            numFetchFailures,
+            numFetchFailures > 0,
+            false
+        );
     }
 
     public void testFatalFailureDuringFetch() throws InterruptedException {


### PR DESCRIPTION
With the recent addition of per-cluster metadata to the `_clusters` section of the response for cross-cluster searches (see #97731), the `is_partial` setting in the async-search response, now acts as a useful summary to end-users that search/aggs data from all shards is potentially incomplete (not all shards fully searched), which could be for one of 3 reasons:

1. at least one shard was not successfully searched (a PARTIAL search cluster state)
2. at least one cluster (marked as `skip_unavailable`=`true`) was unavailable (or all searches on all shards of that cluster failed), causing the cluster to be marked as SKIPPED
3. a search on at least one cluster timed out (`timed_out`=`true`, resulting in a PARTIAL cluster search status)

This commit changes local-only (non-CCS) searches to behave consistently with cross-cluster searches, namely, if any search on any shard fails or if the search times out, the is_partial flag is set to true.

Closes #98725
Relates https://github.com/elastic/elasticsearch/issues/55572