### PR TITLE
ES|QL: Add ignoreOrder option to CSV tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -100,7 +100,13 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         assertNotNull(answer.get("values"));
         @SuppressWarnings("unchecked")
         List<List<Object>> actualValues = (List<List<Object>>) answer.get("values");
-        assertData(expectedColumnsWithValues, actualValues, LOGGER, value -> value == null ? "null" : value.toString());
+        assertData(
+            expectedColumnsWithValues,
+            actualValues,
+            testCase.ignoreOrder,
+            LOGGER,
+            value -> value == null ? "null" : value.toString()
+        );
     }
 
     private Throwable reworkException(Throwable th) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.versionfield.Version;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -37,9 +38,9 @@ import static org.junit.Assert.fail;
 public final class CsvAssert {
     private CsvAssert() {}
 
-    static void assertResults(ExpectedResults expected, ActualResults actual, Logger logger) {
+    static void assertResults(ExpectedResults expected, ActualResults actual, boolean ignoreOrder, Logger logger) {
         assertMetadata(expected, actual, logger);
-        assertData(expected, actual, logger);
+        assertData(expected, actual, ignoreOrder, logger);
     }
 
     static void assertMetadata(ExpectedResults expected, ActualResults actual, Logger logger) {
@@ -147,25 +148,31 @@ public final class CsvAssert {
         }
     }
 
-    static void assertData(ExpectedResults expected, ActualResults actual, Logger logger) {
-        assertData(expected, actual.values(), logger, Function.identity());
+    static void assertData(ExpectedResults expected, ActualResults actual, boolean ignoreOrder, Logger logger) {
+        assertData(expected, actual.values(), ignoreOrder, logger, Function.identity());
     }
 
     public static void assertData(
         ExpectedResults expected,
         Iterator<Iterator<Object>> actualValuesIterator,
+        boolean ignoreOrder,
         Logger logger,
         Function<Object, Object> valueTransformer
     ) {
-        assertData(expected, EsqlTestUtils.getValuesList(actualValuesIterator), logger, valueTransformer);
+        assertData(expected, EsqlTestUtils.getValuesList(actualValuesIterator), ignoreOrder, logger, valueTransformer);
     }
 
     public static void assertData(
         ExpectedResults expected,
         List<List<Object>> actualValues,
+        boolean ignoreOrder,
         Logger logger,
         Function<Object, Object> valueTransformer
     ) {
+        if (ignoreOrder) {
+            expected.values().sort(resultRowComparator(expected.columnTypes()));
+            actualValues.sort(resultRowComparator(expected.columnTypes()));
+        }
         var expectedValues = expected.values();
 
         for (int row = 0; row < expectedValues.size(); row++) {
@@ -218,6 +225,29 @@ public final class CsvAssert {
                 "Elasticsearch still has data after [" + expectedValues.size() + "] entries:\n" + row(actualValues, expectedValues.size())
             );
         }
+    }
+
+    private static Comparator<List<Object>> resultRowComparator(List<Type> types) {
+        return (x, y) -> {
+            for (int i = 0; i < x.size(); i++) {
+                Object left = x.get(i);
+                Object right = y.get(i);
+                if (left == null && right == null) {
+                    continue;
+                }
+                if (left == null) {
+                    return 1;
+                }
+                if (right == null) {
+                    return -1;
+                }
+                int result = types.get(i).comparator().compare(left, right);
+                if (result != 0) {
+                    return result;
+                }
+            }
+            return 0;
+        };
     }
 
     private static Object rebuildExpected(Object expectedValue, Class<?> clazz, Function<Object, Object> mapper) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -32,6 +32,7 @@ import java.math.BigDecimal;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -312,7 +313,11 @@ public final class CsvTestUtils {
         IP(StringUtils::parseIP, BytesRef.class),
         VERSION(v -> new Version(v).toBytesRef(), BytesRef.class),
         NULL(s -> null, Void.class),
-        DATETIME(x -> x == null ? null : DateFormatters.from(UTC_DATE_TIME_FORMATTER.parse(x)).toInstant().toEpochMilli(), Long.class),
+        DATETIME(
+            x -> x == null ? null : DateFormatters.from(UTC_DATE_TIME_FORMATTER.parse(x)).toInstant().toEpochMilli(),
+            (l, r) -> l instanceof Long l2 ? l2.compareTo((Long) r) : l.toString().compareTo(r.toString()),
+            Long.class
+        ),
         BOOLEAN(Booleans::parseBoolean, Boolean.class);
 
         private static final Map<String, Type> LOOKUP = new HashMap<>();
@@ -342,9 +347,20 @@ public final class CsvTestUtils {
 
         private final Function<String, Object> converter;
         private final Class<?> clazz;
+        private final Comparator<Object> comparator;
 
+        @SuppressWarnings("unchecked")
         Type(Function<String, Object> converter, Class<?> clazz) {
+            this(
+                converter,
+                Comparable.class.isAssignableFrom(clazz) ? (a, b) -> ((Comparable) a).compareTo(b) : Comparator.comparing(Object::toString),
+                clazz
+            );
+        }
+
+        Type(Function<String, Object> converter, Comparator<Object> comparator, Class<?> clazz) {
             this.converter = converter;
+            this.comparator = comparator;
             this.clazz = clazz;
         }
 
@@ -374,6 +390,10 @@ public final class CsvTestUtils {
 
         Class<?> clazz() {
             return clazz;
+        }
+
+        public Comparator<Object> comparator() {
+            return comparator;
         }
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ignore-order.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ignore-order.csv-spec
@@ -1,0 +1,85 @@
+# just a few tests to verify that ignoreOrder works as expected
+
+simple
+from employees | where emp_no < 10004 | keep emp_no, still_hired;
+ignoreOrder:true
+emp_no:integer | still_hired:boolean
+10003          | false
+10002          | true
+10001          | true
+;
+
+simple2
+from employees | where emp_no < 10004 | keep emp_no, still_hired;
+ignoreOrder:true
+emp_no:integer | still_hired:boolean
+10001          | true
+10003          | false
+10002          | true
+;
+
+
+booleansFirst
+from employees | where emp_no < 10004 | keep still_hired, emp_no;
+ignoreOrder:true
+still_hired:boolean | emp_no:integer  
+true                | 10001           
+false               | 10003
+true                | 10002          
+;
+
+
+booleansFirst2
+from employees | where emp_no < 10004 | keep still_hired, emp_no;
+ignoreOrder:true
+still_hired:boolean | emp_no:integer  
+true                | 10001           
+true                | 10002          
+false               | 10003
+;
+
+nulls
+from employees | where emp_no >= 10007 and emp_no < 10012 | keep gender, emp_no;
+ignoreOrder:true
+gender:keyword | emp_no:integer
+F              | 10007
+M              | 10008
+F              | 10009
+null           | 10010
+null           | 10011
+;
+
+
+nulls2
+from employees | where emp_no >= 10007 and emp_no < 10012 | keep gender, emp_no;
+ignoreOrder:true
+gender:keyword | emp_no:integer
+null           | 10010
+F              | 10009
+F              | 10007
+M              | 10008
+null           | 10011
+;
+
+dates
+from employees | where emp_no >= 10007 and emp_no < 10012 | keep birth_date, emp_no;
+ignoreOrder:true
+birth_date:date        | emp_no:integer
+1957-05-23T00:00:00Z   | 10007
+1958-02-19T00:00:00Z   | 10008
+1952-04-19T00:00:00Z   | 10009
+1963-06-01T00:00:00Z   | 10010
+1953-11-07T00:00:00Z   | 10011
+;
+
+dates2
+from employees | where emp_no >= 10007 and emp_no < 10012 | keep birth_date, emp_no;
+ignoreOrder:true
+birth_date:date        | emp_no:integer
+1953-11-07T00:00:00Z   | 10011
+1957-05-23T00:00:00Z   | 10007
+1952-04-19T00:00:00Z   | 10009
+1958-02-19T00:00:00Z   | 10008
+1963-06-01T00:00:00Z   | 10010
+;
+

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -233,12 +233,12 @@ public class CsvTests extends ESTestCase {
         var expected = loadCsvSpecValues(testCase.expectedResults);
 
         var log = logResults() ? LOGGER : null;
-        assertResults(expected, actualResults, log);
+        assertResults(expected, actualResults, testCase.ignoreOrder, log);
         assertWarnings(actualResults.responseHeaders().getOrDefault("Warning", List.of()));
     }
 
-    protected void assertResults(ExpectedResults expected, ActualResults actual, Logger logger) {
-        CsvAssert.assertResults(expected, actual, logger);
+    protected void assertResults(ExpectedResults expected, ActualResults actual, boolean ignoreOrder, Logger logger) {
+        CsvAssert.assertResults(expected, actual, ignoreOrder, logger);
         /*
          * Comment the assertion above and enable the next two lines to see the results returned by ES without any assertions being done.
          * This is useful when creating a new test or trying to figure out what are the actual results.

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
@@ -61,6 +61,8 @@ public final class CsvSpecReader {
                 // read data
                 if (line.toLowerCase(Locale.ROOT).startsWith("warning:")) {
                     testCase.expectedWarnings.add(line.substring("warning:".length()).trim());
+                } else if (line.toLowerCase(Locale.ROOT).startsWith("ignoreorder:")) {
+                    testCase.ignoreOrder = Boolean.parseBoolean(line.substring("ignoreOrder:".length()).trim());
                 } else if (line.startsWith(";")) {
                     testCase.expectedResults = data.toString();
                     // clean-up and emit
@@ -83,6 +85,7 @@ public final class CsvSpecReader {
         public String earlySchema;
         public String expectedResults;
         public List<String> expectedWarnings = new ArrayList<>();
+        public boolean ignoreOrder;
     }
 
 }


### PR DESCRIPTION
Add an option to ignore the order of the results in spec tests (both SpecIT and CsvTests)

The syntax is the following:

```
testName
from idx | keep foo, bar;
ignoreOrder:true
foo:keyword | bar:keyword
...
```

The functionality is implemented by sorting the results (and the expected results) in a deterministic order before comparing them.
This solves the problem of testing some non-deterministic queries, but not all of them, eg. in queries with a `LIMIT`, the results could be partial; in this case, the results of the query could be completely different, not only in terms of ordering, but also in terms of which records are returned.

An example: with a dataset with records `"a", "b", "c"`, a query like

```
from idx
```

could return `("a", "b", "c")` or `("b", "c", "a")` and both can be considered correct. The test can assert any of them as a valid result.

But the same query, with a limit:

```
from idx | limit 2
```

could return `("a", b")` or `("c", "b")`, that are different not only in the order, but also in terms of content.
In this case, the test cannot assert one of the possible results as correct, because it will still randomly fail when a different one is returned.

Fixes https://github.com/elastic/elasticsearch/issues/99025