### PR TITLE
[8.10] Fix NPE when GetUser with profile uid before profile index exists (#98961)

### DIFF
--- a/docs/changelog/98961.yaml
+++ b/docs/changelog/98961.yaml
@@ -1,0 +1,5 @@
+pr: 98961
+summary: Fix NPE when `GetUser` with profile uid before profile index exists
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
+++ b/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
@@ -443,14 +443,18 @@ public class ProfileIT extends ESRestTestCase {
         final Request putUserRequest = new Request("PUT", "_security/user/" + username);
         putUserRequest.setJsonEntity("{\"password\":\"x-pack-test-password\",\"roles\":[\"superuser\"]}");
         assertOK(adminClient().performRequest(putUserRequest));
-        final Map<String, Object> profile = doActivateProfile(username, "x-pack-test-password");
 
+        // Get user with profile uid before profile index exists will not show any profile_uid
         final Request getUserRequest = new Request("GET", "_security/user" + (randomBoolean() ? "/" + username : ""));
         getUserRequest.addParameter("with_profile_uid", "true");
-        final Response getUserResponse = adminClient().performRequest(getUserRequest);
-        assertOK(getUserResponse);
+        final Response getUserResponse1 = adminClient().performRequest(getUserRequest);
+        assertOK(getUserResponse1);
+        responseAsMap(getUserResponse1).forEach((k, v) -> assertThat(castToMap(v), not(hasKey("profile_uid"))));
 
-        responseAsMap(getUserResponse).forEach((k, v) -> {
+        // The profile_uid is retrieved for the user after the profile gets activated
+        final Map<String, Object> profile = doActivateProfile(username, "x-pack-test-password");
+        final Response getUserResponse2 = adminClient().performRequest(getUserRequest);
+        responseAsMap(getUserResponse2).forEach((k, v) -> {
             if (username.equals(k)) {
                 assertThat(castToMap(v).get("profile_uid"), equalTo(profile.get("uid")));
             } else {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileIntegTests.java
@@ -834,6 +834,17 @@ public class ProfileIntegTests extends AbstractProfileIntegTestCase {
         );
     }
 
+    public void testGetUsersWithProfileUidWhenProfileIndexDoesNotExists() {
+        final GetUsersRequest getUsersRequest = new GetUsersRequest();
+        getUsersRequest.setWithProfileUid(true);
+        if (randomBoolean()) {
+            getUsersRequest.usernames(ElasticUser.NAME, RAC_USER_NAME);
+        }
+        final GetUsersResponse getUsersResponse = client().execute(GetUsersAction.INSTANCE, getUsersRequest).actionGet();
+        // When profile index does not exist, profile lookup is null
+        assertThat(getUsersResponse.getProfileUidLookup(), nullValue());
+    }
+
     private SuggestProfilesResponse.ProfileHit[] doSuggest(String name) {
         return doSuggest(name, Set.of());
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
@@ -144,7 +144,10 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
         }).toList();
 
         profileService.searchProfilesForSubjects(subjects, ActionListener.wrap(resultsAndErrors -> {
-            if (resultsAndErrors.errors().isEmpty()) {
+            if (resultsAndErrors == null) {
+                // profile index does not exist
+                listener.onResponse(null);
+            } else if (resultsAndErrors.errors().isEmpty()) {
                 assert users.size() == resultsAndErrors.results().size();
                 final Map<String, String> profileUidLookup = resultsAndErrors.results()
                     .stream()


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix NPE when GetUser with profile uid before profile index exists (#98961)