### PR TITLE
Fix testDeleteByQueryOnReadOnlyAllowDeleteIndex

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryBasicTests.java
@@ -244,6 +244,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             if (diskAllocationDeciderEnabled == false) {
                 // Disable the disk allocation decider to ensure the read_only_allow_delete block cannot be released
                 setDiskAllocationDeciderEnabled(false);
+                refreshClusterInfo(); // ensures the logic for removing blocks upon disabling the decider is executed once
             }
             // When a read_only_allow_delete block is set on the index,
             // it will trigger a retry policy in the delete by query request because the rest status of the block is 429


### PR DESCRIPTION
Previous PR #87841 introduces a change where disabling the disk allocation decider makes a single check to remove existing blocks.

This created a race condition with the test that puts a block that it expects to not be removed after disabling the disk allocation decider.

A simple fix is to execute the single check before putting the block.

Closes #98855