### PR TITLE
ES|QL: Implement serialization of InvalidMappedField

### DIFF
--- a/docs/changelog/98972.yaml
+++ b/docs/changelog/98972.yaml
@@ -1,0 +1,6 @@
+pr: 98972
+summary: "ES|QL: Implement serialization of `InvalidMappedField`"
+area: ES|QL
+type: bug
+issues:
+ - 98851

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -168,6 +168,7 @@ import org.elasticsearch.xpack.ql.plan.logical.Project;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DateEsField;
 import org.elasticsearch.xpack.ql.type.EsField;
+import org.elasticsearch.xpack.ql.type.InvalidMappedField;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
 import org.elasticsearch.xpack.ql.type.TextEsField;
 import org.elasticsearch.xpack.ql.type.UnsupportedEsField;
@@ -266,6 +267,7 @@ public final class PlanNamedTypes {
             // EsFields
             of(EsField.class, EsField.class, PlanNamedTypes::writeEsField, PlanNamedTypes::readEsField),
             of(EsField.class, DateEsField.class, PlanNamedTypes::writeDateEsField, PlanNamedTypes::readDateEsField),
+            of(EsField.class, InvalidMappedField.class, PlanNamedTypes::writeInvalidMappedField, PlanNamedTypes::readInvalidMappedField),
             of(EsField.class, KeywordEsField.class, PlanNamedTypes::writeKeywordEsField, PlanNamedTypes::readKeywordEsField),
             of(EsField.class, TextEsField.class, PlanNamedTypes::writeTextEsField, PlanNamedTypes::readTextEsField),
             of(EsField.class, UnsupportedEsField.class, PlanNamedTypes::writeUnsupportedEsField, PlanNamedTypes::readUnsupportedEsField),
@@ -902,6 +904,15 @@ public final class PlanNamedTypes {
         out.writeString(dateEsField.getName());
         out.writeMap(dateEsField.getProperties(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
         out.writeBoolean(dateEsField.isAggregatable());
+    }
+
+    static InvalidMappedField readInvalidMappedField(PlanStreamInput in) throws IOException {
+        return new InvalidMappedField(in.readString(), in.readString());
+    }
+
+    static void writeInvalidMappedField(PlanStreamOutput out, InvalidMappedField field) throws IOException {
+        out.writeString(field.getName());
+        out.writeString(field.errorMessage());
     }
 
     static KeywordEsField readKeywordEsField(PlanStreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -82,6 +82,7 @@ import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.type.DateEsField;
 import org.elasticsearch.xpack.ql.type.EsField;
+import org.elasticsearch.xpack.ql.type.InvalidMappedField;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
 import org.elasticsearch.xpack.ql.type.TextEsField;
 import org.elasticsearch.xpack.ql.type.UnsupportedEsField;
@@ -244,6 +245,19 @@ public class PlanNamedTypesTests extends ESTestCase {
 
     public void testTextEsField() {
         Stream.generate(PlanNamedTypesTests::randomTextEsField).limit(100).forEach(PlanNamedTypesTests::assertNamedEsField);
+    }
+
+    public void testInvalidMappedFieldSimple() throws IOException {
+        var orig = new InvalidMappedField("foo", "bar");
+        BytesStreamOutput bso = new BytesStreamOutput();
+        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry);
+        PlanNamedTypes.writeInvalidMappedField(out, orig);
+        var deser = PlanNamedTypes.readInvalidMappedField(planStreamInput(bso));
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
+    }
+
+    public void testInvalidMappedField() {
+        Stream.generate(PlanNamedTypesTests::randomInvalidMappedField).limit(100).forEach(PlanNamedTypesTests::assertNamedEsField);
     }
 
     public void testEsDateFieldSimple() throws IOException {
@@ -451,6 +465,13 @@ public class PlanNamedTypesTests extends ESTestCase {
             randomProperties(),
             randomBoolean(), // hasDocValues
             randomBoolean() // alias
+        );
+    }
+
+    static InvalidMappedField randomInvalidMappedField() {
+        return new InvalidMappedField(
+            randomAlphaOfLength(randomIntBetween(1, 25)), // name
+            randomAlphaOfLength(randomIntBetween(1, 25)) // error message
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/98851

As from the subject, implement the serialization/deserialization of InvalidMappedField objects.
These objects are instantiated in the execution plan when a field mapping cannot be defined, eg. if two fields with the same name and different types appear in two indexes for the same index pattern.