### PR TITLE
[8.10] Include RCS xpack docs tests (#99038)

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -36,8 +36,6 @@ restResources {
 tasks.named("yamlRestTest").configure {
   if (BuildParams.isSnapshotBuild()) {
     systemProperty 'tests.rest.blacklist', '*/get-builtin-privileges/*'
-  } else {
-    systemProperty 'tests.rest.blacklist', ['*/create-cross-cluster-api-key/*', '*/update-cross-cluster-api-key/*'].join(',')
   }
 }
 


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Include RCS xpack docs tests (#99038)