### PR TITLE
[8.10] [DOC+][Hot Spotting] Pull detailed Node Tasks (#98879)

### DIFF
--- a/docs/reference/troubleshooting/common-issues/hotspotting.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/hotspotting.asciidoc
@@ -259,8 +259,14 @@ direct indices:data/read/eql 10m           node_1  true
 // TEST[skip:illustrative response only]
 
 This surfaces a problematic <<eql-search-api,EQL query>>. We can gain 
-further insight on it via <<tasks,the task management API>>. Its response 
-contains a `description` that reports this query:
+further insight on it via <<tasks,the task management API>>,
+
+[source,console]
+----
+GET _tasks?human&detailed
+----
+
+Its response contains a `description` that reports this query:
 
 [source,eql]
 ----


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[DOC+][Hot Spotting] Pull detailed Node Tasks (#98879)](https://github.com/elastic/elasticsearch/pull/98879)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)