### PR TITLE
Refactor Metadata.buildIndicesLookup a little

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -144,6 +144,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     ) {
         this.name = name;
         this.indices = List.copyOf(indices);
+        assert indices.isEmpty() == false;
         this.generation = generation;
         this.metadata = metadata;
         assert system == false || hidden; // system indices must be hidden


### PR DESCRIPTION
We can speed this one up a bit by refactoring it into 3 separate methods for the 3 loops. It's still quite slow but this helps by about 10% which isn't irrelevant for large deployments since it causes the TreeMap.put calls to inline fully, thus removing any virtual calls for String.compare. Also, makes the code a little easier to follow maybe, multiple loops like that in one method is always a little meh IMO.
