### PR TITLE
[8.10] Drop invalid connections to the fulfiling cluster node

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -383,10 +383,10 @@ public class Netty4Transport extends TcpTransport {
             pipeline.addLast("logging", ESLoggingHandler.INSTANCE);
         }
         pipeline.addLast("chunked_writer", new Netty4WriteThrottlingHandler(getThreadPool().getThreadContext()));
-        pipeline.addLast("dispatcher", new Netty4MessageInboundHandler(this, getInboundPipeline(isRemoteClusterServerChannel)));
+        pipeline.addLast("dispatcher", new Netty4MessageInboundHandler(this, getInboundPipeline(ch, isRemoteClusterServerChannel)));
     }
 
-    protected InboundPipeline getInboundPipeline(boolean isRemoteClusterServerChannel) {
+    protected InboundPipeline getInboundPipeline(Channel ch, boolean isRemoteClusterServerChannel) {
         return new InboundPipeline(
             getStatsTracker(),
             threadPool::relativeTimeInMillis,

--- a/server/src/main/java/org/elasticsearch/transport/Header.java
+++ b/server/src/main/java/org/elasticsearch/transport/Header.java
@@ -49,7 +49,7 @@ public class Header {
         return requestId;
     }
 
-    boolean isRequest() {
+    public boolean isRequest() {
         return TransportStatus.isRequest(status);
     }
 
@@ -61,7 +61,7 @@ public class Header {
         return TransportStatus.isError(status);
     }
 
-    boolean isHandshake() {
+    public boolean isHandshake() {
         return TransportStatus.isHandshake(status);
     }
 
@@ -75,6 +75,11 @@ public class Header {
 
     public Compression.Scheme getCompressionScheme() {
         return compressionScheme;
+    }
+
+    public Map<String, String> getRequestHeaders() {
+        var allHeaders = getHeaders();
+        return allHeaders == null ? null : allHeaders.v1();
     }
 
     boolean needsToReadVariableHeader() {

--- a/server/src/main/java/org/elasticsearch/transport/HeaderValidationException.java
+++ b/server/src/main/java/org/elasticsearch/transport/HeaderValidationException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.transport;
+
+/**
+ * This is used to pack the validation exception with the associated header.
+ */
+public class HeaderValidationException extends RuntimeException {
+    public final Header header;
+    public final Exception validationException;
+
+    public HeaderValidationException(Header header, Exception validationException) {
+        this.header = header;
+        this.validationException = validationException;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
@@ -109,8 +109,7 @@ public class InboundPipeline implements Releasable {
     private void forwardFragments(TcpChannel channel, ArrayList<Object> fragments) throws IOException {
         for (Object fragment : fragments) {
             if (fragment instanceof Header) {
-                assert aggregator.isAggregating() == false;
-                aggregator.headerReceived((Header) fragment);
+                headerReceived((Header) fragment);
             } else if (fragment instanceof Compression.Scheme) {
                 assert aggregator.isAggregating();
                 aggregator.updateCompressionScheme((Compression.Scheme) fragment);
@@ -132,6 +131,11 @@ public class InboundPipeline implements Releasable {
                 aggregator.aggregate((ReleasableBytesReference) fragment);
             }
         }
+    }
+
+    protected void headerReceived(Header header) {
+        assert aggregator.isAggregating() == false;
+        aggregator.headerReceived(header);
     }
 
     private static boolean endOfMessage(Object fragment) {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -753,6 +753,23 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 logger.warn(() -> format("%s, [%s], closing connection", e.getMessage(), channel));
             } else if (e instanceof TransportNotReadyException) {
                 logger.debug(() -> format("%s on [%s], closing connection", e.getMessage(), channel));
+            } else if (e instanceof HeaderValidationException headerValidationException) {
+                Header header = headerValidationException.header;
+                if (channel.isOpen()) {
+                    try {
+                        outboundHandler.sendErrorResponse(
+                            header.getVersion(),
+                            channel,
+                            header.getRequestId(),
+                            header.getActionName(),
+                            ResponseStatsConsumer.NONE,
+                            headerValidationException.validationException
+                        );
+                    } catch (IOException inner) {
+                        inner.addSuppressed(headerValidationException.validationException);
+                        logger.warn(() -> "Failed to send error message back to client for validation failure", inner);
+                    }
+                }
             } else {
                 logger.warn(() -> "exception caught on transport layer [" + channel + "], closing connection", e);
             }

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -18,10 +18,12 @@ import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.transport.InboundDecoder.ChannelType;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -216,6 +218,94 @@ public class InboundDecoderTests extends ESTestCase {
             fragments.clear();
         }
 
+    }
+
+    public void testClientChannelTypeFailsDecodingRequests() throws Exception {
+        String action = "test-request";
+        long requestId = randomNonNegativeLong();
+        if (randomBoolean()) {
+            final String headerKey = randomAlphaOfLength(10);
+            final String headerValue = randomAlphaOfLength(20);
+            if (randomBoolean()) {
+                threadContext.putHeader(headerKey, headerValue);
+            } else {
+                threadContext.addResponseHeader(headerKey, headerValue);
+            }
+        }
+        // a request
+        OutboundMessage message = new OutboundMessage.Request(
+            threadContext,
+            new TestRequest(randomAlphaOfLength(100)),
+            TransportHandshaker.REQUEST_HANDSHAKE_VERSION,
+            action,
+            requestId,
+            randomBoolean(),
+            randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null)
+        );
+
+        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
+            final BytesReference bytes = message.serialize(os);
+            try (InboundDecoder clientDecoder = new InboundDecoder(recycler, ChannelType.CLIENT)) {
+                IllegalArgumentException e = expectThrows(
+                    IllegalArgumentException.class,
+                    () -> clientDecoder.decode(ReleasableBytesReference.wrap(bytes), ignored -> {})
+                );
+                assertThat(e.getMessage(), containsString("client channels do not accept inbound requests, only responses"));
+            }
+            // the same message will be decoded by a server or mixed decoder
+            try (InboundDecoder decoder = new InboundDecoder(recycler, randomFrom(ChannelType.SERVER, ChannelType.MIX))) {
+                final ArrayList<Object> fragments = new ArrayList<>();
+                int bytesConsumed = decoder.decode(ReleasableBytesReference.wrap(bytes), fragments::add);
+                int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + bytes.getInt(
+                    TcpHeader.VARIABLE_HEADER_SIZE_POSITION
+                );
+                assertEquals(totalHeaderSize, bytesConsumed);
+                final Header header = (Header) fragments.get(0);
+                assertEquals(requestId, header.getRequestId());
+            }
+        }
+    }
+
+    public void testServerChannelTypeFailsDecodingResponses() throws Exception {
+        long requestId = randomNonNegativeLong();
+        if (randomBoolean()) {
+            final String headerKey = randomAlphaOfLength(10);
+            final String headerValue = randomAlphaOfLength(20);
+            if (randomBoolean()) {
+                threadContext.putHeader(headerKey, headerValue);
+            } else {
+                threadContext.addResponseHeader(headerKey, headerValue);
+            }
+        }
+        // a response
+        OutboundMessage message = new OutboundMessage.Response(
+            threadContext,
+            new TestResponse(randomAlphaOfLength(100)),
+            TransportHandshaker.REQUEST_HANDSHAKE_VERSION,
+            requestId,
+            randomBoolean(),
+            randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null)
+        );
+
+        try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
+            final BytesReference bytes = message.serialize(os);
+            try (InboundDecoder decoder = new InboundDecoder(recycler, ChannelType.SERVER)) {
+                final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(bytes);
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> decoder.decode(releasable1, ignored -> {}));
+                assertThat(e.getMessage(), containsString("server channels do not accept inbound responses, only requests"));
+            }
+            // the same message will be decoded by a client or mixed decoder
+            try (InboundDecoder decoder = new InboundDecoder(recycler, randomFrom(ChannelType.CLIENT, ChannelType.MIX))) {
+                final ArrayList<Object> fragments = new ArrayList<>();
+                int bytesConsumed = decoder.decode(ReleasableBytesReference.wrap(bytes), fragments::add);
+                int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + bytes.getInt(
+                    TcpHeader.VARIABLE_HEADER_SIZE_POSITION
+                );
+                assertEquals(totalHeaderSize, bytesConsumed);
+                final Header header = (Header) fragments.get(0);
+                assertEquals(requestId, header.getRequestId());
+            }
+        }
     }
 
     public void testCompressedDecode() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -297,7 +297,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
     }
 
-    public void assertNumHandshakes(long expected, Transport transport) {
+    public static void assertNumHandshakes(long expected, Transport transport) {
         if (transport instanceof TcpTransport) {
             assertEquals(expected, ((TcpTransport) transport).getNumHandshakes());
         }

--- a/test/framework/src/main/java/org/elasticsearch/transport/TestOutboundRequestMessage.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/TestOutboundRequestMessage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+
+import java.io.IOException;
+
+public class TestOutboundRequestMessage extends OutboundMessage.Request {
+    public TestOutboundRequestMessage(
+        ThreadContext threadContext,
+        Writeable message,
+        TransportVersion version,
+        String action,
+        long requestId,
+        boolean isHandshake,
+        Compression.Scheme compressionScheme
+    ) {
+        super(threadContext, message, version, action, requestId, isHandshake, compressionScheme);
+
+    }
+
+    @Override
+    public BytesReference serialize(RecyclerBytesStreamOutput bytesStream) throws IOException {
+        return super.serialize(bytesStream);
+    }
+}

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityApiKeyRestIT.java
@@ -328,7 +328,7 @@ public class RemoteClusterSecurityApiKeyRestIT extends AbstractRemoteClusterSecu
                 () -> performRequestWithApiKey(new Request("GET", "/invalid_remote:index1/_search"), apiKeyEncoded)
             );
             assertThat(exception4.getResponse().getStatusLine().getStatusCode(), equalTo(401));
-            assertThat(exception4.getMessage(), containsString("unable to authenticate user "));
+            assertThat(exception4.getMessage(), containsString("unable to find apikey"));
         }
     }
 

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -339,10 +338,7 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
                 () -> performRequestWithRemoteSearchUser(new Request("GET", "/invalid_remote:index1/_search"))
             );
             assertThat(exception4.getResponse().getStatusLine().getStatusCode(), equalTo(401));
-            assertThat(
-                exception4.getMessage(),
-                allOf(containsString("unable to authenticate user "), containsString("unable to find apikey"))
-            );
+            assertThat(exception4.getMessage(), containsString("unable to find apikey"));
 
             // check that REST API key is not supported by cross cluster access
             updateClusterSettings(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1618,7 +1618,8 @@ public class Security extends Plugin
                         circuitBreakerService,
                         ipFilter,
                         getSslService(),
-                        getNettySharedGroupFactory(settings)
+                        getNettySharedGroupFactory(settings),
+                        crossClusterAccessAuthcService.get()
                     )
                 );
                 return transportReference.get();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessAuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessAuthenticationService.java
@@ -112,6 +112,17 @@ public class CrossClusterAccessAuthenticationService {
         }
     }
 
+    public void tryAuthenticate(Map<String, String> headers, ActionListener<Void> listener) {
+        final ApiKeyService.ApiKeyCredentials credentials;
+        try {
+            credentials = extractApiKeyCredentialsFromHeaders(headers);
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        tryAuthenticate(credentials, listener);
+    }
+
     public void tryAuthenticate(ApiKeyService.ApiKeyCredentials credentials, ActionListener<Void> listener) {
         Objects.requireNonNull(credentials);
         apiKeyService.tryAuthenticate(clusterService.threadPool().getThreadContext(), credentials, ActionListener.wrap(authResult -> {
@@ -146,7 +157,7 @@ public class CrossClusterAccessAuthenticationService {
     public ApiKeyService.ApiKeyCredentials extractApiKeyCredentialsFromHeaders(Map<String, String> headers) {
         try {
             apiKeyService.ensureEnabled();
-            final String credentials = headers.get(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY);
+            final String credentials = headers == null ? null : headers.get(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY);
             if (credentials == null) {
                 throw requiredHeaderMissingException(CROSS_CLUSTER_ACCESS_CREDENTIALS_HEADER_KEY);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransport.java
@@ -21,6 +21,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.xpack.core.security.transport.netty4.SecurityNetty4Transport;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.security.authc.CrossClusterAccessAuthenticationService;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 
 public class SecurityNetty4ServerTransport extends SecurityNetty4Transport {
@@ -38,7 +39,8 @@ public class SecurityNetty4ServerTransport extends SecurityNetty4Transport {
         final CircuitBreakerService circuitBreakerService,
         @Nullable final IPFilter authenticator,
         final SSLService sslService,
-        final SharedGroupFactory sharedGroupFactory
+        final SharedGroupFactory sharedGroupFactory,
+        final CrossClusterAccessAuthenticationService crossClusterAccessAuthenticationService
     ) {
         super(
             settings,
@@ -49,7 +51,8 @@ public class SecurityNetty4ServerTransport extends SecurityNetty4Transport {
             namedWriteableRegistry,
             circuitBreakerService,
             sslService,
-            sharedGroupFactory
+            sharedGroupFactory,
+            crossClusterAccessAuthenticationService
         );
         this.authenticator = authenticator;
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HeaderSizeLimitTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HeaderSizeLimitTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.security.authc.CrossClusterAccessAuthenticationService;
 import org.junit.After;
 import org.junit.Before;
 
@@ -89,7 +90,8 @@ public final class SecurityNetty4HeaderSizeLimitTests extends ESTestCase {
             new NoneCircuitBreakerService(),
             null,
             mock(SSLService.class),
-            new SharedGroupFactory(settings)
+            new SharedGroupFactory(settings),
+            mock(CrossClusterAccessAuthenticationService.class)
         );
         requestIdReceived = new AtomicLong(-1L);
         securityNettyTransport.setMessageListener(new TransportMessageListener() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.transport.netty4;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.mocksocket.MockSocket;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.NodeRoles;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.BytesRefRecycler;
+import org.elasticsearch.transport.Compression;
+import org.elasticsearch.transport.ProxyConnectionStrategy;
+import org.elasticsearch.transport.RemoteClusterPortSettings;
+import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.RemoteTransportException;
+import org.elasticsearch.transport.SniffConnectionStrategy;
+import org.elasticsearch.transport.TestOutboundRequestMessage;
+import org.elasticsearch.transport.TransportInterceptor;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.netty4.SharedGroupFactory;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.security.authc.CrossClusterAccessAuthenticationService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.elasticsearch.test.NodeRoles.onlyRole;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    // is non-null when authn passes successfully
+    private AtomicReference<Exception> authenticationException;
+    private String remoteClusterName;
+    private SecurityNetty4ServerTransport remoteSecurityNetty4ServerTransport;
+    private MockTransportService remoteTransportService;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getClass().getName());
+        authenticationException = new AtomicReference<>();
+        remoteClusterName = "test-remote_cluster_service_" + randomAlphaOfLength(8);
+        Settings remoteSettings = Settings.builder()
+            .put("node.name", getClass().getName())
+            .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), remoteClusterName)
+            .put(XPackSettings.TRANSPORT_SSL_ENABLED.getKey(), "false")
+            .put(XPackSettings.REMOTE_CLUSTER_SERVER_SSL_ENABLED.getKey(), "false")
+            .put(XPackSettings.REMOTE_CLUSTER_CLIENT_SSL_ENABLED.getKey(), "false")
+            .put(RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED.getKey(), "true")
+            .put(RemoteClusterPortSettings.PORT.getKey(), 0)
+            .put("transport.ignore_deserialization_errors", true)
+            .build();
+        remoteSettings = NodeRoles.nonRemoteClusterClientNode(remoteSettings);
+        CrossClusterAccessAuthenticationService remoteCrossClusterAccessAuthenticationService = mock(
+            CrossClusterAccessAuthenticationService.class
+        );
+        doAnswer(invocation -> {
+            Exception authnException = authenticationException.get();
+            if (authnException != null) {
+                ((ActionListener<Void>) invocation.getArguments()[1]).onFailure(authnException);
+            } else {
+                ((ActionListener<Void>) invocation.getArguments()[1]).onResponse(null);
+            }
+            return null;
+        }).when(remoteCrossClusterAccessAuthenticationService).tryAuthenticate(any(Map.class), anyActionListener());
+        remoteSecurityNetty4ServerTransport = new SecurityNetty4ServerTransport(
+            remoteSettings,
+            TransportVersion.current(),
+            threadPool,
+            new NetworkService(List.of()),
+            PageCacheRecycler.NON_RECYCLING_INSTANCE,
+            new NamedWriteableRegistry(List.of()),
+            new NoneCircuitBreakerService(),
+            null,
+            mock(SSLService.class),
+            new SharedGroupFactory(remoteSettings),
+            remoteCrossClusterAccessAuthenticationService
+        );
+        remoteTransportService = MockTransportService.createNewService(
+            remoteSettings,
+            remoteSecurityNetty4ServerTransport,
+            VersionInformation.CURRENT,
+            threadPool,
+            null,
+            Collections.emptySet(),
+            // IMPORTANT: we have to mock authentication in two places: one in the "CrossClusterAccessAuthenticationService" and the
+            // other before the action handler here. This is in order to accurately simulate the complete Elasticsearch node behavior.
+            new TransportInterceptor() {
+                @Override
+                public <T extends TransportRequest> TransportRequestHandler<T> interceptHandler(
+                    String action,
+                    String executor,
+                    boolean forceExecution,
+                    TransportRequestHandler<T> actualHandler
+                ) {
+                    return (request, channel, task) -> {
+                        Exception authnException = authenticationException.get();
+                        if (authnException != null) {
+                            channel.sendResponse(authnException);
+                        } else {
+                            actualHandler.messageReceived(request, channel, task);
+                        }
+                    };
+                }
+            }
+        );
+        DiscoveryNode remoteNode = remoteTransportService.getLocalDiscoNode();
+        remoteTransportService.registerRequestHandler(
+            RemoteClusterNodesAction.NAME,
+            ThreadPool.Names.SAME,
+            RemoteClusterNodesAction.Request::new,
+            (request, channel, task) -> channel.sendResponse(new RemoteClusterNodesAction.Response(List.of(remoteNode)))
+        );
+        remoteTransportService.start();
+        remoteTransportService.acceptIncomingRequests();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        logger.info("tearDown");
+        super.tearDown();
+        IOUtils.close(
+            remoteTransportService,
+            remoteSecurityNetty4ServerTransport,
+            () -> ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS)
+        );
+    }
+
+    public void testProxyStrategyConnectionClosesWhenAuthenticatorAlwaysFails() throws Exception {
+        // all requests fail authn
+        authenticationException.set(new ElasticsearchSecurityException("authn failure"));
+        try (
+            MockTransportService localService = MockTransportService.createNewService(
+                proxyLocalTransportSettings(),
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                threadPool
+            )
+        ) {
+            localService.start();
+            // all attempts to obtain a connections will fail
+            for (int i = 0; i < randomIntBetween(2, 4); i++) {
+                CountDownLatch connectionTestDone = new CountDownLatch(1);
+                // {@code RemoteClusterService.REMOTE_CLUSTER_HANDSHAKE_ACTION_NAME} fails authn (both of them) and the connection is
+                // always closed after receiving an error response
+                localService.getRemoteClusterService()
+                    .maybeEnsureConnectedAndGetConnection(remoteClusterName, true, ActionListener.wrap(connection -> {
+                        logger.info("Unexpected: a connection is available");
+                        connectionTestDone.countDown();
+                        fail("No connection should be available if authn fails");
+                    }, e -> {
+                        logger.info("Expected: no connection could not be established");
+                        connectionTestDone.countDown();
+                        assertThat(e, instanceOf(RemoteTransportException.class));
+                        assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
+                    }));
+                assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
+            }
+        }
+        // but if authn passes, valid connections are available
+        authenticationException.set(null);
+        try (
+            MockTransportService localService = MockTransportService.createNewService(
+                proxyLocalTransportSettings(),
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                threadPool
+            )
+        ) {
+            localService.start();
+            CountDownLatch connectionTestDone = new CountDownLatch(1);
+            localService.getRemoteClusterService()
+                .maybeEnsureConnectedAndGetConnection(remoteClusterName, true, ActionListener.wrap(connection -> {
+                    logger.info("Expected: a connection is available");
+                    connectionTestDone.countDown();
+                }, e -> {
+                    logger.info("Unexpected: no connection could be established");
+                    connectionTestDone.countDown();
+                    fail("connection could not be established");
+                    throw new RuntimeException(e);
+                }));
+            assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testSniffStrategyNoConnectionWhenAuthenticatorAlwaysFails() throws Exception {
+        // all requests fail authn
+        authenticationException.set(new ElasticsearchSecurityException("authn failure"));
+        try (
+            MockTransportService localService = MockTransportService.createNewService(
+                sniffLocalTransportSettings(),
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                threadPool
+            )
+        ) {
+            localService.start();
+            // obtain some connections and check that they'll be promptly closed
+            for (int i = 0; i < randomIntBetween(2, 4); i++) {
+                CountDownLatch connectionTestDone = new CountDownLatch(1);
+                // the failed authentication during handshake must surely close the connection before
+                // {@code RemoteClusterNodesAction.NAME} is executed, so node sniffing will fail
+                localService.getRemoteClusterService()
+                    .maybeEnsureConnectedAndGetConnection(remoteClusterName, true, ActionListener.wrap(connection -> {
+                        logger.info("Unexpected: a connection is available");
+                        connectionTestDone.countDown();
+                        fail("No connection should be available if authn fails");
+                    }, e -> {
+                        logger.info("Expected: no connection could be established");
+                        connectionTestDone.countDown();
+                        assertThat(e, instanceOf(RemoteTransportException.class));
+                        assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
+                    }));
+                assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
+            }
+        }
+        // but if authn passes, valid connections are available
+        authenticationException.set(null);
+        try (
+            MockTransportService localService = MockTransportService.createNewService(
+                sniffLocalTransportSettings(),
+                VersionInformation.CURRENT,
+                TransportVersion.current(),
+                threadPool
+            )
+        ) {
+            localService.start();
+            CountDownLatch connectionTestDone = new CountDownLatch(1);
+            localService.getRemoteClusterService()
+                .maybeEnsureConnectedAndGetConnection(remoteClusterName, true, ActionListener.wrap(connection -> {
+                    logger.info("Expected: a connection is available");
+                    connectionTestDone.countDown();
+                }, e -> {
+                    logger.info("Unexpected: no connection could be established");
+                    connectionTestDone.countDown();
+                    fail("connection could not be established");
+                    throw new RuntimeException(e);
+                }));
+            assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
+        }
+    }
+
+    public void testConnectionWorksForPing() throws Exception {
+        authenticationException.set(new ElasticsearchSecurityException("authn failure"));
+        TransportAddress[] boundRemoteIngressAddresses = remoteSecurityNetty4ServerTransport.boundRemoteIngressAddress().boundAddresses();
+        InetSocketAddress remoteIngressTransportAddress = randomFrom(boundRemoteIngressAddresses).address();
+        // ping message
+        final BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        bytesStreamOutput.writeBytes(new byte[] { (byte) 'E', (byte) 'S' });
+        bytesStreamOutput.writeInt(-1);
+        try (Socket socket = new MockSocket(remoteIngressTransportAddress.getAddress(), remoteIngressTransportAddress.getPort())) {
+            final byte[] pingBytes = Arrays.copyOfRange(bytesStreamOutput.bytes().array(), 0, 6);
+            socket.getOutputStream().write(pingBytes);
+            socket.getOutputStream().flush();
+            // We should receive the ping back
+            final byte[] responseBytes = socket.getInputStream().readNBytes(6);
+            assertThat(responseBytes, equalTo(pingBytes));
+            try {
+                socket.setSoTimeout(1000);
+                socket.getInputStream().read();
+                fail("should not reach here");
+            } catch (SocketTimeoutException e) {
+                // timeout exception means the server is still connected. Just no data is coming which is normal
+            }
+        }
+    }
+
+    public void testConnectionDisconnectedWhenAuthnFails() throws Exception {
+        authenticationException.set(new ElasticsearchSecurityException("authn failure"));
+        TransportAddress[] boundRemoteIngressAddresses = remoteSecurityNetty4ServerTransport.boundRemoteIngressAddress().boundAddresses();
+        InetSocketAddress remoteIngressTransportAddress = randomFrom(boundRemoteIngressAddresses).address();
+        try (Socket socket = new MockSocket(remoteIngressTransportAddress.getAddress(), remoteIngressTransportAddress.getPort())) {
+            TestOutboundRequestMessage message = new TestOutboundRequestMessage(
+                threadPool.getThreadContext(),
+                TransportRequest.Empty.INSTANCE,
+                TransportVersion.current(),
+                "internal:whatever",
+                randomNonNegativeLong(),
+                false,
+                randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4, null)
+            );
+            Recycler<BytesRef> recycler = new BytesRefRecycler(PageCacheRecycler.NON_RECYCLING_INSTANCE);
+            RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
+            BytesReference bytesReference = message.serialize(out);
+            socket.getOutputStream().write(Arrays.copyOfRange(bytesReference.array(), 0, bytesReference.length()));
+            socket.getOutputStream().flush();
+
+            final String response = new String(socket.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(response, containsString("authn failure"));
+            // -1 means the other side has disconnected
+            assertThat(socket.getInputStream().read(), equalTo(-1));
+        }
+    }
+
+    private Settings sniffLocalTransportSettings() {
+        Settings localSettings = Settings.builder()
+            .put(onlyRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE))
+            .put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getConcreteSettingForNamespace(remoteClusterName).getKey(), "sniff")
+            .put(
+                SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.getConcreteSettingForNamespace(remoteClusterName).getKey(),
+                remoteTransportService.boundRemoteAccessAddress().publishAddress().toString()
+            )
+            .put(
+                SniffConnectionStrategy.REMOTE_CONNECTIONS_PER_CLUSTER.getKey(),
+                randomIntBetween(1, 3) // easier to debug with just 1 connection
+            )
+            .put(
+                SniffConnectionStrategy.REMOTE_NODE_CONNECTIONS.getConcreteSettingForNamespace(remoteClusterName).getKey(),
+                randomIntBetween(1, 3) // easier to debug with just 1 connection
+            )
+            .build();
+        {
+            final MockSecureSettings secureSettings = new MockSecureSettings();
+            secureSettings.setString(
+                RemoteClusterService.REMOTE_CLUSTER_CREDENTIALS.getConcreteSettingForNamespace(remoteClusterName).getKey(),
+                randomAlphaOfLength(20)
+            );
+            return Settings.builder().put(localSettings).setSecureSettings(secureSettings).build();
+        }
+    }
+
+    private Settings proxyLocalTransportSettings() {
+        Settings localSettings = Settings.builder()
+            .put(onlyRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE))
+            .put(RemoteConnectionStrategy.REMOTE_CONNECTION_MODE.getConcreteSettingForNamespace(remoteClusterName).getKey(), "proxy")
+            .put(
+                ProxyConnectionStrategy.PROXY_ADDRESS.getConcreteSettingForNamespace(remoteClusterName).getKey(),
+                remoteTransportService.boundRemoteAccessAddress().publishAddress().toString()
+            )
+            .put(
+                ProxyConnectionStrategy.REMOTE_SOCKET_CONNECTIONS.getConcreteSettingForNamespace(remoteClusterName).getKey(),
+                randomIntBetween(1, 3) // easier to debug with just 1 connection
+            )
+            .build();
+        {
+            final MockSecureSettings secureSettings = new MockSecureSettings();
+            secureSettings.setString(
+                RemoteClusterService.REMOTE_CLUSTER_CREDENTIALS.getConcreteSettingForNamespace(remoteClusterName).getKey(),
+                randomAlphaOfLength(20)
+            );
+            return Settings.builder().put(localSettings).setSecureSettings(secureSettings).build();
+        }
+    }
+
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -58,6 +58,7 @@ import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.common.socket.SocketAccess;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.security.authc.CrossClusterAccessAuthenticationService;
 import org.elasticsearch.xpack.security.transport.SSLEngineUtils;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 
@@ -107,6 +108,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
 
 public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTransportTestCase {
     @Override
@@ -1050,7 +1052,8 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                 circuitBreakerService,
                 authenticator,
                 sslService,
-                sharedGroupFactory
+                sharedGroupFactory,
+                mock(CrossClusterAccessAuthenticationService.class)
             );
             this.doHandshake = doHandshake;
         }


### PR DESCRIPTION
The RCS 2.0 channel only accepts requests that are
authenticated by cross cluster search type-of API Keys.

Backport of: https://github.com/elastic/elasticsearch/pull/98814

Co-authored-by: Yang Wang ywangd@gmail.com