### PR TITLE
ESQL: Temporarily remove signature generation

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -845,19 +845,6 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
         return EsqlDataTypes.types().stream().filter(EsqlDataTypes::isRepresentable);
     }
 
-    @AfterClass
-    public static void renderSignature() throws IOException {
-        FunctionDefinition definition = definition();
-        if (definition == null) {
-            LogManager.getLogger(getTestClass()).info("Skipping rendering signature because the function isn't registered");
-            return;
-        }
-
-        String rendered = RailRoadDiagram.functionSignature(definition);
-        LogManager.getLogger(getTestClass()).info("Writing function signature");
-        writeToTempDir("signature", rendered, "svg");
-    }
-
     /**
      * Unique signatures encountered by this test.
      * <p>


### PR DESCRIPTION
This seems to be failing on some JDKs but I have no idea why and I can't reproduce.
