### PR TITLE
Remove calls to LuceneTestCase#newSearcher from FiltersAggregatorTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
@@ -64,7 +64,7 @@ public class AggregationCollectorTests extends AggregatorTestCase {
             builder,
             new MatchAllDocsQuery(),
             iw -> {},
-            (indexSearcher, agg) -> assertEquals(expected, agg.scoreMode().needsScores())
+            (indexReader, agg) -> assertEquals(expected, agg.scoreMode().needsScores())
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -1118,7 +1118,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
             new DateHistogramAggregationBuilder("test").field(AGGREGABLE_DATE).calendarInterval(DateHistogramInterval.YEAR).offset(10),
             new MatchAllDocsQuery(),
             iw -> {},
-            (searcher, aggregator) -> {
+            (reader, aggregator) -> {
                 InternalDateHistogram histo = (InternalDateHistogram) aggregator.buildEmptyAggregation();
                 /*
                  * There was a time where we including the offset in the

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -1891,7 +1891,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             terms1 = dh.getBuckets().get(1).getAggregations().get("k");
             assertThat(terms1.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a")));
         }, new AggTestConfig(builder, dft, kft));
-        withAggregator(builder, new MatchAllDocsQuery(), buildIndex, (searcher, aggregator) -> {
+        withAggregator(builder, new MatchAllDocsQuery(), buildIndex, (reader, aggregator) -> {
             TermsAggregator terms = (TermsAggregator) aggregator.subAggregator("k");
             Map<String, Object> info = new HashMap<>();
             terms.collectDebugInfo(info::put);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -866,7 +866,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         AggregationBuilder aggregationBuilder,
         Query query,
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-        CheckedBiConsumer<IndexSearcher, Aggregator, IOException> verify,
+        CheckedBiConsumer<IndexReader, Aggregator, IOException> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
         try (Directory directory = newDirectory()) {
@@ -878,9 +878,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 DirectoryReader unwrapped = DirectoryReader.open(directory);
                 DirectoryReader indexReader = wrapDirectoryReader(unwrapped)
             ) {
-                IndexSearcher searcher = newIndexSearcher(indexReader);
-                try (AggregationContext context = createAggregationContext(searcher, query, fieldTypes)) {
-                    verify.accept(searcher, createAggregator(aggregationBuilder, context));
+                try (AggregationContext context = createAggregationContext(indexReader, query, fieldTypes)) {
+                    verify.accept(indexReader, createAggregator(aggregationBuilder, context));
                 }
             }
         }


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/98924, remove call to lucene index searcher from FiltersAggregatorTests.

fixes https://github.com/elastic/elasticsearch/issues/98958 