### PR TITLE
QL: Add utility for combining QueryBuilders

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
@@ -61,7 +61,7 @@ public class BoxedQueryRequest implements QueryRequest {
         timestampField = timestamp;
         keys = keyNames;
         this.optionalKeyNames = optionalKeyNames;
-        RuntimeUtils.addFilter(timestampRange, searchSource);
+        RuntimeUtils.combineFilters(searchSource, timestampRange);
     }
 
     @Override
@@ -181,7 +181,7 @@ public class BoxedQueryRequest implements QueryRequest {
             }
         }
 
-        RuntimeUtils.replaceFilter(keyFilters, newFilters, searchSource);
+        RuntimeUtils.replaceFilter(searchSource, keyFilters, newFilters);
         keyFilters = newFilters;
         return this;
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/SampleQueryRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/SampleQueryRequest.java
@@ -128,7 +128,7 @@ public class SampleQueryRequest implements QueryRequest {
             }
         }
 
-        RuntimeUtils.replaceFilter(multipleKeyFilters, newFilters, searchSource);
+        RuntimeUtils.replaceFilter(searchSource, multipleKeyFilters, newFilters);
         multipleKeyFilters = newFilters;
     }
 
@@ -158,7 +158,7 @@ public class SampleQueryRequest implements QueryRequest {
         }
 
         SearchSourceBuilder newSource = copySource(searchSource);
-        RuntimeUtils.replaceFilter(singleKeyPairFilters, newFilters, newSource);
+        RuntimeUtils.replaceFilter(newSource, singleKeyPairFilters, newFilters);
         // ask for the minimum needed to get at least N samplese per key
         int minResultsNeeded = maxStages + maxSamplesPerKey - 1;
         newSource.size(minResultsNeeded)

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -106,7 +106,7 @@ public class PITAwareQueryClient extends BasicQueryClient {
         if (CollectionUtils.isEmpty(indices) == false) {
             request.indices(Strings.EMPTY_ARRAY);
             QueryBuilder indexQuery = indices.length == 1 ? termQuery(GetResult._INDEX, indices[0]) : termsQuery(GetResult._INDEX, indices);
-            RuntimeUtils.addFilter(indexQuery, source);
+            RuntimeUtils.combineFilters(source, indexQuery);
         }
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -191,7 +191,9 @@ public final class RuntimeUtils {
      * additionally checks whether the given query exists for safe decoration
      */
     public static SearchSourceBuilder combineFilters(SearchSourceBuilder source, QueryBuilder filter) {
-        return source.query(Queries.combine(FILTER, List.of(source.query(), filter)));
+        var query = Queries.combine(FILTER, Arrays.asList(source.query(), filter));
+        query = query == null ? boolQuery() : query;
+        return source.query(query);
     }
 
     public static SearchSourceBuilder replaceFilter(
@@ -201,7 +203,11 @@ public final class RuntimeUtils {
     ) {
         var query = source.query();
         query = removeFilters(query, oldFilters);
-        query = Queries.combine(FILTER, org.elasticsearch.xpack.ql.util.CollectionUtils.combine(newFilters, query));
+        query = Queries.combine(
+            FILTER,
+            org.elasticsearch.xpack.ql.util.CollectionUtils.combine(Collections.singletonList(query), newFilters)
+        );
+        query = query == null ? boolQuery() : query;
         return source.query(query);
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.ql.expression.gen.pipeline.HitExtractorInput;
 import org.elasticsearch.xpack.ql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.ql.expression.gen.pipeline.ReferenceInput;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
+import org.elasticsearch.xpack.ql.util.Queries;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,6 +48,7 @@ import java.util.Set;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.xpack.ql.execution.search.extractor.AbstractFieldHitExtractor.MultiValueSupport.FULL;
+import static org.elasticsearch.xpack.ql.util.Queries.Clause.FILTER;
 
 public final class RuntimeUtils {
 
@@ -184,62 +186,23 @@ public final class RuntimeUtils {
         return Arrays.asList(response.getHits().getHits());
     }
 
-    // optimized method that adds filter to existing bool queries without additional wrapping
-    // additionally checks whether the given query exists for safe decoration
-    public static SearchSourceBuilder addFilter(QueryBuilder filter, SearchSourceBuilder source) {
-        BoolQueryBuilder bool = null;
-        QueryBuilder query = source.query();
-
-        if (query instanceof BoolQueryBuilder boolQueryBuilder) {
-            bool = boolQueryBuilder;
-            if (filter != null && bool.filter().contains(filter) == false) {
-                bool.filter(filter);
-            }
-        } else {
-            bool = boolQuery();
-            if (query != null) {
-                bool.filter(query);
-            }
-            if (filter != null) {
-                bool.filter(filter);
-            }
-
-            source.query(bool);
-        }
-        return source;
+    /**
+     * optimized method that adds filter to existing bool queries without additional wrapping
+     * additionally checks whether the given query exists for safe decoration
+     */
+    public static SearchSourceBuilder combineFilters(SearchSourceBuilder source, QueryBuilder filter) {
+        return source.query(Queries.combine(FILTER, List.of(source.query(), filter)));
     }
 
     public static SearchSourceBuilder replaceFilter(
+        SearchSourceBuilder source,
         List<QueryBuilder> oldFilters,
-        List<QueryBuilder> newFilters,
-        SearchSourceBuilder source
+        List<QueryBuilder> newFilters
     ) {
-        BoolQueryBuilder bool = null;
-        QueryBuilder query = source.query();
-
-        if (query instanceof BoolQueryBuilder boolQueryBuilder) {
-            bool = boolQueryBuilder;
-            if (oldFilters != null) {
-                bool.filter().removeAll(oldFilters);
-            }
-
-            if (newFilters != null) {
-                bool.filter().addAll(newFilters);
-            }
-        }
-        // no bool query means no old filters
-        else {
-            bool = boolQuery();
-            if (query != null) {
-                bool.filter(query);
-            }
-            if (newFilters != null) {
-                bool.filter().addAll(newFilters);
-            }
-
-            source.query(bool);
-        }
-        return source;
+        var query = source.query();
+        query = removeFilters(query, oldFilters);
+        query = Queries.combine(FILTER, org.elasticsearch.xpack.ql.util.CollectionUtils.combine(newFilters, query));
+        return source.query(query);
     }
 
     public static SearchSourceBuilder wrapAsFilter(SearchSourceBuilder source) {
@@ -251,5 +214,14 @@ public final class RuntimeUtils {
 
         source.query(bool);
         return source;
+    }
+
+    public static QueryBuilder removeFilters(QueryBuilder query, List<QueryBuilder> filters) {
+        if (query instanceof BoolQueryBuilder boolQueryBuilder) {
+            if (org.elasticsearch.xpack.ql.util.CollectionUtils.isEmpty(filters) == false) {
+                boolQueryBuilder.filter().removeAll(filters);
+            }
+        }
+        return query;
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -48,7 +48,7 @@ import java.util.Set;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.ActionListener.runAfter;
 import static org.elasticsearch.xpack.eql.execution.ExecutionUtils.copySource;
-import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.addFilter;
+import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.combineFilters;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.searchHits;
 import static org.elasticsearch.xpack.eql.util.SearchHitUtils.qualifiedIndex;
 
@@ -314,7 +314,7 @@ public class TumblingWindow implements Executable {
                         builder.sort(r.timestampField(), SortOrder.ASC);
                     }
                     addKeyFilter(i, sequence, builder);
-                    RuntimeUtils.addFilter(range, builder);
+                    RuntimeUtils.combineFilters(builder, range);
                     result.add(RuntimeUtils.prepareRequest(builder.size(1).trackTotalHits(false), false, Strings.EMPTY_ARRAY));
                 } else {
                     leading = false;
@@ -331,7 +331,7 @@ public class TumblingWindow implements Executable {
         }
         for (int i = 0; i < keys.size(); i++) {
             Attribute k = keys.get(i);
-            addFilter(new TermQueryBuilder(k.qualifiedName(), sequence.key().asList().get(i)), builder);
+            combineFilters(builder, new TermQueryBuilder(k.qualifiedName(), sequence.key().asList().get(i)));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -135,7 +135,7 @@ public class SearchStats {
     }
 
     //
-    // @see org.elasticsearch.search.query.TopDocsCollectorManagerFactory#shortcutTotalHitCount(IndexReader, Query)
+    // @see org.elasticsearch.search.query.QueryPhaseCollectorManager#shortcutTotalHitCount(IndexReader, Query)
     //
     private static int countEntries(IndexReader indexReader, String field) {
         int count = 0;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/Queries.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/Queries.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql.util;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+
+/**
+ * Utilities for Elasticsearch queries.
+ */
+public class Queries {
+
+    public enum Clause {
+        FILTER(BoolQueryBuilder::filter),
+        MUST(BoolQueryBuilder::must),
+        MUST_NOT(BoolQueryBuilder::mustNot),
+        SHOULD(BoolQueryBuilder::should);
+
+        final Function<BoolQueryBuilder, List<QueryBuilder>> operation;
+
+        Clause(Function<BoolQueryBuilder, List<QueryBuilder>> operation) {
+            this.operation = operation;
+        }
+    }
+
+    /**
+     * Combines the given queries while attempting to NOT create a new bool query and avoid
+     * unnecessary nested queries.
+     * The method tries to detect and reuses existing bool queries instead of simply combining
+     * them to avoid creating unnecessary nested queries.
+     * If a bool query is detected and its {@link BoolQueryBuilder#minimumShouldMatch()} is set,
+     * said query will be added using the given clause instead of being merged onto the existing
+     * ones.
+     */
+    public static QueryBuilder combine(Clause clause, List<QueryBuilder> queries) {
+        QueryBuilder firstQuery = null;
+        BoolQueryBuilder bool = null;
+
+        for (QueryBuilder query : queries) {
+            if (query == null) {
+                continue;
+            }
+            if (firstQuery == null) {
+                firstQuery = query;
+            }
+            // at least two entries, start copying
+            else {
+                // lazy init the root bool
+                if (bool == null) {
+                    bool = combine(clause, boolQuery(), firstQuery);
+                }
+                // keep adding queries to it
+                bool = combine(clause, bool, query);
+            }
+        }
+
+        return bool == null ? firstQuery : bool;
+    }
+
+    private static BoolQueryBuilder combine(Clause clause, BoolQueryBuilder bool, QueryBuilder query) {
+        if (query instanceof BoolQueryBuilder boolQuery && hasDefaultMinMatch(boolQuery)) {
+            bool.filter().addAll(boolQuery.filter());
+            bool.should().addAll(boolQuery.should());
+            bool.must().addAll(boolQuery.must());
+            bool.mustNot().addAll(boolQuery.mustNot());
+        } else {
+            var list = clause.operation.apply(bool);
+            if (list.contains(query) == false) {
+                list.add(query);
+            }
+        }
+        return bool;
+    }
+
+    private static boolean hasDefaultMinMatch(BoolQueryBuilder boolQuery) {
+        var minMatch = boolQuery.minimumShouldMatch();
+        return minMatch == null || "0".equals(minMatch);
+    }
+
+}

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/Queries.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/Queries.java
@@ -26,10 +26,10 @@ public class Queries {
         MUST_NOT(BoolQueryBuilder::mustNot),
         SHOULD(BoolQueryBuilder::should);
 
-        final Function<BoolQueryBuilder, List<QueryBuilder>> operation;
+        final Function<BoolQueryBuilder, List<QueryBuilder>> innerQueries;
 
-        Clause(Function<BoolQueryBuilder, List<QueryBuilder>> operation) {
-            this.operation = operation;
+        Clause(Function<BoolQueryBuilder, List<QueryBuilder>> innerQueries) {
+            this.innerQueries = innerQueries;
         }
     }
 
@@ -68,7 +68,7 @@ public class Queries {
     }
 
     private static BoolQueryBuilder combine(Clause clause, BoolQueryBuilder bool, QueryBuilder query) {
-        var list = clause.operation.apply(bool);
+        var list = clause.innerQueries.apply(bool);
         if (list.contains(query) == false) {
             list.add(query);
         }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/QueriesTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/QueriesTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql.util;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ESTestCase;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class QueriesTests extends ESTestCase {
+
+    private static QueryBuilder randomNonBool() {
+        return randomFrom(
+            random(),
+            QueryBuilders::matchAllQuery,
+            QueryBuilders::idsQuery,
+            () -> QueryBuilders.rangeQuery(randomRealisticUnicodeOfLength(5)),
+            () -> QueryBuilders.termQuery(randomAlphaOfLength(5), randomAlphaOfLength(5)),
+            () -> QueryBuilders.existsQuery(randomAlphaOfLength(5)),
+            () -> QueryBuilders.geoBoundingBoxQuery(randomAlphaOfLength(5))
+        );
+    }
+
+    private static BoolQueryBuilder randomBool() {
+        var bool = QueryBuilders.boolQuery();
+        if (randomBoolean()) {
+            bool.filter(randomNonBool());
+        }
+        if (randomBoolean()) {
+            bool.must(randomNonBool());
+        }
+        if (randomBoolean()) {
+            bool.mustNot(randomNonBool());
+        }
+        if (randomBoolean()) {
+            bool.should(randomNonBool());
+        }
+        return bool;
+    }
+
+    public void testCombineNotCreatingBool() {
+        var clause = randomFrom(Queries.Clause.values());
+        var nonBool = randomNonBool();
+        assertThat(nonBool, sameInstance(Queries.combine(clause, asList(null, null, nonBool, null))));
+    }
+
+    public void testCombineNonBoolQueries() {
+        var queries = randomArray(2, 10, QueryBuilder[]::new, QueriesTests::randomNonBool);
+
+        var clause = randomFrom(Queries.Clause.values());
+        var list = asList(queries);
+        var combination = Queries.combine(clause, list);
+
+        assertThat(combination, instanceOf(BoolQueryBuilder.class));
+        var bool = (BoolQueryBuilder) combination;
+        assertEquals(clause.operation.apply(bool), list);
+    }
+
+    public void testCombineBoolQueries() {
+        var queries = randomArray(2, 10, QueryBuilder[]::new, () -> {
+            var bool = QueryBuilders.boolQuery();
+            if (randomBoolean()) {
+                bool.filter(randomNonBool());
+            }
+            if (randomBoolean()) {
+                bool.must(randomNonBool());
+            }
+            if (randomBoolean()) {
+                bool.mustNot(randomNonBool());
+            }
+            if (randomBoolean()) {
+                bool.should(randomNonBool());
+            }
+            return bool;
+        });
+
+        var clause = randomFrom(Queries.Clause.values());
+        var list = asList(queries);
+        var combination = Queries.combine(clause, list);
+
+        assertThat(combination, instanceOf(BoolQueryBuilder.class));
+        var bool = (BoolQueryBuilder) combination;
+
+        for (QueryBuilder query : queries) {
+            assertThat(query, instanceOf(BoolQueryBuilder.class));
+            BoolQueryBuilder bqb = (BoolQueryBuilder) query;
+            assertThat(bqb.filter(), everyItem(in(bool.filter())));
+            assertThat(bqb.must(), everyItem(in(bool.must())));
+            assertThat(bqb.mustNot(), everyItem(in(bool.mustNot())));
+            assertThat(bqb.should(), everyItem(in(bool.should())));
+        }
+    }
+
+    public void testCombineMixedBoolAndNonBoolQueries() {
+        var nonBool = new int[] { 0 };
+        var queries = randomArray(2, 10, QueryBuilder[]::new, () -> {
+            if (randomBoolean()) {
+                return QueriesTests.randomBool();
+            } else {
+                nonBool[0]++;
+                return QueriesTests.randomNonBool();
+            }
+        });
+
+        var clause = randomFrom(Queries.Clause.values());
+        var list = asList(queries);
+        var combination = Queries.combine(clause, list);
+
+        assertThat(combination, instanceOf(BoolQueryBuilder.class));
+        var bool = (BoolQueryBuilder) combination;
+
+        var innerQueries = clause.operation.apply(bool);
+        assertThat(innerQueries, hasSize(nonBool[0]));
+
+        for (QueryBuilder query : queries) {
+            if (query instanceof BoolQueryBuilder bqb) {
+                assertThat(bqb.filter(), everyItem(in(bool.filter())));
+                assertThat(bqb.must(), everyItem(in(bool.must())));
+                assertThat(bqb.mustNot(), everyItem(in(bool.mustNot())));
+                assertThat(bqb.should(), everyItem(in(bool.should())));
+            } else {
+                assertThat(query, in(innerQueries));
+            }
+        }
+    }
+
+    public void testCombineBoolQueryWithMinClauseSet() {
+        var nonBool = new int[] { 0 };
+        var nonMixedBool = new int[] { 0 };
+        var queries = randomArray(2, 10, QueryBuilder[]::new, () -> {
+            if (randomBoolean()) {
+                var b = QueriesTests.randomBool();
+                if (randomBoolean()) {
+                    nonMixedBool[0]++;
+                    b.minimumShouldMatch(1);
+                }
+                return b;
+            } else {
+                nonBool[0]++;
+                return QueriesTests.randomNonBool();
+            }
+        });
+
+        var clause = randomFrom(Queries.Clause.values());
+        var list = asList(queries);
+        var combination = Queries.combine(clause, list);
+
+        assertThat(combination, instanceOf(BoolQueryBuilder.class));
+        var bool = (BoolQueryBuilder) combination;
+
+        var innerQueries = clause.operation.apply(bool);
+        assertThat(innerQueries, hasSize(nonBool[0] + nonMixedBool[0]));
+
+
+        for (QueryBuilder query : queries) {
+            if (query instanceof BoolQueryBuilder bqb) {
+                if (bqb.minimumShouldMatch() != "0") {
+                    assertThat(query, in(innerQueries));
+                } else {
+                    assertThat(bqb.filter(), everyItem(in(bool.filter())));
+                    assertThat(bqb.must(), everyItem(in(bool.must())));
+                    assertThat(bqb.mustNot(), everyItem(in(bool.mustNot())));
+                    assertThat(bqb.should(), everyItem(in(bool.should())));
+                }
+            } else {
+                assertThat(query, in(innerQueries));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Generify an utility for combining QueryBuilder's while being mindful of
 the number of BoolQueryBuilders created in the process