### PR TITLE
Skip opening Searcher for matchAll in FieldCaps (#98740)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -57,43 +58,72 @@ class FieldCapabilitiesFetcher {
     ) throws IOException {
         final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         final IndexShard indexShard = indexService.getShard(shardId.getId());
+        if (alwaysMatches(indexFilter)) {
+            // no need to open a searcher if we aren't filtering
+            return doFetch(task, shardId, fieldPatterns, filters, fieldTypes, indexFilter, nowInMillis, runtimeFields, indexService, null);
+        }
         try (Engine.Searcher searcher = indexShard.acquireSearcher(Engine.CAN_MATCH_SEARCH_SOURCE)) {
-
-            final SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
-                shardId.id(),
-                0,
-                searcher,
-                () -> nowInMillis,
-                null,
-                runtimeFields
-            );
-
-            if (canMatchShard(shardId, indexFilter, nowInMillis, searchExecutionContext) == false) {
-                return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), null, Collections.emptyMap(), false);
-            }
-
-            final MappingMetadata mapping = indexService.getMetadata().mapping();
-            final String indexMappingHash = mapping != null ? mapping.getSha256() : null;
-            if (indexMappingHash != null) {
-                final Map<String, IndexFieldCapabilities> existing = indexMappingHashToResponses.get(indexMappingHash);
-                if (existing != null) {
-                    return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), indexMappingHash, existing, true);
-                }
-            }
-            task.ensureNotCancelled();
-            Predicate<String> fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
-            final Map<String, IndexFieldCapabilities> responseMap = retrieveFieldCaps(
-                searchExecutionContext,
+            return doFetch(
+                task,
+                shardId,
                 fieldPatterns,
                 filters,
                 fieldTypes,
-                fieldPredicate
+                indexFilter,
+                nowInMillis,
+                runtimeFields,
+                indexService,
+                searcher
             );
-            if (indexMappingHash != null) {
-                indexMappingHashToResponses.put(indexMappingHash, responseMap);
-            }
-            return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), indexMappingHash, responseMap, true);
         }
+    }
+
+    private FieldCapabilitiesIndexResponse doFetch(
+        CancellableTask task,
+        ShardId shardId,
+        String[] fieldPatterns,
+        String[] filters,
+        String[] fieldTypes,
+        QueryBuilder indexFilter,
+        long nowInMillis,
+        Map<String, Object> runtimeFields,
+        IndexService indexService,
+        @Nullable Engine.Searcher searcher
+    ) throws IOException {
+        final SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
+            shardId.id(),
+            0,
+            searcher,
+            () -> nowInMillis,
+            null,
+            runtimeFields
+        );
+
+        if (searcher != null && canMatchShard(shardId, indexFilter, nowInMillis, searchExecutionContext) == false) {
+            return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), null, Collections.emptyMap(), false);
+        }
+
+        final MappingMetadata mapping = indexService.getMetadata().mapping();
+        final String indexMappingHash = mapping != null ? mapping.getSha256() : null;
+        if (indexMappingHash != null) {
+            final Map<String, IndexFieldCapabilities> existing = indexMappingHashToResponses.get(indexMappingHash);
+            if (existing != null) {
+                return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), indexMappingHash, existing, true);
+            }
+        }
+        task.ensureNotCancelled();
+        Predicate<String> fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
+        final Map<String, IndexFieldCapabilities> responseMap = retrieveFieldCaps(
+            searchExecutionContext,
+            fieldPatterns,
+            filters,
+            fieldTypes,
+            fieldPredicate
+        );
+        if (indexMappingHash != null) {
+            indexMappingHashToResponses.put(indexMappingHash, responseMap);
+        }
+        return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), indexMappingHash, responseMap, true);
     }
 
     static Map<String, IndexFieldCapabilities> retrieveFieldCaps(
@@ -181,13 +211,15 @@ class FieldCapabilitiesFetcher {
         long nowInMillis,
         SearchExecutionContext searchExecutionContext
     ) throws IOException {
-        if (indexFilter == null || indexFilter instanceof MatchAllQueryBuilder) {
-            return true;
-        }
+        assert alwaysMatches(indexFilter) == false : "should not be called for always matching [" + indexFilter + "]";
         assert nowInMillis != 0L;
         ShardSearchRequest searchRequest = new ShardSearchRequest(shardId, nowInMillis, AliasFilter.EMPTY);
         searchRequest.source(new SearchSourceBuilder().query(indexFilter));
         return SearchService.queryStillMatchesAfterRewrite(searchRequest, searchExecutionContext);
+    }
+
+    private static boolean alwaysMatches(QueryBuilder indexFilter) {
+        return indexFilter == null || indexFilter instanceof MatchAllQueryBuilder;
     }
 
     private static Predicate<MappedFieldType> buildFilter(


### PR DESCRIPTION
We don't seem to need the searcher in cases where the request isn't filtered so lets not open it in that case.
A next step to optimizing this case might be to not even run this action on the data node if there is no filter since the coordinating node has the mappings available anyway.

back port of #98740 