### PR TITLE
[Search Relevance] GET search application API should return the alias indices

### DIFF
--- a/docs/reference/search-application/apis/get-search-application.asciidoc
+++ b/docs/reference/search-application/apis/get-search-application.asciidoc
@@ -95,6 +95,7 @@ A sample response:
 ----
 {
   "name": "my-app",
+  "indices": [ "index1", "index2" ],
   "updated_at_millis": 1682105622204,
   "template": {
     "script": {

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -182,6 +182,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_066 = registerTransportVersion(8_500_066, "F398ECC6-5D2A-4BD8-A9E8-1101F030DF85");
     public static final TransportVersion V_8_500_067 = registerTransportVersion(8_500_067, "a7c86604-a917-4aff-9a1b-a4d44c3dbe02");
     public static final TransportVersion V_8_500_068 = registerTransportVersion(8_500_068, "2683c8b4-5372-4a6a-bb3a-d61aa679089a");
+    public static final TransportVersion V_8_500_069 = registerTransportVersion(8_500_069, "5b804027-d8a0-421b-9970-1f53d766854b");
 
     /*
      * STOP! READ THIS FIRST! No, really,
@@ -205,7 +206,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
      */
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_068);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_069);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -125,6 +125,7 @@ teardown:
   - do:
       search_application.get:
         name: test-search-application
+  - match: { indices: [ "test-index1", "test-index2" ] }
   - match:
       template:
         script:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -64,6 +64,7 @@ teardown:
         name: test-search-application-1
 
   - match: { name: "test-search-application-1" }
+  - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
   - match: {
     template: {
@@ -101,6 +102,7 @@ teardown:
         name: test-search-application-2
 
   - match: { name: "test-search-application-2" }
+  - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
   - match: {
     template: {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -111,6 +111,9 @@ if (in.getTransportVersion().onOrAfter(INDICES_REMOVED_TRANSPORT_VERSION) {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
+if (out.getTransportVersion().before(INDICES_REMOVED_TRANSPORT_VERSION) {
+        out.writeStringArray(indices); // old behaviour. New behaviour does not serialize indices, so no need to do anything else
+}
         out.writeOptionalString(analyticsCollectionName);
         out.writeLong(updatedAtMillis);
         out.writeOptionalWriteable(searchApplicationTemplate);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -93,10 +93,7 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
     public SearchApplication(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.indices = null;
-        this.analyticsCollectionName = in.readOptionalString();
-        this.updatedAtMillis = in.readLong();
-        this.searchApplicationTemplate = in.readOptionalWriteable(SearchApplicationTemplate::new);
+        this(in, null);
     }
 
     public SearchApplication(StreamInput in, String[] indices) throws IOException {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -98,7 +98,11 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
     public SearchApplication(StreamInput in, String[] indices) throws IOException {
         this.name = in.readString();
-        this.indices = indices;
+if (in.getTransportVersion().onOrAfter(INDICES_REMOVED_TRANSPORT_VERSION) {
+        this.indices = indices; // Uses the provided indices, as they are no longer serialized
+} else {
+        this.indices = in.readStringArray(); // old behaviour, read it from input as it was serialized
+}
         this.analyticsCollectionName = in.readOptionalString();
         this.updatedAtMillis = in.readLong();
         this.searchApplicationTemplate = in.readOptionalWriteable(SearchApplicationTemplate::new);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -52,7 +52,10 @@ public class SearchApplication implements Writeable, ToXContentObject {
     public static final String NO_TEMPLATE_STORED_WARNING = "Using default search application template which is subject to change. "
         + "We recommend storing a template to avoid breaking changes.";
 
+    public static final String NO_ALIAS_WARNING = "Alias is missing for the search application";
     private final String name;
+
+    @Nullable
     private final String[] indices;
     private final long updatedAtMillis;
     private final String analyticsCollectionName;
@@ -90,7 +93,15 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
     public SearchApplication(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.indices = in.readStringArray();
+        this.indices = null;
+        this.analyticsCollectionName = in.readOptionalString();
+        this.updatedAtMillis = in.readLong();
+        this.searchApplicationTemplate = in.readOptionalWriteable(SearchApplicationTemplate::new);
+    }
+
+    public SearchApplication(StreamInput in, String[] indices) throws IOException {
+        this.name = in.readString();
+        this.indices = indices;
         this.analyticsCollectionName = in.readOptionalString();
         this.updatedAtMillis = in.readLong();
         this.searchApplicationTemplate = in.readOptionalWriteable(SearchApplicationTemplate::new);
@@ -99,7 +110,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeStringArray(indices);
         out.writeOptionalString(analyticsCollectionName);
         out.writeLong(updatedAtMillis);
         out.writeOptionalWriteable(searchApplicationTemplate);
@@ -182,7 +192,11 @@ public class SearchApplication implements Writeable, ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+
         builder.field(NAME_FIELD.getPreferredName(), name);
+        if (indices != null) {
+            builder.field(INDICES_FIELD.getPreferredName(), indices);
+        }
         if (analyticsCollectionName != null) {
             builder.field(ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), analyticsCollectionName);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -201,9 +201,18 @@ public class SearchApplicationIndexService {
                 return;
             }
             final BytesReference source = getResponse.getSourceInternal();
-            final SearchApplication res = parseSearchApplicationBinaryFromSource(source);
-            l.onResponse(res);
+            SearchApplication searchApplication = parseSearchApplicationBinaryFromSource(source, getAliasIndices(resourceName));
+            l.onResponse(searchApplication);
         }));
+    }
+
+    private String[] getAliasIndices(String searchApplicationName) {
+        return clusterService.state()
+            .metadata()
+            .aliasedIndices(searchApplicationName)
+            .stream()
+            .map(index -> index.getName())
+            .toArray(String[]::new);
     }
 
     private static String getSearchAliasName(SearchApplication app) {
@@ -421,7 +430,7 @@ public class SearchApplicationIndexService {
         );
     }
 
-    private SearchApplication parseSearchApplicationBinaryFromSource(BytesReference source) {
+    private SearchApplication parseSearchApplicationBinaryFromSource(BytesReference source, String[] indices) {
         try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, XContentType.JSON)) {
             ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser);
             while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -442,7 +451,7 @@ public class SearchApplicationIndexService {
                     try (
                         StreamInput in = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(encodedIn), namedWriteableRegistry)
                     ) {
-                        return parseSearchApplicationBinaryWithVersion(in);
+                        return parseSearchApplicationBinaryWithVersion(in, indices);
                     }
                 } else {
                     XContentParserUtils.parseFieldsValue(parser); // consume and discard unknown fields
@@ -456,11 +465,11 @@ public class SearchApplicationIndexService {
         }
     }
 
-    static SearchApplication parseSearchApplicationBinaryWithVersion(StreamInput in) throws IOException {
+    static SearchApplication parseSearchApplicationBinaryWithVersion(StreamInput in, String[] indices) throws IOException {
         TransportVersion version = TransportVersion.readVersion(in);
         assert version.onOrBefore(TransportVersion.current()) : version + " >= " + TransportVersion.current();
         in.setTransportVersion(version);
-        return new SearchApplication(in);
+        return new SearchApplication(in, indices);
     }
 
     static void writeSearchApplicationBinaryWithVersion(SearchApplication app, OutputStream os, TransportVersion minTransportVersion)

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
@@ -50,6 +50,9 @@ public class TransportGetSearchApplicationAction extends HandledTransportAction<
             if (searchApplication.hasStoredTemplate() == false) {
                 HeaderWarning.addWarning(SearchApplication.NO_TEMPLATE_STORED_WARNING);
             }
+            if (searchApplication.indices() == null || searchApplication.indices().length == 0) {
+                HeaderWarning.addWarning(SearchApplication.NO_ALIAS_WARNING);
+            }
             // Construct a new object to ensure we backfill the stored application with the default template
             return new GetSearchApplicationAction.Response(
                 searchApplication.name(),

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTests.java
@@ -148,7 +148,7 @@ public class SearchApplicationTests extends ESTestCase {
                     namedWriteableRegistry
                 )
             ) {
-                deserializedInstance = SearchApplicationIndexService.parseSearchApplicationBinaryWithVersion(in);
+                deserializedInstance = SearchApplicationIndexService.parseSearchApplicationBinaryWithVersion(in, testInstance.indices());
             }
         }
         assertNotSame(testInstance, deserializedInstance);


### PR DESCRIPTION
We've made a change to not store indices in the search app system index anymore. As a result, the `indices` field is no longer included in the responses from the GET search application and list search applications APIs. In this PR, we modify the GET search application API so that it still includes the `indices` field, representing the indices associated with the alias corresponding to the search app.

https://github.com/elastic/elasticsearch/assets/132922331/39eeae29-210d-4b9a-84bd-7dd745bb7e60


