### PR TITLE
Remove redundant writeList from StreamOutput

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -237,7 +237,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
     protected void doWriteTo(StreamOutput out) throws IOException {
         bucketInfo.writeTo(out);
         out.writeNamedWriteable(format);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
         out.writeVInt(targetBuckets);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
             out.writeVLong(bucketInnerInterval);

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSortPipelineAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSortPipelineAggregationBuilder.java
@@ -100,7 +100,7 @@ public class BucketSortPipelineAggregationBuilder extends AbstractPipelineAggreg
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeList(sorts);
+        out.writeCollection(sorts);
         out.writeVInt(from);
         out.writeOptionalVInt(size);
         gapPolicy.writeTo(out);

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/ExplainDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/ExplainDataStreamLifecycleAction.java
@@ -165,7 +165,7 @@ public class ExplainDataStreamLifecycleAction extends ActionType<ExplainDataStre
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(indices);
+            out.writeCollection(indices);
             out.writeOptionalWriteable(rolloverConfiguration);
         }
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/GetDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/GetDataStreamLifecycleAction.java
@@ -205,7 +205,7 @@ public class GetDataStreamLifecycleAction extends ActionType<GetDataStreamLifecy
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(dataStreamLifecycles);
+            out.writeCollection(dataStreamLifecycles);
             out.writeOptionalWriteable(rolloverConfiguration);
         }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
@@ -103,7 +103,7 @@ public class GeoIpDownloaderStatsAction extends ActionType<GeoIpDownloaderStatsA
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
@@ -116,7 +116,7 @@ public class MultiSearchTemplateRequest extends ActionRequest implements Composi
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVInt(maxConcurrentSearchRequests);
-        out.writeList(requests);
+        out.writeCollection(requests);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassInfo.java
@@ -135,11 +135,11 @@ public class PainlessContextClassInfo implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeBoolean(imported);
-        out.writeList(constructors);
-        out.writeList(staticMethods);
-        out.writeList(methods);
-        out.writeList(staticFields);
-        out.writeList(fields);
+        out.writeCollection(constructors);
+        out.writeCollection(staticMethods);
+        out.writeCollection(methods);
+        out.writeCollection(staticFields);
+        out.writeCollection(fields);
     }
 
     public static PainlessContextClassInfo fromXContent(XContentParser parser) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInfo.java
@@ -157,10 +157,10 @@ public class PainlessContextInfo implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeList(classes);
-        out.writeList(importedMethods);
-        out.writeList(classBindings);
-        out.writeList(instanceBindings);
+        out.writeCollection(classes);
+        out.writeCollection(importedMethods);
+        out.writeCollection(classBindings);
+        out.writeCollection(instanceBindings);
     }
 
     public static PainlessContextInfo fromXContent(XContentParser parser) {

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/MultiLineStringBuilder.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/MultiLineStringBuilder.java
@@ -49,7 +49,7 @@ public class MultiLineStringBuilder extends ShapeBuilder<JtsGeometry, org.elasti
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(lines);
+        out.writeCollection(lines);
     }
 
     public MultiLineStringBuilder linestring(LineStringBuilder line) {

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/MultiPolygonBuilder.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/MultiPolygonBuilder.java
@@ -63,7 +63,7 @@ public class MultiPolygonBuilder extends ShapeBuilder<Shape, MultiPolygon, Multi
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         orientation.writeTo(out);
-        out.writeList(polygons);
+        out.writeCollection(polygons);
     }
 
     public Orientation orientation() {

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/PolygonBuilder.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/PolygonBuilder.java
@@ -93,7 +93,7 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.elasticsearch.
     public void writeTo(StreamOutput out) throws IOException {
         shell.writeTo(out);
         orientation.writeTo(out);
-        out.writeList(holes);
+        out.writeCollection(holes);
     }
 
     public Orientation orientation() {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
@@ -59,7 +59,7 @@ public class EvalQueryQuality implements ToXContentFragment, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(queryId);
         out.writeDouble(metricScore);
-        out.writeList(ratedHits);
+        out.writeCollection(ratedHits);
         out.writeOptionalNamedWriteable(this.optionalMetricDetails);
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
@@ -96,7 +96,7 @@ public class RankEvalSpec implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(ratedRequests);
+        out.writeCollection(ratedRequests);
         out.writeNamedWriteable(metric);
         out.writeMap(templates, StreamOutput::writeString, (o, v) -> v.writeTo(o));
         out.writeVInt(maxConcurrentSearches);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -457,7 +457,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
             super.writeTo(out);
             out.writeInt(id);
             node.writeTo(out);
-            out.writeList(subRequests);
+            out.writeCollection(subRequests);
             out.writeBoolean(timeout);
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -169,7 +169,7 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(current);
+            out.writeCollection(current);
             desired.writeTo(out);
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequest.java
@@ -71,7 +71,7 @@ public class UpdateDesiredNodesRequest extends AcknowledgedRequest<UpdateDesired
         super.writeTo(out);
         out.writeString(historyID);
         out.writeLong(version);
-        out.writeList(nodes);
+        out.writeCollection(nodes);
         if (out.getTransportVersion().onOrAfter(DRY_RUN_VERSION)) {
             out.writeBoolean(dryRun);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
@@ -67,7 +67,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(this.featureUpgradeStatuses);
+        out.writeCollection(this.featureUpgradeStatuses);
         out.writeEnum(upgradeStatus);
     }
 
@@ -178,7 +178,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
             out.writeString(this.featureName);
             IndexVersion.writeVersion(this.minimumIndexVersion, out);
             out.writeEnum(this.upgradeStatus);
-            out.writeList(this.indexInfos);
+            out.writeCollection(this.indexInfos);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeResponse.java
@@ -91,7 +91,7 @@ public class PostFeatureUpgradeResponse extends ActionResponse implements ToXCon
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(this.accepted);
-        out.writeList(this.features);
+        out.writeCollection(this.features);
         out.writeOptionalString(this.reason);
         out.writeOptionalWriteable(this.elasticsearchException);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
@@ -52,7 +52,7 @@ public class NodesHotThreadsResponse extends BaseNodesResponse<NodeHotThreads> {
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeHotThreads> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     private static class LinesIterator implements Iterator<String> {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -49,7 +49,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeInfo> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -42,11 +42,11 @@ public class PluginsAndModules implements ReportingService.Info {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
-            out.writeList(plugins);
+            out.writeCollection(plugins);
         } else {
-            out.writeList(plugins.stream().map(PluginRuntimeInfo::descriptor).toList());
+            out.writeCollection(plugins.stream().map(PluginRuntimeInfo::descriptor).toList());
         }
-        out.writeList(modules);
+        out.writeCollection(modules);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
@@ -45,7 +45,7 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodesReloadSecureSettingsResponse.NodeResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodesRemovalPrevalidation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodesRemovalPrevalidation.java
@@ -52,7 +52,7 @@ public record NodesRemovalPrevalidation(boolean isSafe, String message, List<Nod
     public void writeTo(final StreamOutput out) throws IOException {
         out.writeBoolean(isSafe);
         out.writeString(message);
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateShardPathResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateShardPathResponse.java
@@ -38,6 +38,6 @@ public class PrevalidateShardPathResponse extends BaseNodesResponse<NodePrevalid
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodePrevalidateShardPathResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -39,7 +39,7 @@ public class NodesStatsResponse extends BaseNodesXContentResponse<NodeStats> {
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeStats> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -66,7 +66,7 @@ public class ListTasksResponse extends BaseTasksResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(tasks);
+        out.writeCollection(tasks);
     }
 
     protected static <T> ConstructingObjectParser<T, Void> setupParser(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
@@ -41,7 +41,7 @@ public class NodesUsageResponse extends BaseNodesResponse<NodeUsage> implements 
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeUsage> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
@@ -84,7 +84,7 @@ public class RemoteClusterNodesAction extends ActionType<RemoteClusterNodesActio
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         public List<DiscoveryNode> getNodes() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoResponse.java
@@ -38,7 +38,7 @@ public final class RemoteInfoResponse extends ActionResponse implements ToXConte
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(infos);
+        out.writeCollection(infos);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -130,7 +130,7 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     public List<NodeView> getNodes() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/GetSnapshottableFeaturesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/GetSnapshottableFeaturesResponse.java
@@ -38,7 +38,7 @@ public class GetSnapshottableFeaturesResponse extends ActionResponse implements 
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(snapshottableFeatures);
+        out.writeCollection(snapshottableFeatures);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/ResetFeatureStateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/ResetFeatureStateResponse.java
@@ -69,7 +69,7 @@ public class ResetFeatureStateResponse extends ActionResponse implements ToXCont
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(this.resetFeatureStateStatusList);
+        out.writeCollection(this.resetFeatureStateStatusList);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -148,7 +148,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(snapshots);
+        out.writeCollection(snapshots);
         if (out.getTransportVersion().onOrAfter(GetSnapshotsRequest.MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
             out.writeMap(failures, StreamOutput::writeString, StreamOutput::writeException);
             out.writeOptionalString(next);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -164,7 +164,7 @@ public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         snapshot.writeTo(out);
         out.writeByte(state.value());
-        out.writeList(shards);
+        out.writeCollection(shards);
         out.writeOptionalBoolean(includeGlobalState);
         out.writeLong(stats.getStartTime());
         out.writeLong(stats.getTime());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -52,7 +52,7 @@ public class SnapshotsStatusResponse extends ActionResponse implements ChunkedTo
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(snapshots);
+        out.writeCollection(snapshots);
     }
 
     private static final ConstructingObjectParser<SnapshotsStatusResponse, Void> PARSER = new ConstructingObjectParser<>(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -164,7 +164,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeSnapshotStatus> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
     }
 
@@ -184,7 +184,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeList(snapshots);
+            out.writeCollection(snapshots);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -131,7 +131,7 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
     @Override
     protected void writeNodesTo(StreamOutput out, List<ClusterStatsNodeResponse> nodes) throws IOException {
         // nodeStats and indicesStats are rebuilt from nodes
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -91,7 +91,7 @@ public class PendingClusterTasksResponse extends ActionResponse implements Chunk
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(pendingTasks);
+        out.writeCollection(pendingTasks);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -624,7 +624,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(allAliasActions);
+        out.writeCollection(allAliasActions);
         out.writeOptionalString(origin);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -45,8 +45,8 @@ public class GetAliasesResponse extends ActionResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
-        out.writeMap(dataStreamAliases, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(aliases, StreamOutput::writeString, (streamOutput1, list1) -> streamOutput1.writeCollection(list1));
+        out.writeMap(dataStreamAliases, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -251,8 +251,8 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
             out.writeStringArray(text);
             out.writeOptionalString(analyzer);
             out.writeOptionalWriteable(tokenizer);
-            out.writeList(tokenFilters);
-            out.writeList(charFilters);
+            out.writeCollection(tokenFilters);
+            out.writeCollection(charFilters);
             out.writeOptionalString(field);
             out.writeBoolean(explain);
             out.writeStringArray(attributes);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
@@ -48,7 +48,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         writeShardsAcknowledged(out);
-        out.writeList(indices);
+        out.writeCollection(indices);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/FindDanglingIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/FindDanglingIndexResponse.java
@@ -42,6 +42,6 @@ public class FindDanglingIndexResponse extends BaseNodesResponse<NodeFindDanglin
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeFindDanglingIndexResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/NodeFindDanglingIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/NodeFindDanglingIndexResponse.java
@@ -46,6 +46,6 @@ public class NodeFindDanglingIndexResponse extends BaseNodeResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(this.danglingIndexInfo);
+        out.writeCollection(this.danglingIndexInfo);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
@@ -99,7 +99,7 @@ public class ListDanglingIndicesResponse extends BaseNodesResponse<NodeListDangl
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeListDanglingIndicesResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     // visible for testing

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/NodeListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/NodeListDanglingIndicesResponse.java
@@ -40,6 +40,6 @@ public class NodeListDanglingIndicesResponse extends BaseNodeResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(this.indexMetaData);
+        out.writeCollection(this.indexMetaData);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -173,7 +173,7 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);
         MappingMetadata.writeMappingMetadata(out, mappings);
-        out.writeMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(aliases, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
         out.writeMap(settings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
         out.writeMap(defaultSettings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
         out.writeMap(dataStreams, StreamOutput::writeString, StreamOutput::writeOptionalString);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockResponse.java
@@ -49,7 +49,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         writeShardsAcknowledged(out);
-        out.writeList(indices);
+        out.writeCollection(indices);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -409,9 +409,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(indices);
-            out.writeList(aliases);
-            out.writeList(dataStreams);
+            out.writeCollection(indices);
+            out.writeCollection(aliases);
+            out.writeCollection(dataStreams);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
@@ -70,6 +70,6 @@ public class ShardSegments implements Writeable, Iterable<Segment> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         shardRouting.writeTo(out);
-        out.writeList(segments);
+        out.writeCollection(segments);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -272,7 +272,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements Chunke
             StreamOutput::writeString,
             (o, v) -> o.writeMap(v, StreamOutput::writeInt, StreamOutput::writeCollection)
         );
-        out.writeList(failures);
+        out.writeCollection(failures);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
@@ -41,7 +41,7 @@ public class FieldUsageStatsResponse extends ChunkedBroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(stats, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(stats, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
     }
 
     public Map<String, List<FieldUsageShardResponse>> getStats() {

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -359,7 +359,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(dataStreams);
+            out.writeCollection(dataStreams);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
                 out.writeOptionalWriteable(rolloverConfiguration);
             }

--- a/server/src/main/java/org/elasticsearch/action/datastreams/ModifyDataStreamsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/ModifyDataStreamsAction.java
@@ -66,7 +66,7 @@ public class ModifyDataStreamsAction extends ActionType<AcknowledgedResponse> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeList(actions);
+            out.writeCollection(actions);
         }
 
         public Request(List<DataStreamAction> actions) {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -114,8 +114,8 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
                 return new GroupByMappingHash(indices, indexMappingHash, responseMap);
             })
             .toList();
-        output.writeList(ungroupedResponses);
-        output.writeList(groupedResponses);
+        output.writeCollection(ungroupedResponses);
+        output.writeCollection(groupedResponses);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -122,7 +122,7 @@ class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesReque
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(shardIds);
+        out.writeCollection(shardIds);
         out.writeStringArray(fields);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_2_0)) {
             out.writeStringArray(filters);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -149,7 +149,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
         out.writeStringArray(indices);
         out.writeMap(responseMap, StreamOutput::writeString, FieldCapabilitiesResponse::writeField);
         FieldCapabilitiesIndexResponse.writeList(out, indexResponses);
-        out.writeList(failures);
+        out.writeCollection(failures);
     }
 
     private static void writeField(StreamOutput out, Map<String, FieldCapabilities> map) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -276,7 +276,7 @@ public class MultiGetRequest extends ActionRequest
         out.writeOptionalString(preference);
         out.writeBoolean(refresh);
         out.writeBoolean(realtime);
-        out.writeList(items);
+        out.writeCollection(items);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_4_0)) {
             out.writeBoolean(forceSyntheticSource);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
@@ -188,7 +188,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
         out.writeVLong(nowInMillis);
         out.writeOptionalString(clusterAlias);
         out.writeTimeValue(waitForCheckpointsTimeout);
-        out.writeList(shards);
+        out.writeCollection(shards);
     }
 
     public List<Shard> getShardLevelRequests() {

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeResponse.java
@@ -33,7 +33,7 @@ public class CanMatchNodeResponse extends TransportResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(responses);
+        out.writeCollection(responses);
     }
 
     public List<ResponseOrFailure> getResponses() {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -568,9 +568,9 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_053)) {
                 if (clusterInfo != null) {
                     List<Cluster> clusterList = clusterInfo.values().stream().map(AtomicReference::get).toList();
-                    out.writeList(clusterList);
+                    out.writeCollection(clusterList);
                 } else {
-                    out.writeList(Collections.emptyList());
+                    out.writeCollection(Collections.emptyList());
                 }
             }
         }
@@ -869,7 +869,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             out.writeOptionalInt(failedShards);
             out.writeOptionalLong(took == null ? null : took.millis());
             out.writeBoolean(timedOut);
-            out.writeList(failures);
+            out.writeCollection(failures);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -507,7 +507,7 @@ public abstract class TransportBroadcastByNodeAction<
             assert indicesLevelRequest.hasReferences();
             super.writeTo(out);
             indicesLevelRequest.writeTo(out);
-            out.writeList(shards);
+            out.writeCollection(shards);
             out.writeString(nodeId);
         }
 
@@ -599,7 +599,7 @@ public abstract class TransportBroadcastByNodeAction<
             out.writeCollection(results, StreamOutput::writeOptionalWriteable);
             out.writeBoolean(exceptions != null);
             if (exceptions != null) {
-                out.writeList(exceptions);
+                out.writeCollection(exceptions);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -97,7 +97,7 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
     public void writeTo(StreamOutput out) throws IOException {
         clusterName.writeTo(out);
         writeNodesTo(out, nodes);
-        out.writeList(failures);
+        out.writeCollection(failures);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterSnapshotStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterSnapshotStats.java
@@ -175,7 +175,7 @@ public record ClusterSnapshotStats(
         out.writeVInt(incompleteShardSnapshotCount);
         out.writeVInt(deletionsInProgressCount);
         out.writeVInt(cleanupsInProgressCount);
-        out.writeList(statsByRepository);
+        out.writeCollection(statsByRepository);
     }
 
     public static ClusterSnapshotStats readFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RepositoryCleanupInProgress.java
@@ -64,7 +64,7 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(entries);
+        out.writeCollection(entries);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -153,7 +153,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(entries);
+        out.writeCollection(entries);
     }
 
     public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -1344,7 +1344,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             } else {
                 out.writeMap(shardStatusByRepoShardId);
             }
-            out.writeList(featureStates);
+            out.writeCollection(featureStates);
         }
 
         @Override
@@ -1661,7 +1661,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(entries);
+            out.writeCollection(entries);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -383,8 +383,8 @@ public class ClusterFormationFailureHelper {
             out.writeLong(acceptedTerm);
             lastAcceptedConfiguration.writeTo(out);
             lastCommittedConfiguration.writeTo(out);
-            out.writeList(resolvedAddresses);
-            out.writeList(foundPeers);
+            out.writeCollection(resolvedAddresses);
+            out.writeCollection(foundPeers);
             out.writeLong(currentTerm);
             out.writeBoolean(hasDiscoveredQuorum);
             statusInfo.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1323,7 +1323,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeList(recentMasters);
+                out.writeCollection(recentMasters);
             }
             out.writeOptionalString(remoteExceptionMessage);
             out.writeOptionalString(remoteExceptionStackTrace);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PeersResponse.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PeersResponse.java
@@ -40,7 +40,7 @@ public class PeersResponse extends TransportResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(masterNode.orElse(null));
-        out.writeList(knownPeers);
+        out.writeCollection(knownPeers);
         out.writeLong(term);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -805,7 +805,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeString(TIMESTAMP_FIELD_NAME);
-        out.writeList(indices);
+        out.writeCollection(indices);
         out.writeVLong(generation);
         out.writeGenericMap(metadata);
         out.writeBoolean(hidden);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -141,7 +141,7 @@ public final class IndexGraveyard implements Metadata.Custom {
 
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
-        out.writeList(tombstones);
+        out.writeCollection(tombstones);
     }
 
     @Override
@@ -298,7 +298,7 @@ public final class IndexGraveyard implements Metadata.Custom {
 
         @Override
         public void writeTo(final StreamOutput out) throws IOException {
-            out.writeList(added);
+            out.writeCollection(added);
             out.writeVInt(removedCount);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
@@ -190,7 +190,7 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Custom> implemen
      */
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(repositories);
+        out.writeCollection(repositories);
     }
 
     public static RepositoriesMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AbstractAllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AbstractAllocationDecision.java
@@ -83,7 +83,7 @@ public abstract class AbstractAllocationDecision implements ToXContentFragment, 
         out.writeOptionalWriteable(targetNode);
         if (nodeDecisions != null) {
             out.writeBoolean(true);
-            out.writeList(nodeDecisions);
+            out.writeCollection(nodeDecisions);
         } else {
             out.writeBoolean(false);
         }

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -118,7 +118,7 @@ public class DocumentField implements Writeable, Iterable<Object> {
             out.writeCollection(ignoredValues, StreamOutput::writeGenericValue);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_2_0)) {
-            out.writeList(lookupFields);
+            out.writeCollection(lookupFields);
         } else {
             if (lookupFields.isEmpty() == false) {
                 assert false : "Lookup fields require all nodes be on 8.2 or later";

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -1077,7 +1077,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a list of objects. The list is expected to have been written using {@link StreamOutput#writeList(List)}.
+     * Reads a list of objects. The list is expected to have been written using {@link StreamOutput#writeCollection}.
      * If the returned list contains any entries it will be mutable. If it is empty it might be immutable.
      *
      * @return the list of objects
@@ -1088,7 +1088,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads an list of objects. The list is expected to have been written using {@link StreamOutput#writeList(List)}.
+     * Reads an list of objects. The list is expected to have been written using {@link StreamOutput#writeCollection}.
      * The returned list is immutable.
      *
      * @return the list of objects

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1042,13 +1042,6 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a list of {@link Writeable} objects
-     */
-    public void writeList(List<? extends Writeable> list) throws IOException {
-        writeCollection(list);
-    }
-
-    /**
      * Writes a collection of objects via a {@link Writer}.
      *
      * @param collection the collection of objects

--- a/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
@@ -129,7 +129,7 @@ public class SetBackedScalingCuckooFilter implements Writeable {
         if (isSetMode) {
             out.writeCollection(hashes, StreamOutput::writeZLong);
         } else {
-            out.writeList(filters);
+            out.writeCollection(filters);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/discovery/PeersRequest.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeersRequest.java
@@ -37,7 +37,7 @@ public class PeersRequest extends TransportRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceNode.writeTo(out);
-        out.writeList(knownPeers);
+        out.writeCollection(knownPeers);
     }
 
     public List<DiscoveryNode> getKnownPeers() {

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -248,7 +248,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeGatewayStartedShards> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/health/stats/HealthApiStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/health/stats/HealthApiStatsAction.java
@@ -94,7 +94,7 @@ public class HealthApiStatsAction extends ActionType<HealthApiStatsAction.Respon
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<Node> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         public Counters getStats() {

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -38,7 +38,7 @@ public record HttpStats(long serverOpen, long totalOpen, List<ClientStats> clien
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(serverOpen);
         out.writeVLong(totalOpen);
-        out.writeList(clientStats);
+        out.writeCollection(clientStats);
     }
 
     public long getServerOpen() {

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -209,7 +209,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         out.writeOptionalWriteable(storedFieldsContext);
         out.writeBoolean(docValueFields != null);
         if (docValueFields != null) {
-            out.writeList(docValueFields);
+            out.writeCollection(docValueFields);
         }
         boolean hasScriptFields = scriptFields != null;
         out.writeBoolean(hasScriptFields);
@@ -232,7 +232,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_10_0)) {
             out.writeBoolean(fetchFields != null);
             if (fetchFields != null) {
-                out.writeList(fetchFields);
+                out.writeCollection(fetchFields);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -515,9 +515,9 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeOptionalStringArray(fields);
         out.writeStringArray(likeTexts);
-        out.writeList(Arrays.asList(likeItems));
+        out.writeCollection(Arrays.asList(likeItems));
         out.writeStringArray(unlikeTexts);
-        out.writeList(Arrays.asList(unlikeItems));
+        out.writeCollection(Arrays.asList(unlikeItems));
         out.writeVInt(maxQueryTerms);
         out.writeVInt(minTermFreq);
         out.writeVInt(minDocFreq);

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -148,7 +148,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(query);
-        out.writeList(Arrays.asList(filterFunctionBuilders));
+        out.writeCollection(Arrays.asList(filterFunctionBuilders));
         out.writeFloat(maxBoost);
         out.writeOptionalFloat(minScore);
         out.writeOptionalWriteable(boostMode);

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollResponse.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollResponse.java
@@ -185,8 +185,8 @@ public class BulkByScrollResponse extends ActionResponse implements ToXContentFr
     public void writeTo(StreamOutput out) throws IOException {
         out.writeTimeValue(took);
         status.writeTo(out);
-        out.writeList(bulkFailures);
-        out.writeList(searchFailures);
+        out.writeCollection(bulkFailures);
+        out.writeCollection(searchFailures);
         out.writeBoolean(timedOut);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -206,7 +206,7 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         stats.writeTo(out);
-        out.writeMap(statsByShard, (o, k) -> k.writeTo(o), StreamOutput::writeList);
+        out.writeMap(statsByShard, (o, k) -> k.writeTo(o), (streamOutput, list) -> streamOutput.writeCollection(list));
         if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_STATS_BY_INDEX)) {
             out.writeMap(statsByIndex, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
         }

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -225,7 +225,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
                 assert out.getTransportVersion().onOrAfter(TransportVersion.V_7_17_0) : out.getTransportVersion();
             }
             metadataSnapshot.writeTo(out);
-            out.writeList(peerRecoveryRetentionLeases);
+            out.writeCollection(peerRecoveryRetentionLeases);
         }
 
         public boolean isEmpty() {
@@ -334,7 +334,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeStoreFilesMetadata> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -178,7 +178,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
         mem.writeTo(out);
         threads.writeTo(out);
         gc.writeTo(out);
-        out.writeList(bufferPools);
+        out.writeCollection(bufferPools);
         classes.writeTo(out);
     }
 
@@ -516,7 +516,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
             out.writeVLong(nonHeapCommitted);
             out.writeVLong(nonHeapUsed);
             out.writeVLong(heapMax);
-            out.writeList(pools);
+            out.writeCollection(pools);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -161,7 +161,7 @@ public record ScriptStats(
             out.writeVLong(cacheEvictions);
         }
         out.writeVLong(compilationLimitTriggered);
-        out.writeList(contextStats);
+        out.writeCollection(contextStats);
     }
 
     public List<ScriptContextStats> getContextStats() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -122,7 +122,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
             out.writeArray((o, order) -> order.writeTo(o), missingOrders);
         }
-        out.writeList(buckets);
+        out.writeCollection(buckets);
         out.writeOptionalWriteable(afterKey);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_6_0)) {
             out.writeBoolean(earlyTerminated);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -163,7 +163,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
             out.writeBoolean(keyedBucket);
         }
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
@@ -61,7 +61,7 @@ public abstract class InternalGeoGrid<B extends InternalGeoGridBucket> extends I
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         writeSize(requiredSize, out);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     protected abstract InternalGeoGrid<B> create(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -256,7 +256,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         out.writeLong(offset);
         out.writeNamedWriteable(format);
         out.writeBoolean(keyed);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -250,7 +250,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
         }
         out.writeNamedWriteable(format);
         out.writeBoolean(keyed);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -268,7 +268,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
     protected void doWriteTo(StreamOutput out) throws IOException {
         emptyBucketInfo.writeTo(out);
         out.writeNamedWriteable(format);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
         out.writeVInt(targetNumBuckets);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -216,7 +216,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         out.writeNamedWriteable(format);
         out.writeBoolean(keyed);
         out.writeVLong(minDocCount);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
@@ -109,7 +109,7 @@ public abstract class AbstractRangeBuilder<AB extends AbstractRangeBuilder<AB, R
 
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
-        out.writeList(ranges);
+        out.writeCollection(ranges);
         out.writeBoolean(keyed);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -311,7 +311,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeDouble(origin.lat());
         out.writeDouble(origin.lon());
-        out.writeList(ranges);
+        out.writeCollection(ranges);
         out.writeBoolean(keyed);
         distanceType.writeTo(out);
         unit.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -223,7 +223,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(format);
         out.writeBoolean(keyed);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
@@ -79,7 +79,7 @@ public abstract class InternalMappedRareTerms<A extends InternalRareTerms<A, B>,
     @Override
     protected void writeTermTypeInfoTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(format);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
         filter.writeTo(out);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -67,7 +67,7 @@ public abstract class InternalMappedSignificantTerms<
         out.writeVLong(subsetSize);
         out.writeVLong(supersetSize);
         out.writeNamedWriteable(significanceHeuristic);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
@@ -95,7 +95,7 @@ public abstract class InternalMappedTerms<A extends InternalTerms<A, B>, B exten
         writeSize(shardSize, out);
         out.writeBoolean(showTermDocCountError);
         out.writeVLong(otherDocCount);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -143,7 +143,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         boolean hasFieldDataFields = docValueFields != null;
         out.writeBoolean(hasFieldDataFields);
         if (hasFieldDataFields) {
-            out.writeList(docValueFields);
+            out.writeCollection(docValueFields);
         }
         out.writeOptionalWriteable(storedFieldsContext);
         out.writeVInt(from);
@@ -165,7 +165,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_10_0)) {
             out.writeBoolean(fetchFields != null);
             if (fetchFields != null) {
-                out.writeList(fetchFields);
+                out.writeCollection(fetchFields);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -282,16 +282,16 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalWriteable(fetchSourceContext);
         out.writeBoolean(docValueFields != null);
         if (docValueFields != null) {
-            out.writeList(docValueFields);
+            out.writeCollection(docValueFields);
         }
         out.writeOptionalWriteable(storedFieldsContext);
         out.writeVInt(from);
         out.writeOptionalWriteable(highlightBuilder);
-        out.writeList(indexBoosts);
+        out.writeCollection(indexBoosts);
         out.writeOptionalFloat(minScore);
         out.writeOptionalNamedWriteable(postQueryBuilder);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_013)) {
-            out.writeList(subSearchSourceBuilders);
+            out.writeCollection(subSearchSourceBuilders);
         } else if (out.getTransportVersion().before(TransportVersion.V_8_4_0) && subSearchSourceBuilders.size() >= 2) {
             throw new IllegalArgumentException("cannot serialize [sub_searches] to version [" + out.getTransportVersion() + "]");
         } else {
@@ -305,7 +305,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         boolean hasScriptFields = scriptFields != null;
         out.writeBoolean(hasScriptFields);
         if (hasScriptFields) {
-            out.writeList(scriptFields);
+            out.writeCollection(scriptFields);
         }
         out.writeVInt(size);
         boolean hasSorts = sorts != null;
@@ -333,7 +333,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_10_0)) {
             out.writeBoolean(fetchFields != null);
             if (fetchFields != null) {
-                out.writeList(fetchFields);
+                out.writeCollection(fetchFields);
             }
             out.writeOptionalWriteable(pointInTimeBuilder);
         }

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -85,7 +85,7 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
         out.writeVInt(maxConcurrentGroupRequests);
-        out.writeList(innerHits);
+        out.writeCollection(innerHits);
     }
 
     public static CollapseBuilder fromXContent(XContentParser parser) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -136,7 +136,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeOptionalString(encoder);
         out.writeBoolean(useExplicitFieldOrder);
-        out.writeList(fields);
+        out.writeCollection(fields);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -92,7 +92,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_9_0)) {
             out.writeMap(debug, StreamOutput::writeString, StreamOutput::writeGenericValue);
         }
-        out.writeList(children);
+        out.writeCollection(children);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -64,7 +64,7 @@ public class CollectorResult extends ProfilerCollectorResult implements ToXConte
         out.writeString(getName());
         out.writeString(getReason());
         out.writeLong(getTime());
-        out.writeList(getChildrenResults());
+        out.writeCollection(getChildrenResults());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -317,7 +317,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(name);
             out.writeVInt(size);
-            out.writeList(entries);
+            out.writeCollection(entries);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -161,7 +161,7 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
         }
         out.writeMapWithConsistentOrder(collateParams);
         out.writeOptionalBoolean(collatePrune);
-        out.writeMap(this.generators, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(this.generators, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -1032,7 +1032,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         out.writeVLong(endTime);
         out.writeVInt(totalShards);
         out.writeVInt(successfulShards);
-        out.writeList(shardFailures);
+        out.writeCollection(shardFailures);
         if (version != null) {
             out.writeBoolean(true);
             IndexVersion.writeVersion(version, out);
@@ -1042,7 +1042,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         out.writeOptionalBoolean(includeGlobalState);
         out.writeGenericMap(userMetadata);
         out.writeStringCollection(dataStreams);
-        out.writeList(featureStates);
+        out.writeCollection(featureStates);
 
         out.writeMap(indexSnapshotDetails, StreamOutput::writeString, (stream, value) -> value.writeTo(stream));
     }

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolInfo.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolInfo.java
@@ -31,7 +31,7 @@ public class ThreadPoolInfo implements ReportingService.Info, Iterable<ThreadPoo
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(infos);
+        out.writeCollection(infos);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -124,7 +124,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         public int failureCount() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -146,7 +146,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         public int getFailureCount() {

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -389,7 +389,7 @@ public class TransportNodesActionTests extends ESTestCase {
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<TestNodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -476,7 +476,7 @@ public class BytesStreamsTests extends ESTestCase {
         }
 
         final BytesStreamOutput out = new BytesStreamOutput();
-        out.writeList(expected);
+        out.writeCollection(expected);
 
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -516,7 +516,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         }
 
         final RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
-        out.writeList(expected);
+        out.writeCollection(expected);
 
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
 

--- a/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
@@ -519,7 +519,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeList(tasks);
+            out.writeCollection(tasks);
         }
 
         public List<TestTaskResponse> getTasks() {

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
@@ -95,7 +95,7 @@ public class ErrorQueryBuilder extends AbstractQueryBuilder<ErrorQueryBuilder> {
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeList(indices);
+        out.writeCollection(indices);
     }
 
     @Override

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
@@ -37,7 +37,7 @@ public class NodeSeekStats extends BaseNodeResponse implements ToXContentFragmen
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(seeks, StreamOutput::writeString, StreamOutput::writeList);
+        out.writeMap(seeks, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
     }
 
     @Override

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekStatsResponse.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekStatsResponse.java
@@ -41,7 +41,7 @@ public class SeekStatsResponse extends BaseNodesResponse<NodeSeekStats> implemen
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeSeekStats> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -346,7 +346,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         out.writeVLong(otherDocCount);
         out.writeCollection(formats, StreamOutput::writeNamedWriteable);
         out.writeCollection(keyConverters, StreamOutput::writeEnum);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java
@@ -196,7 +196,7 @@ public class MultiTermsAggregationBuilder extends AbstractAggregationBuilder<Mul
 
     @Override
     protected final void doWriteTo(StreamOutput out) throws IOException {
-        out.writeList(terms);
+        out.writeCollection(terms);
         order.writeTo(out);
         out.writeOptionalWriteable(collectMode);
         bucketCountThresholds.writeTo(out);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -77,7 +77,7 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
         sortOrder.writeTo(out);
         out.writeStringCollection(metricNames);
         out.writeVInt(size);
-        out.writeList(topMetrics);
+        out.writeCollection(topMetrics);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -167,7 +167,7 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeNamedWriteableList(sortBuilders);
         out.writeVInt(size);
-        out.writeList(metricFields);
+        out.writeCollection(metricFields);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/NodeDecisions.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/NodeDecisions.java
@@ -44,7 +44,7 @@ class NodeDecisions implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(canAllocateDecisions);
+        out.writeCollection(canAllocateDecisions);
         out.writeOptionalWriteable(canRemainDecision);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageResponse.java
@@ -113,7 +113,7 @@ public class GetFeatureUsageResponse extends ActionResponse implements ToXConten
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(features);
+        out.writeCollection(features);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Hop.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Hop.java
@@ -71,7 +71,7 @@ public class Hop implements ToXContentFragment {
         if (vertices == null) {
             out.writeVInt(0);
         } else {
-            out.writeList(vertices);
+            out.writeCollection(vertices);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/RemoteClusterFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/RemoteClusterFeatureSetUsage.java
@@ -39,7 +39,7 @@ public class RemoteClusterFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(remoteConnectionInfos);
+        out.writeCollection(remoteConnectionInfos);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/QueryPage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/QueryPage.java
@@ -54,7 +54,7 @@ public final class QueryPage<T extends ToXContent & Writeable> implements ToXCon
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(resultsField.getPreferredName());
-        out.writeList(results);
+        out.writeCollection(results);
         out.writeLong(count);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
@@ -112,7 +112,7 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         public EnumCounters<Item> getStats() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
@@ -102,7 +102,7 @@ public class FollowInfoAction extends ActionType<FollowInfoAction.Response> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(followInfos);
+            out.writeCollection(followInfos);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
@@ -70,7 +70,7 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeList(statsResponse);
+            out.writeCollection(statsResponse);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -79,10 +79,10 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(executingPolicies);
-            out.writeList(coordinatorStats);
+            out.writeCollection(executingPolicies);
+            out.writeCollection(coordinatorStats);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-                out.writeList(cacheStats);
+                out.writeCollection(cacheStats);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/GetEnrichPolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/GetEnrichPolicyAction.java
@@ -99,7 +99,7 @@ public class GetEnrichPolicyAction extends ActionType<GetEnrichPolicyAction.Resp
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(policies);
+            out.writeCollection(policies);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -48,7 +48,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
         boolean hasPolicyStats = policyStats != null;
         out.writeBoolean(hasPolicyStats);
         if (hasPolicyStats) {
-            out.writeList(policyStats);
+            out.writeCollection(policyStats);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
@@ -58,7 +58,7 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(policies);
+            out.writeCollection(policies);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ExplainDataFrameAnalyticsAction.java
@@ -191,7 +191,7 @@ public class ExplainDataFrameAnalyticsAction extends ActionType<ExplainDataFrame
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(fieldSelection);
+            out.writeCollection(fieldSelection);
             memoryEstimation.writeTo(out);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsStatsAction.java
@@ -312,7 +312,7 @@ public class GetDataFrameAnalyticsStatsAction extends ActionType<GetDataFrameAna
                 out.writeString(id);
                 state.writeTo(out);
                 out.writeOptionalString(failureReason);
-                out.writeList(progress);
+                out.writeCollection(progress);
                 dataCounts.writeTo(out);
                 memoryUsage.writeTo(out);
                 out.writeOptionalNamedWriteable(analysisStats);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlMemoryAction.java
@@ -323,7 +323,7 @@ public class MlMemoryAction extends ActionType<MlMemoryAction.Response> {
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<MlMemoryStats> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
@@ -97,7 +97,7 @@ public class PostCalendarEventsAction extends ActionType<PostCalendarEventsActio
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(calendarId);
-            out.writeList(scheduledEvents);
+            out.writeCollection(scheduledEvents);
         }
 
         @Override
@@ -133,7 +133,7 @@ public class PostCalendarEventsAction extends ActionType<PostCalendarEventsActio
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(scheduledEvents);
+            out.writeCollection(scheduledEvents);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
@@ -131,7 +131,7 @@ public class TrainedModelCacheInfoAction extends ActionType<TrainedModelCacheInf
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<CacheInfo> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateProcessAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateProcessAction.java
@@ -115,7 +115,7 @@ public class UpdateProcessAction extends ActionType<UpdateProcessAction.Response
             boolean hasDetectorUpdates = detectorUpdates != null;
             out.writeBoolean(hasDetectorUpdates);
             if (hasDetectorUpdates) {
-                out.writeList(detectorUpdates);
+                out.writeCollection(detectorUpdates);
             }
             out.writeOptionalWriteable(filter);
             out.writeBoolean(updateScheduledEvents);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -529,7 +529,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
 
         if (scriptFields != null) {
             out.writeBoolean(true);
-            out.writeList(scriptFields);
+            out.writeCollection(scriptFields);
         } else {
             out.writeBoolean(false);
         }
@@ -837,7 +837,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
 
             if (scriptFields != null) {
                 out.writeBoolean(true);
-                out.writeList(scriptFields);
+                out.writeCollection(scriptFields);
             } else {
                 out.writeBoolean(false);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -194,7 +194,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
 
         if (scriptFields != null) {
             out.writeBoolean(true);
-            out.writeList(scriptFields);
+            out.writeCollection(scriptFields);
         } else {
             out.writeBoolean(false);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
@@ -263,7 +263,7 @@ public class Accuracy implements EvaluationMetric {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(classes);
+            out.writeCollection(classes);
             out.writeDouble(overallAccuracy);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
@@ -310,7 +310,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(actualClasses);
+            out.writeCollection(actualClasses);
             out.writeVLong(otherActualClassCount);
         }
 
@@ -406,7 +406,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(actualClass);
             out.writeVLong(actualClassDocCount);
-            out.writeList(predictedClasses);
+            out.writeCollection(predictedClasses);
             out.writeVLong(otherPredictedClassDocCount);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
@@ -256,7 +256,7 @@ public class Precision implements EvaluationMetric {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(classes);
+            out.writeCollection(classes);
             out.writeDouble(avgPrecision);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
@@ -226,7 +226,7 @@ public class Recall implements EvaluationMetric {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(classes);
+            out.writeCollection(classes);
             out.writeDouble(avgRecall);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/common/AbstractAucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/common/AbstractAucRoc.java
@@ -322,7 +322,7 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeDouble(value);
-            out.writeList(curve);
+            out.writeCollection(curve);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ValidationLoss.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ValidationLoss.java
@@ -63,7 +63,7 @@ public class ValidationLoss implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(lossType);
-        out.writeList(foldValues);
+        out.writeCollection(foldValues);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/ValidationLoss.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/ValidationLoss.java
@@ -63,7 +63,7 @@ public class ValidationLoss implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(lossType);
-        out.writeList(foldValues);
+        out.writeCollection(foldValues);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -632,7 +632,7 @@ public class AssignmentStats implements ToXContentObject, Writeable {
         out.writeOptionalVInt(numberOfAllocations);
         out.writeOptionalVInt(queueCapacity);
         out.writeInstant(startTime);
-        out.writeList(nodeStats);
+        out.writeCollection(nodeStats);
         if (AssignmentState.FAILED.equals(state) && out.getTransportVersion().before(TransportVersion.V_8_4_0)) {
             out.writeOptionalEnum(AssignmentState.STARTING);
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationFeatureImportance.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationFeatureImportance.java
@@ -85,7 +85,7 @@ public class ClassificationFeatureImportance extends AbstractFeatureImportance {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(featureName);
-        out.writeList(classImportance);
+        out.writeCollection(classImportance);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -147,7 +147,7 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(featureImportance);
+        out.writeCollection(featureImportance);
         out.writeOptionalString(classificationLabel);
         out.writeCollection(topClasses);
         out.writeString(topNumClassesField);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
@@ -62,7 +62,7 @@ public class NerResults extends NlpInferenceResults {
 
     @Override
     void doWriteTo(StreamOutput out) throws IOException {
-        out.writeList(entityGroups);
+        out.writeCollection(entityGroups);
         out.writeString(resultsField);
         out.writeString(annotatedResult);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
@@ -81,7 +81,7 @@ public class RegressionInferenceResults extends SingleValueInferenceResults {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(featureImportance);
+        out.writeCollection(featureImportance);
         out.writeString(resultsField);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
@@ -112,7 +112,7 @@ public class TextExpansionResults extends NlpInferenceResults {
     @Override
     void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(resultsField);
-        out.writeList(weightedTokens);
+        out.writeCollection(weightedTokens);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/FeatureImportanceBaseline.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/FeatureImportanceBaseline.java
@@ -72,7 +72,7 @@ public class FeatureImportanceBaseline implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalDouble(baseline);
-        out.writeList(classBaselines);
+        out.writeCollection(classBaselines);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TotalFeatureImportance.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TotalFeatureImportance.java
@@ -86,7 +86,7 @@ public class TotalFeatureImportance implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(featureName);
         out.writeOptionalWriteable(importance);
-        out.writeList(classImportances);
+        out.writeCollection(classImportances);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TrainedModelMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TrainedModelMetadata.java
@@ -142,9 +142,9 @@ public class TrainedModelMetadata implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
-        out.writeList(totalFeatureImportances);
+        out.writeCollection(totalFeatureImportances);
         out.writeOptionalWriteable(featureImportanceBaselines);
-        out.writeList(hyperparameters);
+        out.writeCollection(hyperparameters);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -200,7 +200,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         perPartitionCategorizationConfig.writeTo(out);
         out.writeOptionalTimeValue(latency);
         out.writeOptionalString(summaryCountFieldName);
-        out.writeList(detectors);
+        out.writeCollection(detectors);
         out.writeStringCollection(influencers);
 
         out.writeOptionalBoolean(multivariateByFields);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/CategorizationAnalyzerConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/CategorizationAnalyzerConfig.java
@@ -237,9 +237,9 @@ public class CategorizationAnalyzerConfig implements ToXContentFragment, Writeab
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(analyzer);
-        out.writeList(charFilters);
+        out.writeCollection(charFilters);
         out.writeOptionalWriteable(tokenizer);
-        out.writeList(tokenFilters);
+        out.writeCollection(tokenFilters);
     }
 
     public String getAnalyzer() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DetectionRule.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DetectionRule.java
@@ -69,7 +69,7 @@ public class DetectionRule implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnumSet(actions);
         scope.writeTo(out);
-        out.writeList(conditions);
+        out.writeCollection(conditions);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
@@ -243,7 +243,7 @@ public class Detector implements ToXContentObject, Writeable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeList(rules);
+        out.writeCollection(rules);
         out.writeInt(detectorIndex);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -205,7 +205,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalString(description);
         out.writeBoolean(detectorUpdates != null);
         if (detectorUpdates != null) {
-            out.writeList(detectorUpdates);
+            out.writeCollection(detectorUpdates);
         }
         out.writeOptionalWriteable(modelPlotConfig);
         out.writeOptionalWriteable(analysisLimits);
@@ -725,7 +725,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
             out.writeOptionalString(description);
             out.writeBoolean(rules != null);
             if (rules != null) {
-                out.writeList(rules);
+                out.writeCollection(rules);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyCause.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyCause.java
@@ -157,7 +157,7 @@ public class AnomalyCause implements ToXContentObject, Writeable {
         boolean hasInfluencers = influencers != null;
         out.writeBoolean(hasInfluencers);
         if (hasInfluencers) {
-            out.writeList(influencers);
+            out.writeCollection(influencers);
         }
         out.writeOptionalWriteable(geoResults);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
@@ -252,7 +252,7 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
         boolean hasCauses = causes != null;
         out.writeBoolean(hasCauses);
         if (hasCauses) {
-            out.writeList(causes);
+            out.writeCollection(causes);
         }
         out.writeDouble(recordScore);
         out.writeDouble(initialRecordScore);
@@ -261,7 +261,7 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
         boolean hasInfluencers = influences != null;
         out.writeBoolean(hasInfluencers);
         if (hasInfluencers) {
-            out.writeList(influences);
+            out.writeCollection(influences);
         }
         out.writeOptionalWriteable(geoResults);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_6_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
@@ -161,10 +161,10 @@ public class Bucket implements ToXContentObject, Writeable {
         out.writeDouble(anomalyScore);
         out.writeLong(bucketSpan);
         out.writeDouble(initialAnomalyScore);
-        out.writeList(records);
+        out.writeCollection(records);
         out.writeLong(eventCount);
         out.writeBoolean(isInterim);
-        out.writeList(bucketInfluencers);
+        out.writeCollection(bucketInfluencers);
         out.writeLong(processingTimeMs);
         out.writeStringCollection(scheduledEvents);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/OverallBucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/OverallBucket.java
@@ -64,7 +64,7 @@ public class OverallBucket implements ToXContentObject, Writeable {
         out.writeLong(timestamp.getTime());
         out.writeLong(bucketSpan);
         out.writeDouble(overallScore);
-        out.writeList(jobs);
+        out.writeCollection(jobs);
         out.writeBoolean(isInterim);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkRequest.java
@@ -120,6 +120,6 @@ public class MonitoringBulkRequest extends ActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(docs);
+        out.writeCollection(docs);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringMigrateAlertsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringMigrateAlertsResponse.java
@@ -36,7 +36,7 @@ public class MonitoringMigrateAlertsResponse extends ActionResponse implements T
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(exporters);
+        out.writeCollection(exporters);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupJobsAction.java
@@ -149,7 +149,7 @@ public class GetRollupJobsAction extends ActionType<GetRollupJobsAction.Response
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeList(jobs);
+            out.writeCollection(jobs);
         }
 
         public List<JobWrapper> getJobs() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollableIndexCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollableIndexCaps.java
@@ -52,7 +52,7 @@ public class RollableIndexCaps implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(indexName);
-        out.writeList(jobCaps);
+        out.writeCollection(jobCaps);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfig.java
@@ -252,7 +252,7 @@ public class RollupJobConfig implements NamedWriteable, ToXContentObject {
         out.writeString(rollupIndex);
         out.writeString(cron);
         out.writeOptionalWriteable(groupConfig);
-        out.writeList(metricsConfig);
+        out.writeCollection(metricsConfig);
         out.writeTimeValue(timeout);
         out.writeInt(pageSize);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
@@ -56,7 +56,7 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
         shardRouting.writeTo(out);
         snapshotId.writeTo(out);
         indexId.writeTo(out);
-        out.writeList(inputStats);
+        out.writeCollection(inputStats);
     }
 
     public ShardRouting getShardRouting() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/ClearSecurityCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/ClearSecurityCacheResponse.java
@@ -37,7 +37,7 @@ public class ClearSecurityCacheResponse extends BaseNodesResponse<ClearSecurityC
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<Node> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
@@ -127,7 +127,7 @@ public final class CreateApiKeyRequest extends AbstractCreateApiKeyRequest {
             out.writeString(name);
         }
         out.writeOptionalTimeValue(expiration);
-        out.writeList(getRoleDescriptors());
+        out.writeCollection(getRoleDescriptors());
         refreshPolicy.writeTo(out);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
             out.writeGenericMap(metadata);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCrossClusterApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCrossClusterApiKeyRequest.java
@@ -73,7 +73,7 @@ public final class CreateCrossClusterApiKeyRequest extends AbstractCreateApiKeyR
         out.writeString(id);
         out.writeString(name);
         out.writeOptionalTimeValue(expiration);
-        out.writeList(roleDescriptors);
+        out.writeCollection(roleDescriptors);
         refreshPolicy.writeTo(out);
         out.writeGenericMap(metadata);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
@@ -133,7 +133,7 @@ public final class QueryApiKeyRequest extends ActionRequest {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeList(fieldSortBuilders);
+            out.writeCollection(fieldSortBuilders);
         }
         out.writeOptionalWriteable(searchAfterBuilder);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_5_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/ClearPrivilegesCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/ClearPrivilegesCacheResponse.java
@@ -37,7 +37,7 @@ public class ClearPrivilegesCacheResponse extends BaseNodesResponse<ClearPrivile
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<Node> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
@@ -127,7 +127,7 @@ public final class PutPrivilegesRequest extends ActionRequest implements Applica
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(privileges);
+        out.writeCollection(privileges);
         refreshPolicy.writeTo(out);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
@@ -45,7 +45,7 @@ public class GetProfilesResponse extends ActionResponse implements ToXContentObj
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(profiles);
+        out.writeCollection(profiles);
         out.writeMap(errors, StreamOutput::writeString, StreamOutput::writeException);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheResponse.java
@@ -37,7 +37,7 @@ public class ClearRealmCacheResponse extends BaseNodesResponse<ClearRealmCacheRe
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<ClearRealmCacheResponse.Node> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheResponse.java
@@ -40,7 +40,7 @@ public class ClearRolesCacheResponse extends BaseNodesResponse<ClearRolesCacheRe
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<ClearRolesCacheResponse.Node> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -209,7 +209,7 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
         for (RoleDescriptor.IndicesPrivileges index : indicesPrivileges) {
             index.writeTo(out);
         }
-        out.writeList(applicationPrivileges);
+        out.writeCollection(applicationPrivileges);
         ConfigurableClusterPrivileges.writeArray(out, this.configurableClusterPrivileges);
         out.writeStringArray(runAs);
         refreshPolicy.writeTo(out);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
@@ -156,7 +156,7 @@ public class PutRoleMappingRequest extends ActionRequest implements WriteRequest
         out.writeBoolean(enabled);
         out.writeStringCollection(roles);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_2_0)) {
-            out.writeList(roleTemplates);
+            out.writeCollection(roleTemplates);
         }
         ExpressionParser.writeExpression(rules, out);
         out.writeGenericMap(metadata);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsNodesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsNodesResponse.java
@@ -50,7 +50,7 @@ public class GetServiceAccountCredentialsNodesResponse extends BaseNodesResponse
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<GetServiceAccountCredentialsNodesResponse.Node> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     public List<TokenInfo> getFileTokenInfos() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsResponse.java
@@ -56,7 +56,7 @@ public class GetServiceAccountCredentialsResponse extends ActionResponse impleme
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(principal);
-        out.writeList(indexTokenInfos);
+        out.writeCollection(indexTokenInfos);
         nodesResponse.writeTo(out);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
@@ -52,7 +52,7 @@ public final class TokenMetadata extends AbstractNamedDiffable<ClusterState.Cust
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeByteArray(currentKeyHash);
-        out.writeList(keys);
+        out.writeCollection(keys);
     }
 
     public static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
@@ -112,7 +112,7 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
         out.writeBoolean(enabled);
         out.writeStringCollection(roles);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_2_0)) {
-            out.writeList(roleTemplates);
+            out.writeCollection(roleTemplates);
         }
         ExpressionParser.writeExpression(expression, out);
         out.writeGenericMap(metadata);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/FieldExpression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/FieldExpression.java
@@ -51,7 +51,7 @@ public final class FieldExpression implements RoleMapperExpression {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
-        out.writeList(values);
+        out.writeCollection(values);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/GetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/GetSnapshotLifecycleAction.java
@@ -116,7 +116,7 @@ public class GetSnapshotLifecycleAction extends ActionType<GetSnapshotLifecycleA
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(lifecycles);
+            out.writeCollection(lifecycles);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/action/SpatialStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/action/SpatialStatsAction.java
@@ -106,7 +106,7 @@ public class SpatialStatsAction extends ActionType<SpatialStatsAction.Response> 
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         public EnumCounters<Item> getStats() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -200,7 +200,7 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0)) {
                 if (errors != null) {
                     out.writeBoolean(true);
-                    out.writeList(errors);
+                    out.writeCollection(errors);
                 } else {
                     out.writeBoolean(false);
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/QueryWatchesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/QueryWatchesAction.java
@@ -154,7 +154,7 @@ public class QueryWatchesAction extends ActionType<QueryWatchesAction.Response> 
             out.writeOptionalNamedWriteable(query);
             if (sorts != null) {
                 out.writeBoolean(true);
-                out.writeList(sorts);
+                out.writeCollection(sorts);
             } else {
                 out.writeBoolean(false);
             }
@@ -230,7 +230,7 @@ public class QueryWatchesAction extends ActionType<QueryWatchesAction.Response> 
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(watches);
+            out.writeCollection(watches);
             out.writeVLong(watchTotalCount);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
@@ -59,7 +59,7 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<Node> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override
@@ -199,11 +199,11 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
 
             out.writeBoolean(snapshots != null);
             if (snapshots != null) {
-                out.writeList(snapshots);
+                out.writeCollection(snapshots);
             }
             out.writeBoolean(queuedWatches != null);
             if (queuedWatches != null) {
-                out.writeList(queuedWatches);
+                out.writeCollection(queuedWatches);
             }
             out.writeBoolean(stats != null);
             if (stats != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockAction.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockAction.java
@@ -77,7 +77,7 @@ public class MockAction implements LifecycleAction {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(steps.stream().map(MockStep::new).collect(Collectors.toList()));
+        out.writeCollection(steps.stream().map(MockStep::new).collect(Collectors.toList()));
         out.writeBoolean(safe);
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -201,11 +201,11 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(clusterSettingsIssues);
-            out.writeList(nodeSettingsIssues);
+            out.writeCollection(clusterSettingsIssues);
+            out.writeCollection(nodeSettingsIssues);
             out.writeMapOfLists(indexSettingsIssues, StreamOutput::writeString, (o, v) -> v.writeTo(o));
             if (out.getTransportVersion().before(TransportVersion.V_7_11_0)) {
-                out.writeList(pluginSettingsIssues.getOrDefault("ml_settings", Collections.emptyList()));
+                out.writeCollection(pluginSettingsIssues.getOrDefault("ml_settings", Collections.emptyList()));
             } else {
                 out.writeMapOfLists(pluginSettingsIssues, StreamOutput::writeString, (o, v) -> v.writeTo(o));
             }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckAction.java
@@ -69,7 +69,7 @@ public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationChec
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeList(this.deprecationIssues);
+            out.writeCollection(this.deprecationIssues);
         }
 
         public List<DeprecationIssue> getDeprecationIssues() {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckResponse.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckResponse.java
@@ -38,7 +38,7 @@ public class NodesDeprecationCheckResponse extends BaseNodesResponse<NodesDeprec
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodesDeprecationCheckAction.NodeResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
@@ -86,7 +86,7 @@ public class DeprecationCacheResetAction extends ActionType<DeprecationCacheRese
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         @Override

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -84,7 +84,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
@@ -134,7 +134,7 @@ public class GetAnalyticsCollectionAction extends ActionType<GetAnalyticsCollect
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(collections);
+            out.writeCollection(collections);
         }
 
         public List<AnalyticsCollection> getAnalyticsCollections() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -148,7 +148,7 @@ public class QueryRule implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
         out.writeString(type.toString());
-        out.writeList(criteria);
+        out.writeCollection(criteria);
         out.writeGenericMap(actions);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleset.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleset.java
@@ -133,7 +133,7 @@ public class QueryRuleset implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
-        out.writeList(rules);
+        out.writeCollection(rules);
     }
 
     public String id() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -463,7 +463,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
             out.writeBoolean(fetchFields != null);
             if (fetchFields != null) {
-                out.writeList(fetchFields);
+                out.writeCollection(fetchFields);
             }
             out.writeGenericMap(runtimeMappings);
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -449,7 +449,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeGenericValue(joinKeys);
-            out.writeList(events);
+            out.writeCollection(events);
         }
 
         @Override
@@ -534,13 +534,13 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
             }
             if (events != null) {
                 out.writeBoolean(true);
-                out.writeList(events);
+                out.writeCollection(events);
             } else {
                 out.writeBoolean(false);
             }
             if (sequences != null) {
                 out.writeBoolean(true);
-                out.writeList(sequences);
+                out.writeCollection(sequences);
             } else {
                 out.writeBoolean(false);
             }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlStatsResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlStatsResponse.java
@@ -38,7 +38,7 @@ public class EqlStatsResponse extends BaseNodesResponse<EqlStatsResponse.NodeSta
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeStatsResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverStatus.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverStatus.java
@@ -67,7 +67,7 @@ public class DriverStatus implements Task.Status {
         out.writeString(sessionId);
         out.writeLong(lastUpdated);
         out.writeString(status.toString());
-        out.writeList(activeOperators);
+        out.writeCollection(activeOperators);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -182,7 +182,7 @@ public class BasicPageTests extends SerializationTestCase {
             new Page(BytesRefBlock.newConstantBlockWith(new BytesRef("Hello World"), positions))
         );
         final BytesStreamOutput out = new BytesStreamOutput();
-        out.writeList(origPages);
+        out.writeCollection(origPages);
         StreamInput in = new NamedWriteableAwareStreamInput(ByteBufferStreamInput.wrap(BytesReference.toBytes(out.bytes())), registry);
 
         List<Page> deserPages = in.readList(new Page.PageReader());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -87,8 +87,8 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(columns);
-        out.writeList(pages);
+        out.writeCollection(columns);
+        out.writeCollection(pages);
         out.writeBoolean(columnar);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequest.java
@@ -67,7 +67,7 @@ final class DataNodeRequest extends TransportRequest implements IndicesRequest {
         super.writeTo(out);
         out.writeString(sessionId);
         configuration.writeTo(out);
-        out.writeList(shardIds);
+        out.writeCollection(shardIds);
         out.writeMap(aliasFilters);
         new PlanStreamOutput(out, planNameRegistry).writePhysicalPlanNode(plan);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlStatsResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlStatsResponse.java
@@ -38,7 +38,7 @@ public class EsqlStatsResponse extends BaseNodesResponse<EsqlStatsResponse.NodeS
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeStatsResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -595,7 +595,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(getSteps().stream().map(s -> (ObservableClusterStateWaitStep) s).collect(Collectors.toList()));
+            out.writeCollection(getSteps().stream().map(s -> (ObservableClusterStateWaitStep) s).collect(Collectors.toList()));
             out.writeBoolean(isSafeAction());
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -266,7 +266,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
             );
         }
         out.writeVInt(similarityThreshold);
-        out.writeList(buckets);
+        out.writeCollection(buckets);
         writeSize(requiredSize, out);
         out.writeVLong(minDocCount);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -198,7 +198,7 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeList(fields);
+        out.writeCollection(fields);
         out.writeDouble(minimumSupport);
         out.writeVInt(minimumSetSize);
         out.writeVInt(size);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregation.java
@@ -101,7 +101,7 @@ public final class InternalItemSetMapReduceAggregation<
         mapReducer.writeTo(out);
         out.writeOptionalWriteable(mapFinalContext);
         out.writeOptionalWriteable(mapReduceResult);
-        out.writeList(fields);
+        out.writeCollection(fields);
         out.writeBoolean(profiling);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
@@ -225,7 +225,7 @@ public class AutodetectResult implements ToXContentObject, Writeable {
         boolean isPresent = writeables != null;
         out.writeBoolean(isPresent);
         if (isPresent) {
-            out.writeList(writeables);
+            out.writeCollection(writeables);
         }
     }
 

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesMeteringResponse.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesMeteringResponse.java
@@ -39,7 +39,7 @@ public final class RepositoriesMeteringResponse extends BaseNodesResponse<Reposi
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<RepositoriesNodeMeteringResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesNodeMeteringResponse.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesNodeMeteringResponse.java
@@ -46,6 +46,6 @@ public final class RepositoriesNodeMeteringResponse extends BaseNodeResponse imp
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(repositoryStatsSnapshots);
+        out.writeCollection(repositoryStatsSnapshots);
     }
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/RollupIndexCaps.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/RollupIndexCaps.java
@@ -178,7 +178,7 @@ public class RollupIndexCaps implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(rollupIndexName);
-        out.writeList(jobCaps);
+        out.writeCollection(jobCaps);
     }
 
     @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
@@ -239,7 +239,7 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeList(docs);
+                out.writeCollection(docs);
             }
         }
         out.writeNamedWriteable(organicQuery);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponse.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponse.java
@@ -73,7 +73,7 @@ public class SearchableSnapshotsStatsResponse extends BroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeList(stats);
+        out.writeCollection(stats);
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
@@ -186,7 +186,7 @@ public class TransportSearchableSnapshotCacheStoresAction extends TransportNodes
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeCacheFilesMetadata> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -294,7 +294,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
 
         @Override
         protected void writeNodesTo(StreamOutput out, List<NodeCachesStatsResponse> nodes) throws IOException {
-            out.writeList(nodes);
+            out.writeCollection(nodes);
         }
 
         @Override

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusAction.java
@@ -102,7 +102,7 @@ public class GetShutdownStatusAction extends ActionType<GetShutdownStatusAction.
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeList(shutdownStatuses);
+            out.writeCollection(shutdownStatuses);
         }
 
         @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -714,7 +714,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
             out.writeString(blobName);
             out.writeVLong(targetLength);
             out.writeLong(seed);
-            out.writeList(nodes);
+            out.writeCollection(nodes);
             out.writeVInt(readNodeCount);
             out.writeVInt(earlyReadNodeCount);
             out.writeBoolean(readEarly);
@@ -857,7 +857,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
             out.writeVLong(writeElapsedNanos);
             out.writeVLong(overwriteElapsedNanos);
             out.writeVLong(writeThrottledNanos);
-            out.writeList(readDetails);
+            out.writeCollection(readDetails);
         }
 
         @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -1102,7 +1102,7 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
             out.writeDouble(rareActionProbability);
             out.writeString(blobPath);
             summary.writeTo(out);
-            out.writeList(blobResponses);
+            out.writeCollection(blobResponses);
             out.writeVLong(listingTimeNanos);
             out.writeVLong(deleteTimeNanos);
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
@@ -38,7 +38,7 @@ public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeSta
 
     @Override
     protected void writeNodesTo(StreamOutput out, List<NodeStatsResponse> nodes) throws IOException {
-        out.writeList(nodes);
+        out.writeCollection(nodes);
     }
 
     @Override


### PR DESCRIPTION
Noticed this when benchmarking FieldCaps transport messages. The `writeList` alias just adds more lines to the code and makes profiling more annoying to read, lets remove it.