### PR TITLE
Concurrent thread access to shared doc values

### DIFF
--- a/docs/changelog/99007.yaml
+++ b/docs/changelog/99007.yaml
@@ -1,5 +1,0 @@
-pr: 99007
-summary: Cardinality nested in time series doc values bug
-area: "Aggregations"
-type: bug
-issues: []

--- a/docs/changelog/99007.yaml
+++ b/docs/changelog/99007.yaml
@@ -1,0 +1,5 @@
+pr: 99007
+summary: Cardinality nested in time series doc values bug
+area: "TSDB, Aggregations"
+type: bug
+issues: []

--- a/docs/changelog/99007.yaml
+++ b/docs/changelog/99007.yaml
@@ -1,5 +1,5 @@
 pr: 99007
 summary: Cardinality nested in time series doc values bug
-area: "TSDB, Aggregations"
+area: "Aggregations"
 type: bug
 issues: []

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesNestedAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesNestedAggregationsIT.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.aggregations.bucket;
+
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.aggregations.AggregationIntegTestCase;
+import org.elasticsearch.aggregations.bucket.timeseries.InternalTimeSeries;
+import org.elasticsearch.aggregations.bucket.timeseries.TimeSeriesAggregationBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalCardinality;
+import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+public class TimeSeriesNestedAggregations extends AggregationIntegTestCase {
+    private static int numberOfDimensions;
+    private static int numberOfDocuments;
+
+    private static final String FOO_DIM_VALUE = "foo".repeat(10);
+    private static final String BAR_DIM_VALUE = "bar".repeat(11);
+    private static final String BAZ_DIM_VALUE = "baz".repeat(12);
+
+    @Before
+    public void setup() throws Exception {
+        numberOfDimensions = randomIntBetween(10, 20);
+        final XContentBuilder mapping = timeSeriesIndexMapping();
+        long startMillis = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-01-01T00:00:00Z");
+        long endMillis = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-01-31T00:00:00Z");
+        numberOfDocuments = randomIntBetween(100, 200);
+        final Iterator<Long> timestamps = getTimestamps(startMillis, endMillis, numberOfDocuments);
+        // NOTE: use also the last (changing) dimension so to make sure documents are not indexed all in the same shard.
+        final String[] routingDimensions = new String[] { "dim_000000", "dim_" + formatDim(numberOfDimensions - 1)};
+        assertTrue(prepareTimeSeriesIndex(mapping, startMillis, endMillis, routingDimensions).isAcknowledged());
+
+        logger.info("Dimensions: " + numberOfDimensions + " docs: " + numberOfDocuments + " start: " + startMillis + " end: " + endMillis);
+
+        final BulkRequestBuilder bulkIndexRequest = client().prepareBulk();
+        for (int docId = 0; docId < numberOfDocuments; docId++) {
+            final XContentBuilder document = timeSeriesDocument(FOO_DIM_VALUE, BAR_DIM_VALUE, BAZ_DIM_VALUE, docId, timestamps::next);
+            bulkIndexRequest.add(client().prepareIndex("index").setOpType(DocWriteRequest.OpType.CREATE).setSource(document));
+        }
+        BulkResponse bulkIndexResponse = bulkIndexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        assertFalse(bulkIndexResponse.hasFailures());
+        assertEquals(RestStatus.OK.getStatus(), client().admin().indices().prepareFlush("index").get().getStatus().getStatus());
+    }
+
+    private static XContentBuilder timeSeriesDocument(
+        final String fooDimValue,
+        final String barDimValue,
+        final String bazDimValue,
+        int docId,
+        final Supplier<Long> timestampSupplier
+    ) throws IOException {
+        final XContentBuilder docSource = XContentFactory.jsonBuilder();
+        docSource.startObject();
+        // NOTE: we assign dimensions in such a way that almost all of them have the same value but the last one.
+        // This way we are going to have just two time series (and two distinct tsid) and the last dimension identifies
+        // which time series the document belongs to.
+        for (int dimId = 0; dimId < numberOfDimensions - 1; dimId++) {
+            docSource.field("dim_" + formatDim(dimId), fooDimValue);
+        }
+        docSource.field("dim_" + formatDim(numberOfDimensions - 1), docId % 2 == 0 ? barDimValue : bazDimValue);
+        docSource.field("counter_metric", docId + 1);
+        docSource.field("gauge_metric", randomDoubleBetween(1000.0, 2000.0, true));
+        docSource.field("@timestamp", timestampSupplier.get());
+        docSource.endObject();
+
+        return docSource;
+    }
+
+    private CreateIndexResponse prepareTimeSeriesIndex(
+        final XContentBuilder mapping,
+        long startMillis,
+        long endMillis,
+        final String[] routingDimensions
+    ) {
+        return prepareCreate("index").setSettings(
+            Settings.builder()
+                .put("mode", "time_series")
+                .put("routing_path", String.join(",", routingDimensions))
+                .put("index.number_of_shards", randomIntBetween(1, 3))
+                .put("index.number_of_replicas", randomIntBetween(1, 3))
+                .put("time_series.start_time", startMillis)
+                .put("time_series.end_time", endMillis)
+                .put(MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING.getKey(), numberOfDimensions + 1)
+                .put(MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING.getKey(), 4192)
+                .build()
+        ).setMapping(mapping).get();
+    }
+
+    private static Iterator<Long> getTimestamps(long startMillis, long endMillis, int numberOfDocs) {
+        final Set<Long> timestamps = new TreeSet<>();
+        while (timestamps.size() < numberOfDocs) {
+            timestamps.add(randomLongBetween(startMillis, endMillis));
+        }
+        return timestamps.iterator();
+    }
+
+    private static XContentBuilder timeSeriesIndexMapping() throws IOException {
+        final XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject("properties");
+        for (int i = 0; i < numberOfDimensions; i++) {
+            builder.startObject("dim_" + formatDim(i));
+            builder.field("type", "keyword");
+            builder.field("time_series_dimension", true);
+            builder.endObject();
+        }
+        builder.startObject("counter_metric");
+        builder.field("type", "double");
+        builder.field("time_series_metric", "counter");
+        builder.endObject();
+        builder.startObject("gauge_metric");
+        builder.field("type", "double");
+        builder.field("time_series_metric", "gauge");
+        builder.endObject();
+        builder.endObject(); // properties
+        builder.endObject();
+        return builder;
+    }
+
+    private static String formatDim(int i) {
+        return String.format("%06d", i);
+    }
+
+    public void testTimeSeriesAggregation() {
+        final TimeSeriesAggregationBuilder timeSeries = new TimeSeriesAggregationBuilder("ts");
+        final SearchResponse aggregationResponse = client().prepareSearch("index").addAggregation(timeSeries).setSize(0).get();
+        final InternalTimeSeries ts = (InternalTimeSeries) aggregationResponse.getAggregations().asList().get(0);
+        assertTimeSeriesAggregation(ts);
+    }
+
+    public void testSumByTsid() {
+        final TimeSeriesAggregationBuilder timeSeries = new TimeSeriesAggregationBuilder("ts").subAggregation(
+            new SumAggregationBuilder("sum").field("gauge_metric")
+        );
+        final SearchResponse searchResponse = client().prepareSearch("index").setQuery(new MatchAllQueryBuilder()).get();
+        assertNotEquals(numberOfDocuments, searchResponse.getHits().getHits().length);
+        final SearchResponse aggregationResponse = client().prepareSearch("index").addAggregation(timeSeries).setSize(0).get();
+        final InternalTimeSeries ts = (InternalTimeSeries) aggregationResponse.getAggregations().asList().get(0);
+        assertTimeSeriesAggregation(ts);
+    }
+
+    public void testTermsByTsid() {
+        final TimeSeriesAggregationBuilder timeSeries = new TimeSeriesAggregationBuilder("ts").subAggregation(
+            new TermsAggregationBuilder("terms").field("dim_0")
+        );
+        final SearchResponse aggregationResponse = client().prepareSearch("index").addAggregation(timeSeries).setSize(0).get();
+        final InternalTimeSeries ts = (InternalTimeSeries) aggregationResponse.getAggregations().asList().get(0);
+        assertTimeSeriesAggregation(ts);
+    }
+
+    public void testDateHistogramByTsid() {
+        final TimeSeriesAggregationBuilder timeSeries = new TimeSeriesAggregationBuilder("ts").subAggregation(
+            new DateHistogramAggregationBuilder("date_histogram").field("@timestamp").calendarInterval(DateHistogramInterval.MINUTE)
+        );
+        final SearchResponse aggregationResponse = client().prepareSearch("index").addAggregation(timeSeries).setSize(0).get();
+        final InternalTimeSeries ts = (InternalTimeSeries) aggregationResponse.getAggregations().asList().get(0);
+        assertTimeSeriesAggregation(ts);
+    }
+
+    public void testCardinalityByTsid() {
+        final TimeSeriesAggregationBuilder timeSeries = new TimeSeriesAggregationBuilder("ts").subAggregation(
+            new CardinalityAggregationBuilder("dim_n_cardinality").field("dim_" + formatDim(numberOfDimensions - 1))
+        );
+        final SearchResponse aggregationResponse = client().prepareSearch("index").addAggregation(timeSeries).setSize(0).get();
+        final InternalTimeSeries ts = (InternalTimeSeries) aggregationResponse.getAggregations().asList().get(0);
+        assertTimeSeriesAggregation(ts);
+        ts.getBuckets().forEach(bucket -> {
+            assertCardinality(bucket.getAggregations().get("dim_n_cardinality"), 1);
+        });
+    }
+
+    private static void assertTimeSeriesAggregation(final InternalTimeSeries timeSeriesAggregation) {
+        final List<Map<String, Object>> dimensions = timeSeriesAggregation.getBuckets()
+            .stream()
+            .map(InternalTimeSeries.InternalBucket::getKey)
+            .toList();
+        // NOTE: only two time series expected as a result of having just two distinct values for the last dimension
+        assertEquals(2, dimensions.size());
+
+        final Map<String, Object> firstTimeSeries = dimensions.get(0);
+        final Map<String, Object> secondTimeSeries = dimensions.get(1);
+
+        assertTsid(firstTimeSeries);
+        assertTsid(secondTimeSeries);
+    }
+
+    private static void assertTsid(final Map<String, Object> timeSeries) {
+        timeSeries.entrySet().stream().sorted(Map.Entry.comparingByKey()).limit(numberOfDimensions - 2).forEach(entry -> {
+            assertThat(entry.getValue().toString(), Matchers.equalTo(FOO_DIM_VALUE));
+        });
+        timeSeries.entrySet().stream().sorted(Map.Entry.comparingByKey()).skip(numberOfDimensions - 1).forEach( entry -> {
+            assertThat(entry.getValue().toString(), Matchers.oneOf(BAR_DIM_VALUE, BAZ_DIM_VALUE));
+        });
+    }
+
+    private static void assertCardinality(final InternalCardinality cardinalityAggregation, int expectedCardinality) {
+        assertEquals(expectedCardinality, cardinalityAggregation.getValue());
+    }
+}

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesNestedAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesNestedAggregationsIT.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -148,8 +149,8 @@ public class TimeSeriesNestedAggregationsIT extends AggregationIntegTestCase {
         return builder;
     }
 
-    private static String formatDim(int i) {
-        return String.format("dim_%06d", i);
+    private static String formatDim(int dimId) {
+        return String.format(Locale.ROOT, "dim_%06d", dimId);
     }
 
     public void testTimeSeriesAggregation() {

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesNestedAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesNestedAggregationsIT.java
@@ -181,7 +181,7 @@ public class TimeSeriesNestedAggregationsIT extends AggregationIntegTestCase {
 
     public void testDateHistogramByTsid() {
         final TimeSeriesAggregationBuilder timeSeries = new TimeSeriesAggregationBuilder("ts").subAggregation(
-            new DateHistogramAggregationBuilder("date_histogram").field("@timestamp").calendarInterval(DateHistogramInterval.MINUTE)
+            new DateHistogramAggregationBuilder("date_histogram").field("@timestamp").calendarInterval(DateHistogramInterval.HOUR)
         );
         final SearchResponse aggregationResponse = client().prepareSearch("index").addAggregation(timeSeries).setSize(0).get();
         final InternalTimeSeries ts = (InternalTimeSeries) aggregationResponse.getAggregations().asList().get(0);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -72,7 +72,6 @@ public class AggregationPhase {
         searcher.setProfiler(context);
         try {
             searcher.search(context.rewrittenQuery(), collector);
-            collector.postCollection();
         } catch (IOException e) {
             throw new AggregationExecutionException("Could not perform time series aggregation", e);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
@@ -105,23 +105,16 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
     private class CompetitiveIterator extends DocIdSetIterator {
 
         private final BitArray visitedOrds;
-        private final SortedSetDocValues values;
         private long numNonVisitedOrds;
         private final TermsEnum indexTerms;
         private final DocIdSetIterator docsWithField;
 
-        CompetitiveIterator(
-            SortedSetDocValues values,
-            int numNonVisitedOrds,
-            BitArray visitedOrds,
-            Terms indexTerms,
-            DocIdSetIterator docsWithField
-        ) throws IOException {
+        CompetitiveIterator(int numNonVisitedOrds, BitArray visitedOrds, Terms indexTerms, DocIdSetIterator docsWithField)
+            throws IOException {
             this.visitedOrds = visitedOrds;
             this.numNonVisitedOrds = numNonVisitedOrds;
             this.indexTerms = Objects.requireNonNull(indexTerms).iterator();
             this.docsWithField = docsWithField;
-            this.values = values;
         }
 
         private Map<Long, PostingsEnum> nonVisitedOrds;
@@ -234,7 +227,7 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
                             }
                             this.bits = bits;
                             final DocIdSetIterator docsWithField = valuesSource.ordinalsValues(aggCtx.getLeafReaderContext());
-                            competitiveIterator = new CompetitiveIterator(docValues, numNonVisitedOrds, bits, indexTerms, docsWithField);
+                            competitiveIterator = new CompetitiveIterator(numNonVisitedOrds, bits, indexTerms, docsWithField);
                             if (numNonVisitedOrds <= MAX_TERMS_FOR_DYNAMIC_PRUNING) {
                                 competitiveIterator.startPruning();
                             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
@@ -211,7 +211,7 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
                 if (maxOrd <= MAX_FIELD_CARDINALITY_FOR_DYNAMIC_PRUNING || numNonVisitedOrds <= MAX_TERMS_FOR_DYNAMIC_PRUNING) {
                     dynamicPruningAttempts++;
                     return new LeafBucketCollector() {
-                        final SortedSetDocValues docValues = valuesSource.globalOrdinalsValues(aggCtx.getLeafReaderContext());
+                        final SortedSetDocValues docValues = values;
 
                         final BitArray bits;
                         final CompetitiveIterator competitiveIterator;
@@ -268,7 +268,7 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
 
         bruteForce++;
         return new LeafBucketCollector() {
-            final SortedSetDocValues docValues = valuesSource.globalOrdinalsValues(aggCtx.getLeafReaderContext());
+            final SortedSetDocValues docValues = values;
 
             @Override
             public void collect(int doc, long bucketOrd) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcher.java
@@ -95,11 +95,13 @@ public class TimeSeriesIndexSearcher {
         Weight weight = searcher.createWeight(query, bucketCollector.scoreMode(), 1);
         if (searcher.getExecutor() == null) {
             search(bucketCollector, weight);
+            bucketCollector.postCollection();
             return;
         }
         // offload to the search worker thread pool whenever possible. It will be null only when search.worker_threads_enabled is false
         RunnableFuture<Void> task = new FutureTask<>(() -> {
             search(bucketCollector, weight);
+            bucketCollector.postCollection();
             return null;
         });
         searcher.getExecutor().execute(task);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -586,8 +586,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     } else {
                         Weight weight = subSearcher.createWeight(rewritten, ScoreMode.COMPLETE, 1f);
                         subSearcher.search(weight, a.asCollector());
+                        a.postCollection();
                     }
-                    a.postCollection();
                     assertEquals(shouldBeCached, context.isCacheable());
                     internalAggs.add(a.buildTopLevel());
                 } finally {
@@ -612,7 +612,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     root.preCollection();
                     aggregators.add(root);
                     new TimeSeriesIndexSearcher(searcher, List.of()).search(rewritten, MultiBucketCollector.wrap(true, List.of(root)));
-                    root.postCollection();
                 } else {
                     CollectorManager<Collector, Void> collectorManager = new CollectorManager<>() {
                         @Override

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -587,6 +587,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
                         Weight weight = subSearcher.createWeight(rewritten, ScoreMode.COMPLETE, 1f);
                         subSearcher.search(weight, a.asCollector());
                     }
+                    a.postCollection();
                     assertEquals(shouldBeCached, context.isCacheable());
                     internalAggs.add(a.buildTopLevel());
                 } finally {
@@ -611,6 +612,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     root.preCollection();
                     aggregators.add(root);
                     new TimeSeriesIndexSearcher(searcher, List.of()).search(rewritten, MultiBucketCollector.wrap(true, List.of(root)));
+                    root.postCollection();
                 } else {
                     CollectorManager<Collector, Void> collectorManager = new CollectorManager<>() {
                         @Override

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -587,7 +587,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
                         Weight weight = subSearcher.createWeight(rewritten, ScoreMode.COMPLETE, 1f);
                         subSearcher.search(weight, a.asCollector());
                     }
-                    a.postCollection();
                     assertEquals(shouldBeCached, context.isCacheable());
                     internalAggs.add(a.buildTopLevel());
                 } finally {
@@ -612,7 +611,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     root.preCollection();
                     aggregators.add(root);
                     new TimeSeriesIndexSearcher(searcher, List.of()).search(rewritten, MultiBucketCollector.wrap(true, List.of(root)));
-                    root.postCollection();
                 } else {
                     CollectorManager<Collector, Void> collectorManager = new CollectorManager<>() {
                         @Override

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -157,7 +157,6 @@ class DownsampleShardIndexer {
             TimeSeriesBucketCollector bucketCollector = new TimeSeriesBucketCollector(bulkProcessor);
             bucketCollector.preCollection();
             timeSeriesSearcher.search(initialStateQuery, bucketCollector);
-            bucketCollector.postCollection();
         }
 
         logger.info(


### PR DESCRIPTION
When trying to run a cardinality aggregation nested inside a 
time series aggregation test called `testCardinalityByTsid`
(sometimes) fails with the following stack **traces** (plural here
is not a mistake, the test appears to fail with different issues).
It looks like something is wrong when accessing dimension fields
doc values.

My idea is that something is wrong with ordinals but can't figure out
if that is the case.

Usually I see one of the following two assertions failing:

```
assert target >= in.docID();
assert target < maxDoc;
```

which means in `GlobalOrdCardinalityAggregator` we try
to fetch incorrect target document when calling `advanceExact`

```
if (values.advanceExact(doc)) {
    for (long ord = values.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = values.nextOrd()) {
        bits.set((int) ord);
    }
}
```

Note also that this branch is exercised only if the cardinality aggregation is
not a top level aggregation. I tried to reproduce the issue with the cardinality
aggregation nested inside a terms aggregation but didn't see any issue.
For this reason I believe something might be wrong when using parent (time
series aggregator) ordinals.

Also worth noting is that sometimes the test fails with other issues. I executed the
test a certain number of times to see it failing. Usually it takes less than 10 executions
to see a failure.

```
ago 29, 2023 12:11:31 PM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_s3][search_worker][T#3],5,TGRP-TimeSeriesNestedAggregationsIT]
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([E92F1D22512328AC]:0)
	at org.apache.lucene.tests.index.AssertingLeafReader$AssertingSortedDocValues.advanceExact(AssertingLeafReader.java:881)
	at org.apache.lucene.index.SingletonSortedSetDocValues.advanceExact(SingletonSortedSetDocValues.java:85)
	at org.elasticsearch.search.aggregations.metrics.GlobalOrdCardinalityAggregator$2.collect(GlobalOrdCardinalityAggregator.java:278)
	at org.elasticsearch.search.aggregations.bucket.BucketsAggregator.collectExistingBucket(BucketsAggregator.java:96)
	at org.elasticsearch.aggregations.bucket.timeseries.TimeSeriesAggregator$1.collect(TimeSeriesAggregator.java:121)
	at org.elasticsearch.search.aggregations.LeafBucketCollector.collect(LeafBucketCollector.java:86)
	at org.elasticsearch.search.aggregations.support.TimeSeriesIndexSearcher$LeafWalker.collectCurrent(TimeSeriesIndexSearcher.java:262)
	at org.elasticsearch.search.aggregations.support.TimeSeriesIndexSearcher.search(TimeSeriesIndexSearcher.java:167)
	at org.elasticsearch.search.aggregations.support.TimeSeriesIndexSearcher.lambda$search$0(TimeSeriesIndexSearcher.java:102)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

This is another different stack trace

```
août 29, 2023 11:20:38 AM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_s0][search][T#2],5,TGRP-TimeSeriesNestedAggregationsIT]
java.lang.AssertionError: Sorted doc values are only supposed to be consumed in the thread in which they have been acquired. But was acquired in Thread[elasticsearch[node_s0][search_worker][T#1],5,TGRP-TimeSeriesNestedAggregationsIT] and consumed in Thread[elasticsearch[node_s0][search][T#2],5,TGRP-TimeSeriesNestedAggregationsIT].
	at __randomizedtesting.SeedInfo.seed([B0787CC8BC021E74]:0)
	at org.apache.lucene.tests.index.AssertingLeafReader.assertThread(AssertingLeafReader.java:67)
	at org.apache.lucene.tests.index.AssertingLeafReader$AssertingSortedDocValues.lookupOrd(AssertingLeafReader.java:908)
	at org.apache.lucene.index.SingletonSortedSetDocValues.lookupOrd(SingletonSortedSetDocValues.java:95)
	at org.elasticsearch.search.aggregations.metrics.GlobalOrdCardinalityAggregator.doPostCollection(GlobalOrdCardinalityAggregator.java:302)
	at org.elasticsearch.search.aggregations.AggregatorBase.postCollection(AggregatorBase.java:294)
	at org.elasticsearch.search.aggregations.MultiBucketCollector$1.postCollection(MultiBucketCollector.java:86)
	at org.elasticsearch.search.aggregations.AggregatorBase.postCollection(AggregatorBase.java:295)
	at org.elasticsearch.search.aggregations.MultiBucketCollector$1.postCollection(MultiBucketCollector.java:86)
	at org.elasticsearch.search.aggregations.AggregationPhase.executeInSortOrder(AggregationPhase.java:75)
	at org.elasticsearch.search.aggregations.AggregationPhase.preProcess(AggregationPhase.java:36)
	at org.elasticsearch.search.query.QueryPhase.executeQuery(QueryPhase.java:132)
	at org.elasticsearch.search.query.QueryPhase.execute(QueryPhase.java:63)
	at org.elasticsearch.search.SearchService.loadOrExecuteQueryPhase(SearchService.java:515)
	at org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:667)
	at org.elasticsearch.search.SearchService.lambda$executeQueryPhase$2(SearchService.java:540)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:51)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:48)
	at org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:73)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```