### PR TITLE
[8.10] _health_report SLM indicator should use the policy ID (not the name) (#99111)

### DIFF
--- a/docs/changelog/99111.yaml
+++ b/docs/changelog/99111.yaml
@@ -1,0 +1,5 @@
+pr: 99111
+summary: '`_health_report` slm indicator should use the policy id (not the name)'
+area: Health
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
@@ -157,8 +157,8 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         return policy;
     }
 
-    public String getName() {
-        return policy.getName();
+    public String getId() {
+        return policy.getId();
     }
 
     public long getVersion() {

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -134,7 +134,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                 .values()
                 .stream()
                 .filter(metadata -> snapshotFailuresExceedWarningCount(failedSnapshotWarnThreshold, metadata))
-                .sorted(Comparator.comparing(SnapshotLifecyclePolicyMetadata::getName))
+                .sorted(Comparator.comparing(SnapshotLifecyclePolicyMetadata::getId))
                 .toList();
 
             if (unhealthyPolicies.size() > 0) {
@@ -152,7 +152,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                 String unhealthyPolicyCauses = unhealthyPolicies.stream()
                     .map(
                         policy -> "- ["
-                            + policy.getName()
+                            + policy.getId()
                             + "] had ["
                             + policy.getInvocationsSinceLastSuccess()
                             + "] repeated failures without successful execution"
@@ -166,7 +166,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                     : "An automated snapshot policy is unhealthy:\n") + unhealthyPolicyCauses;
 
                 String unhealthyPolicyActions = unhealthyPolicies.stream()
-                    .map(policy -> "- GET /_slm/policy/" + policy.getPolicy().getId() + "?human")
+                    .map(policy -> "- GET /_slm/policy/" + policy.getId() + "?human")
                     .collect(Collectors.joining("\n"));
                 String action = "Check the snapshot lifecycle "
                     + (unhealthyPolicies.size() > 1 ? "policies" : "policy")
@@ -185,7 +185,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                                 new Diagnosis.Resource(
                                     Diagnosis.Resource.Type.SLM_POLICY,
                                     unhealthyPolicies.stream()
-                                        .map(SnapshotLifecyclePolicyMetadata::getName)
+                                        .map(SnapshotLifecyclePolicyMetadata::getId)
                                         .limit(Math.min(unhealthyPolicies.size(), maxAffectedResourcesCount))
                                         .toList()
                                 )
@@ -242,7 +242,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                         unhealthyPolicies.stream()
                             .collect(
                                 Collectors.toMap(
-                                    SnapshotLifecyclePolicyMetadata::getName,
+                                    SnapshotLifecyclePolicyMetadata::getId,
                                     SnapshotLifecyclePolicyMetadata::getInvocationsSinceLastSuccess
                                 )
                             )

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
@@ -181,7 +181,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                 Map.of(
                     "test-policy",
                     SnapshotLifecyclePolicyMetadata.builder()
-                        .setPolicy(new SnapshotLifecyclePolicy("policy-id-1", "test-policy", "", "test-repository", null, null))
+                        .setPolicy(new SnapshotLifecyclePolicy("test-policy", "<test-policy-{now/d}>", "", "test-repository", null, null))
                         .setVersion(1L)
                         .setModifiedDate(System.currentTimeMillis())
                         .setLastSuccess(snapshotInvocation(execTime, execTime + 1000L))
@@ -191,7 +191,14 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     "test-policy-without-any-success",
                     SnapshotLifecyclePolicyMetadata.builder()
                         .setPolicy(
-                            new SnapshotLifecyclePolicy("policy-id-2", "test-policy-without-any-success", "", "test-repository", null, null)
+                            new SnapshotLifecyclePolicy(
+                                "test-policy-without-any-success",
+                                "<test-policy-{now/d}>",
+                                "",
+                                "test-repository",
+                                null,
+                                null
+                            )
                         )
                         .setVersion(1L)
                         .setModifiedDate(System.currentTimeMillis())
@@ -203,8 +210,8 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     SnapshotLifecyclePolicyMetadata.builder()
                         .setPolicy(
                             new SnapshotLifecyclePolicy(
-                                "policy-id-3",
                                 "test-policy-without-success-start-time",
+                                "<test-policy-{now/d}>",
                                 "",
                                 "test-repository",
                                 null,
@@ -280,9 +287,9 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                                     + failedInvocations3
                                     + "] repeated failures without successful execution",
                                 "Check the snapshot lifecycle policies for detailed failure info:\n"
-                                    + "- GET /_slm/policy/policy-id-1?human\n"
-                                    + "- GET /_slm/policy/policy-id-2?human\n"
-                                    + "- GET /_slm/policy/policy-id-3?human"
+                                    + "- GET /_slm/policy/test-policy?human\n"
+                                    + "- GET /_slm/policy/test-policy-without-any-success?human\n"
+                                    + "- GET /_slm/policy/test-policy-without-success-start-time?human"
 
                             ),
                             List.of(


### PR DESCRIPTION
Backports the following commits to 8.10:
 - _health_report slm indicator should use the policy id (not the name) (#99111)