### PR TITLE
[8.10] [Doc] Add links to the new API key based remote cluster page (#99115)

### DIFF
--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -69,7 +69,7 @@ Refer to <<skip-unavailable-clusters>>.
     mode is configured.
 
 `cluster_credentials`::
-// TODO: fix the link to new page of API key based remote clusters
 beta:[]
-This field presents and has value of `::es_redacted::` only when the remote cluster
-is configured with the API key based model. Otherwise, the field is not present.
+This field presents and has value of `::es_redacted::` only when the
+<<remote-clusters-api-key,remote cluster is configured with the API key based model>>.
+Otherwise, the field is not present.

--- a/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
@@ -65,12 +65,10 @@ mode are described separately.
   is used as the fallback setting.
 
 
-// TODO: fix the link to new page of API key based remote clusters
-
 `cluster.remote.<cluster_alias>.credentials` (<<secure-settings,Secure>>)::
 
 beta:[]
-  Per cluster setting for configuring remote clusters with the API Key based model.
+  Per cluster setting for configuring <<remote-clusters-api-key,remote clusters with the API Key based model>>.
   This setting takes the encoded value of a
   <<security-api-create-cross-cluster-api-key,cross-cluster API key>> and must be set
   in the <<secure-settings,{es} keystore>> on each node in the cluster.

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -2569,6 +2569,7 @@ beta::[]
 
 :ssl-prefix:             xpack.security.remote_cluster_server
 :component:              Remote cluster server (API key based model)
+:enabled-by-default:
 :client-auth-default:    none
 :verifies!:
 :server:
@@ -2584,6 +2585,7 @@ beta::[]
 
 :ssl-prefix:             xpack.security.remote_cluster_client
 :component:              Remote cluster client (API key based model)
+:enabled-by-default:
 :client-auth-default:    none
 :verifies:
 :server!:
@@ -2636,13 +2638,14 @@ List of IP addresses to allow for this profile.
 (<<dynamic-cluster-setting,Dynamic>>)
 List of IP addresses to deny for this profile.
 
-// TODO: fix the link to new page of API key based remote clusters
 `xpack.security.remote_cluster.filter.allow`::
 (<<dynamic-cluster-setting,Dynamic>>)
-beta:[] List of IP addresses to allow just for the remote cluster server.
+beta:[] List of IP addresses to allow just for the
+<<remote-clusters-api-key,remote cluster server configured with the API key based model>>.
 
 `xpack.security.remote_cluster.filter.deny`::
 (<<dynamic-cluster-setting,Dynamic>>)
-beta:[] List of IP addresses to deny just for the remote cluster server.
+beta:[] List of IP addresses to deny just for the remote cluster server configured with
+the <<remote-clusters-api-key,API key based model>>.
 
 include::security-hash-settings.asciidoc[]

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -1,11 +1,15 @@
 ==== {component} TLS/SSL settings
 You can configure the following TLS/SSL settings.
 
-ifdef::server[]
 +{ssl-prefix}.ssl.enabled+::
 (<<static-cluster-setting,Static>>)
-Used to enable or disable TLS/SSL on the {ssl-layer}. The default is `false`.
-endif::server[]
+Used to enable or disable TLS/SSL on the {ssl-layer}.
+ifdef::enabled-by-default[]
+The default is `true`.
+endif::enabled-by-default[]
+ifndef::enabled-by-default[]
+The default is `false`.
+endif::enabled-by-default[]
 
 +{ssl-prefix}.ssl.supported_protocols+::
 (<<static-cluster-setting,Static>>)

--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -69,8 +69,8 @@ without requiring basic authentication:
 * <<security-api-update-api-key,Update REST API key>>
 * <<security-api-bulk-update-api-keys,Bulk update REST API keys>>
 
-Use the following APIs to create and update cross-cluster API keys for
-API key based remote cluster access:
+beta:[] Use the following APIs to create and update cross-cluster API keys for
+<<remote-clusters-api-key,API key based remote cluster access>>:
 
 * <<security-api-create-cross-cluster-api-key,Create Cross-Cluster API key>>
 * <<security-api-update-cross-cluster-api-key,Update Cross-Cluster API key>>

--- a/x-pack/docs/en/rest-api/security/create-cross-cluster-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-cross-cluster-api-key.asciidoc
@@ -8,7 +8,7 @@ beta::[]
 <titleabbrev>Create Cross-Cluster API key</titleabbrev>
 ++++
 
-Creates an API key of the `cross_cluster` type for the API key based remote cluster access.
+Creates an API key of the `cross_cluster` type for the <<remote-clusters-api-key,API key based remote cluster>> access.
 A `cross_cluster` API key cannot be used to authenticate through the REST interface.
 On the contrary, a <<security-api-create-api-key,REST API key>> is meant to be used through the REST interface
 and cannot be used for the API key based remote cluster access.

--- a/x-pack/docs/en/rest-api/security/create-roles.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-roles.asciidoc
@@ -77,9 +77,8 @@ For more information, see
 `remote_indices`:: beta:[] (list) A list of remote indices permissions entries.
 +
 --
-// TODO: fix the link to new page of API key based remote clusters
-NOTE: Remote indices are effective for remote clusters configured with the API key based model.
-They have no effect for remote clusters configured with the certificate based model.
+NOTE: Remote indices are effective for <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
+They have no effect for remote clusters configured with the <<remote-clusters-cert,certificate based model>>.
 --
 `clusters` (required)::: (list) A list of cluster aliases to which the permissions
 in this entry apply.

--- a/x-pack/docs/en/rest-api/security/update-cross-cluster-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/update-cross-cluster-api-key.asciidoc
@@ -8,7 +8,7 @@ beta::[]
 <titleabbrev>Update Cross-Cluster API key</titleabbrev>
 ++++
 
-Update an existing cross-cluster API Key.
+Update an existing cross-cluster API Key that is used for <<remote-clusters-api-key,API key based remote cluster>> access.
 
 
 [[security-api-update-cross-cluster-api-key-request]]

--- a/x-pack/docs/en/security/authorization/managing-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/managing-roles.asciidoc
@@ -31,10 +31,9 @@ A role is defined by the following JSON structure:
 <4> A list of indices permissions entries. This field is optional (missing `indices`
     privileges effectively mean no index level permissions).
 <5> A list of application privilege entries. This field is optional.
-// TODO: fix the link to new page of API key based remote clusters
 <6> beta:[]
     A list of indices permissions entries for
-    <<remote-clusters,remote clusters configured with the API key based model>>.
+    <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
     This field is optional (missing `remote_indices` privileges effectively mean
     no index level permissions for any API key based remote clusters).
 
@@ -168,8 +167,7 @@ no effect, and will not grant any actions in the
 
 beta::[]
 
-// TODO: fix the link to new page of API key based remote clusters
-For remote clusters configured with the API key based model, remote indices privileges
+For <<remote-clusters-api-key,remote clusters configured with the API key based model>>, remote indices privileges
 can be used to specify desired indices privileges for matching remote clusters. The final
 effective index privileges will be an intersection of the remote indices privileges
 and the <<security-api-create-cross-cluster-api-key,cross-cluster API key>>'s indices privileges.

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -21,7 +21,7 @@ Privileges to create snapshots for existing repositories. Can also list and view
 details on existing repositories and snapshots.
 
 `cross_cluster_replication`::
-beta:[] Privileges to connect to remote clusters configured with the API key based model
+beta:[] Privileges to connect to <<remote-clusters-api-key,remote clusters configured with the API key based model>>
 for cross-cluster replication.
 +
 --
@@ -32,7 +32,7 @@ to manage cross-cluster API keys.
 --
 
 `cross_cluster_search`::
-beta:[] Privileges to connect to remote clusters configured with the API key based model
+beta:[] Privileges to connect to <<remote-clusters-api-key,remote clusters configured with the API key based model>>
 for cross-cluster search.
 +
 --
@@ -301,13 +301,14 @@ requires the `manage` privilege as well, on both the index and the aliases
 names.
 
 `cross_cluster_replication`::
-beta:[] Privileges to perform cross-cluster replication for indices located on remote clusters
-configured with the API key based model. This privilege should only be used for
+beta:[] Privileges to perform cross-cluster replication for indices located on
+<<remote-clusters-api-key,remote clusters configured with the API key based model>>.
+This privilege should only be used for
 the `privileges` field of <<roles-remote-indices-priv,remote indices privileges>>.
 
 `cross_cluster_replication_internal`::
-beta:[] Privileges to perform supporting actions for cross-cluster replication from remote clusters
-configured with the API key based model.
+beta:[] Privileges to perform supporting actions for cross-cluster replication from
+<<remote-clusters-api-key,remote clusters configured with the API key based model>>.
 +
 --
 NOTE: This privilege should _not_ be directly granted. It is used internally by


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [Doc] Add links to the new API key based remote cluster page (#99115)