### PR TITLE
[DRAFT] Initial BlockFactory - move creation of blocks and vectors

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorFunctionSupplierImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorFunctionSupplierImplementer.java
@@ -29,7 +29,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
 import static org.elasticsearch.compute.gen.Types.AGGREGATOR_FUNCTION_SUPPLIER;
-import static org.elasticsearch.compute.gen.Types.BIG_ARRAYS;
+import static org.elasticsearch.compute.gen.Types.DRIVER_CONTEXT;
 import static org.elasticsearch.compute.gen.Types.LIST_INTEGER;
 
 /**
@@ -58,19 +58,19 @@ public class AggregatorFunctionSupplierImplementer {
         createParameters.addAll(groupingAggregatorImplementer.createParameters());
         List<Parameter> sortedParameters = new ArrayList<>(createParameters);
         for (Parameter p : sortedParameters) {
-            if (p.type().equals(BIG_ARRAYS) && false == p.name().equals("bigArrays")) {
-                throw new IllegalArgumentException("BigArrays should always be named bigArrays but was " + p);
+            if (p.type().equals(DRIVER_CONTEXT) && false == p.name().equals("driverContext")) {
+                throw new IllegalArgumentException("DriverContext should always be named driverContext but was " + p);
             }
         }
 
         /*
-         * We like putting BigArrays first and then channels second
+         * We like putting DriverContext first and then channels second
          * regardless of the order that the aggs actually want them.
          * Just a little bit of standardization here.
          */
-        Parameter bigArraysParam = new Parameter(BIG_ARRAYS, "bigArrays");
-        sortedParameters.remove(bigArraysParam);
-        sortedParameters.add(0, bigArraysParam);
+        Parameter driverContextParam = new Parameter(DRIVER_CONTEXT, "driverContext");
+        sortedParameters.remove(driverContextParam);
+        sortedParameters.add(0, driverContextParam);
         sortedParameters.add(1, new Parameter(LIST_INTEGER, "channels"));
 
         this.createParameters = sortedParameters;
@@ -118,7 +118,7 @@ public class AggregatorFunctionSupplierImplementer {
         builder.addStatement(
             "return $T.create($L)",
             aggregatorImplementer.implementation(),
-            Stream.concat(Stream.of("channels"), aggregatorImplementer.createParameters().stream().map(Parameter::name))
+            Stream.concat(Stream.of("channels", "driverContext"), aggregatorImplementer.createParameters().stream().map(Parameter::name))
                 .collect(Collectors.joining(", "))
         );
 
@@ -131,7 +131,7 @@ public class AggregatorFunctionSupplierImplementer {
         builder.addStatement(
             "return $T.create($L)",
             groupingAggregatorImplementer.implementation(),
-            Stream.concat(Stream.of("channels"), groupingAggregatorImplementer.createParameters().stream().map(Parameter::name))
+            Stream.concat(Stream.of("channels", "driverContext"), groupingAggregatorImplementer.createParameters().stream().map(Parameter::name))
                 .collect(Collectors.joining(", "))
         );
         return builder.build();

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/MvEvaluatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/MvEvaluatorImplementer.java
@@ -193,7 +193,7 @@ public class MvEvaluatorImplementer {
         builder.addStatement("int positionCount = v.getPositionCount()");
         if (nullable) {
             TypeName resultBlockType = blockType(resultType);
-            builder.addStatement("$T.Builder builder = $T.newBlockBuilder(positionCount)", resultBlockType, resultBlockType);
+            builder.addStatement("$T.Builder builder = blockFactory.new$TBuilder(positionCount)", resultBlockType, resultBlockType);
         } else if (resultType.equals(BYTES_REF)) {
             builder.addStatement(
                 "$T values = new $T(positionCount, $T.NON_RECYCLING_INSTANCE)",  // TODO blocks should use recycling array

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
@@ -88,6 +88,8 @@ public class Types {
     static final ClassName INTERMEDIATE_STATE_DESC = ClassName.get(AGGREGATION_PACKAGE, "IntermediateStateDesc");
     static final TypeName LIST_AGG_FUNC_DESC = ParameterizedTypeName.get(ClassName.get(List.class), INTERMEDIATE_STATE_DESC);
 
+    static final ClassName DRIVER_CONTEXT = ClassName.get(OPERATOR_PACKAGE, "DriverContext");
+
     static final ClassName EXPRESSION_EVALUATOR = ClassName.get(OPERATOR_PACKAGE, "EvalOperator", "ExpressionEvaluator");
     static final ClassName ABSTRACT_MULTIVALUE_FUNCTION_EVALUATOR = ClassName.get(
         "org.elasticsearch.xpack.esql.expression.function.scalar.multivalue",

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -49,7 +49,7 @@ public sealed interface BooleanBlock extends Block permits FilterBooleanBlock, B
             return BooleanVector.of(in).asBlock();
         }
         final int positions = in.readVInt();
-        var builder = newBlockBuilder(positions);
+        var builder = BlockFactory.getDefault().newBooleanBlockBuilder(positions);
         for (int i = 0; i < positions; i++) {
             if (in.readBoolean()) {
                 builder.appendNull();
@@ -155,14 +155,6 @@ public sealed interface BooleanBlock extends Block permits FilterBooleanBlock, B
             }
         }
         return result;
-    }
-
-    static Builder newBlockBuilder(int estimatedSize) {
-        return new BooleanBlockBuilder(estimatedSize);
-    }
-
-    static BooleanBlock newConstantBlockWith(boolean value, int positions) {
-        return new ConstantBooleanVector(value, positions).asBlock();
     }
 
     sealed interface Builder extends Block.Builder permits BooleanBlockBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -78,7 +78,7 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
         if (constant && positions > 0) {
             return new ConstantBooleanVector(in.readBoolean(), positions);
         } else {
-            var builder = BooleanVector.newVectorBuilder(positions);
+            var builder = BlockFactory.getDefault().newBooleanVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.appendBoolean(in.readBoolean());
             }
@@ -98,10 +98,6 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
                 out.writeBoolean(getBoolean(i));
             }
         }
-    }
-
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new BooleanVectorBuilder(estimatedSize);
     }
 
     sealed interface Builder extends Vector.Builder permits BooleanVectorBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -51,7 +51,7 @@ public sealed interface BytesRefBlock extends Block permits FilterBytesRefBlock,
             return BytesRefVector.of(in).asBlock();
         }
         final int positions = in.readVInt();
-        var builder = newBlockBuilder(positions);
+        var builder = BlockFactory.getDefault().newBytesRefBlockBuilder(positions);
         for (int i = 0; i < positions; i++) {
             if (in.readBoolean()) {
                 builder.appendNull();
@@ -158,14 +158,6 @@ public sealed interface BytesRefBlock extends Block permits FilterBytesRefBlock,
             }
         }
         return result;
-    }
-
-    static Builder newBlockBuilder(int estimatedSize) {
-        return new BytesRefBlockBuilder(estimatedSize);
-    }
-
-    static BytesRefBlock newConstantBlockWith(BytesRef value, int positions) {
-        return new ConstantBytesRefVector(value, positions).asBlock();
     }
 
     sealed interface Builder extends Block.Builder permits BytesRefBlockBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -78,7 +78,7 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
         if (constant && positions > 0) {
             return new ConstantBytesRefVector(in.readBytesRef(), positions);
         } else {
-            var builder = BytesRefVector.newVectorBuilder(positions);
+            var builder = BlockFactory.getDefault().newBytesRefVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.appendBytesRef(in.readBytesRef());
             }
@@ -98,10 +98,6 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
                 out.writeBytesRef(getBytesRef(i, new BytesRef()));
             }
         }
-    }
-
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new BytesRefVectorBuilder(estimatedSize);
     }
 
     sealed interface Builder extends Vector.Builder permits BytesRefVectorBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -49,7 +49,7 @@ public sealed interface DoubleBlock extends Block permits FilterDoubleBlock, Dou
             return DoubleVector.of(in).asBlock();
         }
         final int positions = in.readVInt();
-        var builder = newBlockBuilder(positions);
+        var builder = BlockFactory.getDefault().newDoubleBlockBuilder(positions);
         for (int i = 0; i < positions; i++) {
             if (in.readBoolean()) {
                 builder.appendNull();
@@ -156,14 +156,6 @@ public sealed interface DoubleBlock extends Block permits FilterDoubleBlock, Dou
             }
         }
         return result;
-    }
-
-    static Builder newBlockBuilder(int estimatedSize) {
-        return new DoubleBlockBuilder(estimatedSize);
-    }
-
-    static DoubleBlock newConstantBlockWith(double value, int positions) {
-        return new ConstantDoubleVector(value, positions).asBlock();
     }
 
     sealed interface Builder extends Block.Builder permits DoubleBlockBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -79,7 +79,7 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
         if (constant && positions > 0) {
             return new ConstantDoubleVector(in.readDouble(), positions);
         } else {
-            var builder = DoubleVector.newVectorBuilder(positions);
+            var builder = BlockFactory.getDefault().newDoubleVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.appendDouble(in.readDouble());
             }
@@ -99,10 +99,6 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
                 out.writeDouble(getDouble(i));
             }
         }
-    }
-
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new DoubleVectorBuilder(estimatedSize);
     }
 
     sealed interface Builder extends Vector.Builder permits DoubleVectorBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -49,7 +49,7 @@ public sealed interface IntBlock extends Block permits FilterIntBlock, IntArrayB
             return IntVector.of(in).asBlock();
         }
         final int positions = in.readVInt();
-        var builder = newBlockBuilder(positions);
+        var builder = BlockFactory.getDefault().newIntBlockBuilder(positions);
         for (int i = 0; i < positions; i++) {
             if (in.readBoolean()) {
                 builder.appendNull();
@@ -155,14 +155,6 @@ public sealed interface IntBlock extends Block permits FilterIntBlock, IntArrayB
             }
         }
         return result;
-    }
-
-    static Builder newBlockBuilder(int estimatedSize) {
-        return new IntBlockBuilder(estimatedSize);
-    }
-
-    static IntBlock newConstantBlockWith(int value, int positions) {
-        return new ConstantIntVector(value, positions).asBlock();
     }
 
     sealed interface Builder extends Block.Builder permits IntBlockBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -78,7 +78,7 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, Filt
         if (constant && positions > 0) {
             return new ConstantIntVector(in.readInt(), positions);
         } else {
-            var builder = IntVector.newVectorBuilder(positions);
+            var builder = BlockFactory.getDefault().newIntVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.appendInt(in.readInt());
             }
@@ -98,10 +98,6 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, Filt
                 out.writeInt(getInt(i));
             }
         }
-    }
-
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new IntVectorBuilder(estimatedSize);
     }
 
     /** Create a vector for a range of ints. */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -49,7 +49,7 @@ public sealed interface LongBlock extends Block permits FilterLongBlock, LongArr
             return LongVector.of(in).asBlock();
         }
         final int positions = in.readVInt();
-        var builder = newBlockBuilder(positions);
+        var builder = BlockFactory.getDefault().newLongBlockBuilder(positions);
         for (int i = 0; i < positions; i++) {
             if (in.readBoolean()) {
                 builder.appendNull();
@@ -156,14 +156,6 @@ public sealed interface LongBlock extends Block permits FilterLongBlock, LongArr
             }
         }
         return result;
-    }
-
-    static Builder newBlockBuilder(int estimatedSize) {
-        return new LongBlockBuilder(estimatedSize);
-    }
-
-    static LongBlock newConstantBlockWith(long value, int positions) {
-        return new ConstantLongVector(value, positions).asBlock();
     }
 
     sealed interface Builder extends Block.Builder permits LongBlockBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -79,7 +79,7 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Fi
         if (constant && positions > 0) {
             return new ConstantLongVector(in.readLong(), positions);
         } else {
-            var builder = LongVector.newVectorBuilder(positions);
+            var builder = BlockFactory.getDefault().newLongVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.appendLong(in.readLong());
             }
@@ -99,10 +99,6 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Fi
                 out.writeLong(getLong(i));
             }
         }
-    }
-
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new LongVectorBuilder(estimatedSize);
     }
 
     sealed interface Builder extends Vector.Builder permits LongVectorBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.IntBlock;
 
@@ -30,11 +31,13 @@ public class MultivalueDedupeBytesRef {
      */
     private static final int ALWAYS_COPY_MISSING = 20;  // TODO BytesRef should try adding to the hash *first* and then comparing.
     private final BytesRefBlock block;
+    private final BlockFactory blockFactory;
     private BytesRef[] work = new BytesRef[ArrayUtil.oversize(2, org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
     private int w;
 
-    public MultivalueDedupeBytesRef(BytesRefBlock block) {
+    public MultivalueDedupeBytesRef(BytesRefBlock block, BlockFactory blockFactory) {
         this.block = block;
+        this.blockFactory = blockFactory;
         // TODO very large numbers might want a hash based implementation - and for BytesRef that might not be that big
         fillWork(0, work.length);
     }
@@ -47,7 +50,7 @@ public class MultivalueDedupeBytesRef {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(block.getPositionCount());
+        BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -95,7 +98,7 @@ public class MultivalueDedupeBytesRef {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(block.getPositionCount());
+        BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -123,7 +126,7 @@ public class MultivalueDedupeBytesRef {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(block.getPositionCount());
+        BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -144,7 +147,7 @@ public class MultivalueDedupeBytesRef {
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(BytesRefHash hash) {
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 
@@ -29,11 +30,13 @@ public class MultivalueDedupeDouble {
      */
     private static final int ALWAYS_COPY_MISSING = 110;
     private final DoubleBlock block;
+    private final BlockFactory blockFactory;
     private double[] work = new double[ArrayUtil.oversize(2, Double.BYTES)];
     private int w;
 
-    public MultivalueDedupeDouble(DoubleBlock block) {
+    public MultivalueDedupeDouble(DoubleBlock block, BlockFactory blockFactory) {
         this.block = block;
+        this.blockFactory = blockFactory;
     }
 
     /**
@@ -44,7 +47,7 @@ public class MultivalueDedupeDouble {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(block.getPositionCount());
+        DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -92,7 +95,7 @@ public class MultivalueDedupeDouble {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(block.getPositionCount());
+        DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -120,7 +123,7 @@ public class MultivalueDedupeDouble {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(block.getPositionCount());
+        DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -141,7 +144,7 @@ public class MultivalueDedupeDouble {
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(LongHash hash) {
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 
 import java.util.Arrays;
@@ -28,11 +29,13 @@ public class MultivalueDedupeInt {
      */
     private static final int ALWAYS_COPY_MISSING = 300;
     private final IntBlock block;
+    private final BlockFactory blockFactory;
     private int[] work = new int[ArrayUtil.oversize(2, Integer.BYTES)];
     private int w;
 
-    public MultivalueDedupeInt(IntBlock block) {
+    public MultivalueDedupeInt(IntBlock block, BlockFactory blockFactory) {
         this.block = block;
+        this.blockFactory = blockFactory;
     }
 
     /**
@@ -43,7 +46,7 @@ public class MultivalueDedupeInt {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -91,7 +94,7 @@ public class MultivalueDedupeInt {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -119,7 +122,7 @@ public class MultivalueDedupeInt {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -140,7 +143,7 @@ public class MultivalueDedupeInt {
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(LongHash hash) {
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 
@@ -30,11 +31,13 @@ public class MultivalueDedupeLong {
     private static final int ALWAYS_COPY_MISSING = 300;
 
     private final LongBlock block;
+    private final BlockFactory blockFactory;
     private long[] work = new long[ArrayUtil.oversize(2, Long.BYTES)];
     private int w;
 
-    public MultivalueDedupeLong(LongBlock block) {
+    public MultivalueDedupeLong(LongBlock block, BlockFactory blockFactory) {
         this.block = block;
+        this.blockFactory = blockFactory;
     }
 
     /**
@@ -45,7 +48,7 @@ public class MultivalueDedupeLong {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        LongBlock.Builder builder = blockFactory.newLongBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -93,7 +96,7 @@ public class MultivalueDedupeLong {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        LongBlock.Builder builder = blockFactory.newLongBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -121,7 +124,7 @@ public class MultivalueDedupeLong {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(block.getPositionCount());
+        LongBlock.Builder builder = blockFactory.newLongBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -142,7 +145,7 @@ public class MultivalueDedupeLong {
      * as the grouping block to a {@link GroupingAggregatorFunction}.
      */
     public MultivalueDedupe.HashResult hash(LongHash hash) {
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link CountDistinctBooleanAggregator}.
@@ -28,14 +29,18 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
 
   private final List<Integer> channels;
 
-  public CountDistinctBooleanAggregatorFunction(List<Integer> channels,
+  private final DriverContext driverContext;
+
+  public CountDistinctBooleanAggregatorFunction(List<Integer> channels, DriverContext driverContext,
       CountDistinctBooleanAggregator.SingleState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static CountDistinctBooleanAggregatorFunction create(List<Integer> channels) {
-    return new CountDistinctBooleanAggregatorFunction(channels, CountDistinctBooleanAggregator.initSingle());
+  public static CountDistinctBooleanAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new CountDistinctBooleanAggregatorFunction(channels, driverContext, CountDistinctBooleanAggregator.initSingle(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunctionSupplier.java
@@ -8,31 +8,31 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctBooleanAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class CountDistinctBooleanAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public CountDistinctBooleanAggregatorFunctionSupplier(BigArrays bigArrays,
+  public CountDistinctBooleanAggregatorFunctionSupplier(DriverContext driverContext,
       List<Integer> channels) {
-    this.bigArrays = bigArrays;
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public CountDistinctBooleanAggregatorFunction aggregator() {
-    return CountDistinctBooleanAggregatorFunction.create(channels);
+    return CountDistinctBooleanAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public CountDistinctBooleanGroupingAggregatorFunction groupingAggregator() {
-    return CountDistinctBooleanGroupingAggregatorFunction.create(channels, bigArrays);
+    return CountDistinctBooleanGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -17,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link CountDistinctBooleanAggregator}.
@@ -31,18 +31,18 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   public CountDistinctBooleanGroupingAggregatorFunction(List<Integer> channels,
-      CountDistinctBooleanAggregator.GroupingState state, BigArrays bigArrays) {
+      DriverContext driverContext, CountDistinctBooleanAggregator.GroupingState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
   }
 
   public static CountDistinctBooleanGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new CountDistinctBooleanGroupingAggregatorFunction(channels, CountDistinctBooleanAggregator.initGrouping(bigArrays), bigArrays);
+      DriverContext driverContext) {
+    return new CountDistinctBooleanGroupingAggregatorFunction(channels, driverContext, CountDistinctBooleanAggregator.initGrouping(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -10,12 +10,12 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link CountDistinctBytesRefAggregator}.
@@ -29,21 +29,21 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
   public CountDistinctBytesRefAggregatorFunction(List<Integer> channels,
-      HllStates.SingleState state, BigArrays bigArrays, int precision) {
+      DriverContext driverContext, HllStates.SingleState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctBytesRefAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctBytesRefAggregatorFunction(channels, CountDistinctBytesRefAggregator.initSingle(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctBytesRefAggregatorFunction(channels, driverContext, CountDistinctBytesRefAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctBytesRefAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class CountDistinctBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final int precision;
 
-  public CountDistinctBytesRefAggregatorFunctionSupplier(BigArrays bigArrays,
+  public CountDistinctBytesRefAggregatorFunctionSupplier(DriverContext driverContext,
       List<Integer> channels, int precision) {
-    this.bigArrays = bigArrays;
+    this.driverContext = driverContext;
     this.channels = channels;
     this.precision = precision;
   }
 
   @Override
   public CountDistinctBytesRefAggregatorFunction aggregator() {
-    return CountDistinctBytesRefAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctBytesRefAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override
   public CountDistinctBytesRefGroupingAggregatorFunction groupingAggregator() {
-    return CountDistinctBytesRefGroupingAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctBytesRefGroupingAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link CountDistinctBytesRefAggregator}.
@@ -31,21 +31,21 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
   public CountDistinctBytesRefGroupingAggregatorFunction(List<Integer> channels,
-      HllStates.GroupingState state, BigArrays bigArrays, int precision) {
+      DriverContext driverContext, HllStates.GroupingState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctBytesRefGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctBytesRefGroupingAggregatorFunction(channels, CountDistinctBytesRefAggregator.initGrouping(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctBytesRefGroupingAggregatorFunction(channels, driverContext, CountDistinctBytesRefAggregator.initGrouping(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link CountDistinctDoubleAggregator}.
@@ -31,21 +31,21 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
-  public CountDistinctDoubleAggregatorFunction(List<Integer> channels, HllStates.SingleState state,
-      BigArrays bigArrays, int precision) {
+  public CountDistinctDoubleAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      HllStates.SingleState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctDoubleAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctDoubleAggregatorFunction(channels, CountDistinctDoubleAggregator.initSingle(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctDoubleAggregatorFunction(channels, driverContext, CountDistinctDoubleAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class CountDistinctDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final int precision;
 
-  public CountDistinctDoubleAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels,
-      int precision) {
-    this.bigArrays = bigArrays;
+  public CountDistinctDoubleAggregatorFunctionSupplier(DriverContext driverContext,
+      List<Integer> channels, int precision) {
+    this.driverContext = driverContext;
     this.channels = channels;
     this.precision = precision;
   }
 
   @Override
   public CountDistinctDoubleAggregatorFunction aggregator() {
-    return CountDistinctDoubleAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctDoubleAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override
   public CountDistinctDoubleGroupingAggregatorFunction groupingAggregator() {
-    return CountDistinctDoubleGroupingAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctDoubleGroupingAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -20,6 +19,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link CountDistinctDoubleAggregator}.
@@ -33,21 +33,21 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
   public CountDistinctDoubleGroupingAggregatorFunction(List<Integer> channels,
-      HllStates.GroupingState state, BigArrays bigArrays, int precision) {
+      DriverContext driverContext, HllStates.GroupingState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctDoubleGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctDoubleGroupingAggregatorFunction(channels, CountDistinctDoubleAggregator.initGrouping(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctDoubleGroupingAggregatorFunction(channels, driverContext, CountDistinctDoubleAggregator.initGrouping(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link CountDistinctIntAggregator}.
@@ -31,21 +31,21 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
-  public CountDistinctIntAggregatorFunction(List<Integer> channels, HllStates.SingleState state,
-      BigArrays bigArrays, int precision) {
+  public CountDistinctIntAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      HllStates.SingleState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctIntAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctIntAggregatorFunction(channels, CountDistinctIntAggregator.initSingle(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctIntAggregatorFunction(channels, driverContext, CountDistinctIntAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctIntAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class CountDistinctIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final int precision;
 
-  public CountDistinctIntAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels,
-      int precision) {
-    this.bigArrays = bigArrays;
+  public CountDistinctIntAggregatorFunctionSupplier(DriverContext driverContext,
+      List<Integer> channels, int precision) {
+    this.driverContext = driverContext;
     this.channels = channels;
     this.precision = precision;
   }
 
   @Override
   public CountDistinctIntAggregatorFunction aggregator() {
-    return CountDistinctIntAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctIntAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override
   public CountDistinctIntGroupingAggregatorFunction groupingAggregator() {
-    return CountDistinctIntGroupingAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctIntGroupingAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link CountDistinctIntAggregator}.
@@ -31,21 +31,21 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
   public CountDistinctIntGroupingAggregatorFunction(List<Integer> channels,
-      HllStates.GroupingState state, BigArrays bigArrays, int precision) {
+      DriverContext driverContext, HllStates.GroupingState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctIntGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctIntGroupingAggregatorFunction(channels, CountDistinctIntAggregator.initGrouping(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctIntGroupingAggregatorFunction(channels, driverContext, CountDistinctIntAggregator.initGrouping(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link CountDistinctLongAggregator}.
@@ -31,21 +31,21 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
-  public CountDistinctLongAggregatorFunction(List<Integer> channels, HllStates.SingleState state,
-      BigArrays bigArrays, int precision) {
+  public CountDistinctLongAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      HllStates.SingleState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctLongAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctLongAggregatorFunction(channels, CountDistinctLongAggregator.initSingle(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctLongAggregatorFunction(channels, driverContext, CountDistinctLongAggregator.initSingle(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctLongAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class CountDistinctLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final int precision;
 
-  public CountDistinctLongAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels,
-      int precision) {
-    this.bigArrays = bigArrays;
+  public CountDistinctLongAggregatorFunctionSupplier(DriverContext driverContext,
+      List<Integer> channels, int precision) {
+    this.driverContext = driverContext;
     this.channels = channels;
     this.precision = precision;
   }
 
   @Override
   public CountDistinctLongAggregatorFunction aggregator() {
-    return CountDistinctLongAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctLongAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override
   public CountDistinctLongGroupingAggregatorFunction groupingAggregator() {
-    return CountDistinctLongGroupingAggregatorFunction.create(channels, bigArrays, precision);
+    return CountDistinctLongGroupingAggregatorFunction.create(channels, driverContext, precision);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -20,6 +19,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link CountDistinctLongAggregator}.
@@ -33,21 +33,21 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final int precision;
 
   public CountDistinctLongGroupingAggregatorFunction(List<Integer> channels,
-      HllStates.GroupingState state, BigArrays bigArrays, int precision) {
+      DriverContext driverContext, HllStates.GroupingState state, int precision) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.precision = precision;
   }
 
   public static CountDistinctLongGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, int precision) {
-    return new CountDistinctLongGroupingAggregatorFunction(channels, CountDistinctLongAggregator.initGrouping(bigArrays, precision), bigArrays, precision);
+      DriverContext driverContext, int precision) {
+    return new CountDistinctLongGroupingAggregatorFunction(channels, driverContext, CountDistinctLongAggregator.initGrouping(driverContext, precision), precision);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MaxDoubleAggregator}.
@@ -30,13 +31,18 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public MaxDoubleAggregatorFunction(List<Integer> channels, DoubleState state) {
+  private final DriverContext driverContext;
+
+  public MaxDoubleAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      DoubleState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MaxDoubleAggregatorFunction create(List<Integer> channels) {
-    return new MaxDoubleAggregatorFunction(channels, new DoubleState(MaxDoubleAggregator.init()));
+  public static MaxDoubleAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MaxDoubleAggregatorFunction(channels, driverContext, new DoubleState(MaxDoubleAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = DoubleBlock.newConstantBlockWith(state.doubleValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantDoubleVector(state.doubleValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MaxDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MaxDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MaxDoubleAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public MaxDoubleAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MaxDoubleAggregatorFunction aggregator() {
-    return MaxDoubleAggregatorFunction.create(channels);
+    return MaxDoubleAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MaxDoubleGroupingAggregatorFunction groupingAggregator() {
-    return MaxDoubleGroupingAggregatorFunction.create(channels, bigArrays);
+    return MaxDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MaxDoubleAggregator}.
@@ -33,14 +33,18 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
 
   private final List<Integer> channels;
 
-  public MaxDoubleGroupingAggregatorFunction(List<Integer> channels, DoubleArrayState state) {
+  private final DriverContext driverContext;
+
+  public MaxDoubleGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      DoubleArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static MaxDoubleGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MaxDoubleGroupingAggregatorFunction(channels, new DoubleArrayState(bigArrays, MaxDoubleAggregator.init()));
+      DriverContext driverContext) {
+    return new MaxDoubleGroupingAggregatorFunction(channels, driverContext, new DoubleArrayState(driverContext, MaxDoubleAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MaxIntAggregator}.
@@ -30,13 +31,18 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public MaxIntAggregatorFunction(List<Integer> channels, IntState state) {
+  private final DriverContext driverContext;
+
+  public MaxIntAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      IntState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MaxIntAggregatorFunction create(List<Integer> channels) {
-    return new MaxIntAggregatorFunction(channels, new IntState(MaxIntAggregator.init()));
+  public static MaxIntAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MaxIntAggregatorFunction(channels, driverContext, new IntState(MaxIntAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = IntBlock.newConstantBlockWith(state.intValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantIntVector(state.intValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MaxIntAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MaxIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MaxIntAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public MaxIntAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MaxIntAggregatorFunction aggregator() {
-    return MaxIntAggregatorFunction.create(channels);
+    return MaxIntAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MaxIntGroupingAggregatorFunction groupingAggregator() {
-    return MaxIntGroupingAggregatorFunction.create(channels, bigArrays);
+    return MaxIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -17,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MaxIntAggregator}.
@@ -31,14 +31,18 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
 
   private final List<Integer> channels;
 
-  public MaxIntGroupingAggregatorFunction(List<Integer> channels, IntArrayState state) {
+  private final DriverContext driverContext;
+
+  public MaxIntGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      IntArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static MaxIntGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MaxIntGroupingAggregatorFunction(channels, new IntArrayState(bigArrays, MaxIntAggregator.init()));
+      DriverContext driverContext) {
+    return new MaxIntGroupingAggregatorFunction(channels, driverContext, new IntArrayState(driverContext, MaxIntAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MaxLongAggregator}.
@@ -30,13 +31,18 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public MaxLongAggregatorFunction(List<Integer> channels, LongState state) {
+  private final DriverContext driverContext;
+
+  public MaxLongAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MaxLongAggregatorFunction create(List<Integer> channels) {
-    return new MaxLongAggregatorFunction(channels, new LongState(MaxLongAggregator.init()));
+  public static MaxLongAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MaxLongAggregatorFunction(channels, driverContext, new LongState(MaxLongAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = LongBlock.newConstantBlockWith(state.longValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantLongVector(state.longValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MaxLongAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MaxLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MaxLongAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public MaxLongAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MaxLongAggregatorFunction aggregator() {
-    return MaxLongAggregatorFunction.create(channels);
+    return MaxLongAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MaxLongGroupingAggregatorFunction groupingAggregator() {
-    return MaxLongGroupingAggregatorFunction.create(channels, bigArrays);
+    return MaxLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MaxLongAggregator}.
@@ -33,14 +33,18 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
 
   private final List<Integer> channels;
 
-  public MaxLongGroupingAggregatorFunction(List<Integer> channels, LongArrayState state) {
+  private final DriverContext driverContext;
+
+  public MaxLongGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static MaxLongGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MaxLongGroupingAggregatorFunction(channels, new LongArrayState(bigArrays, MaxLongAggregator.init()));
+      DriverContext driverContext) {
+    return new MaxLongGroupingAggregatorFunction(channels, driverContext, new LongArrayState(driverContext, MaxLongAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
@@ -30,14 +31,18 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
 
   private final List<Integer> channels;
 
+  private final DriverContext driverContext;
+
   public MedianAbsoluteDeviationDoubleAggregatorFunction(List<Integer> channels,
-      QuantileStates.SingleState state) {
+      DriverContext driverContext, QuantileStates.SingleState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MedianAbsoluteDeviationDoubleAggregatorFunction create(List<Integer> channels) {
-    return new MedianAbsoluteDeviationDoubleAggregatorFunction(channels, MedianAbsoluteDeviationDoubleAggregator.initSingle());
+  public static MedianAbsoluteDeviationDoubleAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MedianAbsoluteDeviationDoubleAggregatorFunction(channels, driverContext, MedianAbsoluteDeviationDoubleAggregator.initSingle(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier.java
@@ -8,31 +8,31 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(BigArrays bigArrays,
+  public MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(DriverContext driverContext,
       List<Integer> channels) {
-    this.bigArrays = bigArrays;
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MedianAbsoluteDeviationDoubleAggregatorFunction aggregator() {
-    return MedianAbsoluteDeviationDoubleAggregatorFunction.create(channels);
+    return MedianAbsoluteDeviationDoubleAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MedianAbsoluteDeviationDoubleGroupingAggregatorFunction groupingAggregator() {
-    return MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.create(channels, bigArrays);
+    return MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -20,6 +19,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
@@ -33,18 +33,18 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   public MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(List<Integer> channels,
-      QuantileStates.GroupingState state, BigArrays bigArrays) {
+      DriverContext driverContext, QuantileStates.GroupingState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
   }
 
   public static MedianAbsoluteDeviationDoubleGroupingAggregatorFunction create(
-      List<Integer> channels, BigArrays bigArrays) {
-    return new MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(channels, MedianAbsoluteDeviationDoubleAggregator.initGrouping(bigArrays), bigArrays);
+      List<Integer> channels, DriverContext driverContext) {
+    return new MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(channels, driverContext, MedianAbsoluteDeviationDoubleAggregator.initGrouping(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MedianAbsoluteDeviationIntAggregator}.
@@ -30,14 +31,18 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
 
   private final List<Integer> channels;
 
+  private final DriverContext driverContext;
+
   public MedianAbsoluteDeviationIntAggregatorFunction(List<Integer> channels,
-      QuantileStates.SingleState state) {
+      DriverContext driverContext, QuantileStates.SingleState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MedianAbsoluteDeviationIntAggregatorFunction create(List<Integer> channels) {
-    return new MedianAbsoluteDeviationIntAggregatorFunction(channels, MedianAbsoluteDeviationIntAggregator.initSingle());
+  public static MedianAbsoluteDeviationIntAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MedianAbsoluteDeviationIntAggregatorFunction(channels, driverContext, MedianAbsoluteDeviationIntAggregator.initSingle(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunctionSupplier.java
@@ -8,31 +8,31 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationIntAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MedianAbsoluteDeviationIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MedianAbsoluteDeviationIntAggregatorFunctionSupplier(BigArrays bigArrays,
+  public MedianAbsoluteDeviationIntAggregatorFunctionSupplier(DriverContext driverContext,
       List<Integer> channels) {
-    this.bigArrays = bigArrays;
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MedianAbsoluteDeviationIntAggregatorFunction aggregator() {
-    return MedianAbsoluteDeviationIntAggregatorFunction.create(channels);
+    return MedianAbsoluteDeviationIntAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MedianAbsoluteDeviationIntGroupingAggregatorFunction groupingAggregator() {
-    return MedianAbsoluteDeviationIntGroupingAggregatorFunction.create(channels, bigArrays);
+    return MedianAbsoluteDeviationIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MedianAbsoluteDeviationIntAggregator}.
@@ -31,18 +31,18 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   public MedianAbsoluteDeviationIntGroupingAggregatorFunction(List<Integer> channels,
-      QuantileStates.GroupingState state, BigArrays bigArrays) {
+      DriverContext driverContext, QuantileStates.GroupingState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
   }
 
   public static MedianAbsoluteDeviationIntGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MedianAbsoluteDeviationIntGroupingAggregatorFunction(channels, MedianAbsoluteDeviationIntAggregator.initGrouping(bigArrays), bigArrays);
+      DriverContext driverContext) {
+    return new MedianAbsoluteDeviationIntGroupingAggregatorFunction(channels, driverContext, MedianAbsoluteDeviationIntAggregator.initGrouping(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MedianAbsoluteDeviationLongAggregator}.
@@ -30,14 +31,18 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
 
   private final List<Integer> channels;
 
+  private final DriverContext driverContext;
+
   public MedianAbsoluteDeviationLongAggregatorFunction(List<Integer> channels,
-      QuantileStates.SingleState state) {
+      DriverContext driverContext, QuantileStates.SingleState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MedianAbsoluteDeviationLongAggregatorFunction create(List<Integer> channels) {
-    return new MedianAbsoluteDeviationLongAggregatorFunction(channels, MedianAbsoluteDeviationLongAggregator.initSingle());
+  public static MedianAbsoluteDeviationLongAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MedianAbsoluteDeviationLongAggregatorFunction(channels, driverContext, MedianAbsoluteDeviationLongAggregator.initSingle(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunctionSupplier.java
@@ -8,31 +8,31 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationLongAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MedianAbsoluteDeviationLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MedianAbsoluteDeviationLongAggregatorFunctionSupplier(BigArrays bigArrays,
+  public MedianAbsoluteDeviationLongAggregatorFunctionSupplier(DriverContext driverContext,
       List<Integer> channels) {
-    this.bigArrays = bigArrays;
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MedianAbsoluteDeviationLongAggregatorFunction aggregator() {
-    return MedianAbsoluteDeviationLongAggregatorFunction.create(channels);
+    return MedianAbsoluteDeviationLongAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MedianAbsoluteDeviationLongGroupingAggregatorFunction groupingAggregator() {
-    return MedianAbsoluteDeviationLongGroupingAggregatorFunction.create(channels, bigArrays);
+    return MedianAbsoluteDeviationLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -20,6 +19,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MedianAbsoluteDeviationLongAggregator}.
@@ -33,18 +33,18 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   public MedianAbsoluteDeviationLongGroupingAggregatorFunction(List<Integer> channels,
-      QuantileStates.GroupingState state, BigArrays bigArrays) {
+      DriverContext driverContext, QuantileStates.GroupingState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
   }
 
   public static MedianAbsoluteDeviationLongGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MedianAbsoluteDeviationLongGroupingAggregatorFunction(channels, MedianAbsoluteDeviationLongAggregator.initGrouping(bigArrays), bigArrays);
+      DriverContext driverContext) {
+    return new MedianAbsoluteDeviationLongGroupingAggregatorFunction(channels, driverContext, MedianAbsoluteDeviationLongAggregator.initGrouping(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MinDoubleAggregator}.
@@ -30,13 +31,18 @@ public final class MinDoubleAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public MinDoubleAggregatorFunction(List<Integer> channels, DoubleState state) {
+  private final DriverContext driverContext;
+
+  public MinDoubleAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      DoubleState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MinDoubleAggregatorFunction create(List<Integer> channels) {
-    return new MinDoubleAggregatorFunction(channels, new DoubleState(MinDoubleAggregator.init()));
+  public static MinDoubleAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MinDoubleAggregatorFunction(channels, driverContext, new DoubleState(MinDoubleAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class MinDoubleAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = DoubleBlock.newConstantBlockWith(state.doubleValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantDoubleVector(state.doubleValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MinDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MinDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MinDoubleAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public MinDoubleAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MinDoubleAggregatorFunction aggregator() {
-    return MinDoubleAggregatorFunction.create(channels);
+    return MinDoubleAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MinDoubleGroupingAggregatorFunction groupingAggregator() {
-    return MinDoubleGroupingAggregatorFunction.create(channels, bigArrays);
+    return MinDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MinDoubleAggregator}.
@@ -33,14 +33,18 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
 
   private final List<Integer> channels;
 
-  public MinDoubleGroupingAggregatorFunction(List<Integer> channels, DoubleArrayState state) {
+  private final DriverContext driverContext;
+
+  public MinDoubleGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      DoubleArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static MinDoubleGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MinDoubleGroupingAggregatorFunction(channels, new DoubleArrayState(bigArrays, MinDoubleAggregator.init()));
+      DriverContext driverContext) {
+    return new MinDoubleGroupingAggregatorFunction(channels, driverContext, new DoubleArrayState(driverContext, MinDoubleAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MinIntAggregator}.
@@ -30,13 +31,18 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public MinIntAggregatorFunction(List<Integer> channels, IntState state) {
+  private final DriverContext driverContext;
+
+  public MinIntAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      IntState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MinIntAggregatorFunction create(List<Integer> channels) {
-    return new MinIntAggregatorFunction(channels, new IntState(MinIntAggregator.init()));
+  public static MinIntAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MinIntAggregatorFunction(channels, driverContext, new IntState(MinIntAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = IntBlock.newConstantBlockWith(state.intValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantIntVector(state.intValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MinIntAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MinIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MinIntAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public MinIntAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MinIntAggregatorFunction aggregator() {
-    return MinIntAggregatorFunction.create(channels);
+    return MinIntAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MinIntGroupingAggregatorFunction groupingAggregator() {
-    return MinIntGroupingAggregatorFunction.create(channels, bigArrays);
+    return MinIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -17,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MinIntAggregator}.
@@ -31,14 +31,18 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
 
   private final List<Integer> channels;
 
-  public MinIntGroupingAggregatorFunction(List<Integer> channels, IntArrayState state) {
+  private final DriverContext driverContext;
+
+  public MinIntGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      IntArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static MinIntGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MinIntGroupingAggregatorFunction(channels, new IntArrayState(bigArrays, MinIntAggregator.init()));
+      DriverContext driverContext) {
+    return new MinIntGroupingAggregatorFunction(channels, driverContext, new IntArrayState(driverContext, MinIntAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MinLongAggregator}.
@@ -30,13 +31,18 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public MinLongAggregatorFunction(List<Integer> channels, LongState state) {
+  private final DriverContext driverContext;
+
+  public MinLongAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static MinLongAggregatorFunction create(List<Integer> channels) {
-    return new MinLongAggregatorFunction(channels, new LongState(MinLongAggregator.init()));
+  public static MinLongAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new MinLongAggregatorFunction(channels, driverContext, new LongState(MinLongAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = LongBlock.newConstantBlockWith(state.longValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantLongVector(state.longValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MinLongAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class MinLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public MinLongAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public MinLongAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public MinLongAggregatorFunction aggregator() {
-    return MinLongAggregatorFunction.create(channels);
+    return MinLongAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public MinLongGroupingAggregatorFunction groupingAggregator() {
-    return MinLongGroupingAggregatorFunction.create(channels, bigArrays);
+    return MinLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MinLongAggregator}.
@@ -33,14 +33,18 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
 
   private final List<Integer> channels;
 
-  public MinLongGroupingAggregatorFunction(List<Integer> channels, LongArrayState state) {
+  private final DriverContext driverContext;
+
+  public MinLongGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static MinLongGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new MinLongGroupingAggregatorFunction(channels, new LongArrayState(bigArrays, MinLongAggregator.init()));
+      DriverContext driverContext) {
+    return new MinLongGroupingAggregatorFunction(channels, driverContext, new LongArrayState(driverContext, MinLongAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link PercentileDoubleAggregator}.
@@ -30,18 +31,21 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
 
   private final List<Integer> channels;
 
+  private final DriverContext driverContext;
+
   private final double percentile;
 
-  public PercentileDoubleAggregatorFunction(List<Integer> channels,
+  public PercentileDoubleAggregatorFunction(List<Integer> channels, DriverContext driverContext,
       QuantileStates.SingleState state, double percentile) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
     this.percentile = percentile;
   }
 
   public static PercentileDoubleAggregatorFunction create(List<Integer> channels,
-      double percentile) {
-    return new PercentileDoubleAggregatorFunction(channels, PercentileDoubleAggregator.initSingle(percentile), percentile);
+      DriverContext driverContext, double percentile) {
+    return new PercentileDoubleAggregatorFunction(channels, driverContext, PercentileDoubleAggregator.initSingle(driverContext, percentile), percentile);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class PercentileDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final double percentile;
 
-  public PercentileDoubleAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels,
-      double percentile) {
-    this.bigArrays = bigArrays;
+  public PercentileDoubleAggregatorFunctionSupplier(DriverContext driverContext,
+      List<Integer> channels, double percentile) {
+    this.driverContext = driverContext;
     this.channels = channels;
     this.percentile = percentile;
   }
 
   @Override
   public PercentileDoubleAggregatorFunction aggregator() {
-    return PercentileDoubleAggregatorFunction.create(channels, percentile);
+    return PercentileDoubleAggregatorFunction.create(channels, driverContext, percentile);
   }
 
   @Override
   public PercentileDoubleGroupingAggregatorFunction groupingAggregator() {
-    return PercentileDoubleGroupingAggregatorFunction.create(channels, bigArrays, percentile);
+    return PercentileDoubleGroupingAggregatorFunction.create(channels, driverContext, percentile);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -20,6 +19,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link PercentileDoubleAggregator}.
@@ -33,21 +33,21 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final double percentile;
 
   public PercentileDoubleGroupingAggregatorFunction(List<Integer> channels,
-      QuantileStates.GroupingState state, BigArrays bigArrays, double percentile) {
+      DriverContext driverContext, QuantileStates.GroupingState state, double percentile) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.percentile = percentile;
   }
 
   public static PercentileDoubleGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, double percentile) {
-    return new PercentileDoubleGroupingAggregatorFunction(channels, PercentileDoubleAggregator.initGrouping(bigArrays, percentile), bigArrays, percentile);
+      DriverContext driverContext, double percentile) {
+    return new PercentileDoubleGroupingAggregatorFunction(channels, driverContext, PercentileDoubleAggregator.initGrouping(driverContext, percentile), percentile);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link PercentileIntAggregator}.
@@ -30,17 +31,21 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
 
   private final List<Integer> channels;
 
+  private final DriverContext driverContext;
+
   private final double percentile;
 
-  public PercentileIntAggregatorFunction(List<Integer> channels, QuantileStates.SingleState state,
-      double percentile) {
+  public PercentileIntAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      QuantileStates.SingleState state, double percentile) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
     this.percentile = percentile;
   }
 
-  public static PercentileIntAggregatorFunction create(List<Integer> channels, double percentile) {
-    return new PercentileIntAggregatorFunction(channels, PercentileIntAggregator.initSingle(percentile), percentile);
+  public static PercentileIntAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext, double percentile) {
+    return new PercentileIntAggregatorFunction(channels, driverContext, PercentileIntAggregator.initSingle(driverContext, percentile), percentile);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileIntAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class PercentileIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final double percentile;
 
-  public PercentileIntAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels,
-      double percentile) {
-    this.bigArrays = bigArrays;
+  public PercentileIntAggregatorFunctionSupplier(DriverContext driverContext,
+      List<Integer> channels, double percentile) {
+    this.driverContext = driverContext;
     this.channels = channels;
     this.percentile = percentile;
   }
 
   @Override
   public PercentileIntAggregatorFunction aggregator() {
-    return PercentileIntAggregatorFunction.create(channels, percentile);
+    return PercentileIntAggregatorFunction.create(channels, driverContext, percentile);
   }
 
   @Override
   public PercentileIntGroupingAggregatorFunction groupingAggregator() {
-    return PercentileIntGroupingAggregatorFunction.create(channels, bigArrays, percentile);
+    return PercentileIntGroupingAggregatorFunction.create(channels, driverContext, percentile);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -18,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link PercentileIntAggregator}.
@@ -31,21 +31,21 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final double percentile;
 
   public PercentileIntGroupingAggregatorFunction(List<Integer> channels,
-      QuantileStates.GroupingState state, BigArrays bigArrays, double percentile) {
+      DriverContext driverContext, QuantileStates.GroupingState state, double percentile) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.percentile = percentile;
   }
 
   public static PercentileIntGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, double percentile) {
-    return new PercentileIntGroupingAggregatorFunction(channels, PercentileIntAggregator.initGrouping(bigArrays, percentile), bigArrays, percentile);
+      DriverContext driverContext, double percentile) {
+    return new PercentileIntGroupingAggregatorFunction(channels, driverContext, PercentileIntAggregator.initGrouping(driverContext, percentile), percentile);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link PercentileLongAggregator}.
@@ -30,17 +31,21 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
 
   private final List<Integer> channels;
 
+  private final DriverContext driverContext;
+
   private final double percentile;
 
-  public PercentileLongAggregatorFunction(List<Integer> channels, QuantileStates.SingleState state,
-      double percentile) {
+  public PercentileLongAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      QuantileStates.SingleState state, double percentile) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
     this.percentile = percentile;
   }
 
-  public static PercentileLongAggregatorFunction create(List<Integer> channels, double percentile) {
-    return new PercentileLongAggregatorFunction(channels, PercentileLongAggregator.initSingle(percentile), percentile);
+  public static PercentileLongAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext, double percentile) {
+    return new PercentileLongAggregatorFunction(channels, driverContext, PercentileLongAggregator.initSingle(driverContext, percentile), percentile);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunctionSupplier.java
@@ -8,34 +8,34 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileLongAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class PercentileLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
   private final double percentile;
 
-  public PercentileLongAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels,
-      double percentile) {
-    this.bigArrays = bigArrays;
+  public PercentileLongAggregatorFunctionSupplier(DriverContext driverContext,
+      List<Integer> channels, double percentile) {
+    this.driverContext = driverContext;
     this.channels = channels;
     this.percentile = percentile;
   }
 
   @Override
   public PercentileLongAggregatorFunction aggregator() {
-    return PercentileLongAggregatorFunction.create(channels, percentile);
+    return PercentileLongAggregatorFunction.create(channels, driverContext, percentile);
   }
 
   @Override
   public PercentileLongGroupingAggregatorFunction groupingAggregator() {
-    return PercentileLongGroupingAggregatorFunction.create(channels, bigArrays, percentile);
+    return PercentileLongGroupingAggregatorFunction.create(channels, driverContext, percentile);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongGroupingAggregatorFunction.java
@@ -10,7 +10,6 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -20,6 +19,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link PercentileLongAggregator}.
@@ -33,21 +33,21 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final double percentile;
 
   public PercentileLongGroupingAggregatorFunction(List<Integer> channels,
-      QuantileStates.GroupingState state, BigArrays bigArrays, double percentile) {
+      DriverContext driverContext, QuantileStates.GroupingState state, double percentile) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
     this.percentile = percentile;
   }
 
   public static PercentileLongGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays, double percentile) {
-    return new PercentileLongGroupingAggregatorFunction(channels, PercentileLongAggregator.initGrouping(bigArrays, percentile), bigArrays, percentile);
+      DriverContext driverContext, double percentile) {
+    return new PercentileLongGroupingAggregatorFunction(channels, driverContext, PercentileLongAggregator.initGrouping(driverContext, percentile), percentile);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link SumDoubleAggregator}.
@@ -31,13 +32,18 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public SumDoubleAggregatorFunction(List<Integer> channels, SumDoubleAggregator.SumState state) {
+  private final DriverContext driverContext;
+
+  public SumDoubleAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      SumDoubleAggregator.SumState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static SumDoubleAggregatorFunction create(List<Integer> channels) {
-    return new SumDoubleAggregatorFunction(channels, SumDoubleAggregator.initSingle());
+  public static SumDoubleAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new SumDoubleAggregatorFunction(channels, driverContext, SumDoubleAggregator.initSingle(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link SumDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class SumDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public SumDoubleAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public SumDoubleAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public SumDoubleAggregatorFunction aggregator() {
-    return SumDoubleAggregatorFunction.create(channels);
+    return SumDoubleAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public SumDoubleGroupingAggregatorFunction groupingAggregator() {
-    return SumDoubleGroupingAggregatorFunction.create(channels, bigArrays);
+    return SumDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link SumDoubleAggregator}.
@@ -34,18 +34,18 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
 
   private final List<Integer> channels;
 
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
-  public SumDoubleGroupingAggregatorFunction(List<Integer> channels,
-      SumDoubleAggregator.GroupingSumState state, BigArrays bigArrays) {
+  public SumDoubleGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      SumDoubleAggregator.GroupingSumState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
-    this.bigArrays = bigArrays;
   }
 
   public static SumDoubleGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new SumDoubleGroupingAggregatorFunction(channels, SumDoubleAggregator.initGrouping(bigArrays), bigArrays);
+      DriverContext driverContext) {
+    return new SumDoubleGroupingAggregatorFunction(channels, driverContext, SumDoubleAggregator.initGrouping(driverContext));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link SumIntAggregator}.
@@ -32,13 +33,18 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public SumIntAggregatorFunction(List<Integer> channels, LongState state) {
+  private final DriverContext driverContext;
+
+  public SumIntAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static SumIntAggregatorFunction create(List<Integer> channels) {
-    return new SumIntAggregatorFunction(channels, new LongState(SumIntAggregator.init()));
+  public static SumIntAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new SumIntAggregatorFunction(channels, driverContext, new LongState(SumIntAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -111,7 +117,7 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = LongBlock.newConstantBlockWith(state.longValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantLongVector(state.longValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link SumIntAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class SumIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public SumIntAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public SumIntAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public SumIntAggregatorFunction aggregator() {
-    return SumIntAggregatorFunction.create(channels);
+    return SumIntAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public SumIntGroupingAggregatorFunction groupingAggregator() {
-    return SumIntGroupingAggregatorFunction.create(channels, bigArrays);
+    return SumIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link SumIntAggregator}.
@@ -33,14 +33,18 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
 
   private final List<Integer> channels;
 
-  public SumIntGroupingAggregatorFunction(List<Integer> channels, LongArrayState state) {
+  private final DriverContext driverContext;
+
+  public SumIntGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static SumIntGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new SumIntGroupingAggregatorFunction(channels, new LongArrayState(bigArrays, SumIntAggregator.init()));
+      DriverContext driverContext) {
+    return new SumIntGroupingAggregatorFunction(channels, driverContext, new LongArrayState(driverContext, SumIntAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunction} implementation for {@link SumLongAggregator}.
@@ -30,13 +31,18 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
 
   private final List<Integer> channels;
 
-  public SumLongAggregatorFunction(List<Integer> channels, LongState state) {
+  private final DriverContext driverContext;
+
+  public SumLongAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
-  public static SumLongAggregatorFunction create(List<Integer> channels) {
-    return new SumLongAggregatorFunction(channels, new LongState(SumLongAggregator.init()));
+  public static SumLongAggregatorFunction create(List<Integer> channels,
+      DriverContext driverContext) {
+    return new SumLongAggregatorFunction(channels, driverContext, new LongState(SumLongAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {
@@ -109,7 +115,7 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
       blocks[offset] = Block.constantNullBlock(1);
       return;
     }
-    blocks[offset] = LongBlock.newConstantBlockWith(state.longValue(), 1);
+    blocks[offset] = driverContext.blockFactory().newConstantLongVector(state.longValue(), 1).asBlock();
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionSupplier.java
@@ -8,30 +8,30 @@ import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link SumLongAggregator}.
  * This class is generated. Do not edit it.
  */
 public final class SumLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  private final BigArrays bigArrays;
+  private final DriverContext driverContext;
 
   private final List<Integer> channels;
 
-  public SumLongAggregatorFunctionSupplier(BigArrays bigArrays, List<Integer> channels) {
-    this.bigArrays = bigArrays;
+  public SumLongAggregatorFunctionSupplier(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
     this.channels = channels;
   }
 
   @Override
   public SumLongAggregatorFunction aggregator() {
-    return SumLongAggregatorFunction.create(channels);
+    return SumLongAggregatorFunction.create(channels, driverContext);
   }
 
   @Override
   public SumLongGroupingAggregatorFunction groupingAggregator() {
-    return SumLongGroupingAggregatorFunction.create(channels, bigArrays);
+    return SumLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunction.java
@@ -9,7 +9,6 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link SumLongAggregator}.
@@ -33,14 +33,18 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
 
   private final List<Integer> channels;
 
-  public SumLongGroupingAggregatorFunction(List<Integer> channels, LongArrayState state) {
+  private final DriverContext driverContext;
+
+  public SumLongGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
+      LongArrayState state) {
     this.channels = channels;
+    this.driverContext = driverContext;
     this.state = state;
   }
 
   public static SumLongGroupingAggregatorFunction create(List<Integer> channels,
-      BigArrays bigArrays) {
-    return new SumLongGroupingAggregatorFunction(channels, new LongArrayState(bigArrays, SumLongAggregator.init()));
+      DriverContext driverContext) {
+    return new SumLongGroupingAggregatorFunction(channels, driverContext, new LongArrayState(driverContext, SumLongAggregator.init()));
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractArrayState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractArrayState.java
@@ -9,16 +9,20 @@ package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 public class AbstractArrayState implements Releasable {
     protected final BigArrays bigArrays;
+    protected final BlockFactory blockFactory;
 
     private BitArray seen;
 
-    public AbstractArrayState(BigArrays bigArrays) {
-        this.bigArrays = bigArrays;
+    public AbstractArrayState(DriverContext driverContext) {
+        this.blockFactory = driverContext.blockFactory();
+        this.bigArrays = driverContext.bigArrays();
     }
 
     final boolean hasValue(int groupId) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/Aggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/Aggregator.java
@@ -10,9 +10,10 @@ package org.elasticsearch.compute.aggregation;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 public class Aggregator implements Releasable {
 
@@ -22,7 +23,7 @@ public class Aggregator implements Releasable {
 
     private final AggregatorMode mode;
 
-    public interface Factory extends Supplier<Aggregator>, Describable {}
+    public interface Factory extends Function<DriverContext, Aggregator>, Describable {}
 
     public Aggregator(AggregatorFunction aggregatorFunction, AggregatorMode mode) {
         this.aggregatorFunction = aggregatorFunction;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunctionSupplier.java
@@ -21,7 +21,7 @@ public interface AggregatorFunctionSupplier extends Describable {
     default Aggregator.Factory aggregatorFactory(AggregatorMode mode) {
         return new Aggregator.Factory() {
             @Override
-            public Aggregator get() {
+            public Aggregator apply(DriverContext driverContext) {
                 return new Aggregator(aggregator(), mode);
             }
 
@@ -36,7 +36,7 @@ public interface AggregatorFunctionSupplier extends Describable {
         return new GroupingAggregator.Factory() {
             @Override
             public GroupingAggregator apply(DriverContext driverContext) {
-                return new GroupingAggregator(groupingAggregator(), mode);
+                return new GroupingAggregator(groupingAggregator(driverContext), mode);
             }
 
             @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountAggregatorFunction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.aggregation;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -15,11 +14,12 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 
 import java.util.List;
 
 public class CountAggregatorFunction implements AggregatorFunction {
-    public static AggregatorFunctionSupplier supplier(BigArrays bigArrays, List<Integer> channels) {
+    public static AggregatorFunctionSupplier supplier(DriverContext driverContext, List<Integer> channels) {
         return new AggregatorFunctionSupplier() {
             @Override
             public AggregatorFunction aggregator() {
@@ -28,7 +28,7 @@ public class CountAggregatorFunction implements AggregatorFunction {
 
             @Override
             public GroupingAggregatorFunction groupingAggregator() {
-                return CountGroupingAggregatorFunction.create(bigArrays, channels);
+                return CountGroupingAggregatorFunction.create(driverContext, channels);
             }
 
             @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
@@ -8,20 +8,20 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctBytesRefAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, BytesRef v) {
@@ -38,11 +38,11 @@ public class CountDistinctBytesRefAggregator {
 
     public static Block evaluateFinal(HllStates.SingleState state) {
         long result = state.cardinality();
-        return LongBlock.newConstantBlockWith(result, 1);
+        return state.blockFactory().newConstantLongVector(result, 1).asBlock();
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, BytesRef v) {
@@ -63,7 +63,7 @@ public class CountDistinctBytesRefAggregator {
     }
 
     public static Block evaluateFinal(HllStates.GroupingState state, IntVector selected) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(selected.getPositionCount());
+        LongBlock.Builder builder = state.blockFactory().newLongBlockBuilder(selected.getPositionCount());
         for (int i = 0; i < selected.getPositionCount(); i++) {
             int group = selected.getInt(i);
             long count = state.cardinality(group);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
@@ -8,20 +8,20 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctIntAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, int v) {
@@ -38,11 +38,11 @@ public class CountDistinctIntAggregator {
 
     public static Block evaluateFinal(HllStates.SingleState state) {
         long result = state.cardinality();
-        return LongBlock.newConstantBlockWith(result, 1);
+        return state.blockFactory().newConstantLongVector(result, 1).asBlock();
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, int v) {
@@ -63,7 +63,7 @@ public class CountDistinctIntAggregator {
     }
 
     public static Block evaluateFinal(HllStates.GroupingState state, IntVector selected) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(selected.getPositionCount());
+        LongBlock.Builder builder = state.blockFactory().newLongBlockBuilder(selected.getPositionCount());
         for (int i = 0; i < selected.getPositionCount(); i++) {
             int group = selected.getInt(i);
             long count = state.cardinality(group);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
@@ -8,20 +8,20 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctLongAggregator {
 
-    public static HllStates.SingleState initSingle(BigArrays bigArrays, int precision) {
-        return new HllStates.SingleState(bigArrays, precision);
+    public static HllStates.SingleState initSingle(DriverContext driverContext, int precision) {
+        return new HllStates.SingleState(driverContext, precision);
     }
 
     public static void combine(HllStates.SingleState current, long v) {
@@ -38,11 +38,11 @@ public class CountDistinctLongAggregator {
 
     public static Block evaluateFinal(HllStates.SingleState state) {
         long result = state.cardinality();
-        return LongBlock.newConstantBlockWith(result, 1);
+        return state.blockFactory().newConstantLongVector(result, 1).asBlock();
     }
 
-    public static HllStates.GroupingState initGrouping(BigArrays bigArrays, int precision) {
-        return new HllStates.GroupingState(bigArrays, precision);
+    public static HllStates.GroupingState initGrouping(DriverContext driverContext, int precision) {
+        return new HllStates.GroupingState(driverContext, precision);
     }
 
     public static void combine(HllStates.GroupingState current, int groupId, long v) {
@@ -63,7 +63,7 @@ public class CountDistinctLongAggregator {
     }
 
     public static Block evaluateFinal(HllStates.GroupingState state, IntVector selected) {
-        LongBlock.Builder builder = LongBlock.newBlockBuilder(selected.getPositionCount());
+        LongBlock.Builder builder = state.blockFactory().newLongBlockBuilder(selected.getPositionCount());
         for (int i = 0; i < selected.getPositionCount(); i++) {
             int group = selected.getInt(i);
             long count = state.cardinality(group);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
@@ -8,19 +8,19 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class MedianAbsoluteDeviationDoubleAggregator {
 
-    public static QuantileStates.SingleState initSingle() {
-        return new QuantileStates.SingleState(QuantileStates.MEDIAN);
+    public static QuantileStates.SingleState initSingle(DriverContext driverContext) {
+        return new QuantileStates.SingleState(driverContext, QuantileStates.MEDIAN);
     }
 
     public static void combine(QuantileStates.SingleState current, double v) {
@@ -39,8 +39,8 @@ class MedianAbsoluteDeviationDoubleAggregator {
         return state.evaluateMedianAbsoluteDeviation();
     }
 
-    public static QuantileStates.GroupingState initGrouping(BigArrays bigArrays) {
-        return new QuantileStates.GroupingState(bigArrays, QuantileStates.MEDIAN);
+    public static QuantileStates.GroupingState initGrouping(DriverContext driverContext) {
+        return new QuantileStates.GroupingState(driverContext, QuantileStates.MEDIAN);
     }
 
     public static void combine(QuantileStates.GroupingState state, int groupId, double v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
@@ -8,19 +8,19 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class MedianAbsoluteDeviationIntAggregator {
 
-    public static QuantileStates.SingleState initSingle() {
-        return new QuantileStates.SingleState(QuantileStates.MEDIAN);
+    public static QuantileStates.SingleState initSingle(DriverContext driverContext) {
+        return new QuantileStates.SingleState(driverContext, QuantileStates.MEDIAN);
     }
 
     public static void combine(QuantileStates.SingleState current, int v) {
@@ -39,8 +39,8 @@ class MedianAbsoluteDeviationIntAggregator {
         return state.evaluateMedianAbsoluteDeviation();
     }
 
-    public static QuantileStates.GroupingState initGrouping(BigArrays bigArrays) {
-        return new QuantileStates.GroupingState(bigArrays, QuantileStates.MEDIAN);
+    public static QuantileStates.GroupingState initGrouping(DriverContext driverContext) {
+        return new QuantileStates.GroupingState(driverContext, QuantileStates.MEDIAN);
     }
 
     public static void combine(QuantileStates.GroupingState state, int groupId, int v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
@@ -8,19 +8,19 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class MedianAbsoluteDeviationLongAggregator {
 
-    public static QuantileStates.SingleState initSingle() {
-        return new QuantileStates.SingleState(QuantileStates.MEDIAN);
+    public static QuantileStates.SingleState initSingle(DriverContext driverContext) {
+        return new QuantileStates.SingleState(driverContext, QuantileStates.MEDIAN);
     }
 
     public static void combine(QuantileStates.SingleState current, long v) {
@@ -39,8 +39,8 @@ class MedianAbsoluteDeviationLongAggregator {
         return state.evaluateMedianAbsoluteDeviation();
     }
 
-    public static QuantileStates.GroupingState initGrouping(BigArrays bigArrays) {
-        return new QuantileStates.GroupingState(bigArrays, QuantileStates.MEDIAN);
+    public static QuantileStates.GroupingState initGrouping(DriverContext driverContext) {
+        return new QuantileStates.GroupingState(driverContext, QuantileStates.MEDIAN);
     }
 
     public static void combine(QuantileStates.GroupingState state, int groupId, long v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
@@ -8,19 +8,19 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class PercentileDoubleAggregator {
 
-    public static QuantileStates.SingleState initSingle(double percentile) {
-        return new QuantileStates.SingleState(percentile);
+    public static QuantileStates.SingleState initSingle(DriverContext driverContext, double percentile) {
+        return new QuantileStates.SingleState(driverContext, percentile);
     }
 
     public static void combine(QuantileStates.SingleState current, double v) {
@@ -39,8 +39,8 @@ class PercentileDoubleAggregator {
         return state.evaluatePercentile();
     }
 
-    public static QuantileStates.GroupingState initGrouping(BigArrays bigArrays, double percentile) {
-        return new QuantileStates.GroupingState(bigArrays, percentile);
+    public static QuantileStates.GroupingState initGrouping(DriverContext driverContext, double percentile) {
+        return new QuantileStates.GroupingState(driverContext, percentile);
     }
 
     public static void combine(QuantileStates.GroupingState state, int groupId, double v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
@@ -8,19 +8,19 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class PercentileIntAggregator {
 
-    public static QuantileStates.SingleState initSingle(double percentile) {
-        return new QuantileStates.SingleState(percentile);
+    public static QuantileStates.SingleState initSingle(DriverContext driverContext,double percentile) {
+        return new QuantileStates.SingleState(driverContext, percentile);
     }
 
     public static void combine(QuantileStates.SingleState current, int v) {
@@ -39,8 +39,8 @@ class PercentileIntAggregator {
         return state.evaluatePercentile();
     }
 
-    public static QuantileStates.GroupingState initGrouping(BigArrays bigArrays, double percentile) {
-        return new QuantileStates.GroupingState(bigArrays, percentile);
+    public static QuantileStates.GroupingState initGrouping(DriverContext driverContext, double percentile) {
+        return new QuantileStates.GroupingState(driverContext, percentile);
     }
 
     public static void combine(QuantileStates.GroupingState state, int groupId, int v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
@@ -8,19 +8,19 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
 
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class PercentileLongAggregator {
 
-    public static QuantileStates.SingleState initSingle(double percentile) {
-        return new QuantileStates.SingleState(percentile);
+    public static QuantileStates.SingleState initSingle(DriverContext driverContext, double percentile) {
+        return new QuantileStates.SingleState(driverContext, percentile);
     }
 
     public static void combine(QuantileStates.SingleState current, long v) {
@@ -39,8 +39,8 @@ class PercentileLongAggregator {
         return state.evaluatePercentile();
     }
 
-    public static QuantileStates.GroupingState initGrouping(BigArrays bigArrays, double percentile) {
-        return new QuantileStates.GroupingState(bigArrays, percentile);
+    public static QuantileStates.GroupingState initGrouping(DriverContext driverContext, double percentile) {
+        return new QuantileStates.GroupingState(driverContext, percentile);
     }
 
     public static void combine(QuantileStates.GroupingState state, int groupId, long v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st
@@ -7,10 +7,9 @@
 
 package org.elasticsearch.compute.aggregation;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.$Type$Array;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BlockFactory;
 $if(long)$
 import org.elasticsearch.compute.data.IntVector;
 $endif$
@@ -19,6 +18,7 @@ import org.elasticsearch.compute.data.$Type$Vector;
 $if(double)$
 import org.elasticsearch.compute.data.IntVector;
 $endif$
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -39,10 +39,13 @@ import org.elasticsearch.core.Releasables;
 final class $Type$ArrayState extends AbstractArrayState implements GroupingAggregatorState {
     private final $type$ init;
 
+    private final BlockFactory blockFactory;
+
     private $Type$Array values;
 
-    $Type$ArrayState(BigArrays bigArrays, $type$ init) {
-        super(bigArrays);
+    $Type$ArrayState(DriverContext driverContext, $type$ init) {
+        super(driverContext);
+        this.blockFactory = driverContext.blockFactory();
         this.values = bigArrays.new$Type$Array(1, false);
         this.values.set(0, init);
         this.init = init;
@@ -72,13 +75,13 @@ $endif$
 
     Block toValuesBlock(org.elasticsearch.compute.data.IntVector selected) {
         if (false == trackingGroupIds()) {
-            $Type$Vector.Builder builder = $Type$Vector.newVectorBuilder(selected.getPositionCount());
+            $Type$Vector.Builder builder = blockFactory.new$Type$VectorBuilder(selected.getPositionCount());
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 builder.append$Type$(values.get(selected.getInt(i)));
             }
             return builder.build().asBlock();
         }
-        $Type$Block.Builder builder = $Type$Block.newBlockBuilder(selected.getPositionCount());
+        $Type$Block.Builder builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount());
         for (int i = 0; i < selected.getPositionCount(); i++) {
             int group = selected.getInt(i);
             if (hasValue(group)) {
@@ -102,8 +105,8 @@ $endif$
     @Override
     public void toIntermediate(Block[] blocks, int offset, IntVector selected) {
         assert blocks.length >= offset + 2;
-        var valuesBuilder = $Type$Block.newBlockBuilder(selected.getPositionCount());
-        var hasValueBuilder = BooleanBlock.newBlockBuilder(selected.getPositionCount());
+        var valuesBuilder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount());
+        var hasValueBuilder = blockFactory.newBooleanBlockBuilder(selected.getPositionCount());
         for (int i = 0; i < selected.getPositionCount(); i++) {
             int group = selected.getInt(i);
             if (group < values.size()) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.HashAggregationOperator;
 import org.elasticsearch.core.Releasable;
 
@@ -63,36 +64,37 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
      * @param emitBatchSize maximum batch size to be emitted when handling combinatorial
      *                      explosion of groups caused by multivalued fields
      */
-    public static BlockHash build(List<HashAggregationOperator.GroupSpec> groups, BigArrays bigArrays, int emitBatchSize) {
+    public static BlockHash build(List<HashAggregationOperator.GroupSpec> groups, DriverContext driverContext, int emitBatchSize) {
+        final BigArrays bigArrays = driverContext.bigArrays();
         if (groups.size() == 1) {
-            return newForElementType(groups.get(0).channel(), groups.get(0).elementType(), bigArrays);
+            return newForElementType(groups.get(0).channel(), groups.get(0).elementType(), driverContext);
         }
         if (groups.size() == 2) {
             var g1 = groups.get(0);
             var g2 = groups.get(1);
             if (g1.elementType() == ElementType.LONG && g2.elementType() == ElementType.LONG) {
-                return new LongLongBlockHash(bigArrays, g1.channel(), g2.channel(), emitBatchSize);
+                return new LongLongBlockHash(driverContext, g1.channel(), g2.channel(), emitBatchSize);
             }
             if (g1.elementType() == ElementType.BYTES_REF && g2.elementType() == ElementType.LONG) {
-                return new BytesRefLongBlockHash(bigArrays, g1.channel(), g2.channel(), false, emitBatchSize);
+                return new BytesRefLongBlockHash(driverContext, g1.channel(), g2.channel(), false, emitBatchSize);
             }
             if (g1.elementType() == ElementType.LONG && g2.elementType() == ElementType.BYTES_REF) {
-                return new BytesRefLongBlockHash(bigArrays, g2.channel(), g1.channel(), true, emitBatchSize);
+                return new BytesRefLongBlockHash(driverContext, g2.channel(), g1.channel(), true, emitBatchSize);
             }
         }
-        return new PackedValuesBlockHash(groups, bigArrays, emitBatchSize);
+        return new PackedValuesBlockHash(groups, driverContext, emitBatchSize);
     }
 
     /**
      * Creates a specialized hash table that maps a {@link Block} of the given input element type to ids.
      */
-    private static BlockHash newForElementType(int channel, ElementType type, BigArrays bigArrays) {
+    private static BlockHash newForElementType(int channel, ElementType type, DriverContext driverContext) {
         return switch (type) {
-            case BOOLEAN -> new BooleanBlockHash(channel);
-            case INT -> new IntBlockHash(channel, bigArrays);
-            case LONG -> new LongBlockHash(channel, bigArrays);
-            case DOUBLE -> new DoubleBlockHash(channel, bigArrays);
-            case BYTES_REF -> new BytesRefBlockHash(channel, bigArrays);
+            case BOOLEAN -> new BooleanBlockHash(channel, driverContext);
+            case INT -> new IntBlockHash(channel, driverContext);
+            case LONG -> new LongBlockHash(channel, driverContext);
+            case DOUBLE -> new DoubleBlockHash(channel, driverContext);
+            case BYTES_REF -> new BytesRefBlockHash(channel, driverContext);
             default -> throw new IllegalArgumentException("unsupported grouping element type [" + type + "]");
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleArrayBlock;
 import org.elasticsearch.compute.data.DoubleArrayVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -21,6 +22,7 @@ import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeDouble;
 
@@ -31,6 +33,7 @@ import java.util.BitSet;
  */
 final class DoubleBlockHash extends BlockHash {
     private final int channel;
+    private final BlockFactory blockFactory;
     private final LongHash longHash;
 
     /**
@@ -42,9 +45,10 @@ final class DoubleBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
-    DoubleBlockHash(int channel, BigArrays bigArrays) {
+    DoubleBlockHash(int channel, DriverContext driverContext) {
         this.channel = channel;
-        this.longHash = new LongHash(1, bigArrays);
+        this.blockFactory = driverContext.blockFactory();
+        this.longHash = new LongHash(1, driverContext.bigArrays());
     }
 
     @Override
@@ -67,7 +71,7 @@ final class DoubleBlockHash extends BlockHash {
     }
 
     private IntBlock add(DoubleBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hash(longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block, blockFactory).hash(longHash);
         seenNull |= result.sawNull();
         return result.ords();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -13,11 +13,13 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeInt;
 
@@ -28,6 +30,7 @@ import java.util.BitSet;
  */
 final class IntBlockHash extends BlockHash {
     private final int channel;
+    private final BlockFactory blockFactory;
     private final LongHash longHash;
     /**
      * Have we seen any {@code null} values?
@@ -38,9 +41,10 @@ final class IntBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
-    IntBlockHash(int channel, BigArrays bigArrays) {
+    IntBlockHash(int channel, DriverContext driverContext) {
         this.channel = channel;
-        this.longHash = new LongHash(1, bigArrays);
+        this.blockFactory = driverContext.blockFactory();
+        this.longHash = new LongHash(1, driverContext.bigArrays());
     }
 
     @Override
@@ -63,7 +67,7 @@ final class IntBlockHash extends BlockHash {
     }
 
     private IntBlock add(IntBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeInt(block).hash(longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeInt(block, blockFactory).hash(longHash);
         seenNull |= result.sawNull();
         return result.ords();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
@@ -21,6 +22,7 @@ import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeLong;
 
@@ -31,6 +33,7 @@ import java.util.BitSet;
  */
 final class LongBlockHash extends BlockHash {
     private final int channel;
+    private final BlockFactory blockFactory;
     private final LongHash longHash;
 
     /**
@@ -42,9 +45,10 @@ final class LongBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
-    LongBlockHash(int channel, BigArrays bigArrays) {
+    LongBlockHash(int channel, DriverContext driverContext) {
         this.channel = channel;
-        this.longHash = new LongHash(1, bigArrays);
+        this.blockFactory = driverContext.blockFactory();
+        this.longHash = new LongHash(1, driverContext.bigArrays());
     }
 
     @Override
@@ -67,7 +71,7 @@ final class LongBlockHash extends BlockHash {
     }
 
     private IntBlock add(LongBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeLong(block).hash(longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeLong(block, blockFactory).hash(longHash);
         seenNull |= result.sawNull();
         return result.ords();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.compute.data.Block.MvOrdering;
+
+import java.util.BitSet;
+
+/** A factory for creating Blocks and Vectors. */
+public class BlockFactory {
+
+    private static final BlockFactory DEFAULT = new BlockFactory();
+
+    private BlockFactory() { }
+
+    /** Returns an instance of a block factory. */
+    public static BlockFactory getDefault() {
+        return DEFAULT;
+    }
+
+    /** Returns an instance of a block factory. */
+    public static BlockFactory getInstance() {
+        return new BlockFactory();
+    }
+
+    public BooleanBlock.Builder newBooleanBlockBuilder(int estimatedSize) {
+        return new BooleanBlockBuilder(estimatedSize);
+    }
+
+    public BooleanBlock newBooleanArrayBlock(boolean[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
+        return new BooleanArrayBlock(values, positionCount, firstValueIndexes, nulls, mvOrdering);
+    }
+
+    public BooleanVector.Builder newBooleanVectorBuilder(int estimatedSize) {
+        return new BooleanVectorBuilder(estimatedSize);
+    }
+
+    public BooleanVector newBooleanArrayVector(boolean[] values, int positionCount) {
+        return new BooleanArrayVector(values, positionCount);
+    }
+
+    public BooleanVector newConstantBooleanVector(boolean value, int positions) {
+        return new ConstantBooleanVector(value, positions);
+    }
+
+    public IntBlock.Builder newIntBlockBuilder(int estimatedSize) {
+        return new IntBlockBuilder(estimatedSize);
+    }
+
+    public IntBlock newIntArrayBlock(int[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
+        return new IntArrayBlock(values, positionCount, firstValueIndexes, nulls, mvOrdering);
+    }
+
+    public IntVector.Builder newIntVectorBuilder(int estimatedSize) {
+        return new IntVectorBuilder(estimatedSize);
+    }
+
+    public IntVector newIntArrayVector(int[] values, int positionCount) {
+        return new IntArrayVector(values, positionCount);
+    }
+
+    public IntVector newConstantIntVector(int value, int positions) {
+        return new ConstantIntVector(value, positions);
+    }
+
+    public LongBlock.Builder newLongBlockBuilder(int estimatedSize) {
+        return new LongBlockBuilder(estimatedSize);
+    }
+
+    public LongBlock newLongArrayBlock(long[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
+        return new LongArrayBlock(values, positionCount, firstValueIndexes, nulls, mvOrdering);
+    }
+
+    public LongVector.Builder newLongVectorBuilder(int estimatedSize) {
+        return new LongVectorBuilder(estimatedSize);
+    }
+
+    public LongVector newLongArrayVector(long[] values, int positionCount) {
+        return new LongArrayVector(values, positionCount);
+    }
+
+    public LongVector newConstantLongVector(long value, int positions) {
+        return new ConstantLongVector(value, positions);
+    }
+
+    public DoubleBlock.Builder newDoubleBlockBuilder(int estimatedSize) {
+        return new DoubleBlockBuilder(estimatedSize);
+    }
+
+    public DoubleBlock newDoubleArrayBlock(double[] values, int positionCount,
+                                           int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
+        return new DoubleArrayBlock(values, positionCount, firstValueIndexes, nulls, mvOrdering);
+    }
+
+    public DoubleVector.Builder newDoubleVectorBuilder(int estimatedSize) {
+        return new DoubleVectorBuilder(estimatedSize);
+    }
+
+    public DoubleVector newDoubleArrayVector(double[] values, int positionCount) {
+        return new DoubleArrayVector(values, positionCount);
+    }
+
+    public DoubleVector newConstantDoubleVector(double value, int positions) {
+        return new ConstantDoubleVector(value, positions);
+    }
+
+    public BytesRefBlock.Builder newBytesRefBlockBuilder(int estimatedSize) {
+        return new BytesRefBlockBuilder(estimatedSize);
+    }
+
+    public BytesRefBlock newBytesRefArrayBlock(BytesRefArray values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
+        return new BytesRefArrayBlock(values, positionCount, firstValueIndexes, nulls, mvOrdering);
+    }
+
+    public BytesRefVector.Builder newBytesRefVectorBuilder(int estimatedSize) {
+        return new BytesRefVectorBuilder(estimatedSize);
+    }
+
+    public BytesRefVector newBytesRefArrayVector(BytesRefArray values, int positionCount) {
+        return new BytesRefArrayVector(values, positionCount);
+    }
+
+    public BytesRefVector newConstantBytesRefVector(BytesRef value, int positions) {
+        return new ConstantBytesRefVector(value, positions);
+    }
+
+    /** A builder the for {@link DocBlock}. */
+    public DocBlock.Builder newDocBlockBuilder(int estimatedSize) {
+        return new DocBlock.Builder(estimatedSize, this);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -47,22 +47,16 @@ public class DocBlock extends AbstractVectorBlock implements Block {
         return new DocBlock(asVector().filter(positions));
     }
 
-    /**
-     * A builder the for {@link DocBlock}.
-     */
-    public static Builder newBlockBuilder(int estimatedSize) {
-        return new Builder(estimatedSize);
-    }
 
     public static class Builder implements Block.Builder {
         private final IntVector.Builder shards;
         private final IntVector.Builder segments;
         private final IntVector.Builder docs;
 
-        private Builder(int estimatedSize) {
-            shards = IntVector.newVectorBuilder(estimatedSize);
-            segments = IntVector.newVectorBuilder(estimatedSize);
-            docs = IntVector.newVectorBuilder(estimatedSize);
+        Builder(int estimatedSize, BlockFactory blockFactory) {
+            shards = blockFactory.newIntVectorBuilder(estimatedSize);
+            segments = blockFactory.newIntVectorBuilder(estimatedSize);
+            docs = blockFactory.newIntVectorBuilder(estimatedSize);
         }
 
         public Builder appendShard(int shard) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -61,7 +61,7 @@ $endif$
             return $Type$Vector.of(in).asBlock();
         }
         final int positions = in.readVInt();
-        var builder = newBlockBuilder(positions);
+        var builder = BlockFactory.getDefault().new$Type$BlockBuilder(positions);
         for (int i = 0; i < positions; i++) {
             if (in.readBoolean()) {
                 builder.appendNull();
@@ -188,14 +188,6 @@ $endif$
             }
         }
         return result;
-    }
-
-    static Builder newBlockBuilder(int estimatedSize) {
-        return new $Type$BlockBuilder(estimatedSize);
-    }
-
-    static $Type$Block newConstantBlockWith($type$ value, int positions) {
-        return new Constant$Type$Vector(value, positions).asBlock();
     }
 
     sealed interface Builder extends Block.Builder permits $Type$BlockBuilder {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -112,7 +112,7 @@ $endif$
         if (constant && positions > 0) {
             return new Constant$Type$Vector(in.read$Type$(), positions);
         } else {
-            var builder = $Type$Vector.newVectorBuilder(positions);
+            var builder = BlockFactory.getDefault().new$Type$VectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.append$Type$(in.read$Type$());
             }
@@ -140,10 +140,6 @@ $else$
 $endif$
             }
         }
-    }
-
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new $Type$VectorBuilder(estimatedSize);
     }
 
 $if(int)$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/BlockOrdinalsReader.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/BlockOrdinalsReader.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.lucene;
 
 import org.apache.lucene.index.SortedSetDocValues;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 
@@ -16,15 +17,17 @@ import java.io.IOException;
 public final class BlockOrdinalsReader {
     private final SortedSetDocValues sortedSetDocValues;
     private final Thread creationThread;
+    private final BlockFactory blockFactory;
 
-    public BlockOrdinalsReader(SortedSetDocValues sortedSetDocValues) {
+    public BlockOrdinalsReader(SortedSetDocValues sortedSetDocValues, BlockFactory blockFactory) {
         this.sortedSetDocValues = sortedSetDocValues;
         this.creationThread = Thread.currentThread();
+        this.blockFactory = blockFactory;
     }
 
     public IntBlock readOrdinals(IntVector docs) throws IOException {
         final int positionCount = docs.getPositionCount();
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(positionCount);
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(positionCount);
         for (int p = 0; p < positionCount; p++) {
             int doc = docs.getInt(p);
             if (false == sortedSetDocValues.advanceExact(doc)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.operator;
 import org.elasticsearch.compute.aggregation.Aggregator;
 import org.elasticsearch.compute.aggregation.Aggregator.Factory;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
@@ -38,7 +39,7 @@ public class AggregationOperator implements Operator {
     public record AggregationOperatorFactory(List<Factory> aggregators, AggregatorMode mode) implements OperatorFactory {
         @Override
         public Operator get(DriverContext driverContext) {
-            return new AggregationOperator(aggregators.stream().map(Factory::get).toList());
+            return new AggregationOperator(aggregators.stream().map(f -> f.apply(driverContext)).toList());
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverContext.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.core.Releasable;
 
 import java.util.Collections;
@@ -40,6 +42,23 @@ public class DriverContext {
 
     /** A snapshot of the driver context. */
     public record Snapshot(Set<Releasable> releasables) {}
+
+    private final BlockFactory blockFactory;
+
+    private final BigArrays bigArrays;
+
+    public DriverContext(BlockFactory blockFactory, BigArrays bigArrays) {
+        this.blockFactory = blockFactory;
+        this.bigArrays = bigArrays;
+    }
+
+    public BlockFactory blockFactory() {
+        return blockFactory;
+    }
+
+    public BigArrays bigArrays() {
+        return bigArrays;
+    }
 
     /**
      * Adds a releasable to this context. Releasables are identified by Object identity.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
@@ -34,12 +33,11 @@ public class HashAggregationOperator implements Operator {
     public record HashAggregationOperatorFactory(
         List<GroupSpec> groups,
         List<GroupingAggregator.Factory> aggregators,
-        int maxPageSize,
-        BigArrays bigArrays
+        int maxPageSize
     ) implements OperatorFactory {
         @Override
         public Operator get(DriverContext driverContext) {
-            return new HashAggregationOperator(aggregators, () -> BlockHash.build(groups, bigArrays, maxPageSize), driverContext);
+            return new HashAggregationOperator(aggregators, () -> BlockHash.build(groups, driverContext, maxPageSize), driverContext);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupeBoolean.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupeBoolean.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -30,11 +31,13 @@ public class MultivalueDedupeBoolean {
     public static final int TRUE_ORD = 2;
 
     private final BooleanBlock block;
+    private final BlockFactory blockFactory;
     private boolean seenTrue;
     private boolean seenFalse;
 
-    public MultivalueDedupeBoolean(BooleanBlock block) {
+    public MultivalueDedupeBoolean(BooleanBlock block, BlockFactory blockFactory) {
         this.block = block;
+        this.blockFactory = blockFactory;
     }
 
     /**
@@ -44,7 +47,7 @@ public class MultivalueDedupeBoolean {
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(block.getPositionCount());
+        BooleanBlock.Builder builder = blockFactory.newBooleanBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -66,7 +69,7 @@ public class MultivalueDedupeBoolean {
      * @param everSeen array tracking if the values {@code false} and {@code true} are ever seen
      */
     public IntBlock hash(boolean[] everSeen) {
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -18,15 +18,18 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 $if(int)$
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 
 $elseif(long)$
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 
 $else$
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.IntBlock;
 
@@ -54,11 +57,13 @@ $elseif(long)$
 $endif$
 
     private final $Type$Block block;
+    private final BlockFactory blockFactory;
     private $type$[] work = new $type$[ArrayUtil.oversize(2, $BYTES$)];
     private int w;
 
-    public MultivalueDedupe$Type$($Type$Block block) {
+    public MultivalueDedupe$Type$($Type$Block block, BlockFactory blockFactory) {
         this.block = block;
+        this.blockFactory = blockFactory;
 $if(BytesRef)$
         // TODO very large numbers might want a hash based implementation - and for BytesRef that might not be that big
         fillWork(0, work.length);
@@ -73,7 +78,7 @@ $endif$
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount());
+        $Type$Block.Builder builder = blockFactory.new$Type$BlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -125,7 +130,7 @@ $endif$
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount());
+        $Type$Block.Builder builder = blockFactory.new$Type$BlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -157,7 +162,7 @@ $endif$
         if (false == block.mayHaveMultivaluedFields()) {
             return block;
         }
-        $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount());
+        $Type$Block.Builder builder = blockFactory.new$Type$BlockBuilder(block.getPositionCount());
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);
             int first = block.getFirstValueIndex(p);
@@ -186,7 +191,7 @@ $if(BytesRef)$
 $else$
     public MultivalueDedupe.HashResult hash(LongHash hash) {
 $endif$
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
+        IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount());
         boolean sawNull = false;
         for (int p = 0; p < block.getPositionCount(); p++) {
             int count = block.getValueCount(p);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -40,10 +40,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase {
-    protected abstract AggregatorFunctionSupplier aggregatorFunction(BigArrays bigArrays, List<Integer> inputChannels);
+    protected abstract AggregatorFunctionSupplier aggregatorFunction(DriverContext driverContext, List<Integer> inputChannels);
 
     protected final int aggregatorIntermediateBlockCount() {
-        try (var agg = aggregatorFunction(nonBreakingBigArrays(), List.of()).aggregator()) {
+        try (var agg = aggregatorFunction(nonBreakingDriverContext(), List.of()).aggregator()) {
             return agg.intermediateBlockCount();
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountAggregatorFunctionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BasicBlockTests;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SequenceLongBlockSourceOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 
@@ -26,8 +27,8 @@ public class CountAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(BigArrays bigArrays, List<Integer> inputChannels) {
-        return CountAggregatorFunction.supplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier aggregatorFunction(DriverContext driverContext, List<Integer> inputChannels) {
+        return CountAggregatorFunction.supplier(driverContext, inputChannels);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AbstractBlockSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AbstractBlockSourceOperator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
 
@@ -15,6 +16,7 @@ import org.elasticsearch.test.ESTestCase;
  * number of positions up to a maximum of the given maxPagePositions positions.
  */
 public abstract class AbstractBlockSourceOperator extends SourceOperator {
+    final BlockFactory blockFactory = BlockFactory.getDefault();
 
     private final int maxPagePositions;
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
@@ -60,7 +61,7 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
         Operator.OperatorFactory factory = simple(nonBreakingBigArrays());
         String description = factory.describe();
         assertThat(description, equalTo(expectedDescriptionOfSimple()));
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new DriverContext(nonBreakingBlockFactory(), nonBreakingBigArrays());
         try (Operator op = factory.get(driverContext)) {
             if (op instanceof GroupingAggregatorFunction) {
                 assertThat(description, matchesPattern(GROUPING_AGG_FUNCTION_DESCRIBE_PATTERN));
@@ -74,11 +75,18 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
      * Makes sure the description of {@link #simple} matches the {@link #expectedDescriptionOfSimple}.
      */
     public final void testSimpleToString() {
-        try (Operator operator = simple(nonBreakingBigArrays()).get(new DriverContext())) {
+        try (Operator operator = simple(nonBreakingBigArrays()).get(new DriverContext(defaultBlockFactory(), nonBreakingBigArrays()))) {
             assertThat(operator.toString(), equalTo(expectedToStringOfSimple()));
         }
     }
 
+    protected final DriverContext nonBreakingDriverContext() {
+        return new DriverContext(defaultBlockFactory(), nonBreakingBigArrays());
+    }
+
+    protected final BlockFactory defaultBlockFactory() {
+        return BlockFactory.getDefault();
+    }
     /**
      * A {@link BigArrays} that won't throw {@link CircuitBreakingException}.
      */

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -75,7 +75,7 @@ public class AsyncOperatorTests extends ESTestCase {
 
             @Override
             protected Page createPage(int positionOffset, int length) {
-                LongVector.Builder builder = LongVector.newVectorBuilder(length);
+                LongVector.Builder builder = blockFactory.newLongVectorBuilder(length);
                 for (int i = 0; i < length; i++) {
                     builder.appendLong(ids.get(currentPosition++));
                 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/EvalOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/EvalOperatorTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.operator;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
@@ -27,10 +28,10 @@ public class EvalOperatorTests extends OperatorTestCase {
 
     record Addition(int lhs, int rhs) implements EvalOperator.ExpressionEvaluator {
         @Override
-        public Block eval(Page page) {
+        public Block eval(Page page, BlockFactory blockFactory) {
             LongVector lhsVector = page.<LongBlock>getBlock(0).asVector();
             LongVector rhsVector = page.<LongBlock>getBlock(1).asVector();
-            LongVector.Builder result = LongVector.newVectorBuilder(page.getPositionCount());
+            LongVector.Builder result = blockFactory.newLongVectorBuilder(page.getPositionCount());
             for (int p = 0; p < page.getPositionCount(); p++) {
                 result.appendLong(lhsVector.getLong(p) + rhsVector.getLong(p));
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.operator;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -29,10 +30,10 @@ public class FilterOperatorTests extends OperatorTestCase {
 
     record SameLastDigit(int lhs, int rhs) implements EvalOperator.ExpressionEvaluator {
         @Override
-        public Block eval(Page page) {
+        public Block eval(Page page, BlockFactory blockFactory) {
             LongVector lhsVector = page.<LongBlock>getBlock(0).asVector();
             LongVector rhsVector = page.<LongBlock>getBlock(1).asVector();
-            BooleanVector.Builder result = BooleanVector.newVectorBuilder(page.getPositionCount());
+            BooleanVector.Builder result = blockFactory.newBooleanVectorBuilder(page.getPositionCount());
             for (int p = 0; p < page.getPositionCount(); p++) {
                 result.appendBoolean(lhsVector.getLong(p) % 10 == rhsVector.getLong(p) % 10);
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -126,9 +126,9 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         return result;
     }
 
-    private void assertSimple(BigArrays bigArrays, int size) {
+    private void assertSimple(DriverContext driverContext, int size) {
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(size));
-        List<Page> results = drive(simple(bigArrays.withCircuitBreaking()).get(new DriverContext()), input.iterator());
+        List<Page> results = drive(simple(driverContext.bigArrays.withCircuitBreaking()).get(driverContext), input.iterator());
         assertSimpleOutput(input, results);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TupleBlockSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TupleBlockSourceOperator.java
@@ -44,8 +44,8 @@ public class TupleBlockSourceOperator extends AbstractBlockSourceOperator {
 
     @Override
     protected Page createPage(int positionOffset, int length) {
-        var blockBuilder1 = LongBlock.newBlockBuilder(length);
-        var blockBuilder2 = LongBlock.newBlockBuilder(length);
+        var blockBuilder1 = blockFactory.newLongBlockBuilder(length);
+        var blockBuilder2 = blockFactory.newLongBlockBuilder(length);
         for (int i = 0; i < length; i++) {
             Tuple<Long, Long> item = values.get(positionOffset + i);
             if (item.v1() == null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountAggregatorFunction;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Nullability;
@@ -49,8 +49,8 @@ public class Count extends AggregateFunction implements EnclosedAgg, ToAggregato
     }
 
     @Override
-    public AggregatorFunctionSupplier supplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return CountAggregatorFunction.supplier(bigArrays, inputChannels);
+    public AggregatorFunctionSupplier supplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return CountAggregatorFunction.supplier(driverContext, inputChannels);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctBooleanAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctBytesRefAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.EsqlUnsupportedOperationException;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -68,24 +68,24 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     }
 
     @Override
-    public AggregatorFunctionSupplier supplier(BigArrays bigArrays, List<Integer> inputChannels) {
+    public AggregatorFunctionSupplier supplier(DriverContext driverContext, List<Integer> inputChannels) {
         DataType type = field().dataType();
         int precision = this.precision == null ? DEFAULT_PRECISION : ((Number) this.precision.fold()).intValue();
         if (type == DataTypes.BOOLEAN) {
             // Booleans ignore the precision because there are only two possible values anyway
-            return new CountDistinctBooleanAggregatorFunctionSupplier(bigArrays, inputChannels);
+            return new CountDistinctBooleanAggregatorFunctionSupplier(driverContext, inputChannels);
         }
         if (type == DataTypes.DATETIME || type == DataTypes.LONG) {
-            return new CountDistinctLongAggregatorFunctionSupplier(bigArrays, inputChannels, precision);
+            return new CountDistinctLongAggregatorFunctionSupplier(driverContext, inputChannels, precision);
         }
         if (type == DataTypes.INTEGER) {
-            return new CountDistinctIntAggregatorFunctionSupplier(bigArrays, inputChannels, precision);
+            return new CountDistinctIntAggregatorFunctionSupplier(driverContext, inputChannels, precision);
         }
         if (type == DataTypes.DOUBLE) {
-            return new CountDistinctDoubleAggregatorFunctionSupplier(bigArrays, inputChannels, precision);
+            return new CountDistinctDoubleAggregatorFunctionSupplier(driverContext, inputChannels, precision);
         }
         if (type == DataTypes.KEYWORD || type == DataTypes.IP) {
-            return new CountDistinctBytesRefAggregatorFunctionSupplier(bigArrays, inputChannels, precision);
+            return new CountDistinctBytesRefAggregatorFunctionSupplier(driverContext, inputChannels, precision);
         }
         throw EsqlUnsupportedOperationException.unsupportedDataType(type);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Max.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Max.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.MaxDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.MaxIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.MaxLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -46,17 +47,17 @@ public class Max extends NumericAggregate {
     }
 
     @Override
-    protected AggregatorFunctionSupplier longSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new MaxLongAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier longSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new MaxLongAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 
     @Override
-    protected AggregatorFunctionSupplier intSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new MaxIntAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier intSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new MaxIntAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 
     @Override
-    protected AggregatorFunctionSupplier doubleSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new MaxDoubleAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier doubleSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new MaxDoubleAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Min.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Min.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.MinDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.MinIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.MinLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -46,17 +47,17 @@ public class Min extends NumericAggregate {
     }
 
     @Override
-    protected AggregatorFunctionSupplier longSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new MinLongAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier longSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new MinLongAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 
     @Override
-    protected AggregatorFunctionSupplier intSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new MinIntAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier intSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new MinIntAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 
     @Override
-    protected AggregatorFunctionSupplier doubleSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new MinDoubleAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier doubleSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new MinDoubleAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/NumericAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/NumericAggregate.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.EsqlUnsupportedOperationException;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -57,26 +58,26 @@ public abstract class NumericAggregate extends AggregateFunction implements ToAg
     }
 
     @Override
-    public final AggregatorFunctionSupplier supplier(BigArrays bigArrays, List<Integer> inputChannels) {
+    public final AggregatorFunctionSupplier supplier(DriverContext driverContext, List<Integer> inputChannels) {
         DataType type = field().dataType();
         if (supportsDates() && type == DataTypes.DATETIME) {
-            return longSupplier(bigArrays, inputChannels);
+            return longSupplier(driverContext, inputChannels);
         }
         if (type == DataTypes.LONG) {
-            return longSupplier(bigArrays, inputChannels);
+            return longSupplier(driverContext, inputChannels);
         }
         if (type == DataTypes.INTEGER) {
-            return intSupplier(bigArrays, inputChannels);
+            return intSupplier(driverContext, inputChannels);
         }
         if (type == DataTypes.DOUBLE) {
-            return doubleSupplier(bigArrays, inputChannels);
+            return doubleSupplier(driverContext, inputChannels);
         }
         throw EsqlUnsupportedOperationException.unsupportedDataType(type);
     }
 
-    protected abstract AggregatorFunctionSupplier longSupplier(BigArrays bigArrays, List<Integer> inputChannels);
+    protected abstract AggregatorFunctionSupplier longSupplier(DriverContext driverContext, List<Integer> inputChannels);
 
-    protected abstract AggregatorFunctionSupplier intSupplier(BigArrays bigArrays, List<Integer> inputChannels);
+    protected abstract AggregatorFunctionSupplier intSupplier(DriverContext driverContext, List<Integer> inputChannels);
 
-    protected abstract AggregatorFunctionSupplier doubleSupplier(BigArrays bigArrays, List<Integer> inputChannels);
+    protected abstract AggregatorFunctionSupplier doubleSupplier(DriverContext driverContext, List<Integer> inputChannels);
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.PercentileDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.PercentileIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.PercentileLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -64,18 +65,18 @@ public class Percentile extends NumericAggregate {
     }
 
     @Override
-    protected AggregatorFunctionSupplier longSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new PercentileLongAggregatorFunctionSupplier(bigArrays, inputChannels, percentileValue());
+    protected AggregatorFunctionSupplier longSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new PercentileLongAggregatorFunctionSupplier(driverContext, inputChannels, percentileValue());
     }
 
     @Override
-    protected AggregatorFunctionSupplier intSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new PercentileIntAggregatorFunctionSupplier(bigArrays, inputChannels, percentileValue());
+    protected AggregatorFunctionSupplier intSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new PercentileIntAggregatorFunctionSupplier(driverContext, inputChannels, percentileValue());
     }
 
     @Override
-    protected AggregatorFunctionSupplier doubleSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new PercentileDoubleAggregatorFunctionSupplier(bigArrays, inputChannels, percentileValue());
+    protected AggregatorFunctionSupplier doubleSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new PercentileDoubleAggregatorFunctionSupplier(driverContext, inputChannels, percentileValue());
     }
 
     private int percentileValue() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sum.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Sum.java
@@ -11,6 +11,7 @@ import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.SumDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.SumIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.SumLongAggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -48,17 +49,17 @@ public class Sum extends NumericAggregate {
     }
 
     @Override
-    protected AggregatorFunctionSupplier longSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new SumLongAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier longSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new SumLongAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 
     @Override
-    protected AggregatorFunctionSupplier intSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new SumIntAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier intSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new SumIntAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 
     @Override
-    protected AggregatorFunctionSupplier doubleSupplier(BigArrays bigArrays, List<Integer> inputChannels) {
-        return new SumDoubleAggregatorFunctionSupplier(bigArrays, inputChannels);
+    protected AggregatorFunctionSupplier doubleSupplier(DriverContext driverContext, List<Integer> inputChannels) {
+        return new SumDoubleAggregatorFunctionSupplier(driverContext, inputChannels);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ToAggregator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/ToAggregator.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.esql.planner;
 
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.operator.DriverContext;
 
 import java.util.List;
 
@@ -16,5 +16,5 @@ import java.util.List;
  * Expressions that have a mapping to an {@link AggregatorFunctionSupplier}.
  */
 public interface ToAggregator {
-    AggregatorFunctionSupplier supplier(BigArrays bigArrays, List<Integer> inputChannels);
+    AggregatorFunctionSupplier supplier(DriverContext driverContext, List<Integer> inputChannels);
 }


### PR DESCRIPTION
Centralise the creation of Blocks and Vectors in one place - a BlockFactory. The creation methods are instance (rather than static), which allows for different implementations of the block factory to handle the creation in different ways - namely we want to be able to eventually have different circuit breakers for different factories.

With the removal of the static creation methods we need a context allow to share the block factory instance. Eventually each driver will have its own factory, so DriverContext seems appropriate.

Note: Currently we're close to compiling the compute source code, but not quite there. The tests are way off, and will need mock context, factories, etc. Just sharing early for feedback