### PR TITLE
Support to mock socket in ReadinessService to improve testability

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public class ReadinessClusterIT extends ESIntegTestCase {
+
     private static AtomicLong versionCounter = new AtomicLong(1);
 
     private static String testErrorJSON = """
@@ -112,7 +113,6 @@ public class ReadinessClusterIT extends ESIntegTestCase {
     }
 
     public void testReadinessDuringRestarts() throws Exception {
-
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");
         String dataNode = internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -127,7 +127,7 @@ public class ReadinessClusterIT extends ESIntegTestCase {
         tcpReadinessProbeTrue(internalCluster().getInstance(ReadinessService.class, dataNode));
         tcpReadinessProbeTrue(internalCluster().getInstance(ReadinessService.class, masterNode));
 
-        final var currentMasterNode = internalCluster().getInstance(ReadinessService.class, masterNode);
+        final var masterReadinessService = internalCluster().getInstance(ReadinessService.class, masterNode);
         assertMasterNode(internalCluster().nonMasterClient(), masterNode);
 
         logger.info("--> stop master node");
@@ -135,7 +135,7 @@ public class ReadinessClusterIT extends ESIntegTestCase {
         internalCluster().stopCurrentMasterNode();
         expectMasterNotFound();
 
-        tcpReadinessProbeFalse(currentMasterNode);
+        tcpReadinessProbeFalse(masterReadinessService);
 
         logger.info("--> start previous master node again");
         final String nextMasterEligibleNodeName = internalCluster().startNode(

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -297,7 +297,6 @@ module org.elasticsearch.server {
     exports org.elasticsearch.plugins;
     exports org.elasticsearch.plugins.interceptor to org.elasticsearch.security, org.elasticsearch.serverless.rest;
     exports org.elasticsearch.plugins.spi;
-    exports org.elasticsearch.readiness;
     exports org.elasticsearch.repositories;
     exports org.elasticsearch.repositories.blobstore;
     exports org.elasticsearch.repositories.fs;

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -297,6 +297,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.plugins;
     exports org.elasticsearch.plugins.interceptor to org.elasticsearch.security, org.elasticsearch.serverless.rest;
     exports org.elasticsearch.plugins.spi;
+    exports org.elasticsearch.readiness;
     exports org.elasticsearch.repositories;
     exports org.elasticsearch.repositories.blobstore;
     exports org.elasticsearch.repositories.fs;

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1027,8 +1027,6 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings()
             );
 
-            final ReadinessService readinessService = newReadinessService(clusterService, environment);
-
             final MasterHistoryService masterHistoryService = new MasterHistoryService(transportService, threadPool, clusterService);
             final CoordinationDiagnosticsService coordinationDiagnosticsService = new CoordinationDiagnosticsService(
                 clusterService,
@@ -1157,7 +1155,7 @@ public class Node implements Closeable {
             });
 
             if (ReadinessService.enabled(environment)) {
-                modules.add(b -> b.bind(ReadinessService.class).toInstance(readinessService));
+                modules.add(b -> b.bind(ReadinessService.class).toInstance(newReadinessService(clusterService, environment)));
             }
 
             injector = modules.createInjector();

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1911,7 +1911,7 @@ public class Node implements Closeable {
     }
 
     /**
-     * Creates a new the SearchService. This method can be overwritten by tests to inject mock implementations.
+     * Creates a new SearchService. This method can be overwritten by tests to inject mock implementations.
      */
     protected SearchService newSearchService(
         ClusterService clusterService,
@@ -1940,7 +1940,7 @@ public class Node implements Closeable {
     }
 
     /**
-     * Creates a new the ScriptService. This method can be overwritten by tests to inject mock implementations.
+     * Creates a new ScriptService. This method can be overwritten by tests to inject mock implementations.
      */
     protected ScriptService newScriptService(
         Settings settings,
@@ -1952,7 +1952,7 @@ public class Node implements Closeable {
     }
 
     /**
-     * Creates a new the ReadinessService. This method can be overwritten by tests to inject mock implementations.
+     * Creates a new ReadinessService. This method can be overwritten by tests to inject mock implementations.
      */
     protected ReadinessService newReadinessService(ClusterService clusterService, Environment environment) {
         return new ReadinessService(clusterService, environment);

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.reservedstate.service.FileChangedListener;
 import org.elasticsearch.shutdown.PluginShutdownService;
 import org.elasticsearch.transport.BindTransportException;
@@ -42,7 +41,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     private static final Logger logger = LogManager.getLogger(ReadinessService.class);
 
     interface SocketChannelFactory {
-        ServerSocketChannel open(String nodeName) throws IOException;
+        ServerSocketChannel open() throws IOException;
     }
 
     private final Environment environment;
@@ -61,7 +60,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     public static final Setting<Integer> PORT = Setting.intSetting("readiness.port", -1, Setting.Property.NodeScope);
 
     public ReadinessService(ClusterService clusterService, Environment environment) {
-        this(clusterService, environment, nodeName -> ServerSocketChannel.open());
+        this(clusterService, environment, ServerSocketChannel::open);
     }
 
     // package private to enable mocking (for testing)
@@ -131,7 +130,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
         });
 
         try {
-            serverChannel = socketChannelFactory.open(Node.NODE_NAME_SETTING.get(settings));
+            serverChannel = socketChannelFactory.open();
 
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                 try {

--- a/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
@@ -30,6 +30,8 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.plugins.MockPluginsService;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.readiness.MockReadinessService;
+import org.elasticsearch.readiness.ReadinessService;
 import org.elasticsearch.script.MockScriptService;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
@@ -182,6 +184,14 @@ public class MockNode extends Node {
             return super.newScriptService(settings, engines, contexts, timeProvider);
         }
         return new MockScriptService(settings, engines, contexts);
+    }
+
+    @Override
+    protected ReadinessService newReadinessService(ClusterService clusterService, Environment environment) {
+        if (getPluginsService().filterPlugins(MockReadinessService.TestPlugin.class).isEmpty()) {
+            return super.newReadinessService(clusterService, environment);
+        }
+        return new MockReadinessService(clusterService, environment);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
+++ b/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
@@ -29,6 +29,8 @@ public class MockReadinessService extends ReadinessService {
      */
     public static class TestPlugin extends Plugin {}
 
+    private static final String METHOD_NOT_MOCKED = "This method has not been mocked";
+
     private static class MockServerSocketChannel extends ServerSocketChannel {
 
         static ServerSocketChannel openMock() {
@@ -47,22 +49,22 @@ public class MockReadinessService extends ReadinessService {
 
         @Override
         public <T> ServerSocketChannel setOption(SocketOption<T> name, T value) {
-            throw new UnsupportedOperationException("Calling not mocked method");
+            throw new UnsupportedOperationException(METHOD_NOT_MOCKED);
         }
 
         @Override
         public <T> T getOption(SocketOption<T> name) {
-            throw new UnsupportedOperationException("Calling not mocked method");
+            throw new UnsupportedOperationException(METHOD_NOT_MOCKED);
         }
 
         @Override
         public Set<SocketOption<?>> supportedOptions() {
-            throw new UnsupportedOperationException("Calling not mocked method");
+            throw new UnsupportedOperationException(METHOD_NOT_MOCKED);
         }
 
         @Override
         public ServerSocket socket() {
-            throw new UnsupportedOperationException("Calling not mocked method");
+            throw new UnsupportedOperationException(METHOD_NOT_MOCKED);
         }
 
         @Override
@@ -80,7 +82,7 @@ public class MockReadinessService extends ReadinessService {
 
         @Override
         protected void implConfigureBlocking(boolean block) {
-            throw new UnsupportedOperationException("Calling not mocked method");
+            throw new UnsupportedOperationException(METHOD_NOT_MOCKED);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
+++ b/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.readiness;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.node.MockNode;
+import org.elasticsearch.plugins.Plugin;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class MockReadinessService extends ReadinessService {
+    /**
+     * Marker plugin used by {@link MockNode} to enable {@link MockReadinessService}.
+     */
+    public static class TestPlugin extends Plugin {}
+
+    private static class MockServerSocketChannel extends ServerSocketChannel {
+        private static final Map<String, MockServerSocketChannel> mockedSockets = new HashMap<>();
+
+        static ServerSocketChannel open(String nodeName) {
+            var mockSocket = new MockServerSocketChannel();
+            mockedSockets.put(nodeName, mockSocket);
+            return mockSocket;
+        }
+
+        private MockServerSocketChannel() {
+            super(SelectorProvider.provider());
+        }
+
+        @Override
+        public ServerSocketChannel bind(SocketAddress local, int backlog) {
+            assert isOpen();
+            return this;
+        }
+
+        @Override
+        public <T> ServerSocketChannel setOption(SocketOption<T> name, T value) {
+            throw new UnsupportedOperationException("Calling not mocked method");
+        }
+
+        @Override
+        public <T> T getOption(SocketOption<T> name) {
+            throw new UnsupportedOperationException("Calling not mocked method");
+        }
+
+        @Override
+        public Set<SocketOption<?>> supportedOptions() {
+            throw new UnsupportedOperationException("Calling not mocked method");
+        }
+
+        @Override
+        public ServerSocket socket() {
+            throw new UnsupportedOperationException("Calling not mocked method");
+        }
+
+        @Override
+        public SocketChannel accept() {
+            return null;
+        }
+
+        @Override
+        public SocketAddress getLocalAddress() {
+            return new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        }
+
+        @Override
+        protected void implCloseSelectableChannel() {}
+
+        @Override
+        protected void implConfigureBlocking(boolean block) {
+            throw new UnsupportedOperationException("Calling not mocked method");
+        }
+    }
+
+    public MockReadinessService(ClusterService clusterService, Environment environment) {
+        super(clusterService, environment, MockServerSocketChannel::open);
+    }
+
+    static void tcpReadinessProbeTrue(String nodeName) {
+        MockServerSocketChannel mockedSocket = MockServerSocketChannel.mockedSockets.get(nodeName);
+        if (mockedSocket == null) {
+            throw new AssertionError("Mocked socket not created for this node");
+        }
+        if (mockedSocket.isOpen() == false) {
+            throw new AssertionError("Readiness socket should be open");
+        }
+    }
+
+    static void tcpReadinessProbeFalse(String nodeName) {
+        MockServerSocketChannel mockedSocket = MockServerSocketChannel.mockedSockets.get(nodeName);
+        if (mockedSocket == null) {
+            throw new AssertionError("Mocked socket not created for this node");
+        }
+        if (mockedSocket.isOpen()) {
+            throw new AssertionError("Readiness socket should be closed");
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
+++ b/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
@@ -11,6 +11,7 @@ package org.elasticsearch.readiness;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.MockNode;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 
 import java.net.InetAddress;
@@ -90,7 +91,7 @@ public class MockReadinessService extends ReadinessService {
     }
 
     public MockReadinessService(ClusterService clusterService, Environment environment) {
-        super(clusterService, environment, MockServerSocketChannel::open);
+        super(clusterService, environment, () -> MockServerSocketChannel.open(Node.NODE_NAME_SETTING.get(environment.settings())));
     }
 
     static void tcpReadinessProbeTrue(String nodeName) {


### PR DESCRIPTION
The mock allows to avoid issues due to ephemeral port re-use by testing open/close status by probing the mocked "socket" class directly, instead of trying to open a connection with a TCP client. 

The injection of the mocked sockets happens by overriding the socket `open` method, which is static. 
In this first iteration, the "open" method is abstracted through a static Supplier, defaulting to the real `ServerSocketChannel::open` implementation. The field is static and package private. 

Using and updating a static field have multiple problems (concurrency, time of set vs time of use, etc.). Following iterations will explore better alternatives.
