### PR TITLE
Small cleanup in StreamInput/Output

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1101,10 +1101,7 @@ public abstract class StreamOutput extends OutputStream {
      * Writes a list of {@link NamedWriteable} objects.
      */
     public void writeNamedWriteableList(List<? extends NamedWriteable> list) throws IOException {
-        writeVInt(list.size());
-        for (NamedWriteable obj : list) {
-            writeNamedWriteable(obj);
-        }
+        writeCollection(list, StreamOutput::writeNamedWriteable);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1101,7 +1101,10 @@ public abstract class StreamOutput extends OutputStream {
      * Writes a list of {@link NamedWriteable} objects.
      */
     public void writeNamedWriteableList(List<? extends NamedWriteable> list) throws IOException {
-        writeCollection(list, StreamOutput::writeNamedWriteable);
+        writeVInt(list.size());
+        for (NamedWriteable obj : list) {
+            writeNamedWriteable(obj);
+        }
     }
 
     /**


### PR DESCRIPTION
Dries up another couple of places that read/write a length-prefixed
collection.