### PR TITLE
Don't use test name in jarhell test

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/jdk/JarHellTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/jdk/JarHellTests.java
@@ -121,7 +121,7 @@ public class JarHellTests extends ESTestCase {
     public void testNonJDKModuleURLs() throws Throwable {
         var bootLayer = ModuleLayer.boot();
 
-        Path fooDir = createTempDir(getTestName());
+        Path fooDir = createTempDir();
         Path fooJar = PathUtils.get(makeJar(fooDir, "foo.jar", null, "p/Foo.class").toURI());
         var fooConfiguration = bootLayer.configuration().resolve(ModuleFinder.of(), ModuleFinder.of(fooJar), List.of("foo"));
         Set<URL> urls = JarHell.nonJDKModuleURLs(fooConfiguration).collect(Collectors.toSet());


### PR DESCRIPTION
This commit fixes a jarhell test to create an unnamed temp dir, instead of the existing creation which uses the test method name. The reason this causes problems is when running with many iterations, the test method name is artificially adjusted to include seed information, using special characters that are potentially invalid path characters.

closes #98949