### PR TITLE
[DFA] Make analytics destination index allowed settings customizable at a plugin level

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/DefaultMachineLearningExtension.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/DefaultMachineLearningExtension.java
@@ -7,7 +7,21 @@
 
 package org.elasticsearch.xpack.ml;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.index.mapper.MapperService;
+
 public class DefaultMachineLearningExtension implements MachineLearningExtension {
+
+    public static final String[] ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS = {
+        IndexMetadata.SETTING_NUMBER_OF_SHARDS,
+        IndexMetadata.SETTING_NUMBER_OF_REPLICAS,
+        MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(),
+        MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey(),
+        MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(),
+        MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING.getKey(),
+        MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING.getKey(),
+        MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING.getKey() };
+
     @Override
     public boolean useIlm() {
         return true;
@@ -31,5 +45,10 @@ public class DefaultMachineLearningExtension implements MachineLearningExtension
     @Override
     public boolean isNlpEnabled() {
         return true;
+    }
+
+    @Override
+    public String[] getAnalyticsDestIndexAllowedSettings() {
+        return ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1160,7 +1160,8 @@ public class MachineLearning extends Plugin
             dataFrameAnalyticsAuditor,
             indexNameExpressionResolver,
             resultsPersisterService,
-            modelLoadingService
+            modelLoadingService,
+            machineLearningExtension.get().getAnalyticsDestIndexAllowedSettings()
         );
         this.dataFrameAnalyticsManager.set(dataFrameAnalyticsManager);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtension.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtension.java
@@ -23,5 +23,7 @@ public interface MachineLearningExtension {
 
     boolean isNlpEnabled();
 
-    String[] getAnalyticsDestIndexAllowedSettings();
+    default String[] getAnalyticsDestIndexAllowedSettings() {
+        return DefaultMachineLearningExtension.ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS;
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtension.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtension.java
@@ -22,4 +22,6 @@ public interface MachineLearningExtension {
     boolean isDataFrameAnalyticsEnabled();
 
     boolean isNlpEnabled();
+
+    String[] getAnalyticsDestIndexAllowedSettings();
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/ReindexingStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/ReindexingStep.java
@@ -60,6 +60,7 @@ public class ReindexingStep extends AbstractDataFrameAnalyticsStep {
     private static final Logger LOGGER = LogManager.getLogger(ReindexingStep.class);
 
     private final ClusterService clusterService;
+    private final String[] destIndexAllowedSettings;
     @Nullable
     private volatile Long reindexingTaskId;
     private volatile boolean isReindexingFinished;
@@ -69,10 +70,12 @@ public class ReindexingStep extends AbstractDataFrameAnalyticsStep {
         NodeClient client,
         DataFrameAnalyticsTask task,
         DataFrameAnalyticsAuditor auditor,
-        DataFrameAnalyticsConfig config
+        DataFrameAnalyticsConfig config,
+        String[] destIndexAllowedSettings
     ) {
         super(client, task, auditor, config);
         this.clusterService = Objects.requireNonNull(clusterService);
+        this.destIndexAllowedSettings = Objects.requireNonNull(destIndexAllowedSettings);
     }
 
     @Override
@@ -208,7 +211,13 @@ public class ReindexingStep extends AbstractDataFrameAnalyticsStep {
                     Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX, config.getDest().getIndex())
                 );
                 LOGGER.info("[{}] Creating destination index [{}]", config.getId(), config.getDest().getIndex());
-                DestinationIndex.createDestinationIndex(parentTaskClient, Clock.systemUTC(), config, copyIndexCreatedListener);
+                DestinationIndex.createDestinationIndex(
+                    parentTaskClient,
+                    Clock.systemUTC(),
+                    config,
+                    destIndexAllowedSettings,
+                    copyIndexCreatedListener
+                );
             } else {
                 copyIndexCreatedListener.onFailure(e);
             }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -281,6 +281,8 @@ public class MachineLearningTests extends ESTestCase {
 
     public static class MlTestExtension implements MachineLearningExtension {
 
+        public static final String[] ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS = {};
+
         private final boolean useIlm;
         private final boolean includeNodeInfo;
         private final boolean isAnomalyDetectionEnabled;
@@ -324,6 +326,11 @@ public class MachineLearningTests extends ESTestCase {
         @Override
         public boolean isNlpEnabled() {
             return isNlpEnabled;
+        }
+
+        @Override
+        public String[] getAnalyticsDestIndexAllowedSettings() {
+            return ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS;
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -62,6 +62,7 @@ import java.util.Map;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
+import static org.elasticsearch.xpack.ml.DefaultMachineLearningExtension.ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -332,6 +333,7 @@ public class DestinationIndexTests extends ESTestCase {
                 client,
                 clock,
                 config,
+                ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS,
                 ActionListener.wrap(
                     response -> fail("should not succeed"),
                     e -> assertThat(e.getMessage(), Matchers.matchesRegex(finalErrorMessage))
@@ -341,7 +343,13 @@ public class DestinationIndexTests extends ESTestCase {
             return null;
         }
 
-        DestinationIndex.createDestinationIndex(client, clock, config, ActionTestUtils.assertNoFailureListener(response -> {}));
+        DestinationIndex.createDestinationIndex(
+            client,
+            clock,
+            config,
+            ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS,
+            ActionTestUtils.assertNoFailureListener(response -> {})
+        );
 
         GetSettingsRequest capturedGetSettingsRequest = getSettingsRequestCaptor.getValue();
         assertThat(capturedGetSettingsRequest.indices(), equalTo(SOURCE_INDEX));
@@ -569,6 +577,7 @@ public class DestinationIndexTests extends ESTestCase {
             client,
             clock,
             config,
+            ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS,
             ActionListener.wrap(
                 response -> fail("should not succeed"),
                 e -> assertThat(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameAnalyticsManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameAnalyticsManagerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 
+import static org.elasticsearch.xpack.ml.DefaultMachineLearningExtension.ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
@@ -34,7 +35,8 @@ public class DataFrameAnalyticsManagerTests extends ESTestCase {
             mock(DataFrameAnalyticsAuditor.class),
             mock(IndexNameExpressionResolver.class),
             mock(ResultsPersisterService.class),
-            mock(ModelLoadingService.class)
+            mock(ModelLoadingService.class),
+            ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS
         );
         assertThat(manager.isNodeShuttingDown(), is(false));
 


### PR DESCRIPTION
This PR makes the list of settings allowed when creating destination index customizable at a plugin level.

Marking `>non-issue` as there is no change in behavior.