### PR TITLE
Reset node-left generation on election

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
@@ -267,6 +267,7 @@ public class NodeJoinExecutor implements ClusterStateTaskExecutor<JoinTask> {
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentNodes);
         Map<String, TransportVersion> transportVersions = new HashMap<>(getTransportVersions(currentState));
         nodesBuilder.masterNodeId(currentState.nodes().getLocalNodeId());
+        nodesBuilder.resetNodeLeftGeneration();
 
         for (final var taskContext : taskContexts) {
             for (final var joiningNode : taskContext.getTask().nodes()) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -720,6 +720,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
         private final long oldNodeLeftGeneration;
         @Nullable // if not specified
         private Long nodeLeftGeneration;
+        private boolean resetNodeLeftGeneration;
 
         public Builder() {
             nodes = new HashMap<>();
@@ -855,7 +856,10 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
             } else if (this.nodeLeftGeneration != null) {
                 // only happens during deserialization
                 assert removedNode == false;
+                assert resetNodeLeftGeneration == false;
                 newNodeLeftGeneration = nodeLeftGeneration;
+            } else if (resetNodeLeftGeneration) {
+                newNodeLeftGeneration = 0L;
             } else if (removedNode) {
                 newNodeLeftGeneration = oldNodeLeftGeneration + 1L;
             } else {
@@ -895,7 +899,8 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
         }
 
         public void resetNodeLeftGeneration() {
-            nodeLeftGeneration(0L);
+            assert this.resetNodeLeftGeneration == false;
+            this.resetNodeLeftGeneration = true;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -893,6 +893,10 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
             assert this.nodeLeftGeneration == null : nodeLeftGeneration + " vs " + this.nodeLeftGeneration;
             this.nodeLeftGeneration = nodeLeftGeneration;
         }
+
+        public void resetNodeLeftGeneration() {
+            nodeLeftGeneration(0L);
+        }
     }
 
     private static Map<String, DiscoveryNode> filteredNodes(Map<String, DiscoveryNode> nodes, Predicate<DiscoveryNode> predicate) {


### PR DESCRIPTION
Node-left generations are only comparable within a master term and must
start again from zero in the next term.