### PR TITLE
[buildkite] Migrate DRA workflows

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -59,7 +59,7 @@ if [[ "${USE_LUCENE_SNAPSHOT_CREDS:-}" == "true" ]]; then
   unset data
 fi
 
-if [[ "$USE_DRA_CREDENTIALS" == "true" ]]; then
+if [[ "${USE_DRA_CREDENTIALS:-}" == "true" ]]; then
   DRA_VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
   export DRA_VAULT_ROLE_ID_SECRET
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -58,3 +58,14 @@ if [[ "${USE_LUCENE_SNAPSHOT_CREDS:-}" == "true" ]]; then
 
   unset data
 fi
+
+if [[ "$USE_DRA_CREDENTIALS" == "true" ]]; then
+  DRA_VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
+  export DRA_VAULT_ROLE_ID_SECRET
+
+  DRA_VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
+  export DRA_VAULT_SECRET_ID_SECRET
+
+  DRA_VAULT_ADDR=https://secrets.elastic.co:8200
+  export DRA_VAULT_ADDR
+fi

--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -1,0 +1,9 @@
+steps:
+  - command: .buildkite/scripts/dra-workflow.sh
+    env:
+      USE_DRA_CREDENTIALS: "true"
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -4,6 +4,6 @@ steps:
       USE_DRA_CREDENTIALS: "true"
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/branches.sh
+++ b/.buildkite/scripts/branches.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This determines which branches will have pipelines triggered periodically, for dra workflows.
+BRANCHES=( $(cat branches.json | jq -r '.branches[].branch') )

--- a/.buildkite/scripts/dra-update-staging.sh
+++ b/.buildkite/scripts/dra-update-staging.sh
@@ -43,7 +43,7 @@ steps:
     label: Trigger DRA staging workflow for $BRANCH
     async: true
     build:
-      branch: $BRANCH
+      branch: "$BRANCH"
       env:
         DRA_WORKFLOW: staging
 EOF

--- a/.buildkite/scripts/dra-update-staging.sh
+++ b/.buildkite/scripts/dra-update-staging.sh
@@ -2,42 +2,50 @@
 
 set -euo pipefail
 
-WORKFLOW="${DRA_WORKFLOW:-snapshot}"
+source .buildkite/scripts/branches.sh
 
-# Don't publish main branch to staging
-if [[ "$BUILDKITE_BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
-  exit 0
-fi
+for BRANCH in "${BRANCHES[@]}"; do
+  # Don't publish main branch to staging
+  if [[ "$BRANCH" == "main" ]]; then
+    continue
+  fi
 
-RM_BRANCH="$BUILDKITE_BRANCH"
-if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
-  RM_BRANCH=master
-fi
+  echo "--- Checking $BRANCH"
 
-BEATS_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/beats/latest/${RM_BRANCH}.json" | jq -r '.manifest_url')
-ML_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/ml-cpp/latest/${RM_BRANCH}.json" | jq -r '.manifest_url')
-ES_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/elasticsearch/latest/${RM_BRANCH}.json" | jq -r '.manifest_url')
+  BEATS_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/beats/latest/${BRANCH}.json" | jq -r '.manifest_url')
+  ML_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/ml-cpp/latest/${BRANCH}.json" | jq -r '.manifest_url')
+  ES_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/elasticsearch/latest/${BRANCH}.json" | jq -r '.manifest_url')
 
-ES_BEATS_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "beats") | .build_uri')
-ES_ML_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "ml-cpp") | .build_uri')
+  ES_BEATS_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "beats") | .build_uri')
+  ES_ML_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "ml-cpp") | .build_uri')
 
-SHOULD_TRIGGER=""
+  SHOULD_TRIGGER=""
 
-if [ "$BEATS_MANIFEST" = "$ES_BEATS_DEPENDENCY" ]; then
-  echo "ES has the latest beats"
-else
-  echo "Need to trigger a build, $BEATS_MANIFEST available but ES has $ES_BEATS_DEPENDENCY"
-  SHOULD_TRIGGER=true
-fi
+  if [ "$BEATS_MANIFEST" = "$ES_BEATS_DEPENDENCY" ]; then
+    echo "ES has the latest beats"
+  else
+    echo "Need to trigger a build, $BEATS_MANIFEST available but ES has $ES_BEATS_DEPENDENCY"
+    SHOULD_TRIGGER=true
+  fi
 
-if [ "$ML_MANIFEST" = "$ES_ML_DEPENDENCY" ]; then
-  echo "ES has the latest ml-cpp"
-else
-  echo "Need to trigger a build, $ML_MANIFEST available but ES has $ES_ML_DEPENDENCY"
-  SHOULD_TRIGGER=true
-fi
+  if [ "$ML_MANIFEST" = "$ES_ML_DEPENDENCY" ]; then
+    echo "ES has the latest ml-cpp"
+  else
+    echo "Need to trigger a build, $ML_MANIFEST available but ES has $ES_ML_DEPENDENCY"
+    SHOULD_TRIGGER=true
+  fi
 
-if [[ "$SHOULD_TRIGGER" == "true" ]]; then
-  # TODO do it
-  echo 1
-fi
+  if [[ "$SHOULD_TRIGGER" == "true" ]]; then
+    echo "Triggering DRA staging workflow for $BRANCH"
+    cat << EOF | buildkite-agent pipeline upload
+steps:
+  - trigger: elasticsearch-dra-workflow
+    label: Trigger DRA staging workflow for $BRANCH
+    async: true
+    build:
+      branch: $BRANCH
+      env:
+        DRA_WORKFLOW: staging
+EOF
+  fi
+done

--- a/.buildkite/scripts/dra-update-staging.sh
+++ b/.buildkite/scripts/dra-update-staging.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+WORKFLOW="${DRA_WORKFLOW:-snapshot}"
+
+# Don't publish main branch to staging
+if [[ "$BUILDKITE_BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
+  exit 0
+fi
+
+RM_BRANCH="$BUILDKITE_BRANCH"
+if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+  RM_BRANCH=master
+fi
+
+BEATS_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/beats/latest/${RM_BRANCH}.json" | jq -r '.manifest_url')
+ML_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/ml-cpp/latest/${RM_BRANCH}.json" | jq -r '.manifest_url')
+ES_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/elasticsearch/latest/${RM_BRANCH}.json" | jq -r '.manifest_url')
+
+ES_BEATS_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "beats") | .build_uri')
+ES_ML_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "ml-cpp") | .build_uri')
+
+SHOULD_TRIGGER=""
+
+if [ "$BEATS_MANIFEST" = "$ES_BEATS_DEPENDENCY" ]; then
+  echo "ES has the latest beats"
+else
+  echo "Need to trigger a build, $BEATS_MANIFEST available but ES has $ES_BEATS_DEPENDENCY"
+  SHOULD_TRIGGER=true
+fi
+
+if [ "$ML_MANIFEST" = "$ES_ML_DEPENDENCY" ]; then
+  echo "ES has the latest ml-cpp"
+else
+  echo "Need to trigger a build, $ML_MANIFEST available but ES has $ES_ML_DEPENDENCY"
+  SHOULD_TRIGGER=true
+fi
+
+if [[ "$SHOULD_TRIGGER" == "true" ]]; then
+  # TODO do it
+  echo 1
+fi

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 WORKFLOW="${DRA_WORKFLOW:-snapshot}"
 BRANCH="${BUILDKITE_BRANCH:-}"
-BRANCH=main # TODO remove
 
 # Don't publish main branch to staging
 if [[ "$BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
@@ -74,12 +73,11 @@ find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
 echo --- Running release-manager
 
 # Artifacts should be generated
-# TODO remove echo, fix DRA_VAULT vars
-echo docker run --rm \
+docker run --rm \
   --name release-manager \
   -e VAULT_ADDR="$DRA_VAULT_ADDR" \
-  -e VAULT_ROLE_ID="DRA_VAULT_ROLE_ID_SECRET" \
-  -e VAULT_SECRET_ID="DRA_VAULT_SECRET_ID_SECRET" \
+  -e VAULT_ROLE_ID="$DRA_VAULT_ROLE_ID_SECRET" \
+  -e VAULT_SECRET_ID="$DRA_VAULT_SECRET_ID_SECRET" \
   --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
   docker.elastic.co/infra/release-manager:latest \
   cli collect \

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -36,8 +36,7 @@ BUILD_SNAPSHOT_ARG=""
 
 if [[ "$WORKFLOW" == "staging" ]]; then
   LICENSE_KEY=$(mktemp -d)/license.key
-  # Intentionally leaving this secret here instead of a hook
-  # Since it's getting redirected straight to a file, it's probably even safer to just leave it here rather than stick it in an env var for a short period of time
+  # Notice that only the public key is being read here, which isn't really secret
   vault read -field pubkey secret/ci/elastic-elasticsearch/migrated/license | base64 --decode > "$LICENSE_KEY"
   LICENSE_KEY_ARG="-Dlicense.key=$LICENSE_KEY"
 

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -62,11 +62,12 @@ find "$WORKSPACE" -type f -path "*/build/distributions/*" -exec chmod a+r {} \;
 find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
 
 # Artifacts should be generated
-docker run --rm \
+# TODO remove echo, fix DRA_VAULT vars
+echo docker run --rm \
   --name release-manager \
   -e VAULT_ADDR="$DRA_VAULT_ADDR" \
-  -e VAULT_ROLE_ID="$DRA_VAULT_ROLE_ID_SECRET" \
-  -e VAULT_SECRET_ID="$DRA_VAULT_SECRET_ID_SECRET" \
+  -e VAULT_ROLE_ID="DRA_VAULT_ROLE_ID_SECRET" \
+  -e VAULT_SECRET_ID="DRA_VAULT_SECRET_ID_SECRET" \
   --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
   docker.elastic.co/infra/release-manager:latest \
   cli collect \

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -15,7 +15,7 @@ echo --- Preparing
 
 # TODO move this to image
 sudo apt-get update -y
-sudo apt-get install -y libxml2-utils
+sudo apt-get install -y libxml2-utils python3.10-venv
 
 RM_BRANCH="$BRANCH"
 if [[ "$BRANCH" == "main" ]]; then

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -85,7 +85,7 @@ echo docker run --rm \
   cli collect \
   --project elasticsearch \
   --branch "$RM_BRANCH" \
-  --commit "$GIT_COMMIT" \
+  --commit "$BUILDKITE_COMMIT" \
   --workflow "$WORKFLOW" \
   --version "$ES_VERSION" \
   --artifact-set main \

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -3,14 +3,16 @@
 set -euo pipefail
 
 WORKFLOW="${DRA_WORKFLOW:-snapshot}"
+BRANCH="${BUILDKITE_BRANCH:-}"
+BRANCH=main # TODO remove
 
 # Don't publish main branch to staging
-if [[ "$BUILDKITE_BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
+if [[ "$BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
   exit 0
 fi
 
-RM_BRANCH="$BUILDKITE_BRANCH"
-if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+RM_BRANCH="$BRANCH"
+if [[ "$BRANCH" == "main" ]]; then
   RM_BRANCH=master
 fi
 

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+WORKFLOW="${DRA_WORKFLOW:-snapshot}"
+
+# Don't publish main branch to staging
+if [[ "$BUILDKITE_BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
+  exit 0
+fi
+
+RM_BRANCH="$BUILDKITE_BRANCH"
+if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
+  RM_BRANCH=master
+fi
+
+ES_VERSION=$(grep elasticsearch build-tools-internal/version.properties | sed "s/elasticsearch *= *//g")
+
+VERSION_SUFFIX=""
+if [[ "$WORKFLOW" == "snapshot" ]]; then
+  VERSION_SUFFIX="-SNAPSHOT"
+fi
+
+BEATS_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh beats "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
+ML_CPP_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh ml-cpp "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
+
+LICENSE_KEY_ARG=""
+BUILD_SNAPSHOT_ARG=""
+
+if [[ "$WORKFLOW" == "staging" ]]; then
+  LICENSE_KEY=$(mktemp -d)/license.key
+  # Intentionally leaving this secret here instead of a hook
+  # Since it's getting redirected straight to a file, it's probably even safer to just leave it here rather than stick it in an env var for a short period of time
+  vault read -field pubkey secret/ci/elastic-elasticsearch/migrated/license | base64 --decode > "$LICENSE_KEY"
+  LICENSE_KEY_ARG="-Dlicense.key=$LICENSE_KEY"
+
+  BUILD_SNAPSHOT_ARG="-Dbuild.snapshot=false"
+fi
+
+.ci/scripts/run-gradle.sh -Ddra.artifacts=true \
+  -Ddra.artifacts.dependency.beats="${BEATS_BUILD_ID}" \
+  -Ddra.artifacts.dependency.ml-cpp="${ML_CPP_BUILD_ID}" \
+  -Ddra.workflow="$WORKFLOW" \
+  -Dcsv="$WORKSPACE/build/distributions/dependencies-${ES_VERSION}${VERSION_SUFFIX}.csv" \
+  -Dbuild.snapshot=false \
+  $LICENSE_KEY_ARG \
+  $BUILD_SNAPSHOT_ARG \
+  buildReleaseArtifacts \
+  exportCompressedDockerImages \
+  :distribution:generateDependenciesReport
+
+x-pack/plugin/sql/connectors/tableau/package.sh asm qualifier="$VERSION_SUFFIX"
+
+# we regenerate this file as part of the release manager invocation
+rm "build/distributions/elasticsearch-jdbc-${ES_VERSION}${VERSION_SUFFIX}.taco.sha512"
+
+# Allow other users access to read the artifacts so they are readable in the
+# container
+find "$WORKSPACE" -type f -path "*/build/distributions/*" -exec chmod a+r {} \;
+
+# Allow other users write access to create checksum files
+find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
+
+# Artifacts should be generated
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR="$DRA_VAULT_ADDR" \
+  -e VAULT_ROLE_ID="$DRA_VAULT_ROLE_ID_SECRET" \
+  -e VAULT_SECRET_ID="$DRA_VAULT_SECRET_ID_SECRET" \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
+  docker.elastic.co/infra/release-manager:latest \
+  cli collect \
+  --project elasticsearch \
+  --branch "$RM_BRANCH" \
+  --commit "$GIT_COMMIT" \
+  --workflow "$WORKFLOW" \
+  --version "$ES_VERSION" \
+  --artifact-set main \
+  --dependency "beats:https://artifacts-${WORKFLOW}.elastic.co/beats/${BEATS_BUILD_ID}/manifest-${ES_VERSION}${VERSION_SUFFIX}.json" \
+  --dependency "ml-cpp:https://artifacts-${WORKFLOW}.elastic.co/ml-cpp/${ML_CPP_BUILD_ID}/manifest-${ES_VERSION}${VERSION_SUFFIX}.json"

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -13,6 +13,10 @@ fi
 
 echo --- Preparing
 
+# TODO move this to image
+sudo apt-get update -y
+sudo apt-get install -y libxml2-utils
+
 RM_BRANCH="$BRANCH"
 if [[ "$BRANCH" == "main" ]]; then
   RM_BRANCH=master

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -58,6 +58,7 @@ echo --- Building release artifacts
   exportCompressedDockerImages \
   :distribution:generateDependenciesReport
 
+PATH="$PATH:${JAVA_HOME}/bin" # Required by the following script
 x-pack/plugin/sql/connectors/tableau/package.sh asm qualifier="$VERSION_SUFFIX"
 
 # we regenerate this file as part of the release manager invocation

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -11,6 +11,8 @@ if [[ "$BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
   exit 0
 fi
 
+echo --- Preparing
+
 RM_BRANCH="$BRANCH"
 if [[ "$BRANCH" == "main" ]]; then
   RM_BRANCH=master
@@ -39,12 +41,13 @@ if [[ "$WORKFLOW" == "staging" ]]; then
   BUILD_SNAPSHOT_ARG="-Dbuild.snapshot=false"
 fi
 
+echo --- Building release artifacts
+
 .ci/scripts/run-gradle.sh -Ddra.artifacts=true \
   -Ddra.artifacts.dependency.beats="${BEATS_BUILD_ID}" \
   -Ddra.artifacts.dependency.ml-cpp="${ML_CPP_BUILD_ID}" \
   -Ddra.workflow="$WORKFLOW" \
   -Dcsv="$WORKSPACE/build/distributions/dependencies-${ES_VERSION}${VERSION_SUFFIX}.csv" \
-  -Dbuild.snapshot=false \
   $LICENSE_KEY_ARG \
   $BUILD_SNAPSHOT_ARG \
   buildReleaseArtifacts \
@@ -62,6 +65,8 @@ find "$WORKSPACE" -type f -path "*/build/distributions/*" -exec chmod a+r {} \;
 
 # Allow other users write access to create checksum files
 find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
+
+echo --- Running release-manager
 
 # Artifacts should be generated
 # TODO remove echo, fix DRA_VAULT vars

--- a/.buildkite/scripts/dra-workflow.trigger.sh
+++ b/.buildkite/scripts/dra-workflow.trigger.sh
@@ -7,26 +7,22 @@ echo "steps:"
 source .buildkite/scripts/branches.sh
 
 for BRANCH in "${BRANCHES[@]}"; do
-  cat <<EOF
-  - trigger: elasticsearch-dra-workflow
-    label: Trigger DRA snapshot workflow for $BRANCH
-    async: true
-    build:
-      branch: "$BRANCH"
-      env:
-        DRA_WORKFLOW: snapshot
-EOF
+  if [[ "$BRANCH" == "main" ]]; then
+    continue
+  fi
 
-	# Don't trigger staging workflow for main branch
-	if [[ "$BRANCH" != "main" ]]; then
-		cat <<EOF
+  INTAKE_PIPELINE_SLUG="elasticsearch-intake"
+  BUILD_JSON=$(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "https://api.buildkite.com/v2/organizations/elastic/pipelines/${INTAKE_PIPELINE_SLUG}/builds?branch=${BRANCH}&state=passed&per_page=1" | jq '.[0] | {commit: .commit, url: .web_url}')
+  LAST_GOOD_COMMIT=$(echo "${BUILD_JSON}" | jq -r '.commit')
+
+  cat <<EOF
   - trigger: elasticsearch-dra-workflow
     label: Trigger DRA staging workflow for $BRANCH
     async: true
     build:
       branch: "$BRANCH"
+      commit: "$LAST_GOOD_COMMIT"
       env:
         DRA_WORKFLOW: staging
 EOF
-	fi
 done

--- a/.buildkite/scripts/dra-workflow.trigger.sh
+++ b/.buildkite/scripts/dra-workflow.trigger.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "steps:"
+
+source .buildkite/scripts/branches.sh
+
+for BRANCH in "${BRANCHES[@]}"; do
+  cat <<EOF
+  - trigger: elasticsearch-dra-workflow
+    label: Trigger DRA snapshot workflow for $BRANCH
+    async: true
+    build:
+      branch: $BRANCH
+      env:
+        DRA_WORKFLOW: snapshot
+EOF
+
+	# Don't trigger staging workflow for main branch
+	if [[ "$BRANCH" != "main" ]]; then
+		cat <<EOF
+  - trigger: elasticsearch-dra-workflow
+    label: Trigger DRA staging workflow for $BRANCH
+    async: true
+    build:
+      branch: $BRANCH
+      env:
+        DRA_WORKFLOW: staging
+EOF
+	fi
+done

--- a/.buildkite/scripts/dra-workflow.trigger.sh
+++ b/.buildkite/scripts/dra-workflow.trigger.sh
@@ -12,7 +12,7 @@ for BRANCH in "${BRANCHES[@]}"; do
     label: Trigger DRA snapshot workflow for $BRANCH
     async: true
     build:
-      branch: $BRANCH
+      branch: "$BRANCH"
       env:
         DRA_WORKFLOW: snapshot
 EOF
@@ -24,7 +24,7 @@ EOF
     label: Trigger DRA staging workflow for $BRANCH
     async: true
     build:
-      branch: $BRANCH
+      branch: "$BRANCH"
       env:
         DRA_WORKFLOW: staging
 EOF


### PR DESCRIPTION
- Bring over DRA-related scripts from Jenkins, and adapt for Buildkite
- Create dra-update-staging pipeline that checks all required branches for dependency updates in a single build (rather than one build per branch)
- Create dra-workflow trigger pipeline that triggers DRA workflow for staging/snapshot for each active branch
- Create dra-workflow pipeline that builds and publishes artifacts
- One script is now used for both staging and snapshot (license key configuration only applied in the case of staging, as before)

The Buildkite pipelines for this already exist, we just have to uncomment the schedules to effectively "deploy" them.

Builds:
- [Trigger workflows](https://buildkite.com/elastic/elasticsearch-dra-trigger-workflows/builds/3) - okay that triggered builds failed, the pipelines don't exist yet on those branches
- [Update staging](https://buildkite.com/elastic/elasticsearch-dra-update-staging/builds/1#018a51dd-01c8-423b-b27a-95add8f3b412)
- [dra workflow](https://buildkite.com/elastic/bseeders-elasticsearch-dra/builds/9#018a51b5-5e56-4735-ae4c-d41d75ae5e60) - for this example build, the release manager command just echoes at the end, instead of actually publishing anything