### PR TITLE
Speedup field caps further

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.index.mapper.TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM;
 import static org.elasticsearch.index.mapper.TimeSeriesParams.TIME_SERIES_METRIC_PARAM;
@@ -545,8 +544,13 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             }
         }
 
-        Stream<String> getIndices() {
-            return indicesList.stream().flatMap(c -> Arrays.stream(c.indices));
+        void getIndices(Set<String> into) {
+            for (int i = 0; i < indicesList.size(); i++) {
+                IndexCaps indexCaps = indicesList.get(i);
+                for (String element : indexCaps.indices) {
+                    into.add(element);
+                }
+            }
         }
 
         private String[] filterIndices(int length, Predicate<IndexCaps> pred) {


### PR DESCRIPTION
This about halves first byte latency for running an include_unmapped request that returns a 4G response on a large cluster. This is probably how far this needs logic can be optimized reasonably, given that the runtime  is now almost exclusively dominated by REST response encoding.

Speedup comes from:

* use separate loops for when including unmapped or not (this loop is super hot and we want to give the JVM the best chance possible to optimize it)
   * also makes reading hot_threads/profiling nicer to have it this way
* Exploit the fact that we already have a sorted list of indices that is much faster to loop for calculating the difference with the mapped indices per field than the keyset of the capabilities map
   * as a nice side-effect/(bug fix?) this makes the list of unmapped indices properly ordered!
* Stop it with all the complicated stream stuff that added a lot of overhead
* Reuse scratch set for collecting the mapped indices per field name into (seems this is faster than re-creating the set instance for larger sets despite the cost of `clear()`, at the very least it makes memory usage flatter which is nice)


Profile before:

![image](https://github.com/elastic/elasticsearch/assets/6490959/dd96d474-96bf-4b77-8223-47b58de410ee)

Profile after:

![image](https://github.com/elastic/elasticsearch/assets/6490959/823d7ebe-8511-48ab-8c21-86aff5bd41da)

-> the mountain on the right representing the fieldcaps merging is about half as wide now
-> GC isn't actually up, the relative time spent on GC just went up because the merging got faster
-> first byte latency for the 50k indices, 4G response case from the many-shards benchmark goes from ~10s to ~5s

Given that the same response without including the unmapped fields returns sub-second now even at p100 there is not much of a contribution by the roundtrip to the data nodes here (it's the same whether we include unmapped fields or now).
