### PR TITLE
De-duplicate thread pool names in TransportSearchAction.asyncSearchExecutor()

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1085,7 +1085,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     }
 
     Executor asyncSearchExecutor(final String[] indices) {
-        final List<String> executorsForIndices = Arrays.stream(indices).map(executorSelector::executorForSearch).toList();
+        final List<String> executorsForIndices = Arrays.stream(indices).map(executorSelector::executorForSearch).distinct().toList();
         if (executorsForIndices.size() == 1) { // all indices have same executor
             return threadPool.executor(executorsForIndices.get(0));
         }


### PR DESCRIPTION
Not de-duplicating thread pool names makes the further size checks essentially compare the number of subject indices.
E.g. two indices with the `SYSTEM_CRITICAL_READ` thread pool for search would get the `SEARCH` executor instead.