### PR TITLE
[8.10] Revert "Index mapping: components fields is now mapped as nested with two properties as keywords. Will be use for telemetry collection. (#98471)" (#98990)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -58,15 +58,8 @@
           }
         },
         "components": {
-          "type": "nested",
-          "properties": {
-            "id": {
-              "type": "keyword"
-            },
-            "status": {
-              "type": "keyword"
-            }
-          }
+          "type": "object",
+          "enabled": false
         },
         "last_updated": {
           "type": "date"


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Revert "Index mapping: components fields is now mapped as nested with two properties as keywords. Will be use for telemetry collection. (#98471)" (#98990)