### PR TITLE
[8.10] [Profiling] Mark executables without a name (#98884)

### DIFF
--- a/docs/changelog/98884.yaml
+++ b/docs/changelog/98884.yaml
@@ -1,0 +1,5 @@
+pr: 98884
+summary: "[Profiling] Mark executables without a name"
+area: Application
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [Profiling] Mark executables without a name (#98884)