### PR TITLE
Improve Block builders so that they always build vector implementations for dense single-valued values

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlockBuilder.java
@@ -24,6 +24,7 @@ abstract class AbstractBlockBuilder implements Block.Builder {
     protected boolean positionEntryIsOpen;
 
     protected boolean hasNonNullValue;
+    protected boolean hasMultiValues;
 
     protected Block.MvOrdering mvOrdering = Block.MvOrdering.UNORDERED;
 
@@ -70,6 +71,9 @@ abstract class AbstractBlockBuilder implements Block.Builder {
     public AbstractBlockBuilder endPositionEntry() {
         positionCount++;
         positionEntryIsOpen = false;
+        if (hasMultiValues == false && valueCount != positionCount) {
+            hasMultiValues = true;
+        }
         return this;
     }
 
@@ -78,7 +82,7 @@ abstract class AbstractBlockBuilder implements Block.Builder {
     }
 
     protected final boolean singleValued() {
-        return firstValueIndexes == null;
+        return hasMultiValues == false;
     }
 
     protected final void updatePosition() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockValueAsserter.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockValueAsserter.java
@@ -77,7 +77,13 @@ public class BlockValueAsserter {
 
     private static void assertBooleanRowValues(BooleanBlock block, int firstValueIndex, int valueCount, List<Object> expectedRowValues) {
         for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-            boolean expectedValue = (Boolean) expectedRowValues.get(valueIndex);
+            Object value = expectedRowValues.get(valueIndex);
+            boolean expectedValue;
+            if (value instanceof Number number) {
+                expectedValue = number.intValue() % 2 == 0;
+            } else {
+                expectedValue = (Boolean) expectedRowValues.get(valueIndex);
+            }
             assertThat(block.getBoolean(firstValueIndex + valueIndex), is(equalTo(expectedValue)));
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.data;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.data;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class MultiValueBlockTests extends SerializationTestCase {
 
@@ -232,5 +234,85 @@ public class MultiValueBlockTests extends SerializationTestCase {
         assertThat(bytesRefBlock.elementType(), is(equalTo(ElementType.BYTES_REF)));
         BlockValueAsserter.assertBlockValues(bytesRefBlock, blockValues);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, block -> serializeDeserializeBlock(block));
+    }
+
+    // Tests that the use of Block builder beginPositionEntry (or not) with just a single value,
+    // and no nulls, builds a block backed by a vector.
+    public void testSingleNonNullValues() {
+        List<Object> blockValues = new ArrayList<>();
+        int positions = randomInt(512);
+        for (int i = 0; i < positions; i++) {
+            blockValues.add(randomInt());
+        }
+
+        var blocks = List.of(
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.BOOLEAN),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.BOOLEAN),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.INT),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.INT),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.LONG),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.LONG),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.DOUBLE),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.DOUBLE),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.BYTES_REF),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.BYTES_REF)
+        );
+        for (Block block : blocks) {
+            assertThat(block.asVector(), is(notNullValue()));
+            BlockValueAsserter.assertBlockValues(block, blockValues.stream().map(List::of).toList());
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, unused -> serializeDeserializeBlock(block));
+        }
+    }
+
+    // A default max iteration times, just to avoid an infinite loop.
+    static final int TIMES = 10_000;
+
+    // Tests that the use of Block builder beginPositionEntry (or not) with just a single value,
+    // with nulls, builds a block not backed by a vector.
+    public void testSingleWithNullValues() {
+        List<Object> blockValues = new ArrayList<>();
+        boolean atLeastOneNull = false;
+        int positions = randomIntBetween(1, 512);  // we must have at least one null entry
+        int times = 0;
+        while (atLeastOneNull == false && times < TIMES) {
+            times++;
+            for (int i = 0; i < positions; i++) {
+                boolean isNull = randomBoolean();
+                if (isNull) {
+                    atLeastOneNull = true;
+                    blockValues.add(null); // empty / null
+                } else {
+                    blockValues.add(randomInt());
+                }
+            }
+        }
+        assert atLeastOneNull : "Failed to create a values block with at least one null in " + times + " times";
+
+        var blocks = List.of(
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.BOOLEAN),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.BOOLEAN),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.INT),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.INT),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.LONG),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.LONG),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.DOUBLE),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.DOUBLE),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.BYTES_REF),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.BYTES_REF)
+        );
+        for (Block block : blocks) {
+            assertThat(block.asVector(), is(nullValue()));
+            BlockValueAsserter.assertBlockValues(block, blockValues.stream().map(MultiValueBlockTests::mapToList).toList());
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, unused -> serializeDeserializeBlock(block));
+        }
+    }
+
+    // Returns a list containing the given obj, or an empty list if obj is null
+    static List<Object> mapToList(Object obj) {
+        if (obj == null) {
+            return List.of();
+        } else {
+            return List.of(obj);
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
@@ -44,6 +44,20 @@ public abstract class TestBlockBuilder implements Block.Builder {
         return builder.build();
     }
 
+    // Builds a block of single values. Each value can be null or non-null.
+    // Differs from blockFromValues, as it does not use begin/endPositionEntry
+    public static Block blockFromSingleValues(List<Object> blockValues, ElementType elementType) {
+        TestBlockBuilder builder = builderOf(elementType);
+        for (Object rowValue : blockValues) {
+            if (rowValue == null) {
+                builder.appendNull();
+            } else {
+                builder.appendObject(rowValue);
+            }
+        }
+        return builder.build();
+    }
+
     static TestBlockBuilder builderOf(ElementType type) {
         return switch (type) {
             case INT -> new TestIntBlockBuilder(0);
@@ -305,6 +319,9 @@ public abstract class TestBlockBuilder implements Block.Builder {
 
         @Override
         public TestBlockBuilder appendObject(Object object) {
+            if (object instanceof Number number) {
+                object = number.intValue() % 2 == 0;
+            }
             builder.appendBoolean((boolean) object);
             return this;
         }


### PR DESCRIPTION
This commit improves Block builders so that they always build vector implementations for dense single-valued values. This was not previously the case, as the use of begin/end PositionEntry would kinda "switch" the builder in multivalue mode, even if just a single value was actually written for each entry.
