### PR TITLE
Convert security-basic to internal java rest test

### DIFF
--- a/x-pack/plugin/security/qa/security-basic/build.gradle
+++ b/x-pack/plugin/security/qa/security-basic/build.gradle
@@ -1,5 +1,5 @@
 
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams
 
@@ -9,27 +9,12 @@ dependencies {
   javaRestTestImplementation project(":client:rest-high-level")
 }
 
+tasks.named('javaRestTest') {
+  usesDefaultDistribution()
+}
+
+
 if (BuildParams.inFipsJvm){
   // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
   tasks.named("javaRestTest").configure{enabled = false }
-}
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 2
-
-  setting 'xpack.ml.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'basic'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.security.ssl.diagnose.trust', 'true'
-  setting 'xpack.security.http.ssl.enabled', 'false'
-  setting 'xpack.security.transport.ssl.enabled', 'false'
-  setting 'xpack.security.authc.token.enabled', 'true'
-  setting 'xpack.security.authc.api_key.enabled', 'true'
-
-  rolesFile file('src/javaRestTest/resources/roles.yml')
-  user username: "admin_user", password: "admin-password"
-  user username: "security_test_user", password: "security-test-password", role: "security_test_role"
-  user username: "api_key_admin", password: "security-test-password", role: "api_key_admin_role"
-  user username: "api_key_user", password: "security-test-password", role: "api_key_user_role"
 }

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityInBasicRestTestCase.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityInBasicRestTestCase.java
@@ -10,19 +10,59 @@ package org.elasticsearch.xpack.security;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.local.model.User;
+import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.ClassRule;
 
 public abstract class SecurityInBasicRestTestCase extends ESRestTestCase {
 
+    protected static final String REST_USER = "security_test_user";
+    private static final SecureString REST_PASSWORD = new SecureString("security-test-password".toCharArray());
+
+    private static final String ADMIN_USER = "admin_user";
+    private static final SecureString ADMIN_PASSWORD = new SecureString("admin-password".toCharArray());
+
+    protected static final String API_KEY_USER = "api_key_user";
+    private static final SecureString API_KEY_USER_PASSWORD = new SecureString("security-test-password".toCharArray());
+
+    protected static final String API_KEY_ADMIN_USER = "api_key_admin";
+    private static final SecureString API_KEY_ADMIN_USER_PASSWORD = new SecureString("security-test-password".toCharArray());
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .nodes(2)
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.license.self_generated.type", "basic")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.security.ssl.diagnose.trust", "true")
+        .setting("xpack.security.http.ssl.enabled", "false")
+        .setting("xpack.security.transport.ssl.enabled", "false")
+        .setting("xpack.security.authc.token.enabled", "true")
+        .setting("xpack.security.authc.api_key.enabled", "true")
+        .rolesFile(Resource.fromClasspath("roles.yml"))
+        .user(ADMIN_USER, ADMIN_PASSWORD.toString(), User.ROOT_USER_ROLE, true)
+        .user(REST_USER, REST_PASSWORD.toString(), "security_test_role", false)
+        .user(API_KEY_USER, API_KEY_USER_PASSWORD.toString(), "api_key_user_role", false)
+        .user(API_KEY_ADMIN_USER, API_KEY_ADMIN_USER_PASSWORD.toString(), "api_key_admin_role", false)
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
     @Override
     protected Settings restAdminSettings() {
-        String token = basicAuthHeaderValue("admin_user", new SecureString("admin-password".toCharArray()));
+        String token = basicAuthHeaderValue(ADMIN_USER, ADMIN_PASSWORD);
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
     @Override
     protected Settings restClientSettings() {
-        String token = basicAuthHeaderValue("security_test_user", new SecureString("security-test-password".toCharArray()));
+        String token = basicAuthHeaderValue(REST_USER, REST_PASSWORD);
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 


### PR DESCRIPTION
Converts x-pack/plugin/security/qa/security-basic from legacy java rest test to internal java rest test.
