### PR TITLE
[DOCS] Expand the step that enables the remote cluster server

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -69,11 +69,9 @@ information, refer to https://www.elastic.co/subscriptions.
 .. Set <<remote-cluster-network-settings,`remote_cluster_server.enabled`>> to 
 `true`.
 .. Configure the bind and publish address for remote cluster server traffic, for
-example using <<remote-cluster-network-settings,`remote_cluster.host`>>.
-This defaults to the value of `transport.bind_host`, which in turn defaults to
-the value of `network.host`, which defaults to `_local_`. By default, for single
-node clusters, this means remote cluster traffic is bound to the local 
-interface and remote clusters can't connect.
+example using <<remote-cluster-network-settings,`remote_cluster.host`>>. Without
+configuring the address, remote cluster traffic may be bound to the local
+interface, and as a result remote clusters can't connect.
 .. Optionally, configure the remote server port using 
 <<remote_cluster.port,`remote_cluster.port`>> (defaults to `9443`).
 . Next, generate a certificate authority (CA) and a server certificate/key pair.

--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -71,7 +71,7 @@ information, refer to https://www.elastic.co/subscriptions.
 .. Configure the bind and publish address for remote cluster server traffic, for
 example using <<remote-cluster-network-settings,`remote_cluster.host`>>. Without
 configuring the address, remote cluster traffic may be bound to the local
-interface, and as a result remote clusters can't connect.
+interface, and remote clusters running on other machines can't connect.
 .. Optionally, configure the remote server port using 
 <<remote_cluster.port,`remote_cluster.port`>> (defaults to `9443`).
 . Next, generate a certificate authority (CA) and a server certificate/key pair.

--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -72,7 +72,7 @@ information, refer to https://www.elastic.co/subscriptions.
 example using <<remote-cluster-network-settings,`remote_cluster.host`>>.
 This defaults to the value of `transport.bind_host`, which in turn defaults to
 the value of `network.host`, which defaults to `_local_`. By default, for single
-node clusters, this means remote cluster traffic will be bound to the local 
+node clusters, this means remote cluster traffic is bound to the local 
 interface and remote clusters can't connect.
 .. Optionally, configure the remote server port using 
 <<remote_cluster.port,`remote_cluster.port`>> (defaults to `9443`).

--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -64,11 +64,18 @@ information, refer to https://www.elastic.co/subscriptions.
 ===== On the remote cluster
 
 // tag::remote-cluster-steps[]
-. Enable the remote cluster server port on every node of the remote cluster by
-setting `remote_cluster_server.enabled` to `true` in `elasticsearch.yml`. The
-port number defaults to `9443` and can be configured with the
-`remote_cluster.port` setting. Refer to <<remote-cluster-network-settings>>.
-
+. Enable the remote cluster server on every node of the remote cluster. In 
+`elasticsearch.yml`:
+.. Set <<remote-cluster-network-settings,`remote_cluster_server.enabled`>> to 
+`true`.
+.. Configure the bind and publish address for remote cluster server traffic, for
+example using <<remote-cluster-network-settings,`remote_cluster.host`>>.
+This defaults to the value of `transport.bind_host`, which in turn defaults to
+the value of `network.host`, which defaults to `_local_`. By default, for single
+node clusters, this means remote cluster traffic will be bound to the local 
+interface and remote clusters can't connect.
+.. Optionally, configure the remote server port using 
+<<remote_cluster.port,`remote_cluster.port`>> (defaults to `9443`).
 . Next, generate a certificate authority (CA) and a server certificate/key pair.
 On one of the nodes of the remote cluster, from the directory where {es} has
 been installed:


### PR DESCRIPTION
This PR expands the step where the remote cluster server is enabled, by splitting it into three sub-bullets for each of the `remote_cluster_server.enabled`, `remote_cluster.host`, and `remote_cluster.port` settings. 

Also adds a warning that for single node clusters, remote cluster server traffic may be bound to the local interface by default, preventing remote clusters from connecting.