### PR TITLE
[8.10] Fix how Maps#flatten handle map values inside a list (#98828)

### DIFF
--- a/docs/changelog/98828.yaml
+++ b/docs/changelog/98828.yaml
@@ -1,0 +1,5 @@
+pr: 98828
+summary: Fix how Maps#flatten handle map values inside a list
+area: Geo
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -196,8 +196,7 @@ public class Maps {
             Object cur = list.get(i);
             if (cur instanceof Map) {
                 flatMap.putAll(flatten((Map<String, Object>) cur, true, ordered, prefix + i));
-            }
-            if (cur instanceof List) {
+            } else if (cur instanceof List) {
                 flatMap.putAll(flatten((List<Object>) cur, ordered, prefix + i));
             } else {
                 flatMap.put(prefix + i, cur);

--- a/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
@@ -191,6 +191,15 @@ public class MapsTests extends ESTestCase {
         );
     }
 
+    public void testListFlatten() {
+        Map<String, Object> map = Map.of("parent1", List.of(Map.of("key1", "val1", "key2", "val2")));
+        Map<String, Object> flatten = Maps.flatten(map, true, true);
+        assertThat(flatten.size(), equalTo(2));
+        for (Map.Entry<String, Object> entry : flatten.entrySet()) {
+            assertThat(entry.getKey(), entry.getValue(), equalTo(deepGet(entry.getKey(), map)));
+        }
+    }
+
     public void testFlatten() {
         Map<String, Object> map = randomNestedMap(10);
         Map<String, Object> flatten = Maps.flatten(map, true, true);

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
@@ -64,10 +64,6 @@ class VectorTileUtils {
             // guard for null values
             return;
         }
-        if (value instanceof Map<?, ?> map) {
-            // maps should have been flattened already in Maps#flatten but still contains the original maps
-            return;
-        }
         if (value instanceof Byte || value instanceof Short) {
             // mvt does not support byte and short data types
             value = ((Number) value).intValue();

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtilTests.java
@@ -12,7 +12,6 @@ import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Map;
 import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.containsString;
@@ -45,9 +44,6 @@ public class VectorTileUtilTests extends ESTestCase {
         assertPropertyToFeature(layerProps, featureBuilder, 7);
         // string
         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "string", "7");
-        assertPropertyToFeature(layerProps, featureBuilder, 8);
-        // maps are ignored
-        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, "parent", Map.of("child", "8"));
         assertPropertyToFeature(layerProps, featureBuilder, 8);
         // invalid
         IllegalArgumentException ex = expectThrows(


### PR DESCRIPTION
Backports the following commits to 8.10:

- Fix how Maps#flatten handle map values inside a list (https://github.com/elastic/elasticsearch/pull/98828)