### PR TITLE
Introduce FilterRestHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/DeprecationRestHandler.java
@@ -20,10 +20,10 @@ import java.util.Objects;
  * {@code DeprecationRestHandler} provides a proxy for any existing {@link RestHandler} so that usage of the handler can be
  * logged using the {@link DeprecationLogger}.
  */
-public class DeprecationRestHandler implements RestHandler {
+public class DeprecationRestHandler extends FilterRestHandler implements RestHandler {
 
     public static final String DEPRECATED_ROUTE_KEY = "deprecated_route";
-    private final RestHandler handler;
+
     private final String deprecationMessage;
     private final DeprecationLogger deprecationLogger;
     private final String deprecationKey;
@@ -50,7 +50,7 @@ public class DeprecationRestHandler implements RestHandler {
         String deprecationMessage,
         DeprecationLogger deprecationLogger
     ) {
-        this.handler = Objects.requireNonNull(handler);
+        super(handler);
         this.deprecationMessage = requireValidHeader(deprecationMessage);
         this.deprecationLogger = Objects.requireNonNull(deprecationLogger);
         this.deprecationKey = DEPRECATED_ROUTE_KEY + "_" + method + "_" + path;
@@ -76,12 +76,7 @@ public class DeprecationRestHandler implements RestHandler {
             deprecationLogger.warn(DeprecationCategory.API, deprecationKey, deprecationMessage);
         }
 
-        handler.handleRequest(request, channel, client);
-    }
-
-    @Override
-    public boolean supportsContentStream() {
-        return handler.supportsContentStream();
+        getDelegate().handleRequest(request, channel, client);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/FilterRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/FilterRestHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest;
+
+import java.util.List;
+import java.util.Objects;
+
+public abstract class FilterRestHandler implements RestHandler {
+    private final RestHandler delegate;
+
+    protected FilterRestHandler(RestHandler delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    protected RestHandler getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public RestHandler getConcreteRestHandler() {
+        return delegate.getConcreteRestHandler();
+    }
+
+    @Override
+    public List<RestHandler.Route> routes() {
+        return delegate.routes();
+    }
+
+    @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return delegate.allowSystemIndexAccessByDefault();
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return delegate.canTripCircuitBreaker();
+    }
+
+    @Override
+    public boolean allowsUnsafeBuffers() {
+        return delegate.allowsUnsafeBuffers();
+    }
+
+    @Override
+    public boolean supportsContentStream() {
+        return delegate.supportsContentStream();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -47,6 +47,15 @@ public interface RestHandler {
     }
 
     /**
+     * Returns the concrete RestHandler for this RestHandler. That is, if this is a delegating RestHandler it returns the delegate.
+     * Otherwise it returns itself.
+     * @return The underlying RestHandler
+     */
+    default RestHandler getConcreteRestHandler() {
+        return this;
+    }
+
+    /**
      * Indicates if the RestHandler supports working with pooled buffers. If the request handler will not escape the return
      * {@link RestRequest#content()} or any buffers extracted from it then there is no need to make a copies of any pooled buffers in the
      * {@link RestRequest} instance before passing a request to this handler. If this instance does not support pooled/unsafe buffers

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
@@ -64,6 +64,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -279,6 +280,7 @@ public class SecurityRestFilterTests extends ESTestCase {
         } else {
             assertThat(restResponse.content().utf8ToString(), not(containsString(ElasticsearchException.STACK_TRACE)));
         }
+        verify(restHandler, atLeastOnce()).getConcreteRestHandler();
         verifyNoMoreInteractions(restHandler);
     }
 


### PR DESCRIPTION
RestHandler has a number of methods that affect the behaviour of request processing. If the handler is wrapped (e.g. SecurityRestFilter or DeprecationRestHandler) then these methods must be delegated to the underlying handler.

This commit introduces a new abstract base class `FilterRestHandler` that correctly delegates these methods so that wrappers (subclasses) do not need to implement the behaviour on a case-by-case basis

Backport of: #98861
