### PR TITLE
[DOCS] Removes // from cluster health link

### DIFF
--- a/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
@@ -39,7 +39,7 @@ PUT _watcher/watch/cluster_health_watch
     when you're done experimenting.
 
 To get the status of your cluster, you can call the Elasticsearch
-{ref}//cluster-health.html[cluster health] API:
+{ref}/cluster-health.html[cluster health] API:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Changes `{ref}//cluster-health.html` to `{ref}/cluster-health.html`