### PR TITLE
[8.10] Fix testDeleteByQueryOnReadOnlyAllowDeleteIndex (#99002)

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryBasicTests.java
@@ -244,6 +244,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             if (diskAllocationDeciderEnabled == false) {
                 // Disable the disk allocation decider to ensure the read_only_allow_delete block cannot be released
                 setDiskAllocationDeciderEnabled(false);
+                refreshClusterInfo(); // ensures the logic for removing blocks upon disabling the decider is executed once
             }
             // When a read_only_allow_delete block is set on the index,
             // it will trigger a retry policy in the delete by query request because the rest status of the block is 429


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix testDeleteByQueryOnReadOnlyAllowDeleteIndex (#99002)