### PR TITLE
[8.9] [DOCS] Add link to Elasticsearch labs ELSER Python notebook (#98983)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -361,3 +361,9 @@ PUT my-index
 * {ml-docs}/ml-nlp-elser.html[How to download and deploy ELSER]
 * {ml-docs}/ml-nlp-limitations.html#ml-nlp-elser-v1-limit-512[ELSER v1 limitation]
 * https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model[Improving information retrieval in the Elastic Stack: Introducing Elastic Learned Sparse Encoder, our new retrieval model]
+
+[discrete]
+[[interactive-example]]
+==== Interactive example
+
+* The `elasticsearch-labs` repo has an interactive example of running https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/03-ELSER.ipynb[ELSER-powered semantic search] using the {es} Python client.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] Add link to Elasticsearch labs ELSER Python notebook (#98983)](https://github.com/elastic/elasticsearch/pull/98983)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)