### PR TITLE
Update version check to also include 8.10 patch releases

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -85,11 +85,7 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
         if (version.equals(org.elasticsearch.Version.CURRENT)) {
             return IndexVersion.current();
         } else {
-            assertThat(
-                "Index version needs to be added to restart test parameters",
-                version,
-                lessThan(org.elasticsearch.Version.V_8_11_0)
-            );
+            assertThat("Index version needs to be added to restart test parameters", version, lessThan(org.elasticsearch.Version.V_8_11_0));
             return IndexVersion.fromId(version.id);
         }
     }

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.OLD;
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.UPGRADED;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 
 @TestCaseOrdering(FullClusterRestartTestOrdering.class)
 public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTestCase {
@@ -88,7 +88,7 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
             assertThat(
                 "Index version needs to be added to restart test parameters",
                 version,
-                lessThanOrEqualTo(org.elasticsearch.Version.V_8_10_0)
+                lessThan(org.elasticsearch.Version.V_8_11_0)
             );
             return IndexVersion.fromId(version.id);
         }


### PR DESCRIPTION
When 8.10.1 is released, this check will fail. So update the check to also include any 8.10 patch release

Counterpart to #99003