### PR TITLE
Revert "Index mapping: components fields is now mapped as nested with…

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -59,15 +59,8 @@
           }
         },
         "components": {
-          "type": "nested",
-          "properties": {
-            "id": {
-              "type": "keyword"
-            },
-            "status": {
-              "type": "keyword"
-            }
-          }
+          "type": "object",
+          "enabled": false
         },
         "last_updated": {
           "type": "date"


### PR DESCRIPTION
… two properties as keywords. Will be use for telemetry collection. (#98471)"

This reverts commit a20dda56ec450cc3643eb165cc6a5a2d10e65612.

Revert https://github.com/elastic/elasticsearch/pull/98471 as it is causing an issue with migrating from 8.9