### PR TITLE
[8.10] [ML] Safely drain deployment request queues before allowing node to shutdown (#98406)

### DIFF
--- a/docs/changelog/98406.yaml
+++ b/docs/changelog/98406.yaml
@@ -1,0 +1,5 @@
+pr: 98406
+summary: Safely drain deployment request queues before allowing node to shutdown
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
@@ -40,9 +40,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-deployments]
 
 `force`::
-(Optional, Boolean) If true, the deployment is stopped even if it or one of its 
-model aliases is referenced by ingest pipelines. You can't use these pipelines 
+(Optional, Boolean) If true, the deployment is stopped even if it or one of its
+model aliases is referenced by ingest pipelines. You can't use these pipelines
 until you restart the model deployment.
+
+`finish_pending_work`::
+(Optional, Boolean) If true, the deployment is stopped after any queued work is completed. Defaults to `false`.
 
 ////
 [role="child_attributes"]

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -174,6 +174,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_059 = registerTransportVersion(8_500_059, "2f2090c0-7cd0-4a10-8f02-63d26073604f");
     public static final TransportVersion V_8_500_060 = registerTransportVersion(8_500_060, "ec065a44-b468-4f8a-aded-7b90ca8d792b");
     public static final TransportVersion V_8_500_061 = registerTransportVersion(8_500_061, "4e07f830-8be4-448c-851e-62b3d2f0bf0a");
+    public static final TransportVersion V_8_500_062 = registerTransportVersion(8_500_062, "2683c8b4-5372-4a6a-bb3a-d61aa679089a");
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _
@@ -196,7 +197,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
      */
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_061);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_062);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopTrainedModelDeploymentAction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
@@ -40,10 +41,12 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
 
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
         public static final ParseField FORCE = new ParseField("force");
+        public static final ParseField FINISH_PENDING_WORK = new ParseField("finish_pending_work");
 
         private String id;
         private boolean allowNoMatch = true;
         private boolean force;
+        private boolean finishPendingWork;
 
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
@@ -51,6 +54,7 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
             PARSER.declareString(Request::setId, TrainedModelConfig.MODEL_ID);
             PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH);
             PARSER.declareBoolean(Request::setForce, FORCE);
+            PARSER.declareBoolean(Request::setFinishPendingWork, FINISH_PENDING_WORK);
         }
 
         public static Request parseRequest(String id, XContentParser parser) {
@@ -74,6 +78,12 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
             id = in.readString();
             allowNoMatch = in.readBoolean();
             force = in.readBoolean();
+
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_062)) {
+                finishPendingWork = in.readBoolean();
+            } else {
+                finishPendingWork = false;
+            }
         }
 
         private Request() {}
@@ -102,6 +112,14 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
             return force;
         }
 
+        public boolean shouldFinishPendingWork() {
+            return finishPendingWork;
+        }
+
+        public void setFinishPendingWork(boolean finishPendingWork) {
+            this.finishPendingWork = finishPendingWork;
+        }
+
         @Override
         public boolean match(Task task) {
             return StartTrainedModelDeploymentAction.TaskMatcher.match(task, id);
@@ -113,6 +131,10 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
             out.writeString(id);
             out.writeBoolean(allowNoMatch);
             out.writeBoolean(force);
+
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_062)) {
+                out.writeBoolean(finishPendingWork);
+            }
         }
 
         @Override
@@ -121,13 +143,14 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
             builder.field(TrainedModelConfig.MODEL_ID.getPreferredName(), id);
             builder.field(ALLOW_NO_MATCH.getPreferredName(), allowNoMatch);
             builder.field(FORCE.getPreferredName(), force);
+            builder.field(FINISH_PENDING_WORK.getPreferredName(), finishPendingWork);
             builder.endObject();
             return builder;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, allowNoMatch, force);
+            return Objects.hash(id, allowNoMatch, force, finishPendingWork);
         }
 
         @Override
@@ -136,7 +159,10 @@ public class StopTrainedModelDeploymentAction extends ActionType<StopTrainedMode
             if (o == null || getClass() != o.getClass()) return false;
 
             Request that = (Request) o;
-            return Objects.equals(id, that.id) && allowNoMatch == that.allowNoMatch && force == that.force;
+            return Objects.equals(id, that.id)
+                && allowNoMatch == that.allowNoMatch
+                && force == that.force
+                && finishPendingWork == that.finishPendingWork;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -410,6 +410,15 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             return this;
         }
 
+        /**
+         * Adds the {@link RoutingInfo} regardless of whether it already exists.
+         */
+        public Builder addOrOverwriteRoutingEntry(String nodeId, RoutingInfo routingInfo) {
+            nodeRoutingTable.put(nodeId, routingInfo);
+
+            return this;
+        }
+
         public Builder removeRoutingEntry(String nodeId) {
             nodeRoutingTable.remove(nodeId);
             return this;
@@ -462,6 +471,12 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
                 return this;
             }
             reason = null;
+            return this;
+        }
+
+        public Builder clearNodeRoutingTable() {
+            nodeRoutingTable.clear();
+
             return this;
         }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -672,7 +672,7 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
             )
         );
 
-        stopDeployment(modelId, true);
+        stopDeployment(modelId, true, false);
     }
 
     public void testStopWithModelAliasUsedDeploymentByIngestProcessor() throws IOException {
@@ -704,7 +704,7 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
                     + " by ingest processors; use force to stop the deployment"
             )
         );
-        stopDeployment(modelId, true);
+        stopDeployment(modelId, true, false);
     }
 
     public void testInferenceProcessorWithModelAlias() throws IOException {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -268,15 +268,21 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
     }
 
     protected void stopDeployment(String modelId) throws IOException {
-        stopDeployment(modelId, false);
+        stopDeployment(modelId, false, false);
     }
 
-    protected void stopDeployment(String modelId, boolean force) throws IOException {
+    protected void stopDeployment(String modelId, boolean force, boolean finishPendingWork) throws IOException {
         String endpoint = "/_ml/trained_models/" + modelId + "/deployment/_stop";
-        if (force) {
-            endpoint += "?force=true";
-        }
+
         Request request = new Request("POST", endpoint);
+        if (force) {
+            request.addParameter("force", "true");
+        }
+
+        if (finishPendingWork) {
+            request.addParameter("finish_pending_work", "true");
+        }
+
         client().performRequest(request);
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/StopDeploymentGracefullyIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/StopDeploymentGracefullyIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.client.Response;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus;
+import org.elasticsearch.xpack.core.ml.inference.assignment.Priority;
+
+import java.io.IOException;
+import java.util.List;
+
+public class StopDeploymentGracefullyIT extends PyTorchModelRestTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testStopDeploymentGracefully() throws IOException {
+        String baseModelId = "base-model";
+        putAllModelParts(baseModelId);
+
+        String forSearchDeploymentId = "for-search";
+        startDeployment(baseModelId, forSearchDeploymentId, AllocationStatus.State.STARTED, 1, 1, Priority.LOW);
+
+        Response inference = infer("my words", forSearchDeploymentId);
+        assertOK(inference);
+
+        assertInferenceCountOnDeployment(1, forSearchDeploymentId);
+
+        // infer by model Id
+        inference = infer("my words", baseModelId);
+        assertOK(inference);
+        assertInferenceCountOnModel(2, baseModelId);
+
+        stopDeployment(forSearchDeploymentId, false, true);
+    }
+
+    private void putAllModelParts(String modelId) throws IOException {
+        createPassThroughModel(modelId);
+        putModelDefinition(modelId);
+        putVocabulary(List.of("these", "are", "my", "words"), modelId);
+    }
+
+    private void putModelDefinition(String modelId) throws IOException {
+        putModelDefinition(modelId, PyTorchModelIT.BASE_64_ENCODED_MODEL, PyTorchModelIT.RAW_MODEL_SIZE);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlLifeCycleService.java
@@ -13,8 +13,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedRunner;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
+import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentMetadata;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 import org.elasticsearch.xpack.ml.process.MlController;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
@@ -28,6 +31,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class MlLifeCycleService {
 
@@ -103,12 +108,42 @@ public class MlLifeCycleService {
             return true;
         }
 
+        logger.debug(() -> format("Checking shutdown safety for node id [%s]", nodeId));
+
+        boolean nodeHasRunningDeployments = nodeHasRunningDeployments(nodeId, state);
+
+        logger.debug(() -> format("Node id [%s] has running deployments: %s", nodeId, nodeHasRunningDeployments));
+
         PersistentTasksCustomMetadata tasks = state.metadata().custom(PersistentTasksCustomMetadata.TYPE);
-        // TODO: currently only considering anomaly detection jobs - could extend in the future
         // Ignore failed jobs - the persistent task still exists to remember the failure (because no
         // persistent task means closed), but these don't need to be relocated to another node.
         return MlTasks.nonFailedJobTasksOnNode(tasks, nodeId).isEmpty()
-            && MlTasks.nonFailedSnapshotUpgradeTasksOnNode(tasks, nodeId).isEmpty();
+            && MlTasks.nonFailedSnapshotUpgradeTasksOnNode(tasks, nodeId).isEmpty()
+            && nodeHasRunningDeployments == false;
+    }
+
+    private static boolean nodeHasRunningDeployments(String nodeId, ClusterState state) {
+        TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(state);
+
+        return metadata.allAssignments().values().stream().anyMatch(assignment -> {
+            if (assignment.isRoutedToNode(nodeId)) {
+                RoutingInfo routingInfo = assignment.getNodeRoutingTable().get(nodeId);
+                logger.debug(
+                    () -> format(
+                        "Assignment deployment id [%s] is routed to shutting down nodeId %s state: %s",
+                        assignment.getDeploymentId(),
+                        nodeId,
+                        routingInfo.getState()
+                    )
+                );
+
+                // A routing could exist in the stopped state if the deployment has successfully drained any remaining requests
+                // If a route is starting, started, or stopping then the node is not ready to shut down yet
+                return routingInfo.getState().isNoneOf(RoutingState.STOPPED, RoutingState.FAILED);
+            }
+
+            return false;
+        });
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopTrainedModelDeploymentAction.java
@@ -262,6 +262,7 @@ public class TransportStopTrainedModelDeploymentAction extends TransportTasksAct
     ) {
         task.stop(
             "undeploy_trained_model (api)",
+            request.shouldFinishPendingWork(),
             ActionListener.wrap(r -> listener.onResponse(new StopTrainedModelDeploymentAction.Response(true)), listener::onFailure)
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -62,6 +62,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentUtils.NODES_CHANGED_REASON;
+import static org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentUtils.createShuttingDownRoute;
 
 public class TrainedModelAssignmentClusterService implements ClusterStateListener {
 
@@ -232,6 +234,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         Set<String> assignableNodes = getAssignableNodes(currentState).stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
+        Set<String> shuttingDownNodes = currentState.metadata().nodeShutdowns().getAllNodeIds();
+
         for (TrainedModelAssignment assignment : metadata.allAssignments().values()) {
             Set<String> routedNodeIdsToRemove = Sets.difference(assignment.getNodeRoutingTable().keySet(), assignableNodes);
             if (routedNodeIdsToRemove.isEmpty() == false) {
@@ -242,12 +246,67 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                         routedNodeIdsToRemove
                     )
                 );
-                TrainedModelAssignment.Builder assignmentBuilder = TrainedModelAssignment.Builder.fromAssignment(assignment);
-                routedNodeIdsToRemove.forEach(assignmentBuilder::removeRoutingEntry);
+
+                /*
+                 * This code is to handle the following edge case.
+                 *
+                 * This code was added in 8.11.0. This code path is hit if the version of a node in the cluster is less than 8.4.0.
+                 * - A rolling upgrade is performed from a version less than 8.4.0
+                 * - The versions of the nodes in the cluster is mixed between 8.11.0 and less than 8.4.0
+                 * - The master node upgrades to 8.11.0 (which will have this code change)
+                 * - An ML node upgrades to 8.11.0 and begins shutting down
+                 * - A data node exists on a version less than 8.4.0
+                 *
+                 * The ML node that is shutting down will go through the graceful shutdown by having any routes referencing it, set to
+                 * stopping. The TrainedModelAssignmentNodeService will be notified of the change and see that the route is in stopping
+                 * and complete any remaining work in the processes before stopping them.
+                 *
+                 * If in the future we can simplify and remove this edge case code that'd be ideal.
+                 */
+                TrainedModelAssignment.Builder assignmentBuilder = removeRoutingBuilder(
+                    routedNodeIdsToRemove,
+                    shuttingDownNodes,
+                    assignment
+                );
+
                 builder.updateAssignment(assignment.getDeploymentId(), assignmentBuilder.calculateAndSetAssignmentState());
             }
         }
         return update(currentState, builder);
+    }
+
+    private static TrainedModelAssignment.Builder removeRoutingBuilder(
+        Set<String> nodeIds,
+        Set<String> shuttingDownNodes,
+        TrainedModelAssignment assignment
+    ) {
+        TrainedModelAssignment.Builder assignmentBuilder = TrainedModelAssignment.Builder.fromAssignment(assignment);
+
+        for (String nodeIdToRemove : nodeIds) {
+            RoutingInfo routingInfoToRemove = assignment.getNodeRoutingTable().get(nodeIdToRemove);
+
+            if (shuttingDownNodes.contains(nodeIdToRemove) == false) {
+                logger.debug(
+                    () -> format("[%s] Removing route for unassignable node id [%s]", assignment.getDeploymentId(), nodeIdToRemove)
+                );
+
+                assignmentBuilder.removeRoutingEntry(nodeIdToRemove);
+            } else if (routingInfoToRemove != null && routingInfoToRemove.getState().isAnyOf(RoutingState.STARTED, RoutingState.STARTING)) {
+                logger.debug(
+                    () -> format(
+                        "[%s] Found assignment with route to shutting down node id [%s], adding stopping route",
+                        assignment.getDeploymentId(),
+                        nodeIdToRemove
+                    )
+                );
+
+                RoutingInfo stoppingRouteInfo = createShuttingDownRoute(assignment.getNodeRoutingTable().get(nodeIdToRemove));
+                assignmentBuilder.addOrOverwriteRoutingEntry(nodeIdToRemove, stoppingRouteInfo);
+            }
+
+        }
+
+        return assignmentBuilder;
     }
 
     public void updateModelRoutingTable(
@@ -490,18 +549,85 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         List<DiscoveryNode> nodes = getAssignableNodes(currentState);
         logger.debug(() -> format("assignable nodes are %s", nodes.stream().map(DiscoveryNode::getId).toList()));
         Map<DiscoveryNode, NodeLoad> nodeLoads = detectNodeLoads(nodes, currentState);
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.fromState(currentState);
+
         TrainedModelAssignmentRebalancer rebalancer = new TrainedModelAssignmentRebalancer(
-            TrainedModelAssignmentMetadata.fromState(currentState),
+            currentMetadata,
             nodeLoads,
             nodeAvailabilityZoneMapper.buildMlNodesByAvailabilityZone(currentState),
             modelToAdd,
             allocatedProcessorsScale
         );
-        TrainedModelAssignmentMetadata.Builder rebalanced = rebalancer.rebalance();
+
+        Set<String> shuttingDownNodeIds = currentState.metadata().nodeShutdowns().getAllNodeIds();
+        TrainedModelAssignmentMetadata.Builder rebalanced = setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            shuttingDownNodeIds,
+            rebalancer.rebalance()
+        );
+
         if (modelToAdd.isPresent()) {
             checkModelIsFullyAllocatedIfScalingIsNotPossible(modelToAdd.get().getDeploymentId(), rebalanced, nodes);
         }
+
         return rebalanced;
+    }
+
+    // Default for testing
+    static TrainedModelAssignmentMetadata.Builder setShuttingDownNodeRoutesToStopping(
+        TrainedModelAssignmentMetadata currentMetadata,
+        Set<String> shuttingDownNodeIds,
+        TrainedModelAssignmentMetadata.Builder builder
+    ) {
+        if (shuttingDownNodeIds.isEmpty()) {
+            return builder;
+        }
+
+        for (TrainedModelAssignment existingAssignment : currentMetadata.allAssignments().values()) {
+            boolean foundShuttingDownNodeForAssignment = false;
+
+            String existingDeploymentId = existingAssignment.getDeploymentId();
+            TrainedModelAssignment.Builder assignmentBuilder = builder.hasModelDeployment(existingAssignment.getDeploymentId())
+                ? builder.getAssignment(existingDeploymentId)
+                : TrainedModelAssignment.Builder.fromAssignment(existingAssignment)
+                    /*
+                     * If this code path happens that means that the assignment originally existed prior to the rebalance and then
+                     * disappeared. This would be an anomaly so we'll set the assignment to stopping and attempt to gracefully shut down
+                     * the native process.
+                     */
+                    .stopAssignment(NODES_CHANGED_REASON)
+                    // If there are other routes that are now outdated after the rebalance we don't want to include them, so let's start
+                    // with a fresh table
+                    .clearNodeRoutingTable();
+
+            for (String nodeId : shuttingDownNodeIds) {
+                if (existingAssignment.isRoutedToNode(nodeId)
+                    && existingAssignment.getNodeRoutingTable()
+                        .get(nodeId)
+                        .getState()
+                        .isAnyOf(RoutingState.STARTED, RoutingState.STARTING)) {
+                    logger.debug(
+                        () -> format(
+                            "Found assignment deployment id: [%s] with route to shutting down node id: [%s], adding stopping route",
+                            existingDeploymentId,
+                            nodeId
+                        )
+                    );
+
+                    foundShuttingDownNodeForAssignment = true;
+                    RoutingInfo stoppingRouteInfo = createShuttingDownRoute(existingAssignment.getNodeRoutingTable().get(nodeId));
+
+                    assignmentBuilder.addOrOverwriteRoutingEntry(nodeId, stoppingRouteInfo);
+                }
+            }
+
+            // if we didn't find a shutting down routing info then we don't want to add an empty assignment here
+            if (foundShuttingDownNodeForAssignment) {
+                builder.addOrOverwriteAssignment(existingDeploymentId, assignmentBuilder);
+            }
+        }
+
+        return builder;
     }
 
     private void checkModelIsFullyAllocatedIfScalingIsNotPossible(
@@ -807,7 +933,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         return detectReasonIfMlJobsStopped(event).or(() -> {
             String reason = null;
             if (haveMlNodesChanged(event, newMetadata)) {
-                reason = "nodes changed";
+                reason = NODES_CHANGED_REASON;
             } else if (newMetadata.hasOutdatedAssignments()) {
                 reason = "outdated assignments detected";
             }
@@ -906,7 +1032,10 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     continue;
                 }
                 for (var nodeId : exitingShutDownNodes) {
-                    if (trainedModelAssignment.isRoutedToNode(nodeId)) {
+                    if (trainedModelAssignment.isRoutedToNode(nodeId)
+                        // If the route is stopping then it's draining its queue or being forced to stop so let that continue
+                        // and don't try to rebalance until it has completely finished
+                        && trainedModelAssignment.getNodeRoutingTable().get(nodeId).getState() != RoutingState.STOPPING) {
                         logger.debug(
                             () -> format(
                                 "should rebalance because model deployment [%s] has allocations on shutting down node [%s]",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -235,6 +235,14 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
             return this;
         }
 
+        /**
+         * Adds the assignment regardless of whether it already exists.
+         */
+        public Builder addOrOverwriteAssignment(String deploymentId, TrainedModelAssignment.Builder assignment) {
+            deploymentRoutingEntries.put(deploymentId, assignment);
+            return this;
+        }
+
         public TrainedModelAssignment.Builder getAssignment(String deploymentId) {
             return deploymentRoutingEntries.get(deploymentId);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateTrainedModelAssignmentRoutingInfoAction;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AssignmentState;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfoUpdate;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
@@ -51,17 +52,21 @@ import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ASSIGNMENT_TASK_ACTION;
 import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ASSIGNMENT_TASK_TYPE;
 import static org.elasticsearch.xpack.ml.MachineLearning.ML_PYTORCH_MODEL_INFERENCE_FEATURE;
+import static org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentUtils.NODE_IS_SHUTTING_DOWN;
 
 public class TrainedModelAssignmentNodeService implements ClusterStateListener {
 
@@ -146,24 +151,6 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         this.expressionResolver = expressionResolver;
     }
 
-    void stopDeploymentAsync(TrainedModelDeploymentTask task, String reason, ActionListener<Void> listener) {
-        if (stopped) {
-            return;
-        }
-        task.markAsStopped(reason);
-
-        threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
-            try {
-                deploymentManager.stopDeployment(task);
-                taskManager.unregister(task);
-                deploymentIdToTask.remove(task.getDeploymentId());
-                listener.onResponse(null);
-            } catch (Exception e) {
-                listener.onFailure(e);
-            }
-        });
-    }
-
     public void start() {
         stopped = false;
         scheduledFuture = threadPool.scheduleWithFixedDelay(
@@ -241,22 +228,38 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         loadingModels.addAll(loadingToRetry);
     }
 
-    public void stopDeploymentAndNotify(TrainedModelDeploymentTask task, String reason, ActionListener<AcknowledgedResponse> listener) {
-        final RoutingInfoUpdate updateToStopped = RoutingInfoUpdate.updateStateAndReason(
-            new RoutingStateAndReason(RoutingState.STOPPED, reason)
-        );
+    public void gracefullyStopDeploymentAndNotify(
+        TrainedModelDeploymentTask task,
+        String reason,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
+        logger.debug(() -> format("[%s] Gracefully stopping deployment due to reason %s", task.getDeploymentId(), reason));
 
-        ActionListener<Void> notifyDeploymentOfStopped = ActionListener.wrap(
-            _void -> updateStoredState(task.getDeploymentId(), updateToStopped, listener),
-            failed -> { // if we failed to stop the process, something strange is going on, but we should still notify of stop
-                logger.warn(() -> "[" + task.getDeploymentId() + "] failed to stop due to error", failed);
-                updateStoredState(task.getDeploymentId(), updateToStopped, listener);
-            }
-        );
+        stopAndNotifyHelper(task, reason, listener, deploymentManager::stopAfterCompletingPendingWork);
+    }
+
+    public void stopDeploymentAndNotify(TrainedModelDeploymentTask task, String reason, ActionListener<AcknowledgedResponse> listener) {
+        logger.debug(() -> format("[%s] Forcefully stopping deployment due to reason %s", task.getDeploymentId(), reason));
+
+        stopAndNotifyHelper(task, reason, listener, deploymentManager::stopDeployment);
+    }
+
+    private void stopAndNotifyHelper(
+        TrainedModelDeploymentTask task,
+        String reason,
+        ActionListener<AcknowledgedResponse> listener,
+        Consumer<TrainedModelDeploymentTask> stopDeploymentFunc
+    ) {
+        // Removing the entry from the map to avoid the possibility of a node shutdown triggering a concurrent graceful stopping of the
+        // process while we are attempting to forcefully stop the native process
+        // The graceful stopping will only occur if there is an entry in the map
+        deploymentIdToTask.remove(task.getDeploymentId());
+        ActionListener<Void> notifyDeploymentOfStopped = updateRoutingStateToStoppedListener(task.getDeploymentId(), reason, listener);
+
         updateStoredState(
             task.getDeploymentId(),
             RoutingInfoUpdate.updateStateAndReason(new RoutingStateAndReason(RoutingState.STOPPING, reason)),
-            ActionListener.wrap(success -> stopDeploymentAsync(task, reason, notifyDeploymentOfStopped), e -> {
+            ActionListener.wrap(success -> stopDeploymentHelper(task, reason, stopDeploymentFunc, notifyDeploymentOfStopped), e -> {
                 if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
                     logger.debug(
                         () -> format("[%s] failed to set routing state to stopping as assignment already removed", task.getDeploymentId()),
@@ -267,7 +270,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                     // TODO this means requests may still be routed here, should we not stop deployment?
                     logger.warn(() -> "[" + task.getDeploymentId() + "] failed to set routing state to stopping due to error", e);
                 }
-                stopDeploymentAsync(task, reason, notifyDeploymentOfStopped);
+                stopDeploymentHelper(task, reason, stopDeploymentFunc, notifyDeploymentOfStopped);
             })
         );
     }
@@ -330,82 +333,214 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         latestState = event.state();
-        if (event.metadataChanged()) {
-            final boolean isResetMode = MlMetadata.getMlMetadata(event.state()).isResetMode();
-            TrainedModelAssignmentMetadata modelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(event.state());
-            final String currentNode = event.state().nodes().getLocalNodeId();
-            final boolean isNewAllocationSupported = event.state()
-                .getMinTransportVersion()
-                .onOrAfter(TrainedModelAssignmentClusterService.DISTRIBUTED_MODEL_ALLOCATION_TRANSPORT_VERSION);
+        if (event.metadataChanged() == false) {
+            return;
+        }
 
-            if (isResetMode == false && isNewAllocationSupported) {
-                updateNumberOfAllocations(modelAssignmentMetadata);
-            }
+        final boolean isResetMode = MlMetadata.getMlMetadata(event.state()).isResetMode();
+        TrainedModelAssignmentMetadata modelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(event.state());
+        final String currentNode = event.state().nodes().getLocalNodeId();
+        final boolean isNewAllocationSupported = event.state()
+            .getMinTransportVersion()
+            .onOrAfter(TrainedModelAssignmentClusterService.DISTRIBUTED_MODEL_ALLOCATION_TRANSPORT_VERSION);
+        final Set<String> shuttingDownNodes = Collections.unmodifiableSet(event.state().metadata().nodeShutdowns().getAllNodeIds());
 
-            for (TrainedModelAssignment trainedModelAssignment : modelAssignmentMetadata.allAssignments().values()) {
-                RoutingInfo routingInfo = trainedModelAssignment.getNodeRoutingTable().get(currentNode);
-                // Add new models to start loading
-                if (routingInfo != null && isNewAllocationSupported) {
-                    if (routingInfo.getState() == RoutingState.STARTING
-                        && deploymentIdToTask.containsKey(trainedModelAssignment.getDeploymentId())
-                        && deploymentIdToTask.get(trainedModelAssignment.getDeploymentId()).isFailed()) {
-                        // This is a failed assignment and we are restarting it. For this we need to remove the task first.
-                        taskManager.unregister(deploymentIdToTask.get(trainedModelAssignment.getDeploymentId()));
-                        deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
+        if (isResetMode == false && isNewAllocationSupported) {
+            updateNumberOfAllocations(modelAssignmentMetadata);
+        }
+
+        for (TrainedModelAssignment trainedModelAssignment : modelAssignmentMetadata.allAssignments().values()) {
+            RoutingInfo routingInfo = trainedModelAssignment.getNodeRoutingTable().get(currentNode);
+            if (routingInfo != null) {
+                // Add new models to start loading if the assignment is not stopping
+                if (isNewAllocationSupported && trainedModelAssignment.getAssignmentState() != AssignmentState.STOPPING) {
+                    if (shouldAssignmentBeRestarted(routingInfo, trainedModelAssignment.getDeploymentId())) {
+                        prepareAssignmentForRestart(trainedModelAssignment);
                     }
-                    if (routingInfo.getState().isAnyOf(RoutingState.STARTING, RoutingState.STARTED) // periodic retries of `failed` should
-                                                                                                    // be handled in a separate process
-                        // This means we don't already have a task and should attempt creating one and starting the model loading
-                        // If we don't have a task but are STARTED, this means the cluster state had a started assignment,
-                        // the node crashed and then started again
-                        && deploymentIdToTask.containsKey(trainedModelAssignment.getDeploymentId()) == false
-                        // If we are in reset mode, don't start loading a new model on this node.
-                        && isResetMode == false) {
+
+                    if (shouldLoadModel(routingInfo, trainedModelAssignment.getDeploymentId(), isResetMode)) {
                         prepareModelToLoad(
-                            new StartTrainedModelDeploymentAction.TaskParams(
-                                trainedModelAssignment.getTaskParams().getModelId(),
-                                trainedModelAssignment.getDeploymentId(),
-                                trainedModelAssignment.getTaskParams().getModelBytes(),
-                                routingInfo.getCurrentAllocations(),
-                                trainedModelAssignment.getTaskParams().getThreadsPerAllocation(),
-                                trainedModelAssignment.getTaskParams().getQueueCapacity(),
-                                trainedModelAssignment.getTaskParams().getCacheSize().orElse(null),
-                                trainedModelAssignment.getTaskParams().getPriority()
-                            )
+                            createStartTrainedModelDeploymentTaskParams(trainedModelAssignment, routingInfo.getCurrentAllocations())
                         );
                     }
                 }
-                // This model is not routed to the current node at all
-                if (routingInfo == null) {
-                    TrainedModelDeploymentTask task = deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
-                    if (task != null) {
-                        stopDeploymentAsync(
-                            task,
-                            NODE_NO_LONGER_REFERENCED,
-                            ActionListener.wrap(
-                                r -> logger.trace(() -> "[" + task.getDeploymentId() + "] stopped deployment"),
-                                e -> logger.warn(() -> "[" + task.getDeploymentId() + "] failed to fully stop deployment", e)
-                            )
-                        );
-                    }
+
+                if (isAssignmentOnShuttingDownNode(routingInfo, trainedModelAssignment.getDeploymentId(), shuttingDownNodes, currentNode)) {
+                    gracefullyStopDeployment(trainedModelAssignment.getDeploymentId(), currentNode);
                 }
-            }
-            List<TrainedModelDeploymentTask> toCancel = new ArrayList<>();
-            for (String deploymentIds : Sets.difference(deploymentIdToTask.keySet(), modelAssignmentMetadata.allAssignments().keySet())) {
-                toCancel.add(deploymentIdToTask.remove(deploymentIds));
-            }
-            // should all be stopped in the same executor thread?
-            for (TrainedModelDeploymentTask t : toCancel) {
-                stopDeploymentAsync(
-                    t,
-                    ASSIGNMENT_NO_LONGER_EXISTS,
-                    ActionListener.wrap(
-                        r -> logger.trace(() -> "[" + t.getDeploymentId() + "] stopped deployment"),
-                        e -> logger.warn(() -> "[" + t.getDeploymentId() + "] failed to fully stop deployment", e)
-                    )
-                );
+            } else {
+                stopUnreferencedDeployment(trainedModelAssignment.getDeploymentId(), currentNode);
             }
         }
+
+        List<TrainedModelDeploymentTask> toCancel = new ArrayList<>();
+        for (String deploymentIds : Sets.difference(deploymentIdToTask.keySet(), modelAssignmentMetadata.allAssignments().keySet())) {
+            toCancel.add(deploymentIdToTask.remove(deploymentIds));
+        }
+        // should all be stopped in the same executor thread?
+        for (TrainedModelDeploymentTask t : toCancel) {
+            stopDeploymentAsync(
+                t,
+                ASSIGNMENT_NO_LONGER_EXISTS,
+                ActionListener.wrap(
+                    r -> logger.trace(() -> "[" + t.getDeploymentId() + "] stopped deployment"),
+                    e -> logger.warn(() -> "[" + t.getDeploymentId() + "] failed to fully stop deployment", e)
+                )
+            );
+        }
+    }
+
+    private boolean shouldAssignmentBeRestarted(RoutingInfo routingInfo, String deploymentId) {
+        return routingInfo.getState() == RoutingState.STARTING
+            && deploymentIdToTask.containsKey(deploymentId)
+            && deploymentIdToTask.get(deploymentId).isFailed();
+    }
+
+    private void prepareAssignmentForRestart(TrainedModelAssignment trainedModelAssignment) {
+        // This is a failed assignment and we are restarting it. For this we need to remove the task first.
+        taskManager.unregister(deploymentIdToTask.get(trainedModelAssignment.getDeploymentId()));
+        deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
+    }
+
+    private boolean shouldLoadModel(RoutingInfo routingInfo, String deploymentId, boolean isResetMode) {
+        return routingInfo.getState().isAnyOf(RoutingState.STARTING, RoutingState.STARTED) // periodic retries of `failed`
+            // should
+            // be handled in a separate process
+            // This means we don't already have a task and should attempt creating one and starting the model loading
+            // If we don't have a task but are STARTED, this means the cluster state had a started assignment,
+            // the node crashed and then started again
+            && deploymentIdToTask.containsKey(deploymentId) == false
+            // If we are in reset mode, don't start loading a new model on this node.
+            && isResetMode == false;
+    }
+
+    private static StartTrainedModelDeploymentAction.TaskParams createStartTrainedModelDeploymentTaskParams(
+        TrainedModelAssignment trainedModelAssignment,
+        int currentAllocations
+    ) {
+        return new StartTrainedModelDeploymentAction.TaskParams(
+            trainedModelAssignment.getTaskParams().getModelId(),
+            trainedModelAssignment.getDeploymentId(),
+            trainedModelAssignment.getTaskParams().getModelBytes(),
+            currentAllocations,
+            trainedModelAssignment.getTaskParams().getThreadsPerAllocation(),
+            trainedModelAssignment.getTaskParams().getQueueCapacity(),
+            trainedModelAssignment.getTaskParams().getCacheSize().orElse(null),
+            trainedModelAssignment.getTaskParams().getPriority()
+        );
+    }
+
+    private boolean isAssignmentOnShuttingDownNode(
+        RoutingInfo routingInfo,
+        String deploymentId,
+        Set<String> shuttingDownNodes,
+        String currentNode
+    ) {
+        return deploymentIdToTask.containsKey(deploymentId)
+            && routingInfo.getState() == RoutingState.STOPPING
+            && shuttingDownNodes.contains(currentNode);
+    }
+
+    private void gracefullyStopDeployment(String deploymentId, String currentNode) {
+        logger.debug(() -> format("[%s] Gracefully stopping deployment for shutting down node %s", deploymentId, currentNode));
+
+        TrainedModelDeploymentTask task = deploymentIdToTask.remove(deploymentId);
+        if (task == null) {
+            logger.debug(
+                () -> format(
+                    "[%s] Unable to gracefully stop deployment for shutting down node %s because task does not exit",
+                    deploymentId,
+                    currentNode
+                )
+            );
+            return;
+        }
+
+        ActionListener<AcknowledgedResponse> routingStateListener = ActionListener.wrap(
+            r -> logger.debug(
+                () -> format("[%s] Gracefully stopped deployment for shutting down node %s", task.getDeploymentId(), currentNode)
+            ),
+            e -> logger.error(
+                () -> format("[%s] Failed to gracefully stop deployment for shutting down node %s", task.getDeploymentId(), currentNode),
+                e
+            )
+        );
+
+        ActionListener<Void> notifyDeploymentOfStopped = updateRoutingStateToStoppedListener(
+            task.getDeploymentId(),
+            NODE_IS_SHUTTING_DOWN,
+            routingStateListener
+        );
+
+        stopDeploymentAfterCompletingPendingWorkAsync(task, notifyDeploymentOfStopped);
+    }
+
+    private ActionListener<Void> updateRoutingStateToStoppedListener(
+        String deploymentId,
+        String reason,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
+        final RoutingInfoUpdate updateToStopped = RoutingInfoUpdate.updateStateAndReason(
+            new RoutingStateAndReason(RoutingState.STOPPED, reason)
+        );
+
+        return ActionListener.wrap(_void -> {
+            logger.debug(() -> format("[%s] Updating routing state to stopped", deploymentId));
+            updateStoredState(deploymentId, updateToStopped, listener);
+        }, e -> {
+            // if we failed to stop the process, something strange is going on, but we should set the routing state to stopped
+            logger.warn(() -> format("[%s] Failed to stop deployment due to error", deploymentId), e);
+            updateStoredState(deploymentId, updateToStopped, listener);
+        });
+    }
+
+    private void stopUnreferencedDeployment(String deploymentId, String currentNode) {
+        // This model is not routed to the current node at all
+        TrainedModelDeploymentTask task = deploymentIdToTask.remove(deploymentId);
+        if (task == null) {
+            return;
+        }
+
+        logger.debug(() -> format("[%s] Stopping unreferenced deployment for node %s", deploymentId, currentNode));
+        stopDeploymentAsync(
+            task,
+            NODE_NO_LONGER_REFERENCED,
+            ActionListener.wrap(
+                r -> logger.trace(() -> "[" + task.getDeploymentId() + "] stopped deployment"),
+                e -> logger.warn(() -> "[" + task.getDeploymentId() + "] failed to fully stop deployment", e)
+            )
+        );
+    }
+
+    private void stopDeploymentAsync(TrainedModelDeploymentTask task, String reason, ActionListener<Void> listener) {
+        stopDeploymentHelper(task, reason, deploymentManager::stopDeployment, listener);
+    }
+
+    private void stopDeploymentHelper(
+        TrainedModelDeploymentTask task,
+        String reason,
+        Consumer<TrainedModelDeploymentTask> stopDeploymentFunc,
+        ActionListener<Void> listener
+    ) {
+        if (stopped) {
+            return;
+        }
+        task.markAsStopped(reason);
+
+        threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
+            try {
+                stopDeploymentFunc.accept(task);
+                taskManager.unregister(task);
+                deploymentIdToTask.remove(task.getDeploymentId());
+                listener.onResponse(null);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    private void stopDeploymentAfterCompletingPendingWorkAsync(TrainedModelDeploymentTask task, ActionListener<Void> listener) {
+        stopDeploymentHelper(task, NODE_IS_SHUTTING_DOWN, deploymentManager::stopAfterCompletingPendingWork, listener);
     }
 
     private void updateNumberOfAllocations(TrainedModelAssignmentMetadata assignments) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentUtils.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.assignment;
+
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfoUpdate;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingStateAndReason;
+
+public class TrainedModelAssignmentUtils {
+    public static final String NODES_CHANGED_REASON = "nodes changed";
+    public static final String NODE_IS_SHUTTING_DOWN = "node is shutting down";
+
+    public static RoutingInfo createShuttingDownRoute(RoutingInfo existingRoute) {
+        RoutingInfoUpdate routeUpdate = RoutingInfoUpdate.updateStateAndReason(
+            new RoutingStateAndReason(RoutingState.STOPPING, NODE_IS_SHUTTING_DOWN)
+        );
+
+        return routeUpdate.apply(existingRoute);
+    }
+
+    private TrainedModelAssignmentUtils() {}
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -102,8 +102,13 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
         return params;
     }
 
-    public void stop(String reason, ActionListener<AcknowledgedResponse> listener) {
-        trainedModelAssignmentNodeService.stopDeploymentAndNotify(this, reason, listener);
+    public void stop(String reason, boolean finishPendingWork, ActionListener<AcknowledgedResponse> listener) {
+
+        if (finishPendingWork) {
+            trainedModelAssignmentNodeService.gracefullyStopDeploymentAndNotify(this, reason, listener);
+        } else {
+            trainedModelAssignmentNodeService.stopDeploymentAndNotify(this, reason, listener);
+        }
     }
 
     public void markAsStopped(String reason) {
@@ -128,6 +133,7 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
         logger.info("[{}] task cancelled due to reason [{}]", getDeploymentId(), reason);
         stop(
             reason,
+            true,
             ActionListener.wrap(
                 acknowledgedResponse -> {},
                 e -> logger.error(() -> "[" + getDeploymentId() + "] error stopping the deployment after task cancellation", e)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -179,7 +179,7 @@ public class AutodetectCommunicator implements Closeable {
         });
         try {
             future.get();
-            autodetectWorkerExecutor.shutdown();
+            autodetectWorkerExecutor.shutdownNow();
             dataCountsReporter.writeUnreportedCounts();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -203,7 +203,7 @@ public class AutodetectCommunicator implements Closeable {
         try {
             processKilled = true;
             autodetectResultProcessor.setProcessKilled();
-            autodetectWorkerExecutor.shutdown();
+            autodetectWorkerExecutor.shutdownNow();
             autodetectProcess.kill(awaitCompletion);
 
             if (awaitCompletion) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/JobModelSnapshotUpgrader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/JobModelSnapshotUpgrader.java
@@ -384,7 +384,7 @@ public final class JobModelSnapshotUpgrader {
             if (process.isProcessAlive() == false) {
                 logger.debug("[{}] [{}] process is dead, no need to shutdown", jobId, snapshotId);
                 onFinish.accept(e);
-                autodetectWorkerExecutor.shutdown();
+                autodetectWorkerExecutor.shutdownNow();
                 stateStreamer.cancel();
                 return;
             }
@@ -408,7 +408,7 @@ public final class JobModelSnapshotUpgrader {
             });
             try {
                 future.get();
-                autodetectWorkerExecutor.shutdown();
+                autodetectWorkerExecutor.shutdownNow();
             } catch (InterruptedException interrupt) {
                 Thread.currentThread().interrupt();
             } catch (ExecutionException executionException) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStopTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStopTrainedModelDeploymentAction.java
@@ -55,6 +55,12 @@ public class RestStopTrainedModelDeploymentAction extends BaseRestHandler {
             request.setForce(
                 restRequest.paramAsBoolean(StopTrainedModelDeploymentAction.Request.FORCE.getPreferredName(), request.isForce())
             );
+            request.setFinishPendingWork(
+                restRequest.paramAsBoolean(
+                    StopTrainedModelDeploymentAction.Request.FINISH_PENDING_WORK.getPreferredName(),
+                    request.shouldFinishPendingWork()
+                )
+            );
         }
         return channel -> client.execute(StopTrainedModelDeploymentAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml;
 
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -21,8 +22,12 @@ import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentTaskParamsTests;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
+import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
+import org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignment;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeState;
@@ -30,6 +35,7 @@ import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskP
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskState;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedRunner;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
+import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentMetadata;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 import org.elasticsearch.xpack.ml.process.MlController;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
@@ -173,6 +179,88 @@ public class MlLifeCycleServiceTests extends ESTestCase {
         assertThat(isNodeSafeToShutdown("node-2", clusterState, shutdownStartTime, clock), is(true)); // has failed DFA job
         assertThat(isNodeSafeToShutdown("node-3", clusterState, shutdownStartTime, clock), is(true)); // has failed snapshot upgrade
         assertThat(isNodeSafeToShutdown("node-4", clusterState, shutdownStartTime, clock), is(true)); // has no ML tasks
+    }
+
+    public void testIsNodeSafeToShutdownReturnsFalseWhenStartingDeploymentExists() {
+        String nodeId = "node-1";
+        ClusterState currentState = ClusterState.builder(new ClusterName("test"))
+            .metadata(
+                Metadata.builder()
+                    .putCustom(
+                        TrainedModelAssignmentMetadata.NAME,
+                        TrainedModelAssignmentMetadata.Builder.empty()
+                            .addNewAssignment(
+                                "1",
+                                TrainedModelAssignment.Builder.empty(StartTrainedModelDeploymentTaskParamsTests.createRandom())
+                                    .addRoutingEntry(nodeId, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+
+        Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+
+        assertFalse(isNodeSafeToShutdown("node-1", currentState, null, clock));
+    }
+
+    public void testIsNodeSafeToShutdownReturnsFalseWhenStoppingAndStoppedDeploymentsExist() {
+        String nodeId = "node-1";
+        ClusterState currentState = ClusterState.builder(new ClusterName("test"))
+            .metadata(
+                Metadata.builder()
+                    .putCustom(
+                        TrainedModelAssignmentMetadata.NAME,
+                        TrainedModelAssignmentMetadata.Builder.empty()
+                            .addNewAssignment(
+                                "1",
+                                TrainedModelAssignment.Builder.empty(StartTrainedModelDeploymentTaskParamsTests.createRandom())
+                                    .addRoutingEntry(nodeId, new RoutingInfo(1, 1, RoutingState.STOPPED, ""))
+                            )
+                            .addNewAssignment(
+                                "2",
+                                TrainedModelAssignment.Builder.empty(StartTrainedModelDeploymentTaskParamsTests.createRandom())
+                                    .addRoutingEntry(nodeId, new RoutingInfo(1, 1, RoutingState.STOPPING, ""))
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+
+        Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+
+        assertFalse(isNodeSafeToShutdown("node-1", currentState, null, clock));
+    }
+
+    public void testIsNodeSafeToShutdownReturnsTrueWhenStoppedDeploymentsExist() {
+        String nodeId = "node-1";
+        ClusterState currentState = ClusterState.builder(new ClusterName("test"))
+            .metadata(
+                Metadata.builder()
+                    .putCustom(
+                        TrainedModelAssignmentMetadata.NAME,
+                        TrainedModelAssignmentMetadata.Builder.empty()
+                            .addNewAssignment(
+                                "1",
+                                TrainedModelAssignment.Builder.empty(StartTrainedModelDeploymentTaskParamsTests.createRandom())
+                                    .addRoutingEntry(nodeId, new RoutingInfo(1, 1, RoutingState.STOPPED, ""))
+                            )
+                            .addNewAssignment(
+                                "2",
+                                TrainedModelAssignment.Builder.empty(StartTrainedModelDeploymentTaskParamsTests.createRandom())
+                                    .addRoutingEntry(nodeId, new RoutingInfo(1, 1, RoutingState.STOPPED, ""))
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build();
+
+        Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+
+        assertThat(isNodeSafeToShutdown("node-1", currentState, null, clock), is(true));
     }
 
     public void testSignalGracefulShutdownIncludingLocalNode() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -394,6 +394,94 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         latch.await();
     }
 
+    public void testHaveMlNodesChanged_ReturnsTrueWhenNodeShutsDownAndWasRoutedTo() {
+        String model1 = "model-1";
+        String mlNode1 = "ml-node-with-room";
+        String mlNode2 = "new-ml-node-with-room";
+
+        ClusterState stateWithOneNode = createClusterState(
+            List.of(mlNode1),
+            Metadata.builder()
+                .putCustom(
+                    TrainedModelAssignmentMetadata.NAME,
+                    TrainedModelAssignmentMetadata.Builder.empty()
+                        .addNewAssignment(
+                            model1,
+                            TrainedModelAssignment.Builder.empty(newParams(model1, 100))
+                                .addRoutingEntry(mlNode1, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+                        )
+                        .build()
+                )
+                .putCustom(NodesShutdownMetadata.TYPE, shutdownMetadata(mlNode1))
+                .build()
+        );
+
+        ClusterState stateWithTwoNodes = createClusterState(
+            List.of(mlNode1, mlNode2),
+            Metadata.builder()
+                .putCustom(
+                    TrainedModelAssignmentMetadata.NAME,
+                    TrainedModelAssignmentMetadata.Builder.empty()
+                        .addNewAssignment(
+                            model1,
+                            TrainedModelAssignment.Builder.empty(newParams(model1, 100))
+                                .addRoutingEntry(mlNode1, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        var shutdownEvent = new ClusterChangedEvent("test", stateWithOneNode, stateWithTwoNodes);
+        var metadata = TrainedModelAssignmentMetadata.fromState(shutdownEvent.state());
+
+        assertThat(TrainedModelAssignmentClusterService.haveMlNodesChanged(shutdownEvent, metadata), is(true));
+    }
+
+    public void testHaveMlNodesChanged_ReturnsFalseWhenNodeShutsDownAndWasRoutedTo_ButRouteIsStopping() {
+        String model1 = "model-1";
+        String mlNode1 = "ml-node-with-room";
+        String mlNode2 = "new-ml-node-with-room";
+
+        ClusterState stateWithOneNode = createClusterState(
+            List.of(mlNode1),
+            Metadata.builder()
+                .putCustom(
+                    TrainedModelAssignmentMetadata.NAME,
+                    TrainedModelAssignmentMetadata.Builder.empty()
+                        .addNewAssignment(
+                            model1,
+                            TrainedModelAssignment.Builder.empty(newParams(model1, 100))
+                                .addRoutingEntry(mlNode1, new RoutingInfo(1, 1, RoutingState.STOPPING, ""))
+                        )
+                        .build()
+                )
+                .putCustom(NodesShutdownMetadata.TYPE, shutdownMetadata(mlNode1))
+                .build()
+        );
+
+        ClusterState stateWithTwoNodes = createClusterState(
+            List.of(mlNode1, mlNode2),
+            Metadata.builder()
+                .putCustom(
+                    TrainedModelAssignmentMetadata.NAME,
+                    TrainedModelAssignmentMetadata.Builder.empty()
+                        .addNewAssignment(
+                            model1,
+                            TrainedModelAssignment.Builder.empty(newParams(model1, 100))
+                                .addRoutingEntry(mlNode1, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        var shutdownEvent = new ClusterChangedEvent("test", stateWithOneNode, stateWithTwoNodes);
+        var metadata = TrainedModelAssignmentMetadata.fromState(shutdownEvent.state());
+
+        assertThat(TrainedModelAssignmentClusterService.haveMlNodesChanged(shutdownEvent, metadata), is(false));
+    }
+
     public void testDetectReasonToRebalanceModels() {
         String model1 = "model-1";
         String model2 = "model-2";
@@ -1321,7 +1409,64 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         assertThat(TrainedModelAssignmentClusterService.areAssignedNodesRemoved(event), is(false));
     }
 
-    public void testRemoveRoutingToUnassignableNodes() {
+    public void testRemoveRoutingToUnassignableNodes_RemovesRouteForRemovedNodes() {
+        String modelId1 = "model-1";
+        String modelId2 = "model-2";
+        String nodeId1 = "node-1";
+        String nodeId2 = "node-2";
+        String nodeId3 = "node-3";
+        Metadata metadata = Metadata.builder()
+            .putCustom(
+                TrainedModelAssignmentMetadata.NAME,
+                TrainedModelAssignmentMetadata.Builder.empty()
+                    .addNewAssignment(
+                        modelId1,
+                        TrainedModelAssignment.Builder.empty(newParams(modelId1, 10_000L))
+                            .addRoutingEntry(nodeId1, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                            .addRoutingEntry(nodeId2, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                    )
+                    .addNewAssignment(
+                        modelId2,
+                        TrainedModelAssignment.Builder.empty(newParams(modelId2, 10_000L))
+                            .addRoutingEntry(nodeId1, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                            .addRoutingEntry(nodeId2, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                    )
+                    .build()
+            )
+            // This node should not affect the assignments because it is not routed to
+            .putCustom(
+                NodesShutdownMetadata.TYPE,
+                new NodesShutdownMetadata(
+                    Map.of(
+                        nodeId3,
+                        SingleNodeShutdownMetadata.builder()
+                            .setNodeId(nodeId3)
+                            .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                            .setStartedAtMillis(System.currentTimeMillis())
+                            .setReason("test")
+                            .build()
+                    )
+                )
+            )
+            .build();
+        // This simulates node2 being non-existent but not shutting down
+        ClusterState currentState = createClusterState(List.of(nodeId1, nodeId3), metadata);
+
+        ClusterState resultState = TrainedModelAssignmentClusterService.removeRoutingToUnassignableNodes(currentState);
+
+        TrainedModelAssignmentMetadata trainedModelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(resultState);
+        assertThat(trainedModelAssignmentMetadata.allAssignments(), is(aMapWithSize(2)));
+        for (String modelId : List.of(modelId1, modelId2)) {
+            TrainedModelAssignment assignment = trainedModelAssignmentMetadata.getDeploymentAssignment(modelId);
+            assertThat(assignment, is(notNullValue()));
+            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
+            assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId1));
+            assertThat(assignment.getNodeRoutingTable(), not(hasKey(nodeId3)));
+
+        }
+    }
+
+    public void testRemoveRoutingToUnassignableNodes_AddsAStoppingRouteForShuttingDownNodes() {
         String modelId1 = "model-1";
         String modelId2 = "model-2";
         String nodeId1 = "node-1";
@@ -1362,28 +1507,273 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
                 )
             )
             .build();
-        DiscoveryNode node1 = buildNode(nodeId1, true, ByteSizeValue.ofGb(4).getBytes(), 8);
-        DiscoveryNode node3 = buildNode(nodeId3, true, ByteSizeValue.ofGb(4).getBytes(), 8);
-        ClusterState currentState = ClusterState.builder(new ClusterName("testAreAssignedNodesRemoved"))
-            .nodes(DiscoveryNodes.builder().add(node1).add(node3).build())
-            .putTransportVersion(nodeId1, TransportVersion.current())
-            .putTransportVersion(nodeId3, TransportVersion.current())
-            .metadata(metadata)
+        // This simulates node2 being non-existent but not shutting down
+        ClusterState currentState = createClusterState(List.of(nodeId1, nodeId3), metadata);
+        ClusterState resultState = TrainedModelAssignmentClusterService.removeRoutingToUnassignableNodes(currentState);
+
+        TrainedModelAssignmentMetadata trainedModelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(resultState);
+        assertThat(trainedModelAssignmentMetadata.allAssignments(), is(aMapWithSize(2)));
+
+        for (String modelId : List.of(modelId1, modelId2)) {
+            TrainedModelAssignment assignment = trainedModelAssignmentMetadata.getDeploymentAssignment(modelId);
+            assertThat(assignment, is(notNullValue()));
+            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(2)));
+            assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId1));
+            assertThat(assignment.getNodeRoutingTable().get(nodeId1).getState(), is(RoutingState.STARTED));
+            assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId3));
+            assertThat(assignment.getNodeRoutingTable().get(nodeId3).getState(), is(RoutingState.STOPPING));
+            assertThat(assignment.getNodeRoutingTable(), not(hasKey(nodeId2)));
+        }
+    }
+
+    public void testRemoveRoutingToUnassignableNodes_IgnoresARouteThatIsStoppedForShuttingDownNode() {
+        String modelId1 = "model-1";
+        String modelId2 = "model-2";
+        String nodeId1 = "node-1";
+        String nodeId2 = "node-2";
+        String nodeId3 = "node-3";
+        Metadata metadata = Metadata.builder()
+            .putCustom(
+                TrainedModelAssignmentMetadata.NAME,
+                TrainedModelAssignmentMetadata.Builder.empty()
+                    .addNewAssignment(
+                        modelId1,
+                        TrainedModelAssignment.Builder.empty(newParams(modelId1, 10_000L))
+                            .addRoutingEntry(nodeId1, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                            .addRoutingEntry(nodeId2, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                            .addRoutingEntry(nodeId3, new RoutingInfo(1, 1, RoutingState.STOPPED, ""))
+                    )
+                    .addNewAssignment(
+                        modelId2,
+                        TrainedModelAssignment.Builder.empty(newParams(modelId2, 10_000L))
+                            .addRoutingEntry(nodeId1, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                            .addRoutingEntry(nodeId2, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                            .addRoutingEntry(nodeId3, new RoutingInfo(1, 1, RoutingState.STOPPED, ""))
+                    )
+                    .build()
+            )
+            .putCustom(
+                NodesShutdownMetadata.TYPE,
+                new NodesShutdownMetadata(
+                    Map.of(
+                        nodeId3,
+                        SingleNodeShutdownMetadata.builder()
+                            .setNodeId(nodeId3)
+                            .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                            .setStartedAtMillis(System.currentTimeMillis())
+                            .setReason("test")
+                            .build()
+                    )
+                )
+            )
             .build();
+        // This simulates node2 being non-existent but not shutting down
+        ClusterState currentState = createClusterState(List.of(nodeId1, nodeId3), metadata);
 
         ClusterState resultState = TrainedModelAssignmentClusterService.removeRoutingToUnassignableNodes(currentState);
 
         TrainedModelAssignmentMetadata trainedModelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(resultState);
         assertThat(trainedModelAssignmentMetadata.allAssignments(), is(aMapWithSize(2)));
+
         for (String modelId : List.of(modelId1, modelId2)) {
             TrainedModelAssignment assignment = trainedModelAssignmentMetadata.getDeploymentAssignment(modelId);
             assertThat(assignment, is(notNullValue()));
-            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
+            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(2)));
             assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId1));
+            assertThat(assignment.getNodeRoutingTable().get(nodeId1).getState(), is(RoutingState.STARTED));
+            assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId3));
+            assertThat(assignment.getNodeRoutingTable().get(nodeId3).getState(), is(RoutingState.STOPPED));
+            assertThat(assignment.getNodeRoutingTable(), not(hasKey(nodeId2)));
         }
     }
 
-    private ClusterState.Builder csBuilderWithNodes(String name, DiscoveryNode... nodes) {
+    public void testSetShuttingDownNodeRoutesToStopping_GivenAnAssignmentRoutedToShuttingDownNode_ItSetsShuttingDownNodeRouteToStopping() {
+        var availableNode = "node-1";
+        var availableNodeModelId = "available-model-id";
+        StartTrainedModelDeploymentAction.TaskParams taskParamsRunning = newParams(availableNodeModelId, 100);
+
+        var shuttingDownNodeId = "shutting-down-1";
+        var shuttingDownModelId = "id1";
+        StartTrainedModelDeploymentAction.TaskParams taskParamsShuttingDown = newParams(shuttingDownModelId, 100);
+
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                availableNodeModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsRunning)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .addNewAssignment(
+                shuttingDownModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsShuttingDown)
+                    .addRoutingEntry(shuttingDownNodeId, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .build();
+
+        TrainedModelAssignmentMetadata.Builder rebalanced = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                availableNodeModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsRunning)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .addNewAssignment(
+                shuttingDownModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsRunning)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+            );
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            rebalanced
+        ).build();
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(shuttingDownModelId);
+        assertThat(assignment, is(notNullValue()));
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
+        assertThat(assignment.getNodeRoutingTable().get(availableNode).getState(), is(RoutingState.STARTING));
+        assertThat(assignment.getNodeRoutingTable().get(shuttingDownNodeId).getState(), is(RoutingState.STOPPING));
+        assertThat(assignment.getReason().isPresent(), is(false));
+    }
+
+    public
+        void
+        testSetShuttingDownNodeRoutesToStopping_GivenTwoAssignmentsWithOneOnAShuttingDownNode_ItSetsShuttingDownNodeRouteToStopping() {
+        var availableNode = "node-1";
+
+        var shuttingDownModelId = "id1";
+        StartTrainedModelDeploymentAction.TaskParams taskParamsShuttingDown = newParams(shuttingDownModelId, 300);
+
+        var notShuttingDownModelId = "id2";
+        StartTrainedModelDeploymentAction.TaskParams taskParamsNotShuttingDown = newParams(notShuttingDownModelId, 300);
+
+        var shuttingDownNodeId = "shutting-down-1";
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                shuttingDownModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsShuttingDown)
+                    .addRoutingEntry(shuttingDownNodeId, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .addNewAssignment(
+                notShuttingDownModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsNotShuttingDown)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .build();
+
+        TrainedModelAssignmentMetadata.Builder rebalanced = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                shuttingDownModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsShuttingDown)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
+            )
+            .addNewAssignment(
+                notShuttingDownModelId,
+                TrainedModelAssignment.Builder.empty(taskParamsNotShuttingDown)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            );
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            rebalanced
+        ).build();
+
+        TrainedModelAssignment shuttingDownAssignment = result.getDeploymentAssignment(shuttingDownModelId);
+        assertThat(shuttingDownAssignment, is(notNullValue()));
+        assertThat(shuttingDownAssignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
+        assertThat(shuttingDownAssignment.getNodeRoutingTable().get(availableNode).getState(), is(RoutingState.STARTING));
+        assertThat(shuttingDownAssignment.getNodeRoutingTable().get(shuttingDownNodeId).getState(), is(RoutingState.STOPPING));
+        assertThat(shuttingDownAssignment.getReason().isPresent(), is(false));
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(notShuttingDownModelId);
+        assertThat(assignment, is(notNullValue()));
+        // assignment state is set to starting by default
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
+        assertThat(assignment.getNodeRoutingTable().get(availableNode).getState(), is(RoutingState.STARTED));
+        assertThat(assignment.getNodeRoutingTable().get(shuttingDownNodeId), is(nullValue()));
+        assertThat(assignment.getReason().isPresent(), is(false));
+    }
+
+    public
+        void
+        testSetShuttingDownNodeRoutesToStopping_GivenShuttingDownNodeWithNoAssociatedAssignments_ItDoesNotMarkAnyAssignmentsAsStopping() {
+        var availableNode = "node-1";
+
+        var shuttingDownNodeId = "shutting-down-1";
+        var modelId = "id1";
+        StartTrainedModelDeploymentAction.TaskParams taskParamsShuttingDown = newParams(modelId, 300);
+
+        var disappearingNodeId = "disappearingNode";
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                modelId,
+                TrainedModelAssignment.Builder.empty(taskParamsShuttingDown)
+                    .addRoutingEntry(disappearingNodeId, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .build();
+
+        TrainedModelAssignmentMetadata.Builder rebalanced = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                modelId,
+                TrainedModelAssignment.Builder.empty(taskParamsShuttingDown)
+                    .addRoutingEntry(availableNode, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            );
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            rebalanced
+        ).build();
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
+        assertThat(assignment, is(notNullValue()));
+        // assignment state is set to starting by default
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
+        assertThat(assignment.getNodeRoutingTable().get(availableNode).getState(), is(RoutingState.STARTED));
+        assertThat(assignment.getNodeRoutingTable().get(shuttingDownNodeId), is(nullValue()));
+        assertThat(assignment.getNodeRoutingTable().get(disappearingNodeId), is(nullValue()));
+        assertThat(assignment.getReason().isPresent(), is(false));
+    }
+
+    public void testSetShuttingDownNodeRoutesToStopping_GivenAssignmentDoesNotExist_ItSetsAssignmentStateToStoppingAndRouteToStopping() {
+        var shuttingDownNodeId = "shutting-down-1";
+        var modelId = "id1";
+        StartTrainedModelDeploymentAction.TaskParams taskParamsShuttingDown = newParams(modelId, 300);
+
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                modelId,
+                TrainedModelAssignment.Builder.empty(taskParamsShuttingDown)
+                    .addRoutingEntry(shuttingDownNodeId, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .build();
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            TrainedModelAssignmentMetadata.Builder.empty()
+        ).build();
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
+        assertThat(assignment, is(notNullValue()));
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STOPPING));
+        assertThat(assignment.getNodeRoutingTable().get(shuttingDownNodeId).getState(), is(RoutingState.STOPPING));
+        assertThat(assignment.getReason().isPresent(), is(true));
+        assertThat(assignment.getReason().get(), is("nodes changed"));
+    }
+
+    private static ClusterState createClusterState(List<String> nodeIds, Metadata metadata) {
+        DiscoveryNode[] nodes = nodeIds.stream()
+            .map(id -> buildNode(id, true, ByteSizeValue.ofGb(4).getBytes(), 8))
+            .toArray(DiscoveryNode[]::new);
+
+        ClusterState.Builder csBuilder = csBuilderWithNodes("test", nodes);
+        nodeIds.forEach(id -> csBuilder.putTransportVersion(id, TransportVersion.current()));
+
+        return csBuilder.metadata(metadata).build();
+    }
+
+    private static ClusterState.Builder csBuilderWithNodes(String name, DiscoveryNode... nodes) {
         var csBuilder = ClusterState.builder(new ClusterName(name));
         var nodeBuilder = DiscoveryNodes.builder();
         for (var node : nodes) {
@@ -1440,6 +1830,20 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         assertThat(
             TrainedModelAssignmentMetadata.fromState(modified).getDeploymentAssignment(modelId).getAssignmentState(),
             equalTo(AssignmentState.STOPPING)
+        );
+    }
+
+    static NodesShutdownMetadata shutdownMetadata(String nodeId) {
+        return new NodesShutdownMetadata(
+            Collections.singletonMap(
+                nodeId,
+                SingleNodeShutdownMetadata.builder()
+                    .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                    .setStartedAtMillis(randomNonNegativeLong())
+                    .setReason("tests")
+                    .setNodeId(nodeId)
+                    .build()
+            )
         );
     }
 
@@ -1542,17 +1946,4 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         );
     }
 
-    private static NodesShutdownMetadata shutdownMetadata(String nodeId) {
-        return new NodesShutdownMetadata(
-            Collections.singletonMap(
-                nodeId,
-                SingleNodeShutdownMetadata.builder()
-                    .setType(SingleNodeShutdownMetadata.Type.REMOVE)
-                    .setStartedAtMillis(randomNonNegativeLong())
-                    .setReason("tests")
-                    .setNodeId(nodeId)
-                    .build()
-            )
-        );
-    }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
@@ -39,11 +39,18 @@ public class TrainedModelDeploymentTaskTests extends ESTestCase {
         TrainedModelAssignmentNodeService nodeService = mock(TrainedModelAssignmentNodeService.class);
 
         ArgumentCaptor<TrainedModelDeploymentTask> taskCaptor = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
-        ArgumentCaptor<String> reasonCaptur = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> reasonCaptor = ArgumentCaptor.forClass(String.class);
         doAnswer(invocation -> {
-            taskCaptor.getValue().markAsStopped(reasonCaptur.getValue());
+            taskCaptor.getValue().markAsStopped(reasonCaptor.getValue());
             return null;
-        }).when(nodeService).stopDeploymentAndNotify(taskCaptor.capture(), reasonCaptur.capture(), any());
+        }).when(nodeService).stopDeploymentAndNotify(taskCaptor.capture(), reasonCaptor.capture(), any());
+
+        ArgumentCaptor<TrainedModelDeploymentTask> taskCaptorGraceful = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
+        ArgumentCaptor<String> reasonCaptorGraceful = ArgumentCaptor.forClass(String.class);
+        doAnswer(invocation -> {
+            taskCaptorGraceful.getValue().markAsStopped(reasonCaptorGraceful.getValue());
+            return null;
+        }).when(nodeService).gracefullyStopDeploymentAndNotify(taskCaptorGraceful.capture(), reasonCaptorGraceful.capture(), any());
 
         TrainedModelDeploymentTask task = new TrainedModelDeploymentTask(
             0,
@@ -77,7 +84,11 @@ public class TrainedModelDeploymentTaskTests extends ESTestCase {
     }
 
     public void testOnStop() {
-        assertTrackingComplete(t -> t.stop("foo", ActionListener.noop()), randomAlphaOfLength(10), randomAlphaOfLength(10));
+        assertTrackingComplete(t -> t.stop("foo", false, ActionListener.noop()), randomAlphaOfLength(10), randomAlphaOfLength(10));
+    }
+
+    public void testOnStopGracefully() {
+        assertTrackingComplete(t -> t.stop("foo", true, ActionListener.noop()), randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public void testCancelled() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
@@ -40,7 +40,7 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         ProcessWorkerExecutorService executor = createExecutorService();
 
         threadPool.generic().execute(executor::start);
-        executor.shutdown();
+        executor.shutdownNow();
         AtomicBoolean rejected = new AtomicBoolean(false);
         AtomicBoolean initialized = new AtomicBoolean(false);
         executor.execute(new AbstractInitializableRunnable() {
@@ -106,9 +106,9 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         boolean shutdownWithError = randomBoolean();
         // now shutdown
         if (shutdownWithError) {
-            executor.shutdownWithError(new ElasticsearchException("stopping the executor because an error occurred"));
+            executor.shutdownNowWithError(new ElasticsearchException("stopping the executor because an error occurred"));
         } else {
-            executor.shutdown();
+            executor.shutdownNow();
         }
         latch.countDown();
         executorFinished.get();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicatorTests.java
@@ -206,7 +206,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         communicator.killProcess(awaitCompletion, finish);
         verify(resultProcessor).setProcessKilled();
         verify(process).kill(awaitCompletion);
-        verify(executorService).shutdown();
+        verify(executorService).shutdownNow();
         if (awaitCompletion) {
             verify(resultProcessor).awaitCompletion();
         } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[ML] Safely drain deployment request queues before allowing node to shutdown (#98406)](https://github.com/elastic/elasticsearch/pull/98406)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)