### PR TITLE
Make ESQL csv spec tests deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/build.gradle
+++ b/x-pack/plugin/esql/qa/testFixtures/build.gradle
@@ -12,3 +12,21 @@ dependencies {
     implementation project(':server')
     api "net.sf.supercsv:super-csv:${versions.supercsv}"
 }
+
+/**
+ * Runs CSV Spec Tests data loader to load data to a running stand-alone instance
+ * Accepts an URL as first argument, eg. http://localhost:9200 or http://user:pass@localhost:9200
+ *
+ * eg.
+ * ./gradlew :x-pack:plugin:esql:qa:testFixtures:loadCsvSpecData --args="http://elastic-admin:elastic-password@localhost:9200"
+ *
+ * If no arguments are specified, the default URL is http://localhost:9200 without authentication.
+ * It also supports HTTPS.
+ */
+task loadCsvSpecData(type: JavaExec) {
+  group = "Execution"
+  description = "Loads ESQL CSV Spec Tests data on a running stand-alone instance"
+  classpath = sourceSets.main.runtimeClasspath
+  mainClass = "org.elasticsearch.xpack.esql.CsvTestsDataLoader"
+}
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -231,7 +231,13 @@ public final class CsvAssert {
         return (x, y) -> {
             for (int i = 0; i < x.size(); i++) {
                 Object left = x.get(i);
+                if (left instanceof List<?> l) {
+                    left = l.isEmpty() ? null : l.get(0);
+                }
                 Object right = y.get(i);
+                if (right instanceof List<?> r) {
+                    right = r.isEmpty() ? null : r.get(0);
+                }
                 if (left == null && right == null) {
                     continue;
                 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -310,7 +310,13 @@ public final class CsvTestUtils {
         SCALED_FLOAT(s -> s == null ? null : scaledFloat(s, "100"), Double.class),
         KEYWORD(Object::toString, BytesRef.class),
         TEXT(Object::toString, BytesRef.class),
-        IP(StringUtils::parseIP, BytesRef.class),
+        IP(
+            StringUtils::parseIP,
+            (l, r) -> l instanceof String l2
+                ? StringUtils.parseIP(l2).compareTo(StringUtils.parseIP((String) r))
+                : ((BytesRef) l).compareTo((BytesRef) r),
+            BytesRef.class
+        ),
         VERSION(v -> new Version(v).toBytesRef(), BytesRef.class),
         NULL(s -> null, Void.class),
         DATETIME(

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -312,8 +312,8 @@ public final class CsvTestUtils {
         TEXT(Object::toString, BytesRef.class),
         IP(
             StringUtils::parseIP,
-            (l, r) -> l instanceof String l2
-                ? StringUtils.parseIP(l2).compareTo(StringUtils.parseIP((String) r))
+            (l, r) -> l instanceof String maybeIP
+                ? StringUtils.parseIP(maybeIP).compareTo(StringUtils.parseIP(String.valueOf(r)))
                 : ((BytesRef) l).compareTo((BytesRef) r),
             BytesRef.class
         ),
@@ -321,7 +321,7 @@ public final class CsvTestUtils {
         NULL(s -> null, Void.class),
         DATETIME(
             x -> x == null ? null : DateFormatters.from(UTC_DATE_TIME_FORMATTER.parse(x)).toInstant().toEpochMilli(),
-            (l, r) -> l instanceof Long l2 ? l2.compareTo((Long) r) : l.toString().compareTo(r.toString()),
+            (l, r) -> l instanceof Long maybeIP ? maybeIP.compareTo((Long) r) : l.toString().compareTo(r.toString()),
             Long.class
         ),
         BOOLEAN(Booleans::parseBoolean, Boolean.class);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
@@ -49,7 +49,7 @@ avg(salary):double | always_false:boolean
 
 in
 from employees | keep emp_no, is_rehired, still_hired | where is_rehired in (still_hired, true) | where is_rehired != still_hired;
-
+ignoreOrder:true
 emp_no:integer |is_rehired:boolean |still_hired:boolean
 10021          |true               |false
 10029          |true               |false
@@ -150,7 +150,7 @@ tf:boolean    |tt:boolean |ff:boolean |ttff:boolean
 ;
 
 convertFromString
-from employees | keep emp_no, is_rehired, first_name | eval rehired_str = to_string(is_rehired) | eval rehired_bool = to_boolean(rehired_str) | eval all_false = to_boolean(first_name) | drop first_name | limit 5;
+from employees | sort emp_no | keep emp_no, is_rehired, first_name | eval rehired_str = to_string(is_rehired) | eval rehired_bool = to_boolean(rehired_str) | eval all_false = to_boolean(first_name) | drop first_name | limit 5;
 emp_no:integer |is_rehired:boolean         |rehired_str:keyword        |rehired_bool:boolean        |all_false:boolean
 10001          |[false, true]              |[false, true]              |[false, true]               |false
 10002          |[false, false]             |[false, false]             |[false, false]              |false
@@ -174,7 +174,7 @@ str:keyword                                | bool:boolean
 
 convertFromDouble
 from employees | eval h_2 = height - 2.0, double2bool = to_boolean(h_2) | where emp_no in (10036, 10037, 10038) | keep emp_no, height, *2bool;
-
+ignoreOrder:true
 emp_no:integer |height:double |double2bool:boolean
 10036          |1.61          |true
 10037          |2.0           |false
@@ -189,7 +189,7 @@ row ul = [9223372036854775808, 9223372036854775807, 1, 0] | eval bool = to_bool(
 ;
 
 convertFromIntAndLong
-from employees | keep emp_no, salary_change* | eval int2bool = to_boolean(salary_change.int), long2bool = to_boolean(salary_change.long) | limit 10;
+from employees | sort emp_no | keep emp_no, salary_change* | eval int2bool = to_boolean(salary_change.int), long2bool = to_boolean(salary_change.long) | limit 10;
 
 emp_no:integer |salary_change:double      |salary_change.int:integer | salary_change.keyword:keyword |salary_change.long:long |int2bool:boolean          |long2bool:boolean       
 10001          |1.19                      |1                |1.19                      |1                 |true                     |true                     
@@ -207,7 +207,7 @@ emp_no:integer |salary_change:double      |salary_change.int:integer | salary_ch
 // short and byte aren't actually tested, these are loaded as int blocks atm
 convertFromByteAndShort
 from employees | eval byte2bool = to_boolean(languages.byte), short2bool = to_boolean(languages.short) | where emp_no in (10019, 10020, 10030) | keep emp_no, languages, *2bool;
-
+ignoreOrder:true
 emp_no:integer |languages:integer |byte2bool:boolean |short2bool:boolean
 10019          |1                 |true              |true
 10020          |null              |null              |null

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/comparison.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/comparison.csv-spec
@@ -9,6 +9,7 @@ emp_no:integer
 
 longToLong
 from employees
+| sort emp_no
 | where languages.long < avg_worked_seconds
 | limit 1
 | keep emp_no;
@@ -19,6 +20,7 @@ emp_no:integer
 
 doubleToDouble
 from employees
+| sort emp_no
 | where height < 10.0
 | limit 1
 | keep emp_no;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -1,5 +1,6 @@
 twoConditionsWithDefault
 from employees
+| sort emp_no
 | eval type = case(
     languages <= 1, "monolingual",
     languages <= 2, "bilingual",
@@ -22,6 +23,7 @@ emp_no:integer | type:keyword
 
 singleCondition
 from employees
+| sort emp_no
 | eval g = case(gender == "F", true)
 | keep gender, g
 | limit 10;
@@ -41,6 +43,7 @@ null           |null
 
 conditionIsNull
 from employees 
+| sort emp_no
 | eval g = case(
     gender == "F", 1,
     languages > 1, 2,
@@ -78,6 +81,7 @@ M              |null             |3
 
 nullValue
 from employees
+| sort emp_no
 | eval g = case(gender == "F", 1 + null, 10)
 | keep gender, g
 | limit 5;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -58,6 +58,7 @@ emp_no:integer | x:keyword                     | y:keyword
 
 compareToString
 from employees | where hire_date < "1985-03-01T00:00:00Z" | keep emp_no, hire_date;
+ignoreOrder:true
 
 emp_no:integer | hire_date:date
 10009          | 1985-02-18T00:00:00.000Z
@@ -159,7 +160,7 @@ x:date                  |hire_date:date
 ;
 
 convertFromDatetime
-from employees| keep birth_date | eval bd = to_datetime(birth_date) | limit 2;
+from employees | sort emp_no | keep birth_date | eval bd = to_datetime(birth_date) | limit 2;
 
 birth_date:date         |bd:date
 1953-09-02T00:00:00.000Z|1953-09-02T00:00:00.000Z
@@ -438,6 +439,7 @@ dateFields
 from employees | where emp_no == 10049 or emp_no == 10050 
 | eval year = date_extract(birth_date, "year"), month = date_extract(birth_date, "month_of_year"), day = date_extract(birth_date, "day_of_month")
 | keep emp_no, year, month, day;
+ignoreOrder:true
 
 emp_no:integer | year:long    | month:long    | day:long
 10049          | null         | null          | null
@@ -448,6 +450,7 @@ emp_no:integer | year:long    | month:long    | day:long
 dateFormatLocale
 from employees | where emp_no == 10049 or emp_no == 10050 | sort emp_no 
 | eval birth_month = date_format(birth_date, "MMMM") | keep emp_no, birth_date, birth_month;
+ignoreOrder:true
 
 emp_no:integer  |  birth_date:datetime       | birth_month:keyword
 10049           |  null                      | null
@@ -563,6 +566,7 @@ plus:datetime
 
 fieldDateMathSimple
 from employees
+| sort emp_no
 | eval bd = 1 year + birth_date - 1 millisecond
 | keep birth_date, bd
 | limit 5;
@@ -589,6 +593,7 @@ c:long
 
 filteringWithDateMath
 from employees
+| sort emp_no
 | where birth_date < to_dt("2023-08-25T11:25:41.052Z") - 70 years
 | keep birth_date;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -21,6 +21,7 @@ avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword 
 docsEval
 // tag::eval[]
 FROM employees
+| SORT emp_no
 | KEEP first_name, last_name, height
 | EVAL height_feet = height * 3.281, height_cm = height * 100
 // end::eval[]
@@ -36,6 +37,7 @@ Georgi |Facello | 2.03 | 6.66043 | 202.99999999999997
 docsEvalReplace
 // tag::evalReplace[]
 FROM employees
+| SORT emp_no
 | KEEP first_name, last_name, height
 | EVAL height = height * 3.281
 // end::evalReplace[]
@@ -51,10 +53,10 @@ Georgi | Facello | 6.66043
 docsLimit
 // tag::limit[]
 FROM employees
+| SORT emp_no ASC
 | LIMIT 5
 // end::limit[]
 | KEEP emp_no
-| SORT emp_no ASC
 ;
 
 emp_no:integer

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/drop.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/drop.csv-spec
@@ -1,19 +1,19 @@
 sortWithLimitOne_DropHeight
-from employees | sort languages | limit 1 | drop height*;
+from employees | sort languages, emp_no | limit 1 | drop height*;
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean
 244294991         |1955-01-21T00:00:00.000Z|10005          |Kyoichi        |M              |1989-09-12T00:00:00.000Z|[false, false, false, true]|null           |1              |1              |1              |1              |Maliniak       |63528          |[-2.14, 13.07] |[-2, 13]        |[-2.14, 13.07] |[-2, 13]          |true
 ;
 
 simpleEvalWithSortAndLimitOne_DropHeight
-from employees | eval x = languages + 7 | sort x | limit 1 | drop height*;
+from employees | eval x = languages + 7 | sort x, emp_no | limit 1 | drop height*;
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean | x:integer
 244294991         |1955-01-21T00:00:00.000Z|10005          |Kyoichi        |M              |1989-09-12T00:00:00.000Z|[false, false, false, true]|null           |1              |1              |1              |1              |Maliniak       |63528          |[-2.14, 13.07] |[-2, 13]         |[-2.14, 13.07] |[-2, 13]          |true           |8
 ;
 
 whereWithEvalGeneratedValue_DropHeight
-from employees | eval x = salary / 2 | where x > 37000 | drop height*;
+from employees | sort emp_no | eval x = salary / 2 | where x > 37000 | drop height*;
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean | x:integer
 393084805         |1957-05-23T00:00:00.000Z|10007          |Tzvetan        |F              |1989-02-10T00:00:00.000Z|[false, false, true, true]|null                                                                        |4              |4              |4              |4              |Zielinski      |74572          |[-7.06, 0.57, 1.99] |[-7, 0, 1]       |[-7.06, 0.57, 1.99]  |[-7, 0, 1]        |true           |37286          

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -1,7 +1,7 @@
 // Floating point types-specific tests
 
 inDouble
-from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002);
+from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002) | sort emp_no;
 
 emp_no:integer |height:double  |height.float:double |height.half_float:double |height.scaled_float:double
 10001          |2.03           |2.0299999713897705  |2.029296875              |2.0300000000000002
@@ -9,7 +9,7 @@ emp_no:integer |height:double  |height.float:double |height.half_float:double |h
 ;
 
 inFloat
-from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height.float in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002);
+from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height.float in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002) | sort emp_no;
 
 emp_no:integer |height:double  |height.float:double |height.half_float:double |height.scaled_float:double
 10001          |2.03           |2.0299999713897705  |2.029296875              |2.0300000000000002
@@ -17,7 +17,7 @@ emp_no:integer |height:double  |height.float:double |height.half_float:double |h
 ;
 
 inHalfFloat
-from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height.half_float in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002);
+from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height.half_float in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002) | sort emp_no;
 
 emp_no:integer |height:double  |height.float:double |height.half_float:double |height.scaled_float:double
 10001          |2.03           |2.0299999713897705  |2.029296875              |2.0300000000000002
@@ -25,7 +25,7 @@ emp_no:integer |height:double  |height.float:double |height.half_float:double |h
 ;
 
 inScaledFloat
-from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height.scaled_float in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002);
+from employees | keep emp_no, height, height.float, height.half_float, height.scaled_float | where height.scaled_float in (2.03, 2.0299999713897705, 2.029296875, 2.0300000000000002) | sort emp_no;
 
 emp_no:integer |height:double  |height.float:double |height.half_float:double |height.scaled_float:double
 10001          |2.03           |2.0299999713897705  |2.029296875              |2.0300000000000002

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/id.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/id.csv-spec
@@ -4,6 +4,7 @@
 
 selectAll
 FROM apps [metadata _id];
+ignoreOrder:true
 
 id:integer |name:keyword   |version:version     | _id:keyword
 1          |aaaaa          |1                   | 1

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
@@ -9,6 +9,7 @@ emp_no:integer |avg_worked_seconds:long
 
 inShortAndByte
 from employees | keep emp_no, languages.short, languages.byte | where languages.short in (2, 4, 5) and languages.byte in (4, -1) and emp_no < 10010;
+ignoreOrder:true
 
 emp_no:integer |languages.short:short|languages.byte:byte
 10003          |4                    |4
@@ -17,6 +18,7 @@ emp_no:integer |languages.short:short|languages.byte:byte
 
 inCast
 from employees | keep emp_no, languages.byte, avg_worked_seconds, height | where languages.byte in (4, -1, avg_worked_seconds, 1000000000000, null, height) and emp_no < 10010;
+ignoreOrder:true
 
 emp_no:integer |languages.byte:byte |avg_worked_seconds:long |height:double
 10003          |4                   |200296405               |1.83
@@ -26,6 +28,7 @@ emp_no:integer |languages.byte:byte |avg_worked_seconds:long |height:double
 // `<= 10030` insures going over records where is_null(languages)==true; `in (.., emp_no)` prevents pushing the IN to Lucene
 inOverNulls
 from employees | keep emp_no, languages | where languages is null or emp_no <= 10030 | where languages in (2, 3, emp_no);
+ignoreOrder:true
 
 emp_no:integer |languages:integer
 10001          |2

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -1,5 +1,6 @@
 simpleProject
 from hosts | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip
 eth0           |alpha          |127.0.0.1                                                                        |127.0.0.1
@@ -113,6 +114,7 @@ null           |[127.0.0.1, 127.0.0.2, 127.0.0.3]
 
 conditional
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | keep eq, ip0, ip1;
+ignoreOrder:true
 
 eq:ip                                                 |ip0:ip                                                                           |ip1:ip
 127.0.0.1                                             |127.0.0.1                                                                        |127.0.0.1
@@ -129,6 +131,7 @@ fe80::cae2:65ff:fece:fec1                             |[fe80::cae2:65ff:fece:feb
 
 in
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip                   |eq:ip
 eth0           |alpha          |127.0.0.1                                                                        |127.0.0.1                |127.0.0.1
@@ -150,6 +153,7 @@ eth1           |beta           |127.0.0.1      |127.0.0.2
 
 cidrMatchNullField
 from hosts | where cidr_match(ip0, "127.0.0.2/32") is null | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip
 eth0           |epsilon        |[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece:fec0, fe80::cae2:65ff:fece:fec1]|fe80::cae2:65ff:fece:fec1
@@ -159,6 +163,7 @@ eth2           |epsilon        |[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece
 
 cdirMatchMultipleArgs
 from hosts | where cidr_match(ip1, "127.0.0.2/32", "127.0.0.3/32") | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip                   |ip1:ip
 eth1           |beta           |127.0.0.1                |127.0.0.2
@@ -167,6 +172,7 @@ eth0           |gamma          |fe80::cae2:65ff:fece:feb9|127.0.0.3
 
 cidrMatchFunctionArg
 from hosts | where cidr_match(ip1, concat("127.0.0.2", "/32"), "127.0.0.3/32") | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip                   |ip1:ip
 eth1           |beta           |127.0.0.1                |127.0.0.2
@@ -175,6 +181,7 @@ eth0           |gamma          |fe80::cae2:65ff:fece:feb9|127.0.0.3
 
 cidrMatchFieldArg
 from hosts | eval cidr="127.0.0.2" | where cidr_match(ip1, cidr, "127.0.0.3/32") | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip                   |ip1:ip
 eth1           |beta           |127.0.0.1                |127.0.0.2
@@ -207,6 +214,7 @@ str1:keyword |str2:keyword |ip1:ip  |ip2:ip
 
 pushDownIP
 from hosts | where ip1 == to_ip("::1") | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip     |ip1:ip
 eth1           |alpha          |::1        |::1
@@ -215,6 +223,7 @@ eth0           |beta           |127.0.0.1  |::1
 
 pushDownIPWithIn
 from hosts | where ip1 in (to_ip("::1"), to_ip("127.0.0.1")) | keep card, host, ip0, ip1;
+ignoreOrder:true
 
 card:keyword   |host:keyword   |ip0:ip      |ip1:ip
 eth0           |alpha          |127.0.0.1   |127.0.0.1
@@ -224,6 +233,7 @@ eth0           |beta           |127.0.0.1   |::1
 
 pushDownIPWithComparision
 from hosts | where ip1 > to_ip("127.0.0.1") | keep card, ip1;
+ignoreOrder:true
 
 card:keyword   |ip1:ip
 eth1           |127.0.0.2

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -1,5 +1,5 @@
 projectFrom
-from employees | keep languages, emp_no, first_name, last_name | limit 10;
+from employees | sort emp_no | keep languages, emp_no, first_name, last_name | limit 10;
 
 languages:integer | emp_no:integer | first_name:keyword | last_name:keyword
 2 | 10001 | Georgi | Facello
@@ -15,7 +15,8 @@ languages:integer | emp_no:integer | first_name:keyword | last_name:keyword
 ;
 
 projectFromWithFilter
-from employees | keep languages, emp_no, first_name, last_name | eval x = emp_no + 10 | where x > 10040 and x < 10050 | limit 5;
+from employees | keep languages, emp_no, first_name, last_name | eval x = emp_no + 10 | where x > 10040 and x < 10046;
+ignoreOrder:true
 
 languages:integer | emp_no:integer | first_name:keyword | last_name:keyword | x:integer
 4 | 10031 | null | Joslin | 10041
@@ -41,6 +42,7 @@ c : long
 
 averageByField
 from employees | stats avg(avg_worked_seconds) by languages;
+ignoreOrder:true
 
 avg(avg_worked_seconds):double | languages:integer
           3.181719481E8        | null 
@@ -60,6 +62,7 @@ avg(avg_worked_seconds):double | languages.long:long
 
 statsBySubField
 from employees | stats avg=avg(avg_worked_seconds),min=min(avg_worked_seconds),max=max(avg_worked_seconds) by languages.long;
+ignoreOrder:true
 
           avg:double | min:long  | max:long  | languages.long:long
 3.181719481E8        | 226435054 | 374037782 | null
@@ -137,6 +140,7 @@ avg(salary):double | last_name:keyword
 
 statsOfInteger
 from employees | where starts_with(last_name, "L") | stats a=avg(salary), s=sum(salary), c=count(last_name) by last_name;
+ignoreOrder:true
 
    a:double    |    s:long     |     c:long    |last_name:keyword   
 42520.0        |85040          |2              |Lortz          
@@ -178,6 +182,7 @@ med:double | languages:integer
 
 multiConditionalWhere
 from employees | eval abc = 1+2 | where (abc + emp_no > 10100 or languages == 1) or (abc + emp_no < 10005 and gender == "F") | keep emp_no, languages, gender, first_name, abc;
+ignoreOrder:true
 
 emp_no:integer | languages:integer | gender:keyword | first_name:keyword | abc:integer
 10005 | 1 | M | Kyoichi | 3
@@ -201,7 +206,7 @@ emp_no:integer | languages:integer | gender:keyword | first_name:keyword | abc:i
 ;
 
 projectFromWithStatsAfterLimit
-from employees | keep gender, avg_worked_seconds, first_name, last_name | limit 10 | stats m = max(avg_worked_seconds) by gender;
+from employees | sort emp_no | keep gender, avg_worked_seconds, first_name, last_name | limit 10 | stats m = max(avg_worked_seconds) by gender;
 
    m:long | gender:keyword
 315236372 | null
@@ -232,7 +237,7 @@ emp_no:integer | languages:integer | first_name:keyword | last_name:keyword
 ;
 
 sortWithLimitOne
-from employees | sort languages | limit 1;
+from employees | sort languages, emp_no | limit 1;
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | height:double | height.float:double | height.half_float:double | height.scaled_float:double | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean
 244294991         |1955-01-21T00:00:00.000Z|10005          |Kyoichi        |M              |2.05           |2.049999952316284|2.05078125       |2.05               |1989-09-12T00:00:00.000Z|[false, false, false, true]|null           |1              |1              |1              |1              |Maliniak       |63528          |[-2.14, 13.07] |[-2, 13]         |[-2.14, 13.07] |[-2, 13]          |true                      
@@ -283,6 +288,7 @@ avg(ratio):double
 
 simpleWhere
 from employees | where salary > 70000 | keep first_name, last_name, salary;
+ignoreOrder:true
 
 first_name:keyword | last_name:keyword | salary:integer
 Tzvetan | Zielinski | 74572
@@ -297,6 +303,7 @@ Valter | Sullins | 73578
 
 whereAfterProject
 from employees | keep salary | where salary > 70000;
+ignoreOrder:true
 
 salary:integer
 74572
@@ -313,6 +320,7 @@ whereWithEvalGeneratedValue
 // the result from running on ES is the one with many decimals the test that runs locally is the one rounded to 2 decimals
 // the "height" fields have the values as 1.7, 1.7000000476837158, 1.7001953125, 1.7
 from employees | eval x = salary / 2 | where x > 37000;
+ignoreOrder:true
 
 avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | height:double | height.float:double | height.half_float:double | height.scaled_float:double | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long | still_hired:boolean | x:integer
 393084805         |1957-05-23T00:00:00.000Z|10007          |Tzvetan        |F              |1.7            |1.7000000476837158|1.7001953125     |1.7                |1989-02-10T00:00:00.000Z|[false, false, true, true]|null                                                                        |4              |4              |4              |4              |Zielinski      |74572          |[-7.06, 0.57, 1.99] |[-7, 0, 1]       |[-7.06, 0.57, 1.99] |[-7, 0, 1]        |true           |37286          
@@ -329,6 +337,7 @@ x:double
 
 statsByDouble
 from employees | eval abc=1+2 | where abc + languages > 4 | stats count(height) by height;
+ignoreOrder:true
 
 count(height):long | height:double
 2 | 2.03
@@ -391,7 +400,7 @@ count(height):long | h1:double
 
 
 whereNegatedCondition
-from employees | eval abc=1+2 | where abc + languages > 4 and languages.long != 1 | eval x=abc+languages | keep x, languages, languages.long | limit 3;
+from employees | sort emp_no | eval abc=1+2 | where abc + languages > 4 and languages.long != 1 | eval x=abc+languages | keep x, languages, languages.long | limit 3;
 
 x:integer | languages:integer | languages.long:long
 5 | 2 | 2
@@ -400,7 +409,7 @@ x:integer | languages:integer | languages.long:long
 ;
 
 evalOverride
-from employees | eval languages = languages + 1 | eval languages = languages + 1 | limit 5 | keep l*;
+from employees | sort emp_no | eval languages = languages + 1 | eval languages = languages + 1 | limit 5 | keep l*;
 
 languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | languages:integer
 2 | 2 | 2 | Facello  | 4
@@ -425,15 +434,15 @@ avg(nullsum):double | count(nullsum):long
 ;
 
 fromStatsLimit
-from employees | stats ac = avg(salary) by languages | limit 2;
+from employees | stats ac = avg(salary) by languages | sort ac | limit 2;
 
 ac:double         | languages:integer
-52519.6           | null
-48178.84210526316 | 2
+41680.76190476191 | 5              
+47733.0           | 4     
 ;
 
 fromLimit
-from employees | keep first_name | limit 2;
+from employees | sort emp_no | keep first_name | limit 2;
 
 first_name:keyword
 Georgi
@@ -470,6 +479,7 @@ x:integer
 
 filterKeyword
 from employees | where first_name != "abc" and emp_no < 10010 | keep first_name;
+ignoreOrder:true
 
 first_name:keyword 
 Georgi
@@ -484,7 +494,7 @@ Sumant
 ;
 
 projectMultiValueKeywords
-from employees | keep emp_no, job_positions, still_hired | limit 5;
+from employees | sort emp_no | keep emp_no, job_positions, still_hired | limit 5;
 
 emp_no:integer |                         job_positions:keyword                        |still_hired:boolean  
 10001          |[Accountant, Senior Python Developer]                                 |true           
@@ -495,7 +505,7 @@ emp_no:integer |                         job_positions:keyword                  
 ;
 
 projectMultiValueBooleans
-from employees | keep emp_no, is_rehired, still_hired | limit 5;
+from employees | sort emp_no | keep emp_no, is_rehired, still_hired | limit 5;
   
 emp_no:integer |     is_rehired:boolean    |still_hired:boolean
 10001          |[false, true]              |true           
@@ -506,7 +516,7 @@ emp_no:integer |     is_rehired:boolean    |still_hired:boolean
 ;
 
 projectMultiValueNumbers
-from employees | keep emp_no, salary_change, salary_change.int, salary_change.long | limit 10;
+from employees | sort emp_no | keep emp_no, salary_change, salary_change.int, salary_change.long | limit 10;
   
 emp_no:integer |   salary_change:double   |salary_change.int:integer|salary_change.long:long
 10001          |1.19                      |1                        |1                 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata-ignoreCsvTests.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata-ignoreCsvTests.csv-spec
@@ -102,7 +102,7 @@ min:integer |i:double
 ;
 
 overwritten
-from employees [metadata _index, _version] | eval _index = 3, _version = "version" | keep emp_no, _index, _version | limit 3;
+from employees [metadata _index, _version] | sort emp_no | eval _index = 3, _version = "version" | keep emp_no, _index, _version | limit 3;
 
 emp_no:integer |_index:integer |_version:keyword
 10001          |3              |version

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
@@ -76,7 +76,7 @@ d:integer | c:integer
 ;
 
 renameEvalProject
-from employees | rename languages as x | keep x | eval z = 2 * x | keep x, z | limit 3;
+from employees | sort emp_no  | rename languages as x | keep x | eval z = 2 * x | keep x, z | limit 3;
 
 x:integer | z:integer
 2 | 4
@@ -85,7 +85,7 @@ x:integer | z:integer
 ;
 
 renameProjectEval
-from employees | eval y = languages | rename languages as x | keep x, y | eval x2 = x + 1 | eval y2 = y + 2 | limit 3;
+from employees | sort emp_no | eval y = languages | rename languages as x | keep x, y | eval x2 = x + 1 | eval y2 = y + 2 | limit 3;
 
 x:integer | y:integer | x2:integer | y2:integer
 2 | 2 | 3 | 4
@@ -94,7 +94,7 @@ x:integer | y:integer | x2:integer | y2:integer
 ;
 
 renameWithFilterPushedToES
-from employees | rename emp_no as x | keep languages, first_name, last_name, x | where x > 10030 and x < 10040 | limit 5;
+from employees | sort emp_no | rename emp_no as x | keep languages, first_name, last_name, x | where x > 10030 and x < 10040 | limit 5;
 
 languages:integer | first_name:keyword | last_name:keyword | x:integer
 4 | null | Joslin | 10031
@@ -105,7 +105,7 @@ languages:integer | first_name:keyword | last_name:keyword | x:integer
 ;
 
 renameNopProject
-from employees | rename emp_no as emp_no | keep emp_no, last_name | limit 3;
+from employees | sort emp_no | rename emp_no as emp_no | keep emp_no, last_name | limit 3;
 
 emp_no:integer | last_name:keyword
 10001 | Facello
@@ -114,7 +114,7 @@ emp_no:integer | last_name:keyword
 ;
 
 renameOverride
-from employees | rename emp_no as languages | keep languages, last_name | limit 3;
+from employees | sort emp_no | rename emp_no as languages | keep languages, last_name | limit 3;
 
 languages:integer | last_name:keyword
 10001 | Facello

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -392,7 +392,7 @@ c:long | languages:integer | still_hired:boolean
 ;
 
 byDateAndKeywordAndInt
-from employees | eval d = date_trunc(1 year, hire_date) | stats c = count(emp_no) by d, gender, languages | sort c desc, d, languages desc | limit 10;
+from employees | eval d = date_trunc(1 year, hire_date) | stats c = count(emp_no) by d, gender, languages | sort c desc, d, languages desc, gender desc | limit 10;
 
 c:long |           d:date         | gender:keyword | languages:integer
      3 | 1986-01-01T00:00:00.000Z | M              | 2
@@ -408,7 +408,7 @@ c:long |           d:date         | gender:keyword | languages:integer
 ;
 
 byDateAndKeywordAndIntWithAlias
-from employees | eval d = date_trunc(1 year, hire_date) | rename gender as g, languages as l, emp_no as e | keep d, g, l, e | stats c = count(e) by d, g, l | sort c desc, d, l desc | limit 10;
+from employees | eval d = date_trunc(1 year, hire_date) | rename gender as g, languages as l, emp_no as e | keep d, g, l, e | stats c = count(e) by d, g, l | sort c desc, d, l desc, g desc | limit 10;
 
 c:long |           d:date         | g:keyword | l:integer
      3 | 1986-01-01T00:00:00.000Z | M         | 2

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -55,6 +55,7 @@ emp_no:integer | first_name:keyword  | f_S:boolean
 
 startsWithField
 from employees | where emp_no <= 10010 | eval f_l = starts_with(last_name, gender) | keep emp_no, last_name, gender, f_l;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | gender:keyword | f_l:boolean
 10001 | Facello   | M    | false
@@ -71,6 +72,7 @@ emp_no:integer | last_name:keyword | gender:keyword | f_l:boolean
 
 substring
 from employees | where emp_no <= 10010 | eval f_l = substring(last_name, 3) | keep emp_no, last_name, f_l;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | f_l:keyword
 10001 | Facello   | cello
@@ -87,6 +89,7 @@ emp_no:integer | last_name:keyword | f_l:keyword
 
 substring with length
 from employees | where emp_no <= 10010 | eval f_l = substring(last_name, 3, 1) | keep emp_no, last_name, f_l;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | f_l:keyword
 10001 | Facello   | c
@@ -103,6 +106,7 @@ emp_no:integer | last_name:keyword | f_l:keyword
 
 substring negative start
 from employees | where emp_no <= 10010 | eval f_l = substring(last_name, -3) | keep emp_no, last_name, f_l;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | f_l:keyword
 10001 | Facello   | llo
@@ -119,6 +123,7 @@ emp_no:integer | last_name:keyword | f_l:keyword
 
 substring nested negative start
 from employees | where emp_no <= 10010 | eval f_l = substring(substring(last_name, -3),-1) | keep emp_no, last_name, f_l;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | f_l:keyword
 10001 | Facello   | o
@@ -135,6 +140,7 @@ emp_no:integer | last_name:keyword | f_l:keyword
 
 substring length
 from employees | where emp_no <= 10010 | eval f_l = length(substring(last_name, 3)) | keep emp_no, last_name, f_l;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | f_l:integer
 10001 | Facello   | 5
@@ -151,6 +157,7 @@ emp_no:integer | last_name:keyword | f_l:integer
 
 substring pair
 from employees | where emp_no <= 10010 | eval x = substring(last_name, 1, 1), y = 1, z = substring("abcdef", y, y) | keep emp_no, last_name, x, z;
+ignoreOrder:true
 
 emp_no:integer | last_name:keyword | x:keyword | z:keyword
 10001 | Facello   | F | a
@@ -294,6 +301,7 @@ emp_no:integer | name:keyword
 // Note: no matches in MV returned
 in
 from employees | where job_positions in ("Internship", first_name) | keep emp_no, job_positions;
+ignoreOrder:true
 
 emp_no:integer |job_positions:keyword
 10048          |Internship
@@ -302,7 +310,7 @@ emp_no:integer |job_positions:keyword
 
 in3VLNoNull
 // filtering for SVs, since IN uses EQUALS evaluators, that turn MVs into NULL
-from employees | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval is_in = job_positions in ("Accountant", "Internship");
+from employees | sort emp_no | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval is_in = job_positions in ("Accountant", "Internship");
 
 emp_no:integer |job_positions:keyword |is_in:boolean
 10024          |Junior Developer      |false
@@ -311,7 +319,7 @@ emp_no:integer |job_positions:keyword |is_in:boolean
 ;
 
 in3VLWithNull
-from employees | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval is_in = job_positions in ("Accountant", "Internship", null);
+from employees | sort emp_no | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval is_in = job_positions in ("Accountant", "Internship", null);
 
 emp_no:integer |job_positions:keyword |is_in:boolean
 10024          |Junior Developer      |null
@@ -320,7 +328,7 @@ emp_no:integer |job_positions:keyword |is_in:boolean
 ;
 
 in3VLWithComputedNull
-from employees | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval nil = concat("", null) | eval is_in = job_positions in ("Accountant", "Internship", nil);
+from employees | sort emp_no | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval nil = concat("", null) | eval is_in = job_positions in ("Accountant", "Internship", nil);
 
 emp_no:integer |job_positions:keyword |nil:keyword |is_in:boolean
 10024          |Junior Developer      |null        |null
@@ -329,7 +337,7 @@ emp_no:integer |job_positions:keyword |nil:keyword |is_in:boolean
 ;
 
 in3VLWithNullAsValue
-from employees | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval is_in = null in ("Accountant", "Internship", null);
+from employees | sort emp_no | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval is_in = null in ("Accountant", "Internship", null);
 
 emp_no:integer |job_positions:keyword |is_in:boolean
 10024          |Junior Developer      |null
@@ -338,7 +346,7 @@ emp_no:integer |job_positions:keyword |is_in:boolean
 ;
 
 in3VLWithComputedNullAsValue
-from employees | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval nil = concat("", null) | eval is_in = nil in ("Accountant", "Internship", null);
+from employees | sort emp_no | where mv_count(job_positions) <= 1 | where emp_no >= 10024 | limit 3 | keep emp_no, job_positions | eval nil = concat("", null) | eval is_in = nil in ("Accountant", "Internship", null);
 
 emp_no:integer |job_positions:keyword |nil:keyword |is_in:boolean
 10024          |Junior Developer      |null        |null
@@ -436,7 +444,7 @@ min(salary):integer | max(salary):integer | job_positions:keyword
 ;
 
 convertFromString
-from employees | eval positions = to_string(job_positions) | keep emp_no, positions, job_positions | limit 5;
+from employees | sort emp_no | eval positions = to_string(job_positions) | keep emp_no, positions, job_positions | limit 5;
 
 emp_no:integer |positions:keyword                                                     |job_positions:keyword
 10001          |[Accountant, Senior Python Developer]                                 |[Accountant, Senior Python Developer]                                 
@@ -548,7 +556,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 convertFromBoolean
-from employees | eval rehired = to_string(is_rehired) | keep emp_no, rehired, is_rehired | limit 5;
+from employees | sort emp_no | eval rehired = to_string(is_rehired) | keep emp_no, rehired, is_rehired | limit 5;
 
 emp_no:integer |rehired:string              |is_rehired:boolean
 10001          |[false, true]               |[false, true]
@@ -559,7 +567,7 @@ emp_no:integer |rehired:string              |is_rehired:boolean
 ;
 
 convertFromDatetime
-from employees | sort emp_no| eval hired_at = to_string(hire_date) | keep emp_no, hired_at, hire_date  | limit 1;
+from employees | sort emp_no | eval hired_at = to_string(hire_date) | keep emp_no, hired_at, hire_date  | limit 1;
 
 emp_no:integer |hired_at:keyword         |hire_date:date
 10001          |1986-06-26T00:00:00.000Z |1986-06-26T00:00:00.000Z
@@ -567,6 +575,7 @@ emp_no:integer |hired_at:keyword         |hire_date:date
 
 convertFromIP
 from hosts | where host=="epsilon" | eval str0 = to_string(ip0) | keep str0, ip0;
+ignoreOrder:true
 
 str0:keyword                                                                            |ip0:ip
 ["fe80::cae2:65ff:fece:feb9", "fe80::cae2:65ff:fece:fec0", "fe80::cae2:65ff:fece:fec1"] |[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece:fec0, fe80::cae2:65ff:fece:fec1]
@@ -638,6 +647,7 @@ ROW a=[10, 9, 8]
 
 showTextFields
 from hosts | where host == "beta" | keep host, host_group, description;
+ignoreOrder:true
 
 host:keyword     | host_group:text          | description:text
 beta             | Kubernetes cluster       | beta k8s server
@@ -647,6 +657,7 @@ beta             | Kubernetes cluster       | [beta k8s server, beta k8s server2
 
 lengthOfText
 from hosts | where host=="epsilon" | eval l1 = length(host_group), l2 = length(description) | keep l1, l2;
+ignoreOrder:true
 
 l1:integer             | l2:integer
 null                   | 19
@@ -656,6 +667,7 @@ null                   | 19
 
 startsWithText
 from hosts | where host=="epsilon" | eval l1 = starts_with(host_group, host), l2 = starts_with(description, host) | keep l1, l2;
+ignoreOrder:true
 
 l1:boolean             | l2:boolean
 null                   | true
@@ -665,6 +677,7 @@ false                  | null
 
 substringOfText
 from hosts | where host=="epsilon" | eval l1 = substring(host_group, 0, 5), l2 = substring(description, 0, 5) | keep l1, l2;
+ignoreOrder:true
 
 l1:keyword             | l2:keyword
 null                   | epsil

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unsigned_long.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unsigned_long.csv-spec
@@ -91,7 +91,7 @@ from ul_logs | where bytes_in == bytes_out;
 ;
 
 filterOnFieldsInequality
-from ul_logs | where bytes_in < bytes_out | eval b_in = bytes_in / to_ul(pow(10.,15)), b_out = bytes_out / to_ul(pow(10.,15)) | limit 5;
+from ul_logs | sort id | where bytes_in < bytes_out | eval b_in = bytes_in / to_ul(pow(10.,15)), b_out = bytes_out / to_ul(pow(10.,15)) | limit 5;
 
        @timestamp:date  |      bytes_in:ul   |     bytes_out:ul   |      id:i     |    status:k   |     b_in:ul   | b_out:ul
 2017-11-10T21:15:54.000Z|4348801185987554667 |12749081495402663265|1              |OK             |4348           |12749

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -43,6 +43,7 @@ emp_no:integer | first_name:keyword | last_name:keyword
 
 likeAndOr
 from employees | where first_name like "Eberhar*" or first_name like "*zuh*" and last_name like "*eha" | keep emp_no, first_name, last_name;
+ignoreOrder:true
 
 emp_no:integer | first_name:keyword | last_name:keyword
 10013          | Eberhardt          | Terkki
@@ -180,6 +181,7 @@ emp_no:integer | first_name:keyword | last_name:keyword
 
 rLikeAndOr
 from employees | where first_name rlike "Eberhar.*" or first_name rlike ".*zuh.*" and last_name rlike ".*eha" | keep emp_no, first_name, last_name;
+ignoreOrder:true
 
 emp_no:integer | first_name:keyword | last_name:keyword
 10013          | Eberhardt          | Terkki


### PR DESCRIPTION
Some tests did not have a completely deterministic behavior, because queries did not have an explicit ordering.

This PR makes the behavior deterministic by:
- adding `ignoreOrder:true` where possible
- adding a `SORT` command to queries that cannot be fixed with `ignoreOrder`, eg. because they have a LIMIT