### PR TITLE
Deprecate executor-name-based scheduling

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -20,6 +20,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.threadpool.ScheduledExecutorServiceScheduler;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
@@ -221,9 +222,7 @@ public class BulkProcessor implements Closeable {
     }
 
     private static Scheduler buildScheduler(ScheduledThreadPoolExecutor scheduledThreadPoolExecutor) {
-        return (command, delay, executor) -> Scheduler.wrapAsScheduledCancellable(
-            scheduledThreadPoolExecutor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS)
-        );
+        return new ScheduledExecutorServiceScheduler(scheduledThreadPoolExecutor);
     }
 
     private final int bulkActions;

--- a/server/src/main/java/org/elasticsearch/threadpool/ScheduledExecutorServiceScheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ScheduledExecutorServiceScheduler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.core.TimeValue;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link Scheduler} which wraps a {@link ScheduledExecutorService}. It ignores the supplied {@code executor} or {@code executorName} and
+ * instead uses the inner executor to execute the delayed commands.
+ */
+public final class ScheduledExecutorServiceScheduler implements Scheduler {
+    private final ScheduledExecutorService executor;
+
+    public ScheduledExecutorServiceScheduler(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
+    private ScheduledCancellable schedule(Runnable command, TimeValue delay) {
+        return Scheduler.wrapAsScheduledCancellable(executor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+        return schedule(command, delay);
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executorName) {
+        return schedule(command, delay);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -454,6 +454,16 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     }
 
     /**
+     * @deprecated Use {@link #schedule(Runnable, TimeValue, Executor)} instead.
+     */
+    @Override
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true)
+    public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
+        return schedule(command, delay, executor(executor));
+    }
+
+    /**
      * Schedules a one-shot command to run after a given delay. The command is run in the context of the calling thread.
      *
      * @param command the command to run
@@ -467,11 +477,11 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
      * @throws org.elasticsearch.common.util.concurrent.EsRejectedExecutionException if the task cannot be scheduled for execution
      */
     @Override
-    public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
+    public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
         final Runnable contextPreservingRunnable = threadContext.preserveContext(command);
         final Runnable toSchedule;
-        if (Names.SAME.equals(executor) == false) {
-            toSchedule = new ThreadedRunnable(contextPreservingRunnable, executor(executor));
+        if (executor != EsExecutors.DIRECT_EXECUTOR_SERVICE) {
+            toSchedule = new ThreadedRunnable(contextPreservingRunnable, executor);
         } else if (slowSchedulerWarnThresholdNanos > 0) {
             toSchedule = new Runnable() {
                 @Override
@@ -503,7 +513,16 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         return new ScheduledCancellableAdapter(scheduler.schedule(toSchedule, delay.millis(), TimeUnit.MILLISECONDS));
     }
 
+    /**
+     * @deprecated Use {@link #scheduleUnlessShuttingDown(TimeValue, Executor, Runnable)} instead.
+     */
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true)
     public void scheduleUnlessShuttingDown(TimeValue delay, String executor, Runnable command) {
+        scheduleUnlessShuttingDown(delay, executor(executor), command);
+    }
+
+    public void scheduleUnlessShuttingDown(TimeValue delay, Executor executor, Runnable command) {
         try {
             schedule(command, delay, executor);
         } catch (EsRejectedExecutionException e) {
@@ -523,8 +542,17 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         }
     }
 
+    /**
+     * @deprecated Use {@link #scheduleWithFixedDelay(Runnable, TimeValue, Executor)} instead.
+     */
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true)
     @Override
     public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
+        return scheduleWithFixedDelay(command, interval, executor(executor));
+    }
+
+    public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, Executor executor) {
         var runnable = new ReschedulingRunnable(command, interval, executor, this, (e) -> {
             if (logger.isDebugEnabled()) {
                 logger.debug(() -> format("scheduled task [%s] was rejected on thread pool [%s]", command, executor), e);

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ScheduledExecutorServiceScheduler;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -39,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -225,7 +227,7 @@ public class BulkProcessorTests extends ESTestCase {
                 maxBatchSize,
                 ByteSizeValue.ofBytes(Integer.MAX_VALUE),
                 null,
-                (command, delay, executor) -> null,
+                UnusedScheduler.INSTANCE,
                 () -> called.set(true),
                 BulkRequest::new
             )
@@ -344,9 +346,7 @@ public class BulkProcessorTests extends ESTestCase {
                 maxBatchSize,
                 ByteSizeValue.ofBytes(Integer.MAX_VALUE),
                 TimeValue.timeValueMillis(simulateWorkTimeInMillis * 2),
-                (command, delay, executor) -> Scheduler.wrapAsScheduledCancellable(
-                    flushExecutor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS)
-                ),
+                new ScheduledExecutorServiceScheduler(flushExecutor),
                 () -> {
                     flushExecutor.shutdown();
                     try {
@@ -447,7 +447,7 @@ public class BulkProcessorTests extends ESTestCase {
             10,
             ByteSizeValue.ofBytes(1000),
             null,
-            (command, delay, executor) -> null,
+            UnusedScheduler.INSTANCE,
             () -> called.set(true),
             BulkRequest::new
         );
@@ -545,5 +545,20 @@ public class BulkProcessorTests extends ESTestCase {
 
     private DocWriteResponse mockResponse() {
         return new IndexResponse(new ShardId("index", "uid", 0), "id", 1, 1, 1, true);
+    }
+
+    private static class UnusedScheduler implements Scheduler {
+        static UnusedScheduler INSTANCE = new UnusedScheduler();
+
+        @Override
+        public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+            throw new AssertionError("should not be called");
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executorName) {
+            throw new AssertionError("should not be called");
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
@@ -213,7 +213,7 @@ public class TransportVersionsFixupListenerTests extends ESTestCase {
         verify(client, times(1)).nodesInfo(any(), action.capture());
         // do response immediately
         action.getValue().onFailure(new RuntimeException("failure"));
-        verify(scheduler).schedule(retry.capture(), any(), any());
+        verify(scheduler).schedule(retry.capture(), any(), anyString());
 
         // running retry should cause another check
         retry.getValue().run();

--- a/server/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -79,7 +80,7 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
             (e) -> {}
         );
         // not scheduled yet
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(), any(), anyString());
 
         reschedulingRunnable.start();
         // this call was made by start

--- a/server/src/test/java/org/elasticsearch/transport/TransportKeepAliveTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportKeepAliveTests.java
@@ -21,6 +21,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -190,7 +191,16 @@ public class TransportKeepAliveTests extends ESTestCase {
         }
 
         @Override
+        public ScheduledCancellable schedule(Runnable task, TimeValue delay, Executor executor) {
+            return doSchedule(task, delay);
+        }
+
+        @Override
         public ScheduledCancellable schedule(Runnable task, TimeValue delay, String executor) {
+            return doSchedule(task, delay);
+        }
+
+        private ScheduledCancellable doSchedule(Runnable task, TimeValue delay) {
             scheduledTasks.add(new Tuple<>(delay, task));
             return null;
         }

--- a/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Delayed;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -354,7 +355,7 @@ public class DeterministicTaskQueue {
             }
 
             @Override
-            public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
                 final int NOT_STARTED = 0;
                 final int STARTED = 1;
                 final int CANCELLED = 2;
@@ -397,11 +398,6 @@ public class DeterministicTaskQueue {
                     }
 
                 };
-            }
-
-            @Override
-            public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
-                return super.scheduleWithFixedDelay(command, interval, executor);
             }
 
             @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -57,7 +58,7 @@ public class MlInitializationServiceTests extends ESTestCase {
         when(threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME)).thenReturn(executorService);
 
         Scheduler.ScheduledCancellable scheduledCancellable = mock(Scheduler.ScheduledCancellable.class);
-        when(threadPool.schedule(any(), any(), any())).thenReturn(scheduledCancellable);
+        when(threadPool.schedule(any(), any(), anyString())).thenReturn(scheduledCancellable);
 
         when(clusterService.getClusterName()).thenReturn(CLUSTER_NAME);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunnerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunnerTests.java
@@ -167,7 +167,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         datafeedRunner.run(task, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(), any(), anyString());
         verify(auditor).warning(JOB_ID, "Datafeed lookback retrieved no data");
     }
 
@@ -178,7 +178,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         datafeedRunner.run(task, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(), any(), anyString());
     }
 
     public void testStart_extractionProblem() throws Exception {
@@ -188,7 +188,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         datafeedRunner.run(task, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
-        verify(threadPool, never()).schedule(any(), any(), any());
+        verify(threadPool, never()).schedule(any(), any(), anyString());
         verify(auditor, times(1)).error(eq(JOB_ID), anyString());
     }
 
@@ -202,7 +202,7 @@ public class DatafeedRunnerTests extends ESTestCase {
                 r.run();
             }
             return mock(Scheduler.ScheduledCancellable.class);
-        }).when(threadPool).schedule(any(), any(), any());
+        }).when(threadPool).schedule(any(), any(), anyString());
 
         when(datafeedJob.runLookBack(anyLong(), anyLong())).thenThrow(new DatafeedJob.EmptyDataCountException(0L, false));
         when(datafeedJob.runRealtime()).thenThrow(new DatafeedJob.EmptyDataCountException(0L, false));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/ThreadSettingsControlMessagePytorchActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/ThreadSettingsControlMessagePytorchActionTests.java
@@ -60,7 +60,7 @@ public class ThreadSettingsControlMessagePytorchActionTests extends ESTestCase {
 
         Scheduler.ScheduledCancellable cancellable = mock(Scheduler.ScheduledCancellable.class);
         ThreadPool tp = mock(ThreadPool.class);
-        when(tp.schedule(any(), any(), any())).thenReturn(cancellable);
+        when(tp.schedule(any(), any(), anyString())).thenReturn(cancellable);
 
         {
             ActionListener<ThreadSettings> listener = mock(ActionListener.class);
@@ -116,7 +116,7 @@ public class ThreadSettingsControlMessagePytorchActionTests extends ESTestCase {
 
         Scheduler.ScheduledCancellable cancellable = mock(Scheduler.ScheduledCancellable.class);
         ThreadPool tp = mock(ThreadPool.class);
-        when(tp.schedule(any(), any(), any())).thenReturn(cancellable);
+        when(tp.schedule(any(), any(), anyString())).thenReturn(cancellable);
 
         ActionListener<ThreadSettings> listener = mock(ActionListener.class);
         ArgumentCaptor<BytesReference> messageCapture = ArgumentCaptor.forClass(BytesReference.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -306,7 +306,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         }
 
         ThreadPool.Cancellable cancellable = mock(ThreadPool.Cancellable.class);
-        when(threadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(cancellable);
+        when(threadPool.scheduleWithFixedDelay(any(), any(), anyString())).thenReturn(cancellable);
 
         AutodetectProcess autodetectProcess = mock(AutodetectProcess.class);
         when(autodetectProcess.isProcessAlive()).thenReturn(true);
@@ -740,7 +740,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         ExecutorService executorService = mock(ExecutorService.class);
         doThrow(new EsRejectedExecutionException("")).when(executorService).submit(any(Runnable.class));
         when(threadPool.executor(anyString())).thenReturn(executorService);
-        when(threadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(mock(ThreadPool.Cancellable.class));
+        when(threadPool.scheduleWithFixedDelay(any(), any(), anyString())).thenReturn(mock(ThreadPool.Cancellable.class));
         Job job = createJobDetails("my_id");
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -812,7 +812,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
     private AutodetectProcessManager createNonSpyManager(String jobId) {
         ExecutorService executorService = mock(ExecutorService.class);
         when(threadPool.executor(anyString())).thenReturn(executorService);
-        when(threadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(mock(ThreadPool.Cancellable.class));
+        when(threadPool.scheduleWithFixedDelay(any(), any(), anyString())).thenReturn(mock(ThreadPool.Cancellable.class));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];


### PR DESCRIPTION
Today `ThreadPool#schedule` and various related APIs require the name of
an executor within the threadpool, which means that callers can only use
one of the pooled executors and cannot provide their own. There's no
good reason for avoiding unpooled executors in this situation, so this
commit introduces more general APIs that accept any old `Executor`
instead. It also deprecates the name-based APIs and marks them for
removal, but leaves the migration to using the new APIs to be completed
in later commits.

Relates #97873, #97879