### PR TITLE
Halve memory footprint of ESQL text output

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -14,8 +14,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.ToIntFunction;
 
 public class Iterators {
 
@@ -226,6 +228,38 @@ public class Iterators {
             }
             return value;
         }
+    }
+
+    public static <T> boolean equals(Iterator<? extends T> iterator1, Iterator<? extends T> iterator2, BiPredicate<T, T> itemComparer) {
+        if (iterator1 == null) {
+            return iterator2 == null;
+        }
+        if (iterator2 == null) {
+            return false;
+        }
+
+        while (iterator1.hasNext()) {
+            if (iterator2.hasNext() == false) {
+                return false;
+            }
+
+            if (itemComparer.test(iterator1.next(), iterator2.next()) == false) {
+                return false;
+            }
+        }
+
+        return iterator2.hasNext() == false;
+    }
+
+    public static <T> int hashCode(Iterator<? extends T> iterator, ToIntFunction<T> itemHashcode) {
+        if (iterator == null) {
+            return 0;
+        }
+        int result = 1;
+        while (iterator.hasNext()) {
+            result = 31 * result + itemHashcode.applyAsInt(iterator.next());
+        }
+        return result;
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
@@ -17,7 +17,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
 
 public class IteratorsTests extends ESTestCase {
@@ -206,6 +209,48 @@ public class IteratorsTests extends ESTestCase {
         Iterators.map(Iterators.forArray(array), i -> i * 2)
             .forEachRemaining(i -> assertEquals(array[index.getAndIncrement()] * 2, (long) i));
         assertEquals(array.length, index.get());
+    }
+
+    public void testEquals() {
+        final BiPredicate<Object, Object> notCalled = (a, b) -> { throw new AssertionError("not called"); };
+
+        assertTrue(Iterators.equals(null, null, notCalled));
+        assertFalse(Iterators.equals(Collections.emptyIterator(), null, notCalled));
+        assertFalse(Iterators.equals(null, Collections.emptyIterator(), notCalled));
+        assertTrue(Iterators.equals(Collections.emptyIterator(), Collections.emptyIterator(), notCalled));
+
+        assertFalse(Iterators.equals(Collections.emptyIterator(), List.of(1).iterator(), notCalled));
+        assertFalse(Iterators.equals(List.of(1).iterator(), Collections.emptyIterator(), notCalled));
+        assertTrue(Iterators.equals(List.of(1).iterator(), List.of(1).iterator(), Objects::equals));
+        assertFalse(Iterators.equals(List.of(1).iterator(), List.of(2).iterator(), Objects::equals));
+        assertFalse(Iterators.equals(List.of(1, 2).iterator(), List.of(1).iterator(), Objects::equals));
+        assertFalse(Iterators.equals(List.of(1).iterator(), List.of(1, 2).iterator(), Objects::equals));
+
+        final var strings1 = randomList(10, () -> randomAlphaOfLength(10));
+        final var strings2 = new ArrayList<>(strings1);
+
+        assertTrue(Iterators.equals(strings1.iterator(), strings2.iterator(), Objects::equals));
+
+        if (strings2.size() == 0 || randomBoolean()) {
+            strings2.add(randomAlphaOfLength(10));
+        } else {
+            final var index = between(0, strings2.size() - 1);
+            if (randomBoolean()) {
+                strings2.remove(index);
+            } else {
+                strings2.set(index, randomValueOtherThan(strings2.get(index), () -> randomAlphaOfLength(10)));
+            }
+        }
+        assertFalse(Iterators.equals(strings1.iterator(), strings2.iterator(), Objects::equals));
+    }
+
+    public void testHashCode() {
+        final ToIntFunction<Object> notCalled = (a) -> { throw new AssertionError("not called"); };
+        assertEquals(0, Iterators.hashCode(null, notCalled));
+        assertEquals(1, Iterators.hashCode(Collections.emptyIterator(), notCalled));
+
+        final var numbers = randomIntegerArray();
+        assertEquals(Arrays.hashCode(numbers), Iterators.hashCode(Arrays.stream(numbers).iterator(), Objects::hashCode));
     }
 
     private static Integer[] randomIntegerArray() {

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testImplementation('org.webjars.npm:fontsource__roboto-mono:4.5.7')
 
   internalClusterTestImplementation project(":client:rest-high-level")
+  internalClusterTestImplementation project("qa:testFixtures")
 }
 
 /*

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   testImplementation('org.webjars.npm:fontsource__roboto-mono:4.5.7')
 
   internalClusterTestImplementation project(":client:rest-high-level")
-  internalClusterTestImplementation project("qa:testFixtures")
 }
 
 /*

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.versionfield.Version;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -148,6 +149,15 @@ public final class CsvAssert {
 
     static void assertData(ExpectedResults expected, ActualResults actual, Logger logger) {
         assertData(expected, actual.values(), logger, Function.identity());
+    }
+
+    public static void assertData(
+        ExpectedResults expected,
+        Iterator<Iterator<Object>> actualValuesIterator,
+        Logger logger,
+        Function<Object, Object> valueTransformer
+    ) {
+        assertData(expected, EsqlTestUtils.getValuesList(actualValuesIterator), logger, valueTransformer);
     }
 
     public static void assertData(

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -33,6 +33,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -383,7 +384,7 @@ public final class CsvTestUtils {
         List<Page> pages,
         Map<String, List<String>> responseHeaders
     ) {
-        List<List<Object>> values() {
+        Iterator<Iterator<Object>> values() {
             return EsqlQueryResponse.pagesToValues(dataTypes(), pages);
         }
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
@@ -28,6 +29,8 @@ import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.TypesTests;
 import org.junit.Assert;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -123,5 +126,19 @@ public final class EsqlTestUtils {
                 return missingFields.contains(field) == false;
             }
         };
+    }
+
+    public static List<List<Object>> getValuesList(EsqlQueryResponse results) {
+        return getValuesList(results.values());
+    }
+
+    public static List<List<Object>> getValuesList(Iterator<Iterator<Object>> values) {
+        var valuesList = new ArrayList<List<Object>>();
+        values.forEachRemaining(row -> {
+            var rowValues = new ArrayList<>();
+            row.forEachRemaining(rowValues::add);
+            valuesList.add(rowValues);
+        });
+        return valuesList;
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionRuntimeFieldIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionRuntimeFieldIT.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -53,19 +54,19 @@ public class EsqlActionRuntimeFieldIT extends AbstractEsqlIntegTestCase {
     public void testLong() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("long");
         EsqlQueryResponse response = run("from test | stats sum(const)");
-        assertThat(response.values(), equalTo(List.of(List.of((long) SIZE))));
+        assertThat(getValuesList(response), equalTo(List.of(List.of((long) SIZE))));
     }
 
     public void testDouble() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("double");
         EsqlQueryResponse response = run("from test | stats sum(const)");
-        assertThat(response.values(), equalTo(List.of(List.of((double) SIZE))));
+        assertThat(getValuesList(response), equalTo(List.of(List.of((double) SIZE))));
     }
 
     public void testKeyword() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("keyword");
         EsqlQueryResponse response = run("from test | keep const | limit 1");
-        assertThat(response.values(), equalTo(List.of(List.of("const"))));
+        assertThat(getValuesList(response), equalTo(List.of(List.of("const"))));
     }
 
     /**
@@ -75,20 +76,20 @@ public class EsqlActionRuntimeFieldIT extends AbstractEsqlIntegTestCase {
     public void testKeywordBy() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("keyword");
         EsqlQueryResponse response = run("from test | stats max(foo) by const");
-        assertThat(response.values(), equalTo(List.of(List.of(SIZE - 1L, "const"))));
+        assertThat(getValuesList(response), equalTo(List.of(List.of(SIZE - 1L, "const"))));
     }
 
     public void testBoolean() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("boolean");
         EsqlQueryResponse response = run("from test | sort foo | limit 3");
-        assertThat(response.values(), equalTo(List.of(List.of(true, 0L), List.of(true, 1L), List.of(true, 2L))));
+        assertThat(getValuesList(response), equalTo(List.of(List.of(true, 0L), List.of(true, 1L), List.of(true, 2L))));
     }
 
     public void testDate() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("date");
         EsqlQueryResponse response = run("""
             from test | eval d=date_format(const, "yyyy") | stats min (foo) by d""");
-        assertThat(response.values(), equalTo(List.of(List.of(0L, "2023"))));
+        assertThat(getValuesList(response), equalTo(List.of(List.of(0L, "2023"))));
     }
 
     private void createIndexWithConstRuntimeField(String type) throws InterruptedException, IOException {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -78,22 +79,22 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 });
             }
             EsqlQueryResponse resp = run("from events_*", randomPragmas(), new RangeQueryBuilder("@timestamp").gte("2023-01-01"));
-            assertThat(resp.values(), hasSize(4));
+            assertThat(getValuesList(resp), hasSize(4));
             assertThat(queriedIndices, equalTo(Set.of("events_2023")));
             queriedIndices.clear();
 
             resp = run("from events_*", randomPragmas(), new RangeQueryBuilder("@timestamp").lt("2023-01-01"));
-            assertThat(resp.values(), hasSize(3));
+            assertThat(getValuesList(resp), hasSize(3));
             assertThat(queriedIndices, equalTo(Set.of("events_2022")));
             queriedIndices.clear();
 
             resp = run("from events_*", randomPragmas(), new RangeQueryBuilder("@timestamp").gt("2022-01-01").lt("2023-12-31"));
-            assertThat(resp.values(), hasSize(7));
+            assertThat(getValuesList(resp), hasSize(7));
             assertThat(queriedIndices, equalTo(Set.of("events_2022", "events_2023")));
             queriedIndices.clear();
 
             resp = run("from events_*", randomPragmas(), new RangeQueryBuilder("@timestamp").gt("2021-01-01").lt("2021-12-31"));
-            assertThat(resp.values(), hasSize(0));
+            assertThat(getValuesList(resp), hasSize(0));
             assertThat(queriedIndices, empty());
             queriedIndices.clear();
 
@@ -131,47 +132,47 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
         EsqlQueryResponse resp;
         // employees index
         resp = run("from employees | stats count(emp_no)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(6L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(6L)));
         resp = run("from employees | stats avg(salary)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(26.95d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(26.95d)));
 
         resp = run("from employees | stats count(emp_no)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(4L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(4L)));
         resp = run("from employees | stats avg(salary)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(26.65d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(26.65d)));
 
         // match both employees index and engineers alias -> employees
         resp = run("from e* | stats count(emp_no)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(6L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(6L)));
         resp = run("from employees | stats avg(salary)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(26.95d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(26.95d)));
 
         resp = run("from e* | stats count(emp_no)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(4L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(4L)));
         resp = run("from e* | stats avg(salary)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(26.65d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(26.65d)));
 
         // engineers alias
         resp = run("from engineer* | stats count(emp_no)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(4L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(4L)));
         resp = run("from engineer* | stats avg(salary)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(26.65d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(26.65d)));
 
         resp = run("from engineer* | stats count(emp_no)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(3L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(3L)));
         resp = run("from engineer* | stats avg(salary)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(27.2d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(27.2d)));
 
         // sales alias
         resp = run("from sales | stats count(emp_no)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(2L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(2L)));
         resp = run("from sales | stats avg(salary)", randomPragmas());
-        assertThat(resp.values().get(0), equalTo(List.of(27.55d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(27.55d)));
 
         resp = run("from sales | stats count(emp_no)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(1L)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(1L)));
         resp = run("from sales | stats avg(salary)", randomPragmas(), new RangeQueryBuilder("hired").lt("2012-04-30"));
-        assertThat(resp.values().get(0), equalTo(List.of(25.0d)));
+        assertThat(getValuesList(resp).get(0), equalTo(List.of(25.0d)));
     }
 
     public void testFailOnUnavailableShards() throws Exception {
@@ -211,7 +212,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest().source("timestamp", 11, "message", "bb"))
             .get();
         EsqlQueryResponse resp = run("from events,logs | KEEP timestamp,message");
-        assertThat(resp.values(), hasSize(5));
+        assertThat(getValuesList(resp), hasSize(5));
         internalCluster().stopNode(logsOnlyNode);
         ensureClusterSizeConsistency();
         Exception error = expectThrows(Exception.class, () -> run("from events,logs | KEEP timestamp,message"));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -100,7 +100,7 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
         return pages;
     }
 
-    public List<List<Object>> values() {
+    public Iterator<Iterator<Object>> values() {
         return pagesToValues(columns.stream().map(ColumnInfo::type).toList(), pages);
     }
 
@@ -175,12 +175,14 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EsqlQueryResponse that = (EsqlQueryResponse) o;
-        return Objects.equals(columns, that.columns) && Objects.equals(values(), that.values()) && columnar == that.columnar;
+        return Objects.equals(columns, that.columns)
+            && columnar == that.columnar
+            && Iterators.equals(values(), that.values(), (row1, row2) -> Iterators.equals(row1, row2, Objects::equals));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(columns, values(), columnar);
+        return Objects.hash(columns, Iterators.hashCode(values(), row -> Iterators.hashCode(row, Objects::hashCode)), columnar);
     }
 
     @Override
@@ -188,40 +190,33 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
         return Strings.toString(ChunkedToXContent.wrapAsToXContent(this));
     }
 
-    public static List<List<Object>> pagesToValues(List<String> dataTypes, List<Page> pages) {
+    public static Iterator<Iterator<Object>> pagesToValues(List<String> dataTypes, List<Page> pages) {
         BytesRef scratch = new BytesRef();
-        List<List<Object>> result = new ArrayList<>();
-        for (Page page : pages) {
-            for (int p = 0; p < page.getPositionCount(); p++) {
-                List<Object> row = new ArrayList<>(page.getBlockCount());
-                for (int b = 0; b < page.getBlockCount(); b++) {
-                    Block block = page.getBlock(b);
-                    if (block.isNull(p)) {
-                        row.add(null);
-                        continue;
-                    }
-                    /*
-                     * Use the ESQL data type to map to the output to make sure compute engine
-                     * respects its types. See the INTEGER clause where is doesn't always
-                     * respect it.
-                     */
-                    int count = block.getValueCount(p);
-                    int start = block.getFirstValueIndex(p);
-                    if (count == 1) {
-                        row.add(valueAt(dataTypes.get(b), block, start, scratch));
-                        continue;
-                    }
-                    List<Object> thisResult = new ArrayList<>(count);
-                    int end = count + start;
-                    for (int i = start; i < end; i++) {
-                        thisResult.add(valueAt(dataTypes.get(b), block, i, scratch));
-                    }
-                    row.add(thisResult);
+        return Iterators.flatMap(
+            pages.iterator(),
+            page -> Iterators.forRange(0, page.getPositionCount(), p -> Iterators.forRange(0, page.getBlockCount(), b -> {
+                Block block = page.getBlock(b);
+                if (block.isNull(p)) {
+                    return null;
                 }
-                result.add(row);
-            }
-        }
-        return result;
+                /*
+                 * Use the ESQL data type to map to the output to make sure compute engine
+                 * respects its types. See the INTEGER clause where is doesn't always
+                 * respect it.
+                 */
+                int count = block.getValueCount(p);
+                int start = block.getFirstValueIndex(p);
+                if (count == 1) {
+                    return valueAt(dataTypes.get(b), block, start, scratch);
+                }
+                List<Object> thisResult = new ArrayList<>(count);
+                int end = count + start;
+                for (int i = start; i < end; i++) {
+                    thisResult.add(valueAt(dataTypes.get(b), block, i, scratch));
+                }
+                return thisResult;
+            }))
+        );
     }
 
     private static Object valueAt(String dataType, Block block, int offset, BytesRef scratch) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormat.java
@@ -286,13 +286,12 @@ public enum TextFormat implements MediaType {
 
     public Iterator<CheckedConsumer<Writer, IOException>> format(RestRequest request, EsqlQueryResponse esqlResponse) {
         final var delimiter = delimiter(request);
-        return Iterators.concat(hasHeader(request) && esqlResponse.columns() != null ?
-        // if the header is requested return the info
-            Iterators.single(writer -> row(writer, esqlResponse.columns(), ColumnInfo::name, delimiter)) : Collections.emptyIterator(),
-            Iterators.map(
-                esqlResponse.values().iterator(),
-                row -> writer -> row(writer, row, f -> Objects.toString(f, StringUtils.EMPTY), delimiter)
-            )
+        return Iterators.concat(
+            // if the header is requested return the info
+            hasHeader(request) && esqlResponse.columns() != null
+                ? Iterators.single(writer -> row(writer, esqlResponse.columns().iterator(), ColumnInfo::name, delimiter))
+                : Collections.emptyIterator(),
+            Iterators.map(esqlResponse.values(), row -> writer -> row(writer, row, f -> Objects.toString(f, StringUtils.EMPTY), delimiter))
         );
     }
 
@@ -315,12 +314,15 @@ public enum TextFormat implements MediaType {
     }
 
     // utility method for consuming a row.
-    <F> void row(Writer writer, List<F> row, Function<F, String> toString, Character delimiter) throws IOException {
-        for (int i = 0; i < row.size(); i++) {
-            writeEscaped(toString.apply(row.get(i)), delimiter, writer);
-            if (i < row.size() - 1) {
+    <F> void row(Writer writer, Iterator<F> row, Function<F, String> toString, Character delimiter) throws IOException {
+        boolean firstColumn = true;
+        while (row.hasNext()) {
+            if (firstColumn) {
+                firstColumn = false;
+            } else {
                 writer.append(delimiter);
             }
+            writeEscaped(toString.apply(row.next()), delimiter, writer);
         }
         writer.append(eol());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormatter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormatter.java
@@ -46,10 +46,14 @@ public class TextFormatter {
         }
 
         // 2. Expand columns to fit the largest value
-        for (var row : response.values()) {
+        var iterator = response.values();
+        while (iterator.hasNext()) {
+            var row = iterator.next();
             for (int i = 0; i < width.length; i++) {
-                width[i] = Math.max(width[i], FORMATTER.apply(row.get(i)).length());
+                assert row.hasNext();
+                width[i] = Math.max(width[i], FORMATTER.apply(row.next()).length());
             }
+            assert row.hasNext() == false;
         }
     }
 
@@ -91,12 +95,13 @@ public class TextFormatter {
     }
 
     private Iterator<CheckedConsumer<Writer, IOException>> formatResults() {
-        return Iterators.map(response.values().iterator(), row -> writer -> {
+        return Iterators.map(response.values(), row -> writer -> {
             for (int i = 0; i < width.length; i++) {
+                assert row.hasNext();
                 if (i > 0) {
                     writer.append('|');
                 }
-                String string = FORMATTER.apply(row.get(i));
+                String string = FORMATTER.apply(row.next());
                 if (string.length() <= width[i]) {
                     // Pad
                     writer.append(string);
@@ -107,6 +112,7 @@ public class TextFormatter {
                     writer.append('~');
                 }
             }
+            assert row.hasNext() == false;
             writer.append('\n');
         });
     }


### PR DESCRIPTION
Today when rendering an ESQL response as text we materialize the entire
table as a `List<List<Object>>` before rendering it with
chunked-encoding. With this commit we avoid the intermediate data
structure and just read it directly from the underlying `Page` objects
on demand.