### PR TITLE
[DOCS] Remove dupe JVM setting instructions in Docker install docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -184,7 +184,7 @@ endif::[]
 
 [source,sh,subs="attributes"]
 ----
-docker run -e ENROLLMENT_TOKEN="<token>" --name es02 --net elastic -it {docker-image}
+docker run -e ENROLLMENT_TOKEN="<token>" --name es02 --net elastic -it -m 1GB {docker-image}
 ----
 --
 
@@ -195,19 +195,6 @@ docker run -e ENROLLMENT_TOKEN="<token>" --name es02 --net elastic -it {docker-i
 curl --cacert http_ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200/_cat/nodes
 ----
 // NOTCONSOLE
-
-===== Setting JVM heap size
-If you experience issues where the container where your first node is running
-exits when your second node starts, explicitly set values for the JVM heap size.
-To <<set-jvm-heap-size,manually configure the heap size>>, include the
-`ES_JAVA_OPTS` variable and set values for `-Xms` and `-Xmx` when starting each
-node. For example, the following command starts node `es02` and sets the
-minimum and maximum JVM heap size to 1 GB:
-
-[source,sh,subs="attributes"]
-----
-docker run -e ES_JAVA_OPTS="-Xms1g -Xmx1g" -e ENROLLMENT_TOKEN="<token>" --name es02 -p 9201:9200 --net elastic -it {docker-image}
-----
 
 ===== Next steps
 
@@ -546,12 +533,16 @@ To manually set the heap size in production, bind mount a <<set-jvm-options,JVM
 options>> file under `/usr/share/elasticsearch/config/jvm.options.d` that
 includes your desired <<set-jvm-heap-size,heap size>> settings.
 
-For testing, you can also manually set the heap size using the `ES_JAVA_OPTS`
-environment variable. For example, to use 16GB, specify `-e
-ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`. The `ES_JAVA_OPTS` variable
-overrides all other JVM options. We do not recommend using `ES_JAVA_OPTS` in
-production. The `docker-compose.yml` file above sets the heap size to 512MB.
+For testing, you can manually set the heap size using the `ES_JAVA_OPTS`
+environment variable. Example:
 
+[source,sh]
+----
+docker run -e ES_JAVA_OPTS="-Xms1g -Xmx1g" --name es01 --net elastic -p 9200:9200 -it -m 1GB {docker-image}
+----
+
+The `ES_JAVA_OPTS` variable overrides all other JVM options. We don't recommend
+using `ES_JAVA_OPTS` in production.
 
 ===== Pin deployments to a specific image version
 

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -538,7 +538,7 @@ environment variable. Example:
 
 [source,sh]
 ----
-docker run -e ES_JAVA_OPTS="-Xms1g -Xmx1g" --name es01 --net elastic -p 9200:9200 -it -m 1GB {docker-image}
+docker run -e ES_JAVA_OPTS="-Xms1g -Xmx1g" --name es01 --net elastic -p 9200:9200 -it -m 2GB {docker-image}
 ----
 
 The `ES_JAVA_OPTS` variable overrides all other JVM options. We don't recommend


### PR DESCRIPTION
**Problem:**
 The [Docker install](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) docs page duplicates docs for using JVM heap settings in Docker. We don't recommend users change these settings.

**Solution:**

-  Removes the [Setting JVM heap size](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_setting_jvm_heap_size) section in favor of the [Manually set the heap size](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-set-heap-size) section.
- Adds an `-m` flag to the `docker run` command in [Add more nodes](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_add_more_nodes). This limits memory for the container and eliminates the need to manually set JVM heap size.
- Adds an example `docker run` command to the [Manually set the heap size](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-set-heap-size) section.