### PR TITLE
ESQL: Improve signature gen ergonomics

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -56,7 +56,7 @@ sourceSets.main.java {
 }
 
 tasks.getByName('test') {
-  if (BuildParams.isCi() == false && filter.includePatterns.isEmpty() && filter.excludePatterns.isEmpty()) {
+  if (BuildParams.isCi() == false) {
     systemProperty 'generateDocs', true
     doFirst {
       project.delete(

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -64,8 +64,8 @@ tasks.getByName('test') {
       )
     }
     doLast {
-      List signatures = file("${projectDir}/build/testrun/test/temp/esql/functions/signature").list()
-      List types = file("${projectDir}/build/testrun/test/temp/esql/functions/signature").list()
+      List signatures = file("${projectDir}/build/testrun/test/temp/esql/functions/signature").list().findAll {it.endsWith("svg")}
+      List types = file("${projectDir}/build/testrun/test/temp/esql/functions/types").list().findAll {it.endsWith("asciidoc")}
       int count = signatures == null ? 0 : signatures.size()
       if (count == 0) {
         logger.quiet("ESQL Docs: No function signatures created. Skipping sync.")

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -56,7 +56,7 @@ sourceSets.main.java {
 }
 
 tasks.getByName('test') {
-  if (BuildParams.isCi() == false) {
+  if (BuildParams.isCi() == false && filter.includePatterns.isEmpty() && filter.excludePatterns.isEmpty()) {
     systemProperty 'generateDocs', true
     doFirst {
       project.delete(
@@ -64,12 +64,29 @@ tasks.getByName('test') {
       )
     }
     doLast {
-      project.sync {
-        from "${projectDir}/build/testrun/test/temp/esql/functions"
-        into "${rootDir}/docs/reference/esql/functions"
-        include '**/*.asciidoc', '**/*.svg'
-        preserve {
-          include '/*.asciidoc'
+      List signatures = file("${projectDir}/build/testrun/test/temp/esql/functions/signature").list()
+      List types = file("${projectDir}/build/testrun/test/temp/esql/functions/signature").list()
+      int count = signatures == null ? 0 : signatures.size()
+      if (count == 0) {
+        logger.quiet("ESQL Docs: No function signatures created. Skipping sync.")
+      } else if (count == 1) {
+        logger.quiet("ESQL Docs: Only updated $signatures and $types, patching them into place")
+        project.sync {
+          from "${projectDir}/build/testrun/test/temp/esql/functions"
+          into "${rootDir}/docs/reference/esql/functions"
+          include '**/*.asciidoc', '**/*.svg'
+          preserve {
+            include '/*.asciidoc', '**/*.asciidoc', '**/*.svg'
+          }
+        }
+      } else {
+        project.sync {
+          from "${projectDir}/build/testrun/test/temp/esql/functions"
+          into "${rootDir}/docs/reference/esql/functions"
+          include '**/*.asciidoc', '**/*.svg'
+          preserve {
+            include '/*.asciidoc'
+          }
         }
       }
     }


### PR DESCRIPTION
Changes the behavior of syncing generated function signatures:
1. If the test run didn't generate any signatures, don't sync anything. This prevents stuff like `./gradlew test --tests "*Csv*"` from blowing away all of the signatures.
2. If there's a single test signature just copy it into the list without blowing away the others. This means that `./gradlew test --tests "*Ceil*"` will patch your new signature into place.
3. If there is more than one signature then sync the directories as before. That way adding or removing functions will remove the generated signatures.

This should make it so the function signature work is *mostly* invisible to users. It's not perfect - if you generate two signatues it'll make a bit of a mess, but that's pretty rare.
