### PR TITLE
Update graph YAML tests for severless

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/graph/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/graph/10_basic.yml
@@ -33,7 +33,8 @@ setup:
   - do:
       cluster.health:
            index: test_1
-           wait_for_status: green
+           wait_for_status: yellow
+           wait_for_no_initializing_shards: true
 
   - do:
       graph.explore:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/graph/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/graph/10_basic.yml
@@ -7,7 +7,7 @@ setup:
         settings:
           index:
             number_of_shards:   1
-            number_of_replicas: 0
+            number_of_replicas: 1
         mappings:
           properties:
             keys:


### PR DESCRIPTION
This YAML rest test made assumptions about the behaviour of the Elasticsearch cluster that are not always true on Serverless ES.

- Always set at least 1 replica because in serverless these correspond to search shards. Some tests previously set 0 replicas for simplicity/performance but this is no longer viable.
