### PR TITLE
Dry up writing string+named-writeable collections via StreamOutput

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSelectorPipelineAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSelectorPipelineAggregationBuilder.java
@@ -55,7 +55,7 @@ public class BucketSelectorPipelineAggregationBuilder extends AbstractPipelineAg
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeMap(bucketsPathsMap, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(bucketsPathsMap, StreamOutput::writeString);
         script.writeTo(out);
         gapPolicy.writeTo(out);
     }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
@@ -116,7 +116,7 @@ public class GrokProcessorGetAction extends ActionType<GrokProcessorGetAction.Re
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(grokPatterns, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(grokPatterns, StreamOutput::writeString);
         }
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
@@ -127,7 +127,7 @@ class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(databases, StreamOutput::writeString, (o, v) -> {
+        out.writeMap(databases, (o, v) -> {
             o.writeLong(v.lastUpdate);
             o.writeVInt(v.firstChunk);
             o.writeVInt(v.lastChunk);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
@@ -208,10 +208,10 @@ public class GeoIpDownloaderStatsAction extends ActionType<GeoIpDownloaderStatsA
             if (stats != null) {
                 stats.writeTo(out);
             }
-            out.writeCollection(databases, StreamOutput::writeString);
-            out.writeCollection(filesInTemp, StreamOutput::writeString);
+            out.writeStringCollection(databases);
+            out.writeStringCollection(filesInTemp);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)) {
-                out.writeCollection(configDatabases, StreamOutput::writeString);
+                out.writeStringCollection(configDatabases);
             }
         }
 

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/GeometryCollectionBuilder.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/builders/GeometryCollectionBuilder.java
@@ -51,7 +51,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder<Shape, GeometryColle
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(shapes);
+        out.writeNamedWriteableCollection(shapes);
     }
 
     public GeometryCollectionBuilder shape(ShapeBuilder<?, ?, ?> shape) {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -88,8 +88,8 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeDouble(metricScore);
-        out.writeMap(details, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(failures, StreamOutput::writeString, StreamOutput::writeException);
+        out.writeMap(details, (o, v) -> v.writeTo(o));
+        out.writeMap(failures, StreamOutput::writeException);
     }
 
     @Override

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
@@ -98,7 +98,7 @@ public class RankEvalSpec implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(ratedRequests);
         out.writeNamedWriteable(metric);
-        out.writeMap(templates, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(templates, (o, v) -> v.writeTo(o));
         out.writeVInt(maxConcurrentSearches);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -76,7 +76,6 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
         }
         out.writeMap(
             routingTable,
-            StreamOutput::writeString,
             (shardsOut, shards) -> shardsOut.writeMap(
                 shards,
                 StreamOutput::writeVInt,
@@ -308,7 +307,7 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeCollection(nodeIds, StreamOutput::writeString);
+            out.writeStringCollection(nodeIds);
             out.writeVInt(total);
             out.writeVInt(unassigned);
             out.writeVInt(ignored);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathRequest.java
@@ -37,7 +37,7 @@ public class NodePrevalidateShardPathRequest extends TransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeCollection(shardIds, (o, value) -> value.writeTo(o));
+        out.writeCollection(shardIds);
     }
 
     public Set<ShardId> getShardIds() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -37,7 +37,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(groups);
         out.writeArray(nodes);
-        out.writeMap(indicesAndFilters, StreamOutput::writeString, (o, s) -> s.writeTo(o));
+        out.writeMap(indicesAndFilters, (o, s) -> s.writeTo(o));
     }
 
     public ClusterSearchShardsResponse(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -150,7 +150,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(snapshots);
         if (out.getTransportVersion().onOrAfter(GetSnapshotsRequest.MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
-            out.writeMap(failures, StreamOutput::writeString, StreamOutput::writeException);
+            out.writeMap(failures, StreamOutput::writeException);
             out.writeOptionalString(next);
         } else {
             if (failures.isEmpty() == false) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponse.java
@@ -40,7 +40,7 @@ public class GetShardSnapshotResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(latestShardSnapshot);
-        out.writeMap(repositoryFailures, StreamOutput::writeString, (o, err) -> err.writeTo(o));
+        out.writeMap(repositoryFailures, (o, err) -> err.writeTo(o));
     }
 
     public Optional<RepositoryException> getFailureForRepository(String repository) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -210,11 +210,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             if (status != null) {
-                out.writeMap(
-                    status,
-                    (o, s) -> s.writeTo(o),
-                    (output, v) -> output.writeMap(v, (o, shardId) -> shardId.writeTo(o), (o, sis) -> sis.writeTo(o))
-                );
+                out.writeMap(status, (o, s) -> s.writeTo(o), StreamOutput::writeMap);
             } else {
                 out.writeVInt(0);
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -301,7 +301,7 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         out.writeCollection(usedBuiltInTokenFilters);
         out.writeCollection(usedBuiltInAnalyzers);
         if (out.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)) {
-            out.writeMap(usedSynonyms, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(usedSynonyms, (o, v) -> v.writeTo(o));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/FieldStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/FieldStats.java
@@ -42,7 +42,7 @@ public class FieldStats extends IndexFeatureStats {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVInt(scriptCount);
-        out.writeCollection(scriptLangs, StreamOutput::writeString);
+        out.writeStringCollection(scriptLangs);
         fieldScriptStats.writeTo(out);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/RuntimeFieldStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/RuntimeFieldStats.java
@@ -53,7 +53,7 @@ public final class RuntimeFieldStats implements Writeable, ToXContentObject {
         out.writeString(type);
         out.writeInt(count);
         out.writeInt(indexCount);
-        out.writeCollection(scriptLangs, StreamOutput::writeString);
+        out.writeStringCollection(scriptLangs);
         out.writeLong(scriptLessCount);
         out.writeLong(shadowedCount);
         fieldScriptStats.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
@@ -58,8 +58,8 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(queries, StreamOutput::writeString, StreamOutput::writeLong);
-        out.writeMap(sections, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(queries, StreamOutput::writeLong);
+        out.writeMap(sections, StreamOutput::writeLong);
         out.writeVLong(totalSearchCount);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -45,8 +45,8 @@ public class GetAliasesResponse extends ActionResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(aliases, StreamOutput::writeString, (streamOutput1, list1) -> streamOutput1.writeCollection(list1));
-        out.writeMap(dataStreamAliases, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
+        out.writeMap(aliases, StreamOutput::writeCollection);
+        out.writeMap(dataStreamAliases, StreamOutput::writeCollection);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
@@ -125,7 +125,7 @@ public class ReloadAnalyzersResponse extends BroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(reloadDetails, StreamOutput::writeString, (stream, details) -> details.writeTo(stream));
+        out.writeMap(reloadDetails, (stream, details) -> details.writeTo(stream));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageResponse.java
@@ -40,7 +40,7 @@ public final class AnalyzeIndexDiskUsageResponse extends BroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(stats, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(stats, (o, v) -> v.writeTo(o));
     }
 
     Map<String, IndexDiskUsageStats> getStats() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
@@ -61,7 +61,7 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(fields, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(fields, (o, v) -> v.writeTo(o));
         out.writeVLong(indexSizeInBytes);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -173,10 +173,10 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);
         MappingMetadata.writeMappingMetadata(out, mappings);
-        out.writeMap(aliases, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
-        out.writeMap(settings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(defaultSettings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(dataStreams, StreamOutput::writeString, StreamOutput::writeOptionalString);
+        out.writeMap(aliases, StreamOutput::writeCollection);
+        out.writeMap(settings, (o, v) -> v.writeTo(o));
+        out.writeMap(defaultSettings, (o, v) -> v.writeTo(o));
+        out.writeMap(dataStreams, StreamOutput::writeOptionalString);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -153,12 +153,12 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(mappings, StreamOutput::writeString, (outpt, map) -> {
+        out.writeMap(mappings, (outpt, map) -> {
             if (outpt.getTransportVersion().before(TransportVersion.V_8_0_0)) {
                 outpt.writeVInt(1);
                 outpt.writeString(MapperService.SINGLE_MAPPING_NAME);
             }
-            outpt.writeMap(map, StreamOutput::writeString, (o, v) -> {
+            outpt.writeMap(map, (o, v) -> {
                 o.writeString(v.fullName());
                 o.writeBytesReference(v.source);
             });

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConditions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConditions.java
@@ -115,9 +115,8 @@ public class RolloverConditions implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeCollection(
-            conditions.values().stream().filter(c -> c.includedInVersion(out.getTransportVersion())).toList(),
-            StreamOutput::writeNamedWriteable
+        out.writeNamedWriteableCollection(
+            conditions.values().stream().filter(c -> c.includedInVersion(out.getTransportVersion())).toList()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
@@ -71,7 +71,7 @@ public class RolloverConfiguration implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeWriteable(concreteConditions);
-        out.writeCollection(automaticConditions, StreamOutput::writeString);
+        out.writeStringCollection(automaticConditions);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
@@ -88,7 +88,7 @@ public class RolloverInfo implements SimpleDiffable<RolloverInfo>, Writeable, To
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(alias);
         out.writeVLong(time);
-        out.writeNamedWriteableList(metConditions);
+        out.writeNamedWriteableCollection(metConditions);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
@@ -120,7 +120,7 @@ public final class RolloverResponse extends ShardsAcknowledgedResponse implement
         super.writeTo(out);
         out.writeString(oldIndex);
         out.writeString(newIndex);
-        out.writeMap(conditionStatus, StreamOutput::writeString, StreamOutput::writeBoolean);
+        out.writeMap(conditionStatus, StreamOutput::writeBoolean);
         out.writeBoolean(dryRun);
         out.writeBoolean(rolledOver);
         out.writeBoolean(shardsAcknowledged);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -79,8 +79,8 @@ public class GetSettingsResponse extends ActionResponse implements ChunkedToXCon
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(indexToSettings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(indexToDefaultSettings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(indexToSettings, (o, v) -> v.writeTo(o));
+        out.writeMap(indexToDefaultSettings, (o, v) -> v.writeTo(o));
     }
 
     private static void parseSettingsField(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -267,11 +267,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements Chunke
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(
-            storeStatuses,
-            StreamOutput::writeString,
-            (o, v) -> o.writeMap(v, StreamOutput::writeInt, StreamOutput::writeCollection)
-        );
+        out.writeMap(storeStatuses, (o, v) -> o.writeMap(v, StreamOutput::writeInt, StreamOutput::writeCollection));
         out.writeCollection(failures);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
@@ -41,7 +41,7 @@ public class FieldUsageStatsResponse extends ChunkedBroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(stats, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
+        out.writeMap(stats, StreamOutput::writeCollection);
     }
 
     public Map<String, List<FieldUsageShardResponse>> getStats() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -172,8 +172,8 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
         super.writeTo(out);
         out.writeArray(shards);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0)) {
-            out.writeMap(indexHealthMap, StreamOutput::writeString, (o, s) -> s.writeTo(o));
-            out.writeMap(indexStateMap, StreamOutput::writeString, (o, s) -> s.writeTo(o));
+            out.writeMap(indexHealthMap, (o, s) -> s.writeTo(o));
+            out.writeMap(indexStateMap, (o, s) -> s.writeTo(o));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -148,7 +148,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(componentTemplates, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(componentTemplates, (o, v) -> v.writeTo(o));
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
                 out.writeOptionalWriteable(rolloverConfiguration);
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -146,7 +146,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(indexTemplates, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(indexTemplates, (o, v) -> v.writeTo(o));
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
                 out.writeOptionalWriteable(rolloverConfiguration);
             }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -264,7 +264,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             out.writeOptionalStringArray(nonDimensionIndices);
             out.writeOptionalStringArray(metricConflictsIndices);
         }
-        out.writeMap(meta, StreamOutput::writeString, (o, set) -> o.writeCollection(set, StreamOutput::writeString));
+        out.writeMap(meta, StreamOutput::writeStringCollection);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -60,7 +60,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(indexName);
-        out.writeMap(responseMap, StreamOutput::writeString, (valueOut, fc) -> fc.writeTo(valueOut));
+        out.writeMap(responseMap, (valueOut, fc) -> fc.writeTo(valueOut));
         out.writeBoolean(canMatch);
         if (out.getTransportVersion().onOrAfter(MAPPING_HASH_VERSION)) {
             out.writeOptionalString(indexMappingHash);
@@ -78,7 +78,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeStringCollection(indices);
             out.writeString(indexMappingHash);
-            out.writeMap(responseMap, StreamOutput::writeString, (valueOut, fc) -> fc.writeTo(valueOut));
+            out.writeMap(responseMap, (valueOut, fc) -> fc.writeTo(valueOut));
         }
 
         Stream<FieldCapabilitiesIndexResponse> getResponses() {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -147,13 +147,13 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);
-        out.writeMap(responseMap, StreamOutput::writeString, FieldCapabilitiesResponse::writeField);
+        out.writeMap(responseMap, FieldCapabilitiesResponse::writeField);
         FieldCapabilitiesIndexResponse.writeList(out, indexResponses);
         out.writeCollection(failures);
     }
 
     private static void writeField(StreamOutput out, Map<String, FieldCapabilities> map) throws IOException {
-        out.writeMap(map, StreamOutput::writeString, (valueOut, fc) -> fc.writeTo(valueOut));
+        out.writeMap(map, (valueOut, fc) -> fc.writeTo(valueOut));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -89,7 +89,7 @@ public class IndexFieldCapabilities implements Writeable {
             out.writeBoolean(isDimension);
             out.writeOptionalEnum(metricType);
         }
-        out.writeMap(meta, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(meta, StreamOutput::writeString);
     }
 
     public String getName() {

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -717,7 +717,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             out.writeBoolean(requireAlias);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
-            out.writeMap(dynamicTemplates, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(dynamicTemplates, StreamOutput::writeString);
         } else {
             if (dynamicTemplates.isEmpty() == false) {
                 throw new IllegalArgumentException("[dynamic_templates] parameter requires all nodes on " + Version.V_7_13_0 + " or later");

--- a/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
@@ -74,8 +73,8 @@ public final class SearchContextId {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setTransportVersion(version);
             TransportVersion.writeVersion(version, out);
-            out.writeMap(shards, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
-            out.writeMap(aliasFilter, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(shards);
+            out.writeMap(aliasFilter, (o, v) -> v.writeTo(o));
             return Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(out.bytes()));
         } catch (IOException e) {
             throw new IllegalArgumentException(e);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -312,7 +312,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         }
         TransportVersion waitForCheckpointsVersion = TransportVersion.V_7_16_0;
         if (out.getTransportVersion().onOrAfter(waitForCheckpointsVersion)) {
-            out.writeMap(waitForCheckpoints, StreamOutput::writeString, StreamOutput::writeLongArray);
+            out.writeMap(waitForCheckpoints, StreamOutput::writeLongArray);
             out.writeTimeValue(waitForCheckpointsTimeout);
         } else if (waitForCheckpoints.isEmpty() == false) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
@@ -56,7 +56,7 @@ public final class SearchShardsResponse extends ActionResponse {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(groups);
         out.writeCollection(nodes);
-        out.writeMap(aliasFilters, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(aliasFilters, (o, v) -> v.writeTo(o));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -106,9 +106,9 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.leastAvailableSpaceUsage, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(this.mostAvailableSpaceUsage, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(this.shardSizes, StreamOutput::writeString, (o, v) -> o.writeLong(v == null ? -1 : v));
+        out.writeMap(this.leastAvailableSpaceUsage, (o, v) -> v.writeTo(o));
+        out.writeMap(this.mostAvailableSpaceUsage, (o, v) -> v.writeTo(o));
+        out.writeMap(this.shardSizes, (o, v) -> o.writeLong(v == null ? -1 : v));
         if (out.getTransportVersion().onOrAfter(DATA_SET_SIZE_SIZE_VERSION)) {
             out.writeMap(this.shardDataSetSizes, (o, s) -> s.writeTo(o), StreamOutput::writeLong);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -968,7 +968,7 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
         routingTable.writeTo(out);
         nodes.writeTo(out);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            out.writeMap(transportVersions, StreamOutput::writeString, (o, v) -> TransportVersion.writeVersion(v, o));
+            out.writeMap(transportVersions, (o, v) -> TransportVersion.writeVersion(v, o));
         }
         blocks.writeTo(out);
         VersionedNamedWriteable.writeVersionedWritables(out, customs);

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -277,7 +277,7 @@ public class ClusterBlocks implements SimpleDiffable<ClusterBlocks> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         writeBlockSet(global, out);
-        out.writeMap(indicesBlocks, StreamOutput::writeString, (o, s) -> writeBlockSet(s, o));
+        out.writeMap(indicesBlocks, (o, s) -> writeBlockSet(s, o));
     }
 
     private static void writeBlockSet(Set<ClusterBlock> blocks, StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -378,7 +378,7 @@ public class ClusterFormationFailureHelper {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeStringCollection(initialMasterNodesSetting);
             localNode.writeTo(out);
-            out.writeMap(masterEligibleNodes, StreamOutput::writeString, (streamOutput, node) -> node.writeTo(streamOutput));
+            out.writeMap(masterEligibleNodes, (streamOutput, node) -> node.writeTo(streamOutput));
             out.writeLong(clusterStateVersion);
             out.writeLong(acceptedTerm);
             lastAcceptedConfiguration.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1331,7 +1331,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeMap(nodeToClusterFormationDescriptionMap, StreamOutput::writeString, StreamOutput::writeString);
+                out.writeMap(nodeToClusterFormationDescriptionMap, StreamOutput::writeString);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -92,7 +92,7 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.componentTemplates, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.componentTemplates, (stream, val) -> val.writeTo(stream));
     }
 
     public static ComponentTemplateMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -97,7 +97,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.indexTemplates, StreamOutput::writeString, (outstream, val) -> val.writeTo(outstream));
+        out.writeMap(this.indexTemplates, (outstream, val) -> val.writeTo(outstream));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -399,7 +399,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         out.writeStringCollection(dataStreams);
         out.writeOptionalString(writeDataStream);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-            out.writeMap(dataStreamToFilterMap, StreamOutput::writeString, (out1, filter) -> filter.writeTo(out1));
+            out.writeMap(dataStreamToFilterMap, (out1, filter) -> filter.writeTo(out1));
         } else {
             if (dataStreamToFilterMap.isEmpty()) {
                 out.writeBoolean(false);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -221,8 +221,8 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.dataStreams, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
-        out.writeMap(this.dataStreamAliases, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.dataStreams, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.dataStreamAliases, (stream, val) -> val.writeTo(stream));
     }
 
     public static DataStreamMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -135,7 +135,7 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeStringCollection(deletes);
-            out.writeMap(upserts, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(upserts, StreamOutput::writeString);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1714,7 +1714,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
         }
         out.writeCollection(aliases.values());
-        out.writeMap(customData, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(customData, (o, v) -> v.writeTo(o));
         out.writeMap(
             inSyncAllocationIds,
             StreamOutput::writeVInt,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -206,7 +206,7 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
         out.writeInt(order);
         out.writeStringCollection(patterns);
         settings.writeTo(out);
-        out.writeMap(mappings, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(mappings, (o, v) -> v.writeTo(o));
         out.writeCollection(aliases.values());
         out.writeOptionalVInt(version);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -75,7 +75,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
     }
 
     public static void writeMappingMetadata(StreamOutput out, Map<String, MappingMetadata> mappings) throws IOException {
-        out.writeMap(mappings, StreamOutput::writeString, out.getTransportVersion().before(TransportVersion.V_8_0_0) ? (o, v) -> {
+        out.writeMap(mappings, out.getTransportVersion().before(TransportVersion.V_8_0_0) ? (o, v) -> {
             o.writeVInt(v == EMPTY_MAPPINGS ? 0 : 1);
             if (v != EMPTY_MAPPINGS) {
                 o.writeString(MapperService.SINGLE_MAPPING_NAME);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -79,7 +79,7 @@ public class NodesShutdownMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(nodes, StreamOutput::writeString, (outStream, v) -> v.writeTo(outStream));
+        out.writeMap(nodes, (outStream, v) -> v.writeTo(outStream));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateErrorMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateErrorMetadata.java
@@ -51,7 +51,7 @@ public record ReservedStateErrorMetadata(Long version, ErrorKind errorKind, List
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(version);
         out.writeString(errorKind.getKindValue());
-        out.writeCollection(errors, StreamOutput::writeString);
+        out.writeStringCollection(errors);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateHandlerMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateHandlerMetadata.java
@@ -42,7 +42,7 @@ public record ReservedStateHandlerMetadata(String name, Set<String> keys)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeCollection(keys, StreamOutput::writeString);
+        out.writeStringCollection(keys);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -173,7 +173,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeMap(this.aliases, StreamOutput::writeString, (stream, aliasMetadata) -> aliasMetadata.writeTo(stream));
+            out.writeMap(this.aliases, (stream, aliasMetadata) -> aliasMetadata.writeTo(stream));
         }
         if (out.getTransportVersion().onOrAfter(DataStreamLifecycle.ADDED_ENABLED_FLAG_VERSION)) {
             out.writeOptionalWriteable(lifecycle);

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -375,7 +375,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         out.writeString(hostName);
         out.writeString(hostAddress);
         address.writeTo(out);
-        out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(attributes, StreamOutput::writeString);
         out.writeCollection(roles, (o, role) -> {
             o.writeString(role.roleName());
             o.writeString(role.roleNameAbbreviation());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -324,7 +324,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         out.writeException(failure);
         out.writeVInt(failedAllocations);
         lastAllocationStatus.writeTo(out);
-        out.writeCollection(failedNodeIds, StreamOutput::writeString);
+        out.writeStringCollection(failedNodeIds);
         if (out.getTransportVersion().onOrAfter(VERSION_LAST_ALLOCATED_NODE_ADDED)) {
             out.writeOptionalString(lastAllocatedNodeId);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
@@ -65,8 +65,8 @@ public record ClusterBalanceStats(Map<String, TierBalanceStats> tiers, Map<Strin
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(tiers, StreamOutput::writeString, StreamOutput::writeWriteable);
-        out.writeMap(nodes, StreamOutput::writeString, StreamOutput::writeWriteable);
+        out.writeMap(tiers, StreamOutput::writeWriteable);
+        out.writeMap(nodes, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
@@ -99,7 +99,7 @@ public class AllocationCommands implements ToXContentFragment {
      * @throws IOException if something happens during write
      */
     public static void writeTo(AllocationCommands commands, StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(commands.commands);
+        out.writeNamedWriteableCollection(commands.commands);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
@@ -125,7 +125,7 @@ public final class ClusterApplierRecordingService {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(recordings, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+            out.writeMap(recordings, (out1, value) -> value.writeTo(out1));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
+++ b/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
@@ -53,7 +53,7 @@ public final class FieldMemoryStats implements Writeable, Iterable<Map.Entry<Str
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(stats, StreamOutput::writeString, StreamOutput::writeVLong);
+        out.writeMap(stats, StreamOutput::writeVLong);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -552,10 +552,7 @@ public abstract class StreamOutput extends OutputStream {
         assert false == (map instanceof LinkedHashMap);
         this.writeByte((byte) 10);
         this.writeVInt(map.size());
-        Iterator<? extends Map.Entry<String, ?>> iterator = map.entrySet()
-            .stream()
-            .sorted((a, b) -> a.getKey().compareTo(b.getKey()))
-            .iterator();
+        Iterator<? extends Map.Entry<String, ?>> iterator = map.entrySet().stream().sorted(Map.Entry.comparingByKey()).iterator();
         while (iterator.hasNext()) {
             Map.Entry<String, ?> next = iterator.next();
             if (this.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
@@ -627,6 +624,13 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
+     * Same as {@link #writeMap(Map, Writer, Writer)} but for {@code String} keys.
+     */
+    public final <V> void writeMap(final Map<String, V> map, final Writer<V> valueWriter) throws IOException {
+        writeMap(map, StreamOutput::writeString, valueWriter);
+    }
+
+    /**
      * Writes an {@link Instant} to the stream with nanosecond resolution
      */
     public final void writeInstant(Instant instant) throws IOException {
@@ -695,7 +699,7 @@ public abstract class StreamOutput extends OutputStream {
             } else {
                 @SuppressWarnings("unchecked")
                 final Map<String, ?> map = (Map<String, ?>) v;
-                o.writeMap(map, StreamOutput::writeString, StreamOutput::writeGenericValue);
+                o.writeMap(map, StreamOutput::writeGenericValue);
             }
         }),
         entry(Byte.class, (o, v) -> {
@@ -1100,11 +1104,8 @@ public abstract class StreamOutput extends OutputStream {
     /**
      * Writes a list of {@link NamedWriteable} objects.
      */
-    public void writeNamedWriteableList(List<? extends NamedWriteable> list) throws IOException {
-        writeVInt(list.size());
-        for (NamedWriteable obj : list) {
-            writeNamedWriteable(obj);
-        }
+    public void writeNamedWriteableCollection(Collection<? extends NamedWriteable> collection) throws IOException {
+        writeCollection(collection, StreamOutput::writeNamedWriteable);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -637,7 +637,7 @@ public class KeyStoreWrapper implements SecureSettings {
         out.writeBoolean(hasPassword);
         out.writeOptionalByteArray(dataBytes);
         var entriesMap = entries.get();
-        out.writeMap((entriesMap == null) ? Map.of() : entriesMap, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap((entriesMap == null) ? Map.of() : entriesMap, (o, v) -> v.writeTo(o));
         out.writeBoolean(closed);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -264,7 +264,7 @@ public class LocallyMountedSecrets implements SecureSettings {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             assert out.getTransportVersion() == TransportVersion.current();
-            out.writeMap((entries == null) ? Map.of() : entries, StreamOutput::writeString, StreamOutput::writeByteArray);
+            out.writeMap((entries == null) ? Map.of() : entries, StreamOutput::writeByteArray);
             metadata.writeTo(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -645,7 +645,7 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         // pull settings to exclude secure settings in size()
-        out.writeMap(settings, StreamOutput::writeString, Settings::writeSettingValue);
+        out.writeMap(settings, Settings::writeSettingValue);
     }
 
     private static void writeSettingValue(StreamOutput streamOutput, Object value) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -892,8 +892,8 @@ public final class ThreadContext implements Writeable {
                 requestHeaders.putAll(this.requestHeaders);
             }
 
-            out.writeMap(requestHeaders, StreamOutput::writeString, StreamOutput::writeString);
-            out.writeMap(responseHeaders, StreamOutput::writeString, StreamOutput::writeStringCollection);
+            out.writeMap(requestHeaders, StreamOutput::writeString);
+            out.writeMap(responseHeaders, StreamOutput::writeStringCollection);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/health/node/HealthInfo.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthInfo.java
@@ -28,6 +28,6 @@ public record HealthInfo(Map<String, DiskHealthInfo> diskInfoByNode) implements 
 
     @Override
     public void writeTo(StreamOutput output) throws IOException {
-        output.writeMap(diskInfoByNode, StreamOutput::writeString, (out, diskHealthInfo) -> diskHealthInfo.writeTo(out));
+        output.writeMap(diskInfoByNode, (out, diskHealthInfo) -> diskHealthInfo.writeTo(out));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -83,7 +83,7 @@ public final class CommitStats implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(userData, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(userData, StreamOutput::writeString);
         out.writeLong(generation);
         out.writeOptionalString(id);
         out.writeInt(numDocs);

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -168,7 +168,7 @@ public class Segment implements Writeable {
         boolean hasAttributes = attributes != null;
         out.writeBoolean(hasAttributes);
         if (hasAttributes) {
-            out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(attributes, StreamOutput::writeString);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -114,7 +114,7 @@ public class FieldDataStats implements Writeable, ToXContentFragment {
             out.writeVLong(globalOrdinalsStats.buildTimeMillis);
             if (globalOrdinalsStats.fieldGlobalOrdinalsStats != null) {
                 out.writeBoolean(true);
-                out.writeMap(globalOrdinalsStats.fieldGlobalOrdinalsStats, StreamOutput::writeString, (out1, value) -> {
+                out.writeMap(globalOrdinalsStats.fieldGlobalOrdinalsStats, (out1, value) -> {
                     out1.writeVLong(value.totalBuildingTime);
                     out1.writeVLong(value.valueCount);
                 });

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -224,7 +224,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         boolean hasSorts = sorts != null;
         out.writeBoolean(hasSorts);
         if (hasSorts) {
-            out.writeNamedWriteableList(sorts);
+            out.writeNamedWriteableCollection(sorts);
         }
         out.writeOptionalWriteable(highlightBuilder);
         out.writeOptionalWriteable(innerCollapseBuilder);

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -332,7 +332,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeNamedWriteableList(subSources);
+            out.writeNamedWriteableCollection(subSources);
             out.writeOptionalWriteable(filter);
         }
 
@@ -447,7 +447,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(ordered);
-            out.writeNamedWriteableList(subSources);
+            out.writeNamedWriteableCollection(subSources);
             out.writeInt(maxGaps);
             out.writeOptionalWriteable(filter);
         }

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -234,7 +234,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeGenericValue(value);
-        out.writeMap(fieldsBoosts, StreamOutput::writeString, StreamOutput::writeFloat);
+        out.writeMap(fieldsBoosts, StreamOutput::writeFloat);
         type.writeTo(out);
         operator.writeTo(out);
         out.writeOptionalString(analyzer);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -192,7 +192,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(this.queryString);
         out.writeOptionalString(this.defaultField);
-        out.writeMap(this.fieldsAndWeights, StreamOutput::writeString, StreamOutput::writeFloat);
+        out.writeMap(this.fieldsAndWeights, StreamOutput::writeFloat);
         this.defaultOperator.writeTo(out);
         out.writeOptionalString(this.analyzer);
         out.writeOptionalString(this.quoteAnalyzer);

--- a/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
@@ -57,7 +57,7 @@ public class FieldUsageStats implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(stats, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(stats, (o, v) -> v.writeTo(o));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -398,7 +398,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeMap(groupStats, StreamOutput::writeString, (stream, stats) -> stats.writeTo(stream));
+            out.writeMap(groupStats, (stream, stats) -> stats.writeTo(stream));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1602,7 +1602,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(clusterStateVersion);
-            out.writeMap(checkpoints, (streamOutput, s) -> out.writeString(s), (streamOutput, cps) -> cps.writeTo(out));
+            out.writeMap(checkpoints, (streamOutput, cps) -> cps.writeTo(streamOutput));
             IndexShardRoutingTable.Builder.writeTo(routingTable, out);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -885,7 +885,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMapValues(fileMetadataMap);
-            out.writeMap(commitUserData, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(commitUserData, StreamOutput::writeString);
             out.writeLong(numDocs);
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -206,9 +206,9 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         stats.writeTo(out);
-        out.writeMap(statsByShard, (o, k) -> k.writeTo(o), (streamOutput, list) -> streamOutput.writeCollection(list));
+        out.writeMap(statsByShard, (o, k) -> k.writeTo(o), StreamOutput::writeCollection);
         if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_STATS_BY_INDEX)) {
-            out.writeMap(statsByIndex, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
+            out.writeMap(statsByIndex);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -313,7 +313,7 @@ public class JvmInfo implements ReportingService.Info {
         }
         out.writeString(bootClassPath);
         out.writeString(classPath);
-        out.writeMap(this.systemProperties, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(this.systemProperties, StreamOutput::writeString);
         mem.writeTo(out);
         out.writeStringArray(gcCollectors);
         out.writeStringArray(memoryPools);

--- a/server/src/main/java/org/elasticsearch/node/AdaptiveSelectionStats.java
+++ b/server/src/main/java/org/elasticsearch/node/AdaptiveSelectionStats.java
@@ -48,8 +48,8 @@ public class AdaptiveSelectionStats implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.clientOutgoingConnections, StreamOutput::writeString, StreamOutput::writeLong);
-        out.writeMap(this.nodeComputedStats, StreamOutput::writeString, (stream, stats) -> stats.writeTo(stream));
+        out.writeMap(this.clientOutgoingConnections, StreamOutput::writeLong);
+        out.writeMap(this.nodeComputedStats, (stream, stats) -> stats.writeTo(stream));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -542,7 +542,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             .stream()
             .filter(t -> VersionedNamedWriteable.shouldSerialize(out, t.getParams()))
             .collect(Collectors.toMap(PersistentTask::getId, Function.identity()));
-        out.writeMap(filteredTasks, StreamOutput::writeString, (stream, value) -> value.writeTo(stream));
+        out.writeMap(filteredTasks, (stream, value) -> value.writeTo(stream));
     }
 
     public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java
@@ -42,7 +42,7 @@ public class RepositoriesStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_011)) {
-            out.writeMap(repositoryThrottlingStats, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(repositoryThrottlingStats, (o, v) -> v.writeTo(o));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryInfo.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryInfo.java
@@ -76,7 +76,7 @@ public final class RepositoryInfo implements Writeable, ToXContentFragment {
         out.writeString(ephemeralId);
         out.writeString(name);
         out.writeString(type);
-        out.writeMap(location, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(location, StreamOutput::writeString);
         out.writeLong(startedAt);
         out.writeOptionalLong(stoppedAt);
     }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryStats.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryStats.java
@@ -43,7 +43,7 @@ public class RepositoryStats implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(requestCounts, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(requestCounts, StreamOutput::writeLong);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
@@ -114,7 +114,7 @@ public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(typesAllowed);
-        out.writeMap(languageContexts, StreamOutput::writeString, StreamOutput::writeStringCollection);
+        out.writeMap(languageContexts, StreamOutput::writeStringCollection);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
@@ -258,7 +258,7 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(scripts, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(scripts, (o, v) -> v.writeTo(o));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -264,8 +264,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             writeExplanation(out, explanation);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_8_0)) {
-            out.writeMap(documentFields, StreamOutput::writeString, (stream, documentField) -> documentField.writeTo(stream));
-            out.writeMap(metaFields, StreamOutput::writeString, (stream, documentField) -> documentField.writeTo(stream));
+            out.writeMap(documentFields, (stream, documentField) -> documentField.writeTo(stream));
+            out.writeMap(metaFields, (stream, documentField) -> documentField.writeTo(stream));
         } else {
             writeFields(out, this.getFields());
         }
@@ -277,7 +277,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         sortValues.writeTo(out);
 
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            out.writeMap(matchedQueries, StreamOutput::writeString, StreamOutput::writeFloat);
+            out.writeMap(matchedQueries, StreamOutput::writeFloat);
         } else {
             out.writeStringArray(matchedQueries.keySet().toArray(new String[0]));
         }
@@ -285,7 +285,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (innerHits == null) {
             out.writeVInt(0);
         } else {
-            out.writeMap(innerHits, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(innerHits, (o, v) -> v.writeTo(o));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -303,8 +303,8 @@ public class AggregatorFactories {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeCollection(this.aggregationBuilders, StreamOutput::writeNamedWriteable);
-            out.writeCollection(this.pipelineAggregatorBuilders, StreamOutput::writeNamedWriteable);
+            out.writeNamedWriteableCollection(this.aggregationBuilders);
+            out.writeNamedWriteableCollection(this.pipelineAggregatorBuilders);
         }
 
         public boolean mustVisitAllDocs() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -64,7 +64,7 @@ public final class InternalAggregations extends Aggregations implements Writeabl
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(getInternalAggregations());
+        out.writeNamedWriteableCollection(getInternalAggregations());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -157,7 +157,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         boolean hasSorts = sorts != null;
         out.writeBoolean(hasSorts);
         if (hasSorts) {
-            out.writeNamedWriteableList(sorts);
+            out.writeNamedWriteableCollection(sorts);
         }
         out.writeBoolean(trackScores);
         out.writeBoolean(version);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptPipelineAggregationBuilder.java
@@ -95,7 +95,7 @@ public class BucketScriptPipelineAggregationBuilder extends AbstractPipelineAggr
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeMap(bucketsPathsMap, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(bucketsPathsMap, StreamOutput::writeString);
         script.writeTo(out);
         out.writeOptionalString(format);
         gapPolicy.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationInfo.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationInfo.java
@@ -52,7 +52,7 @@ public class AggregationInfo implements ReportingService.Info {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(aggs, StreamOutput::writeString, StreamOutput::writeStringCollection);
+        out.writeMap(aggs, StreamOutput::writeStringCollection);
     }
 
     public Map<String, Set<String>> getAggregations() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -104,7 +104,7 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
 
     @Override
     protected final void doWriteTo(StreamOutput out) throws IOException {
-        out.writeMap(fields, StreamOutput::writeString, (o, value) -> value.writeTo(o));
+        out.writeMap(fields, (o, value) -> value.writeTo(o));
         out.writeOptionalWriteable(userValueTypeHint);
         out.writeOptionalString(format);
         innerWriteTo(out);

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -300,7 +300,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         boolean hasRescoreBuilders = rescoreBuilders != null;
         out.writeBoolean(hasRescoreBuilders);
         if (hasRescoreBuilders) {
-            out.writeNamedWriteableList(rescoreBuilders);
+            out.writeNamedWriteableCollection(rescoreBuilders);
         }
         boolean hasScriptFields = scriptFields != null;
         out.writeBoolean(hasScriptFields);
@@ -311,7 +311,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         boolean hasSorts = sorts != null;
         out.writeBoolean(hasSorts);
         if (hasSorts) {
-            out.writeNamedWriteableList(sorts);
+            out.writeNamedWriteableCollection(sorts);
         }
         boolean hasStats = stats != null;
         out.writeBoolean(hasStats);
@@ -324,7 +324,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeBoolean(trackScores);
         out.writeOptionalBoolean(version);
         out.writeOptionalBoolean(seqNoAndPrimaryTerm);
-        out.writeNamedWriteableList(extBuilders);
+        out.writeNamedWriteableCollection(extBuilders);
         out.writeBoolean(profile);
         out.writeOptionalWriteable(searchAfterBuilder);
         out.writeOptionalWriteable(sliceBuilder);

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
@@ -158,7 +158,7 @@ public class DfsSearchResult extends SearchPhaseResult {
     }
 
     public static void writeFieldStats(StreamOutput out, Map<String, CollectionStatistics> fieldStatistics) throws IOException {
-        out.writeMap(fieldStatistics, StreamOutput::writeString, (o, statistics) -> {
+        out.writeMap(fieldStatistics, (o, statistics) -> {
             assert statistics.maxDoc() >= 0;
             o.writeVLong(statistics.maxDoc());
             // stats are always positive numbers

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -382,7 +382,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
                     rankQueryBuilders.add(subSearchSourceBuilder.getQueryBuilder());
                 }
             }
-            out.writeNamedWriteableList(rankQueryBuilders);
+            out.writeNamedWriteableCollection(rankQueryBuilders);
         }
         if (out.getTransportVersion().before(TransportVersion.V_8_0_0)) {
             // types not supported so send an empty array to previous versions

--- a/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -88,9 +88,9 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         out.writeString(type);
         out.writeString(description);
         out.writeLong(nodeTime);            // not Vlong because can be negative
-        out.writeMap(breakdown, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(breakdown, StreamOutput::writeLong);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_9_0)) {
-            out.writeMap(debug, StreamOutput::writeString, StreamOutput::writeGenericValue);
+            out.writeMap(debug, StreamOutput::writeGenericValue);
         }
         out.writeCollection(children);
     }

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
@@ -67,10 +67,10 @@ public final class SearchProfileResults implements Writeable, ToXContentFragment
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-            out.writeMap(shardResults, StreamOutput::writeString, (o, r) -> r.writeTo(o));
+            out.writeMap(shardResults, (o, r) -> r.writeTo(o));
         } else {
             // Before 8.0.0 we only send the query phase
-            out.writeMap(shardResults, StreamOutput::writeString, (o, r) -> r.getQueryPhase().writeTo(o));
+            out.writeMap(shardResults, (o, r) -> r.getQueryPhase().writeTo(o));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -112,7 +112,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(suggestions);
+        out.writeNamedWriteableCollection(suggestions);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -161,7 +161,7 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
         }
         out.writeMapWithConsistentOrder(collateParams);
         out.writeOptionalBoolean(collatePrune);
-        out.writeMap(this.generators, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
+        out.writeMap(this.generators, StreamOutput::writeCollection);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -375,7 +375,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         out.writeVInt(k);
         out.writeVInt(numCands);
         out.writeFloatArray(queryVector);
-        out.writeNamedWriteableList(filterQueries);
+        out.writeNamedWriteableCollection(filterQueries);
         out.writeFloat(boost);
         if (out.getTransportVersion().before(TransportVersion.V_8_7_0) && queryVectorBuilder != null) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -1044,7 +1044,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         out.writeStringCollection(dataStreams);
         out.writeCollection(featureStates);
 
-        out.writeMap(indexSnapshotDetails, StreamOutput::writeString, (stream, value) -> value.writeTo(stream));
+        out.writeMap(indexSnapshotDetails, (stream, value) -> value.writeTo(stream));
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {

--- a/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -95,7 +95,7 @@ public record TaskInfo(
         out.writeBoolean(cancellable);
         out.writeBoolean(cancelled);
         parentTaskId.writeTo(out);
-        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(headers, StreamOutput::writeString);
     }
 
     public long id() {

--- a/server/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -109,7 +109,7 @@ public class TransportStats implements Writeable, ChunkedToXContent {
             }
         }
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            out.writeMap(transportActionStats, StreamOutput::writeString, StreamOutput::writeWriteable);
+            out.writeMap(transportActionStats, StreamOutput::writeWriteable);
         } // else just drop these stats
     }
 

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -74,11 +74,7 @@ public class FeatureMigrationResults implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(
-            featureStatuses,
-            StreamOutput::writeString,
-            (StreamOutput outStream, SingleFeatureMigrationResult featureStatus) -> featureStatus.writeTo(outStream)
-        );
+        out.writeMap(featureStatuses, (outStream, featureStatus) -> featureStatus.writeTo(outStream));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -386,7 +386,7 @@ public class BytesStreamsTests extends ESTestCase {
         }
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
-            out.writeNamedWriteableList(expected);
+            out.writeNamedWriteableCollection(expected);
             try (StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), namedWriteableRegistry)) {
                 assertEquals(expected, in.readNamedWriteableList(BaseNamedWriteable.class));
                 assertEquals(0, in.available());

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -426,7 +426,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         }
 
         try (RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler)) {
-            out.writeNamedWriteableList(expected);
+            out.writeNamedWriteableCollection(expected);
             try (StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), namedWriteableRegistry)) {
                 assertEquals(expected, in.readNamedWriteableList(BaseNamedWriteable.class));
                 assertEquals(0, in.available());

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
@@ -37,7 +37,7 @@ public class NodeSeekStats extends BaseNodeResponse implements ToXContentFragmen
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(seeks, StreamOutput::writeString, (streamOutput, list) -> streamOutput.writeCollection(list));
+        out.writeMap(seeks, StreamOutput::writeCollection);
     }
 
     @Override

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/ShardSeekStats.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/ShardSeekStats.java
@@ -26,7 +26,7 @@ public record ShardSeekStats(String shard, Map<String, Long> seeksPerFile) imple
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(this.shard);
-        out.writeMap(this.seeksPerFile, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(this.seeksPerFile, StreamOutput::writeLong);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -344,7 +344,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         writeSize(shardSize, out);
         out.writeBoolean(showTermDocCountError);
         out.writeVLong(otherDocCount);
-        out.writeCollection(formats, StreamOutput::writeNamedWriteable);
+        out.writeNamedWriteableCollection(formats);
         out.writeCollection(keyConverters, StreamOutput::writeEnum);
         out.writeCollection(buckets);
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -104,7 +104,7 @@ public class InternalStringStats extends InternalAggregation {
         out.writeVLong(totalLength);
         out.writeVInt(minLength);
         out.writeVInt(maxLength);
-        out.writeMap(charOccurrences, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(charOccurrences, StreamOutput::writeLong);
     }
 
     public String getWriteableName() {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -165,7 +165,7 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(sortBuilders);
+        out.writeNamedWriteableCollection(sortBuilders);
         out.writeVInt(size);
         out.writeCollection(metricFields);
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
@@ -90,7 +90,7 @@ public class GetAutoscalingCapacityAction extends ActionType<GetAutoscalingCapac
 
         @Override
         public void writeTo(final StreamOutput out) throws IOException {
-            out.writeMap(results, StreamOutput::writeString, (o, decision) -> decision.writeTo(o));
+            out.writeMap(results, (o, decision) -> decision.writeTo(o));
         }
 
         public SortedMap<String, AutoscalingDeciderResults> results() {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
@@ -109,7 +109,7 @@ public class PutAutoscalingPolicyAction extends ActionType<AcknowledgedResponse>
             out.writeString(name);
             if (roles != null) {
                 out.writeBoolean(true);
-                out.writeCollection(roles, StreamOutput::writeString);
+                out.writeStringCollection(roles);
             } else {
                 out.writeBoolean(false);
             }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
@@ -71,7 +71,7 @@ public class AutoscalingDeciderResults implements ToXContentObject, Writeable {
     public void writeTo(final StreamOutput out) throws IOException {
         currentCapacity.writeTo(out);
         out.writeCollection(currentNodes);
-        out.writeMap(results, StreamOutput::writeString, (output, result) -> result.writeTo(output));
+        out.writeMap(results, (output, result) -> result.writeTo(output));
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
@@ -99,7 +99,7 @@ public class AutoscalingPolicy implements SimpleDiffable<AutoscalingPolicy>, ToX
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeCollection(roles, StreamOutput::writeString);
+        out.writeStringCollection(roles);
         out.writeInt(deciders.size());
         for (Map.Entry<String, Settings> entry : deciders.entrySet()) {
             out.writeString(entry.getKey());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartBasicResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartBasicResponse.java
@@ -95,7 +95,7 @@ public class PostStartBasicResponse extends AcknowledgedResponse implements Stat
         super.writeTo(out);
         out.writeEnum(status);
         out.writeOptionalString(acknowledgeMessage);
-        out.writeMap(acknowledgeMessages, StreamOutput::writeString, StreamOutput::writeStringArray);
+        out.writeMap(acknowledgeMessages, StreamOutput::writeStringArray);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java
@@ -88,7 +88,7 @@ public class PostStartTrialResponse extends ActionResponse {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(status);
         out.writeOptionalString(acknowledgeMessage);
-        out.writeMap(acknowledgeMessages, StreamOutput::writeString, StreamOutput::writeStringArray);
+        out.writeMap(acknowledgeMessages, StreamOutput::writeStringArray);
     }
 
     Map<String, String[]> getAcknowledgementMessages() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/PutLicenseResponse.java
@@ -72,7 +72,7 @@ public class PutLicenseResponse extends AcknowledgedResponse {
         super.writeTo(out);
         out.writeVInt(status.id());
         out.writeOptionalString(acknowledgeHeader);
-        out.writeMap(acknowledgeMessages, StreamOutput::writeString, StreamOutput::writeStringArray);
+        out.writeMap(acknowledgeMessages, StreamOutput::writeStringArray);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
@@ -52,7 +52,7 @@ public class DataTiersFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(tierStats, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(tierStats, (o, v) -> v.writeTo(o));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -41,7 +41,7 @@ public class XPackUsageResponse extends ActionResponse {
     }
 
     private static void writeTo(final StreamOutput out, final List<XPackFeatureSet.Usage> usages) throws IOException {
-        out.writeNamedWriteableList(usages);
+        out.writeNamedWriteableCollection(usages);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -142,13 +142,9 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(patterns, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+        out.writeMap(patterns, (out1, value) -> value.writeTo(out1));
         out.writeMapOfLists(followedLeaderIndexUUIDs, StreamOutput::writeString, StreamOutput::writeString);
-        out.writeMap(
-            headers,
-            StreamOutput::writeString,
-            (valOut, header) -> valOut.writeMap(header, StreamOutput::writeString, StreamOutput::writeString)
-        );
+        out.writeMap(headers, (valOut, header) -> valOut.writeMap(header, StreamOutput::writeString));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowStats.java
@@ -133,11 +133,11 @@ public class AutoFollowStats implements Writeable, ToXContentObject {
         out.writeVLong(numberOfFailedFollowIndices);
         out.writeVLong(numberOfFailedRemoteClusterStateRequests);
         out.writeVLong(numberOfSuccessfulFollowIndices);
-        out.writeMap(recentAutoFollowErrors, StreamOutput::writeString, (out1, value) -> {
+        out.writeMap(recentAutoFollowErrors, (out1, value) -> {
             out1.writeZLong(value.v1());
             out1.writeException(value.v2());
         });
-        out.writeMap(autoFollowedClusters, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+        out.writeMap(autoFollowedClusters, (out1, value) -> value.writeTo(out1));
     }
 
     public long getNumberOfFailedFollowIndices() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
@@ -93,7 +93,7 @@ public class GetAutoFollowPatternAction extends ActionType<GetAutoFollowPatternA
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(autoFollowPatterns, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+            out.writeMap(autoFollowPatterns, (out1, value) -> value.writeTo(out1));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTask.java
@@ -152,7 +152,7 @@ public class ShardFollowTask extends ImmutableFollowParameters implements Persis
         followShardId.writeTo(out);
         leaderShardId.writeTo(out);
         super.writeTo(out);
-        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(headers, StreamOutput::writeString);
     }
 
     public static ShardFollowTask fromXContent(XContentParser parser) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
@@ -93,7 +93,7 @@ public final class EnrichMetadata extends AbstractNamedDiffable<Metadata.Custom>
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(policies, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+        out.writeMap(policies, (out1, value) -> value.writeTo(out1));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -111,7 +111,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(phaseStats, StreamOutput::writeString, (o, p) -> p.writeTo(o));
+            out.writeMap(phaseStats, (o, p) -> p.writeTo(o));
             out.writeVInt(indicesManaged);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -75,7 +75,7 @@ public class IndexLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(policyMetadatas, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(policyMetadatas, (o, v) -> v.writeTo(o));
         out.writeEnum(operationMode);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -135,7 +135,7 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
     public void writeTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(type);
         out.writeString(name);
-        out.writeMap(phases, StreamOutput::writeString, (o, val) -> val.writeTo(o));
+        out.writeMap(phases, (o, val) -> val.writeTo(o));
         out.writeGenericMap(this.metadata);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
@@ -87,8 +87,8 @@ public class EstimateModelMemoryAction extends ActionType<EstimateModelMemoryAct
             } else {
                 out.writeBoolean(false);
             }
-            out.writeMap(overallCardinality, StreamOutput::writeString, StreamOutput::writeVLong);
-            out.writeMap(maxBucketCardinality, StreamOutput::writeString, StreamOutput::writeVLong);
+            out.writeMap(overallCardinality, StreamOutput::writeVLong);
+            out.writeMap(maxBucketCardinality, StreamOutput::writeVLong);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
@@ -213,7 +213,7 @@ public class EvaluateDataFrameAction extends ActionType<EvaluateDataFrameAction.
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(evaluationName);
-            out.writeNamedWriteableList(metrics);
+            out.writeNamedWriteableCollection(metrics);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
@@ -180,7 +180,7 @@ public class GetDatafeedRunningStateAction extends ActionType<GetDatafeedRunning
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeMap(datafeedRunningState, StreamOutput::writeString, (o, w) -> w.writeTo(o));
+            out.writeMap(datafeedRunningState, (o, w) -> w.writeTo(o));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -86,7 +86,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeCollection(this.includes, StreamOutput::writeString);
+            out.writeStringCollection(this.includes);
         }
 
         public boolean isIncludeModelDefinition() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -335,7 +335,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeNamedWriteableList(inferenceResults);
+            out.writeNamedWriteableCollection(inferenceResults);
             out.writeBoolean(isLicensed);
             out.writeOptionalString(id);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -332,7 +332,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             super.writeTo(out);
 
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_6_1)) {
-                out.writeNamedWriteableList(results);
+                out.writeNamedWriteableCollection(results);
             } else {
                 out.writeNamedWriteable(results.get(0));
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -535,7 +535,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         }
         out.writeOptionalVInt(scrollSize);
         out.writeOptionalWriteable(chunkingConfig);
-        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(headers, StreamOutput::writeString);
         out.writeOptionalWriteable(delayedDataCheckConfig);
         out.writeOptionalVInt(maxEmptySearches);
         indicesOptions.writeIndicesOptions(out);
@@ -843,7 +843,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             }
             out.writeOptionalVInt(scrollSize);
             out.writeOptionalWriteable(chunkingConfig);
-            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(headers, StreamOutput::writeString);
             out.writeOptionalWriteable(delayedDataCheckConfig);
             out.writeOptionalVInt(maxEmptySearches);
             out.writeBoolean(indicesOptions != null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -309,7 +309,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         out.writeNamedWriteable(analysis);
         out.writeOptionalWriteable(analyzedFields);
         out.writeOptionalWriteable(modelMemoryLimit);
-        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(headers, StreamOutput::writeString);
         out.writeOptionalInstant(createTime);
         if (version != null) {
             out.writeBoolean(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -278,7 +278,7 @@ public class Classification implements DataFrameAnalysis {
         out.writeOptionalVInt(numTopClasses);
         out.writeDouble(trainingPercent);
         out.writeOptionalLong(randomizeSeed);
-        out.writeNamedWriteableList(featureProcessors);
+        out.writeNamedWriteableCollection(featureProcessors);
         out.writeBoolean(earlyStoppingEnabled);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -238,7 +238,7 @@ public class Regression implements DataFrameAnalysis {
         out.writeOptionalLong(randomizeSeed);
         out.writeEnum(lossFunction);
         out.writeOptionalDouble(lossFunctionParameter);
-        out.writeNamedWriteableList(featureProcessors);
+        out.writeNamedWriteableCollection(featureProcessors);
         out.writeBoolean(earlyStoppingEnabled);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
@@ -140,7 +140,7 @@ public class Classification implements Evaluation {
         out.writeOptionalString(fields.getTopClassesField());
         out.writeOptionalString(fields.getPredictedClassField());
         out.writeOptionalString(fields.getPredictedProbabilityField());
-        out.writeNamedWriteableList(metrics);
+        out.writeNamedWriteableCollection(metrics);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
@@ -125,7 +125,7 @@ public class OutlierDetection implements Evaluation {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fields.getActualField());
         out.writeString(fields.getPredictedProbabilityField());
-        out.writeNamedWriteableList(metrics);
+        out.writeNamedWriteableCollection(metrics);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
@@ -114,7 +114,7 @@ public class Regression implements Evaluation {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fields.getActualField());
         out.writeString(fields.getPredictedField());
-        out.writeNamedWriteableList(metrics);
+        out.writeNamedWriteableCollection(metrics);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/explain/FieldSelection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/explain/FieldSelection.java
@@ -118,7 +118,7 @@ public class FieldSelection implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
-        out.writeCollection(mappingTypes, StreamOutput::writeString);
+        out.writeStringCollection(mappingTypes);
         out.writeBoolean(isIncluded);
         out.writeBoolean(isRequired);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -428,7 +428,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         out.writeOptionalString(description);
         out.writeInstant(createTime);
         out.writeOptionalWriteable(definition);
-        out.writeCollection(tags, StreamOutput::writeString);
+        out.writeStringCollection(tags);
         out.writeGenericMap(metadata);
         input.writeTo(out);
         out.writeVLong(modelSize);
@@ -436,7 +436,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         out.writeString(licenseLevel.description());
         if (defaultFieldMap != null) {
             out.writeBoolean(true);
-            out.writeMap(defaultFieldMap, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(defaultFieldMap, StreamOutput::writeString);
         } else {
             out.writeBoolean(false);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinition.java
@@ -90,7 +90,7 @@ public class TrainedModelDefinition implements ToXContentObject, Writeable, Acco
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(trainedModel);
-        out.writeNamedWriteableList(preProcessors);
+        out.writeNamedWriteableCollection(preProcessors);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -306,7 +306,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         taskParams.writeTo(out);
-        out.writeMap(nodeRoutingTable, StreamOutput::writeString, (o, w) -> w.writeTo(o));
+        out.writeMap(nodeRoutingTable, (o, w) -> w.writeTo(o));
         out.writeEnum(assignmentState);
         out.writeOptionalString(reason);
         out.writeInstant(startTime);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
@@ -159,7 +159,7 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
         out.writeString(featureName);
-        out.writeMap(frequencyMap, StreamOutput::writeString, StreamOutput::writeDouble);
+        out.writeMap(frequencyMap, StreamOutput::writeDouble);
         out.writeBoolean(custom);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/Multi.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/Multi.java
@@ -130,9 +130,9 @@ public class Multi implements LenientlyParsedPreProcessor, StrictlyParsedPreProc
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(Arrays.asList(processors));
+        out.writeNamedWriteableCollection(Arrays.asList(processors));
         out.writeBoolean(custom);
-        out.writeMap(outputFields, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(outputFields, StreamOutput::writeString);
         out.writeStringArray(inputFields);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
@@ -143,7 +143,7 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
-        out.writeMap(hotMap, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(hotMap, StreamOutput::writeString);
         out.writeBoolean(custom);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -171,7 +171,7 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
         out.writeString(featureName);
-        out.writeMap(meanMap, StreamOutput::writeString, StreamOutput::writeDouble);
+        out.writeMap(meanMap, StreamOutput::writeDouble);
         out.writeDouble(defaultValue);
         out.writeBoolean(custom);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
@@ -120,7 +120,7 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeNamedWriteableList(featureExtractorBuilders);
+        out.writeNamedWriteableCollection(featureExtractorBuilders);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfigUpdate.java
@@ -117,7 +117,7 @@ public class LearnToRankConfigUpdate implements InferenceConfigUpdate, NamedXCon
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalVInt(numTopFeatureImportanceValues);
-        out.writeNamedWriteableList(featureExtractorBuilderList);
+        out.writeNamedWriteableCollection(featureExtractorBuilderList);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
@@ -266,7 +266,7 @@ public class ModelPackageConfig implements ToXContentObject, Writeable {
         out.writeGenericMap(inferenceConfigSource);
         out.writeGenericMap(metadata);
         out.writeOptionalString(modelType);
-        out.writeOptionalCollection(tags, StreamOutput::writeString);
+        out.writeOptionalStringCollection(tags);
         out.writeOptionalString(vocabularyFile);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -143,7 +143,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(featureNames);
-        out.writeNamedWriteableList(models);
+        out.writeNamedWriteableCollection(models);
         out.writeNamedWriteable(outputAggregator);
         targetType.writeTo(out);
         out.writeBoolean(classificationLabels != null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
@@ -73,7 +73,7 @@ public class RuleScope implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(scope, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+        out.writeMap(scope, (out1, value) -> value.writeTo(out1));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/stats/CountAccumulator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/stats/CountAccumulator.java
@@ -63,7 +63,7 @@ public class CountAccumulator implements Writeable {
     }
 
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(counts, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(counts, StreamOutput::writeLong);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
@@ -125,7 +125,7 @@ public class GetRollupCapsAction extends ActionType<GetRollupCapsAction.Response
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(jobs, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+            out.writeMap(jobs, (out1, value) -> value.writeTo(out1));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -154,7 +154,7 @@ public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsActio
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(jobs, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+            out.writeMap(jobs, (out1, value) -> value.writeTo(out1));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
@@ -94,7 +94,7 @@ public class RollupJobCaps implements Writeable, ToXContentObject {
         out.writeString(jobID);
         out.writeString(rollupIndex);
         out.writeString(indexPattern);
-        out.writeMap(fieldCapLookup, StreamOutput::writeString, (o, value) -> value.writeTo(o));
+        out.writeMap(fieldCapLookup, (o, value) -> value.writeTo(o));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJob.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJob.java
@@ -86,7 +86,7 @@ public class RollupJob implements SimpleDiffable<RollupJob>, PersistentTaskParam
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         config.writeTo(out);
-        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(headers, StreamOutput::writeString);
     }
 
     static Diff<RollupJob> readJobDiffFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyResponse.java
@@ -67,7 +67,7 @@ public final class BulkUpdateApiKeyResponse extends ActionResponse implements To
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(updated);
         out.writeStringCollection(noops);
-        out.writeMap(errorDetails, StreamOutput::writeString, StreamOutput::writeException);
+        out.writeMap(errorDetails, StreamOutput::writeException);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponse.java
@@ -45,7 +45,7 @@ public final class DeletePrivilegesResponse extends ActionResponse implements To
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeCollection(found, StreamOutput::writeString);
+        out.writeStringCollection(found);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -50,7 +50,7 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(created, StreamOutput::writeString, StreamOutput::writeStringCollection);
+        out.writeMap(created, StreamOutput::writeStringCollection);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
@@ -46,7 +46,7 @@ public class GetProfilesResponse extends ActionResponse implements ToXContentObj
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(profiles);
-        out.writeMap(errors, StreamOutput::writeString, StreamOutput::writeException);
+        out.writeMap(errors, StreamOutput::writeException);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
@@ -101,11 +101,11 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeCollection(cluster, StreamOutput::writeString);
+        out.writeStringCollection(cluster);
         out.writeCollection(configurableClusterPrivileges, ConfigurableClusterPrivileges.WRITER);
         out.writeCollection(index);
         out.writeCollection(application);
-        out.writeCollection(runAs, StreamOutput::writeString);
+        out.writeStringCollection(runAs);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
             out.writeCollection(remoteIndex);
         } else if (hasRemoteIndicesPrivileges()) {
@@ -305,8 +305,8 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeCollection(indices, StreamOutput::writeString);
-            out.writeCollection(privileges, StreamOutput::writeString);
+            out.writeStringCollection(indices);
+            out.writeStringCollection(privileges);
             out.writeCollection(fieldSecurity, (output, fields) -> {
                 output.writeOptionalStringArray(fields.getGrantedFields());
                 output.writeOptionalStringArray(fields.getExcludedFields());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
@@ -86,7 +86,7 @@ public class GetUsersResponse extends ActionResponse implements ToXContentObject
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_5_0)) {
             if (profileUidLookup != null) {
                 out.writeBoolean(true);
-                out.writeMap(profileUidLookup, StreamOutput::writeString, StreamOutput::writeString);
+                out.writeMap(profileUidLookup, StreamOutput::writeString);
             } else {
                 out.writeBoolean(false);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesResponse.java
@@ -128,9 +128,9 @@ public class HasPrivilegesResponse extends ActionResponse implements ToXContentO
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(completeMatch);
-        out.writeMap(cluster, StreamOutput::writeString, StreamOutput::writeBoolean);
+        out.writeMap(cluster, StreamOutput::writeBoolean);
         writeResourcePrivileges(out, index);
-        out.writeMap(application, StreamOutput::writeString, HasPrivilegesResponse::writeResourcePrivileges);
+        out.writeMap(application, HasPrivilegesResponse::writeResourcePrivileges);
         out.writeString(username);
     }
 
@@ -138,7 +138,7 @@ public class HasPrivilegesResponse extends ActionResponse implements ToXContentO
         out.writeVInt(privileges.size());
         for (ResourcePrivileges priv : privileges) {
             out.writeString(priv.getResource());
-            out.writeMap(priv.getPrivileges(), StreamOutput::writeString, StreamOutput::writeBoolean);
+            out.writeMap(priv.getPrivileges(), StreamOutput::writeBoolean);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesResponse.java
@@ -69,7 +69,7 @@ public class ProfileHasPrivilegesResponse extends ActionResponse implements ToXC
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(hasPrivilegeUids);
-        out.writeMap(errors, StreamOutput::writeString, StreamOutput::writeException);
+        out.writeMap(errors, StreamOutput::writeException);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -767,7 +767,7 @@ public final class Authentication implements ToXContentObject {
         (out, v) -> {
             @SuppressWarnings("unchecked")
             final List<RoleDescriptorsBytes> roleDescriptorsBytesList = (List<RoleDescriptorsBytes>) v;
-            out.writeCollection(roleDescriptorsBytesList, (o, rdb) -> rdb.writeTo(o));
+            out.writeCollection(roleDescriptorsBytesList);
         }
     );
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/CrossClusterAccessSubjectInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/CrossClusterAccessSubjectInfo.java
@@ -158,7 +158,7 @@ public final class CrossClusterAccessSubjectInfo {
         out.setTransportVersion(authentication.getEffectiveSubject().getTransportVersion());
         TransportVersion.writeVersion(authentication.getEffectiveSubject().getTransportVersion(), out);
         authentication.writeTo(out);
-        out.writeCollection(roleDescriptorsBytesList, (o, rdb) -> rdb.writeTo(o));
+        out.writeCollection(roleDescriptorsBytesList);
         return Base64.getEncoder().encodeToString(BytesReference.toBytes(out.bytes()));
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionParser.java
@@ -40,7 +40,7 @@ public final class ExpressionParser {
     }
 
     static void writeExpressionList(List<RoleMapperExpression> list, StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(list);
+        out.writeNamedWriteableCollection(list);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
@@ -73,7 +73,7 @@ public class ApplicationPrivilegeDescriptor implements ToXContentObject, Writeab
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(application);
         out.writeString(name);
-        out.writeCollection(actions, StreamOutput::writeString);
+        out.writeStringCollection(actions);
         out.writeGenericMap(metadata);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
@@ -188,7 +188,7 @@ public final class ConfigurableClusterPrivileges {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeCollection(this.applicationNames, StreamOutput::writeString);
+            out.writeStringCollection(this.applicationNames);
         }
 
         public static WriteProfileDataPrivileges createFrom(StreamInput in) throws IOException {
@@ -297,7 +297,7 @@ public final class ConfigurableClusterPrivileges {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeCollection(this.applicationNames, StreamOutput::writeString);
+            out.writeStringCollection(this.applicationNames);
         }
 
         public static ManageApplicationPrivileges createFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -136,7 +136,7 @@ public class SnapshotLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.snapshotConfigurations, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
+        out.writeMap(this.snapshotConfigurations, (out1, value) -> value.writeTo(out1));
         out.writeEnum(this.operationMode);
         this.slmStats.writeTo(out);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java
@@ -210,7 +210,7 @@ public class SnapshotLifecycleStats implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(policyStats, StreamOutput::writeString, (v, o) -> o.writeTo(v));
+        out.writeMap(policyStats, (v, o) -> o.writeTo(v));
         out.writeVLong(retentionRunCount.count());
         out.writeVLong(retentionFailedCount.count());
         out.writeVLong(retentionTimedOut.count());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
@@ -391,7 +391,7 @@ public class FindStructureAction extends ActionType<FindStructureAction.Response
                 out.writeBoolean(false);
             } else {
                 out.writeBoolean(true);
-                out.writeCollection(columnNames, StreamOutput::writeString);
+                out.writeStringCollection(columnNames);
             }
             out.writeOptionalBoolean(hasHeaderRow);
             if (delimiter == null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -255,7 +255,7 @@ public class TextStructure implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeCollection(columnNames, StreamOutput::writeString);
+            out.writeStringCollection(columnNames);
         }
         out.writeOptionalBoolean(hasHeaderRow);
         if (delimiter == null) {
@@ -279,13 +279,13 @@ public class TextStructure implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeCollection(jodaTimestampFormats, StreamOutput::writeString);
+            out.writeStringCollection(jodaTimestampFormats);
         }
         if (javaTimestampFormats == null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeCollection(javaTimestampFormats, StreamOutput::writeString);
+            out.writeStringCollection(javaTimestampFormats);
         }
         out.writeOptionalString(timestampField);
         out.writeBoolean(needClientTimezone);
@@ -296,8 +296,8 @@ public class TextStructure implements ToXContentObject, Writeable {
             out.writeBoolean(true);
             out.writeGenericMap(ingestPipeline);
         }
-        out.writeMap(fieldStats, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
-        out.writeCollection(explanation, StreamOutput::writeString);
+        out.writeMap(fieldStats, (out1, value) -> value.writeTo(out1));
+        out.writeStringCollection(explanation);
     }
 
     public int getNumLinesAnalyzed() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -55,8 +55,8 @@ public class TransformFeatureSetUsage extends Usage {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(transformCountByState, StreamOutput::writeString, StreamOutput::writeLong);
-        out.writeMap(transformCountByFeature, StreamOutput::writeString, StreamOutput::writeLong);
+        out.writeMap(transformCountByState, StreamOutput::writeLong);
+        out.writeMap(transformCountByFeature, StreamOutput::writeLong);
         accumulatedStats.writeTo(out);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointAction.java
@@ -121,7 +121,7 @@ public class GetCheckpointAction extends ActionType<GetCheckpointAction.Response
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(getCheckpoints(), StreamOutput::writeString, StreamOutput::writeLongArray);
+            out.writeMap(getCheckpoints(), StreamOutput::writeLongArray);
         }
 
         public Map<String, long[]> getCheckpoints() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointNodeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointNodeAction.java
@@ -49,7 +49,7 @@ public class GetCheckpointNodeAction extends ActionType<GetCheckpointNodeAction.
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(getCheckpoints(), StreamOutput::writeString, StreamOutput::writeLongArray);
+            out.writeMap(getCheckpoints(), StreamOutput::writeLongArray);
         }
 
         public Map<String, long[]> getCheckpoints() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformAction.java
@@ -110,7 +110,7 @@ public class ValidateTransformAction extends ActionType<ValidateTransformAction.
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(destIndexMappings, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(destIndexMappings, StreamOutput::writeString);
         }
 
         public Map<String, String> getDestIndexMappings() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NodeAttributes.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NodeAttributes.java
@@ -164,6 +164,6 @@ public class NodeAttributes implements ToXContentObject, Writeable {
         out.writeString(name);
         out.writeString(ephemeralId);
         out.writeString(transportAddress);
-        out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(attributes, StreamOutput::writeString);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -411,7 +411,7 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
         source.writeTo(out);
         dest.writeTo(out);
         out.writeOptionalTimeValue(frequency);
-        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(headers, StreamOutput::writeString);
         out.writeOptionalWriteable(pivotConfig);
         out.writeOptionalWriteable(latestConfig);
         out.writeOptionalString(description);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
@@ -174,7 +174,7 @@ public class TransformConfigUpdate implements Writeable {
         out.writeOptionalNamedWriteable(syncConfig);
         if (headers != null) {
             out.writeBoolean(true);
-            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(headers, StreamOutput::writeString);
         } else {
             out.writeBoolean(false);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfig.java
@@ -93,7 +93,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeGenericMap(source);
-        out.writeMap(groups, StreamOutput::writeString, (stream, value) -> {
+        out.writeMap(groups, (stream, value) -> {
             stream.writeByte(value.getType().getId());
             value.writeTo(stream);
         });

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
@@ -248,7 +248,7 @@ public class WatchStatus implements ToXContentObject, Writeable {
         boolean statusHasHeaders = headers != null && headers.isEmpty() == false;
         out.writeBoolean(statusHasHeaders);
         if (statusHasHeaders) {
-            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(headers, StreamOutput::writeString);
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -187,7 +187,7 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
             out.writeLong(eventTime);
             XContentHelper.writeTo(out, xContentType);
             out.writeBytesReference(payload);
-            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeStringCollection);
+            out.writeMap(headers, StreamOutput::writeStringCollection);
             out.writeOptionalString(clientAddress);
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -301,7 +301,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
                 out.writeBoolean(fetchFields != null);
                 if (fetchFields != null) {
-                    out.writeMap(fetchFields, StreamOutput::writeString, (stream, documentField) -> documentField.writeTo(stream));
+                    out.writeMap(fetchFields, (stream, documentField) -> documentField.writeTo(stream));
                 }
             }
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_038)) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionProcessor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionProcessor.java
@@ -38,7 +38,7 @@ public class CIDRMatchFunctionProcessor implements Processor {
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(source);
-        out.writeNamedWriteableList(addresses);
+        out.writeNamedWriteableCollection(addresses);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -160,7 +160,7 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeMap(readersBuilt, StreamOutput::writeString, StreamOutput::writeVInt);
+            out.writeMap(readersBuilt, StreamOutput::writeVInt);
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.io.stream;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.dissect.DissectParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
@@ -887,7 +886,7 @@ public final class PlanNamedTypes {
     static void writeEsField(PlanStreamOutput out, EsField esField) throws IOException {
         out.writeString(esField.getName());
         out.writeString(esField.getDataType().typeName());
-        out.writeMap(esField.getProperties(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
+        out.writeMap(esField.getProperties(), (o, v) -> out.writeNamed(EsField.class, v));
         out.writeBoolean(esField.isAggregatable());
         out.writeBoolean(esField.isAlias());
     }
@@ -902,7 +901,7 @@ public final class PlanNamedTypes {
 
     static void writeDateEsField(PlanStreamOutput out, DateEsField dateEsField) throws IOException {
         out.writeString(dateEsField.getName());
-        out.writeMap(dateEsField.getProperties(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
+        out.writeMap(dateEsField.getProperties(), (o, v) -> out.writeNamed(EsField.class, v));
         out.writeBoolean(dateEsField.isAggregatable());
     }
 
@@ -928,7 +927,7 @@ public final class PlanNamedTypes {
 
     static void writeKeywordEsField(PlanStreamOutput out, KeywordEsField keywordEsField) throws IOException {
         out.writeString(keywordEsField.getName());
-        out.writeMap(keywordEsField.getProperties(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
+        out.writeMap(keywordEsField.getProperties(), (o, v) -> out.writeNamed(EsField.class, v));
         out.writeBoolean(keywordEsField.isAggregatable());
         out.writeInt(keywordEsField.getPrecision());
         out.writeBoolean(keywordEsField.getNormalized());
@@ -946,7 +945,7 @@ public final class PlanNamedTypes {
 
     static void writeTextEsField(PlanStreamOutput out, TextEsField textEsField) throws IOException {
         out.writeString(textEsField.getName());
-        out.writeMap(textEsField.getProperties(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
+        out.writeMap(textEsField.getProperties(), (o, v) -> out.writeNamed(EsField.class, v));
         out.writeBoolean(textEsField.isAggregatable());
         out.writeBoolean(textEsField.isAlias());
     }
@@ -964,7 +963,7 @@ public final class PlanNamedTypes {
         out.writeString(unsupportedEsField.getName());
         out.writeString(unsupportedEsField.getOriginalType());
         out.writeOptionalString(unsupportedEsField.getInherited());
-        out.writeMap(unsupportedEsField.getProperties(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
+        out.writeMap(unsupportedEsField.getProperties(), (o, v) -> out.writeNamed(EsField.class, v));
     }
 
     // -- BinaryComparison
@@ -1459,7 +1458,7 @@ public final class PlanNamedTypes {
 
     static void writeEsIndex(PlanStreamOutput out, EsIndex esIndex) throws IOException {
         out.writeString(esIndex.name());
-        out.writeMap(esIndex.mapping(), StreamOutput::writeString, (o, v) -> out.writeNamed(EsField.class, v));
+        out.writeMap(esIndex.mapping(), (o, v) -> out.writeNamed(EsField.class, v));
         out.writeGenericValue(esIndex.concreteIndices());
     }
 

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineResponse.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineResponse.java
@@ -38,7 +38,7 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(pipelines, StreamOutput::writeString, StreamOutput::writeBytesReference);
+        out.writeMap(pipelines, StreamOutput::writeBytesReference);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
@@ -101,7 +101,7 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeArray(frequentItemSets);
-            out.writeMap(profilingInfo, StreamOutput::writeString, StreamOutput::writeGenericValue);
+            out.writeMap(profilingInfo, StreamOutput::writeGenericValue);
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilder.java
@@ -252,7 +252,7 @@ public class InferencePipelineAggregationBuilder extends AbstractPipelineAggrega
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
-        out.writeMap(bucketPathMap, StreamOutput::writeString, StreamOutput::writeString);
+        out.writeMap(bucketPathMap, StreamOutput::writeString);
         out.writeOptionalNamedWriteable(inferenceConfig);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregation.java
@@ -40,7 +40,7 @@ public class InternalKSTestAggregation extends InternalAggregation {
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeMap(modeValues, StreamOutput::writeString, StreamOutput::writeDouble);
+        out.writeMap(modeValues, StreamOutput::writeDouble);
     }
 
     Map<String, Double> getModeValues() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
@@ -117,7 +117,7 @@ public class ModelAliasMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.modelAliases, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.modelAliases, (stream, val) -> val.writeTo(stream));
     }
 
     public String getModelId(String modelAlias) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -160,7 +160,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(deploymentRoutingEntries, StreamOutput::writeString, (o, w) -> w.writeTo(o));
+        out.writeMap(deploymentRoutingEntries, (o, w) -> w.writeTo(o));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
@@ -77,7 +77,7 @@ public class InternalItemSetMapReduceAggregationTests extends InternalAggregatio
 
             @Override
             public void writeTo(StreamOutput out) throws IOException {
-                out.writeMap(frequencies, StreamOutput::writeString, StreamOutput::writeLong);
+                out.writeMap(frequencies, StreamOutput::writeLong);
             }
 
             @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
@@ -81,10 +81,10 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
     public void writeTo(StreamOutput out) throws IOException {
         if (stackTraces != null) {
             out.writeBoolean(true);
-            out.writeMap(stackTraces, StreamOutput::writeString, (o, v) -> {
+            out.writeMap(stackTraces, (o, v) -> {
                 o.writeCollection(v.addressOrLines, StreamOutput::writeInt);
-                o.writeCollection(v.fileIds, StreamOutput::writeString);
-                o.writeCollection(v.frameIds, StreamOutput::writeString);
+                o.writeStringCollection(v.fileIds);
+                o.writeStringCollection(v.frameIds);
                 o.writeCollection(v.typeIds, StreamOutput::writeInt);
             });
         } else {
@@ -92,9 +92,9 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
         }
         if (stackFrames != null) {
             out.writeBoolean(true);
-            out.writeMap(stackFrames, StreamOutput::writeString, (o, v) -> {
-                o.writeCollection(v.fileName, StreamOutput::writeString);
-                o.writeCollection(v.functionName, StreamOutput::writeString);
+            out.writeMap(stackFrames, (o, v) -> {
+                o.writeStringCollection(v.fileName);
+                o.writeStringCollection(v.functionName);
                 o.writeCollection(v.functionOffset, StreamOutput::writeInt);
                 o.writeCollection(v.lineNumber, StreamOutput::writeInt);
             });
@@ -103,13 +103,13 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
         }
         if (executables != null) {
             out.writeBoolean(true);
-            out.writeMap(executables, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeMap(executables, StreamOutput::writeString);
         } else {
             out.writeBoolean(false);
         }
         if (stackTraceEvents != null) {
             out.writeBoolean(true);
-            out.writeMap(stackTraceEvents, StreamOutput::writeString, StreamOutput::writeInt);
+            out.writeMap(stackTraceEvents, StreamOutput::writeInt);
         } else {
             out.writeBoolean(false);
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/InProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/InProcessor.java
@@ -36,7 +36,7 @@ public class InProcessor implements Processor {
 
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(processsors);
+        out.writeNamedWriteableCollection(processsors);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggCursor.java
@@ -91,7 +91,7 @@ public class CompositeAggCursor implements Cursor {
         nextQuery.writeTo(out);
         out.writeVInt(limit);
 
-        out.writeNamedWriteableList(extractors);
+        out.writeNamedWriteableCollection(extractors);
         out.writeByteArray(mask.toByteArray());
         out.writeBoolean(includeFrozen);
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
@@ -77,7 +77,7 @@ public class SearchHitCursor implements Cursor {
         nextQuery.writeTo(out);
         out.writeVInt(limit);
 
-        out.writeNamedWriteableList(extractors);
+        out.writeNamedWriteableCollection(extractors);
         out.writeByteArray(mask.toByteArray());
         out.writeBoolean(includeFrozen);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/CaseProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/CaseProcessor.java
@@ -35,7 +35,7 @@ public class CaseProcessor implements Processor {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(processors);
+        out.writeNamedWriteableCollection(processors);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalProcessor.java
@@ -70,7 +70,7 @@ public class ConditionalProcessor implements Processor {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteableList(processors);
+        out.writeNamedWriteableCollection(processors);
         out.writeEnum(operation);
     }
 


### PR DESCRIPTION
We can dry up and shorten a bunch of spots by using the overloads we already have in the code. Also, added a new overload for writing a map with string keys.
