### PR TITLE
Ensure indexversion comparison for test parameters works for 8.10 patch releases 

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.OLD;
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.UPGRADED;
+import static org.hamcrest.Matchers.lessThan;
 
 @TestCaseOrdering(FullClusterRestartTestOrdering.class)
 public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTestCase {
@@ -84,6 +85,11 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
         if (version.equals(org.elasticsearch.Version.CURRENT)) {
             return IndexVersion.current();
         } else {
+            assertThat(
+                "Index version needs to be added to restart test parameters",
+                version,
+                lessThan(org.elasticsearch.Version.fromId(8_11_00_99))
+            );
             return IndexVersion.fromId(version.id);
         }
     }

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.OLD;
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.UPGRADED;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @TestCaseOrdering(FullClusterRestartTestOrdering.class)
 public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTestCase {
@@ -85,11 +84,6 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
         if (version.equals(org.elasticsearch.Version.CURRENT)) {
             return IndexVersion.current();
         } else {
-            assertThat(
-                "Index version needs to be added to restart test parameters",
-                version,
-                lessThanOrEqualTo(org.elasticsearch.Version.V_8_10_0)
-            );
             return IndexVersion.fromId(version.id);
         }
     }


### PR DESCRIPTION
When 8.10.2 is released, this check will fail when run on 8.10.1. So just remove this check on the 8.10 branch, it only applies on main

Counterpart to https://github.com/elastic/elasticsearch/pull/99004