### PR TITLE
Add machine-readable list of currently active branches/versions

### DIFF
--- a/branches.json
+++ b/branches.json
@@ -1,20 +1,16 @@
 {
   "notice": "This file is not maintained outside of the main branch and should only be used for tooling.",
-  "versions": [
+  "branches": [
     {
-      "version": "8.11.0",
       "branch": "main"
     },
     {
-      "version": "8.10.0",
       "branch": "8.10"
     },
     {
-      "version": "8.9.2",
       "branch": "8.9"
     },
     {
-      "version": "7.17.13",
       "branch": "7.17"
     }
   ]

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,21 @@
+{
+  "notice": "This file is not maintained outside of the main branch and should only be used for tooling.",
+  "versions": [
+    {
+      "version": "8.11.0",
+      "branch": "main"
+    },
+    {
+      "version": "8.10.0",
+      "branch": "8.10"
+    },
+    {
+      "version": "8.9.2",
+      "branch": "8.9"
+    },
+    {
+      "version": "7.17.13",
+      "branch": "7.17"
+    }
+  ]
+}


### PR DESCRIPTION
With the migration to Buildkite, we don't have anything that can drive automation related to currently active branches. For example, if we need to kick off a daily job that runs tests against all active branches, how do we determine the branches?

Right now, this is done using a hard-coded list in each separate repo/location that has automation around branches. For example, [see here](https://github.com/elastic/elasticsearch-sql-odbc/blob/main/.buildkite/branches.sh)

If we maintain this file during version bumps, we can simply use it to drive automation everywhere.

This is the same as the versions file I [created for kibana](https://github.com/elastic/kibana/blob/main/versions.json), with the fields we don't need removed.

I'm open to other locations in the repo, it doesn't matter from a consumption standpoint.

I chose JSON because it's easily consumed pretty much everywhere.

Later, I believe we can automatically generate this file.