### PR TITLE
[8.10] [DOC+] Write threadpool also covers ingest pipelines (#99010)

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -42,7 +42,7 @@ There are several thread pools, but the important ones include:
     size of `16`.
 
 `write`::
-    For single-document index/delete/update and bulk requests. Thread pool type
+    For single-document index/delete/update, ingest processors, and bulk requests. Thread pool type
     is `fixed` with a size of <<node.processors, `# of allocated processors`>>,
     queue_size of `10000`. The maximum size for this pool is
     `pass:[1 + ]`<<node.processors, `# of allocated processors`>>.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[DOC+] Write threadpool also covers ingest pipelines (#99010)](https://github.com/elastic/elasticsearch/pull/99010)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)