### PR TITLE
Dry up Writeable.writeTo lambda usage around StreamOutput

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -88,7 +88,7 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeDouble(metricScore);
-        out.writeMap(details, (o, v) -> v.writeTo(o));
+        out.writeMap(details, StreamOutput::writeWriteable);
         out.writeMap(failures, StreamOutput::writeException);
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalSpec.java
@@ -98,7 +98,7 @@ public class RankEvalSpec implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(ratedRequests);
         out.writeNamedWriteable(metric);
-        out.writeMap(templates, (o, v) -> v.writeTo(o));
+        out.writeMap(templates, StreamOutput::writeWriteable);
         out.writeVInt(maxConcurrentSearches);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -76,11 +76,7 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
         }
         out.writeMap(
             routingTable,
-            (shardsOut, shards) -> shardsOut.writeMap(
-                shards,
-                StreamOutput::writeVInt,
-                (desiredShardsOut, desiredShards) -> desiredShards.writeTo(desiredShardsOut)
-            )
+            (shardsOut, shards) -> shardsOut.writeMap(shards, StreamOutput::writeVInt, StreamOutput::writeWriteable)
         );
         if (out.getTransportVersion().onOrAfter(CLUSTER_INFO_VERSION)) {
             out.writeWriteable(clusterInfo);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -37,7 +37,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(groups);
         out.writeArray(nodes);
-        out.writeMap(indicesAndFilters, (o, s) -> s.writeTo(o));
+        out.writeMap(indicesAndFilters, StreamOutput::writeWriteable);
     }
 
     public ClusterSearchShardsResponse(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponse.java
@@ -40,7 +40,7 @@ public class GetShardSnapshotResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(latestShardSnapshot);
-        out.writeMap(repositoryFailures, (o, err) -> err.writeTo(o));
+        out.writeMap(repositoryFailures, StreamOutput::writeWriteable);
     }
 
     public Optional<RepositoryException> getFailureForRepository(String repository) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -210,7 +210,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             if (status != null) {
-                out.writeMap(status, (o, s) -> s.writeTo(o), StreamOutput::writeMap);
+                out.writeMap(status, StreamOutput::writeWriteable, StreamOutput::writeMap);
             } else {
                 out.writeVInt(0);
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -301,7 +301,7 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
         out.writeCollection(usedBuiltInTokenFilters);
         out.writeCollection(usedBuiltInAnalyzers);
         if (out.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)) {
-            out.writeMap(usedSynonyms, (o, v) -> v.writeTo(o));
+            out.writeMap(usedSynonyms, StreamOutput::writeWriteable);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
@@ -125,7 +125,7 @@ public class ReloadAnalyzersResponse extends BroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(reloadDetails, (stream, details) -> details.writeTo(stream));
+        out.writeMap(reloadDetails, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageResponse.java
@@ -40,7 +40,7 @@ public final class AnalyzeIndexDiskUsageResponse extends BroadcastResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(stats, (o, v) -> v.writeTo(o));
+        out.writeMap(stats, StreamOutput::writeWriteable);
     }
 
     Map<String, IndexDiskUsageStats> getStats() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
@@ -61,7 +61,7 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(fields, (o, v) -> v.writeTo(o));
+        out.writeMap(fields, StreamOutput::writeWriteable);
         out.writeVLong(indexSizeInBytes);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -174,8 +174,8 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
         out.writeStringArray(indices);
         MappingMetadata.writeMappingMetadata(out, mappings);
         out.writeMap(aliases, StreamOutput::writeCollection);
-        out.writeMap(settings, (o, v) -> v.writeTo(o));
-        out.writeMap(defaultSettings, (o, v) -> v.writeTo(o));
+        out.writeMap(settings, StreamOutput::writeWriteable);
+        out.writeMap(defaultSettings, StreamOutput::writeWriteable);
         out.writeMap(dataStreams, StreamOutput::writeOptionalString);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -91,7 +91,7 @@ public class RecoveryResponse extends BaseBroadcastResponse implements ChunkedTo
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMapOfLists(shardRecoveryStates, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        out.writeMap(shardRecoveryStates, StreamOutput::writeCollection);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -79,8 +79,8 @@ public class GetSettingsResponse extends ActionResponse implements ChunkedToXCon
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(indexToSettings, (o, v) -> v.writeTo(o));
-        out.writeMap(indexToDefaultSettings, (o, v) -> v.writeTo(o));
+        out.writeMap(indexToSettings, StreamOutput::writeWriteable);
+        out.writeMap(indexToDefaultSettings, StreamOutput::writeWriteable);
     }
 
     private static void parseSettingsField(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -172,8 +172,8 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
         super.writeTo(out);
         out.writeArray(shards);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0)) {
-            out.writeMap(indexHealthMap, (o, s) -> s.writeTo(o));
-            out.writeMap(indexStateMap, (o, s) -> s.writeTo(o));
+            out.writeMap(indexHealthMap, StreamOutput::writeWriteable);
+            out.writeMap(indexStateMap, StreamOutput::writeWriteable);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -148,7 +148,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(componentTemplates, (o, v) -> v.writeTo(o));
+            out.writeMap(componentTemplates, StreamOutput::writeWriteable);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
                 out.writeOptionalWriteable(rolloverConfiguration);
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -146,7 +146,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(indexTemplates, (o, v) -> v.writeTo(o));
+            out.writeMap(indexTemplates, StreamOutput::writeWriteable);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
                 out.writeOptionalWriteable(rolloverConfiguration);
             }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -60,7 +60,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(indexName);
-        out.writeMap(responseMap, (valueOut, fc) -> fc.writeTo(valueOut));
+        out.writeMap(responseMap, StreamOutput::writeWriteable);
         out.writeBoolean(canMatch);
         if (out.getTransportVersion().onOrAfter(MAPPING_HASH_VERSION)) {
             out.writeOptionalString(indexMappingHash);
@@ -78,7 +78,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeStringCollection(indices);
             out.writeString(indexMappingHash);
-            out.writeMap(responseMap, (valueOut, fc) -> fc.writeTo(valueOut));
+            out.writeMap(responseMap, StreamOutput::writeWriteable);
         }
 
         Stream<FieldCapabilitiesIndexResponse> getResponses() {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
@@ -45,7 +45,7 @@ class FieldCapabilitiesNodeResponse extends ActionResponse implements Writeable 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         FieldCapabilitiesIndexResponse.writeList(out, indexResponses);
-        out.writeMap(failures, (o, v) -> v.writeTo(o), StreamOutput::writeException);
+        out.writeMap(failures, StreamOutput::writeWriteable, StreamOutput::writeException);
         out.writeCollection(unmatchedShardIds);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -153,7 +153,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
     }
 
     private static void writeField(StreamOutput out, Map<String, FieldCapabilities> map) throws IOException {
-        out.writeMap(map, (valueOut, fc) -> fc.writeTo(valueOut));
+        out.writeMap(map, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
@@ -74,7 +75,7 @@ public final class SearchContextId {
             out.setTransportVersion(version);
             TransportVersion.writeVersion(version, out);
             out.writeMap(shards);
-            out.writeMap(aliasFilter, (o, v) -> v.writeTo(o));
+            out.writeMap(aliasFilter, StreamOutput::writeWriteable);
             return Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(out.bytes()));
         } catch (IOException e) {
             throw new IllegalArgumentException(e);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
@@ -56,7 +56,7 @@ public final class SearchShardsResponse extends ActionResponse {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(groups);
         out.writeCollection(nodes);
-        out.writeMap(aliasFilters, (o, v) -> v.writeTo(o));
+        out.writeMap(aliasFilters, StreamOutput::writeWriteable);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -106,14 +106,14 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.leastAvailableSpaceUsage, (o, v) -> v.writeTo(o));
-        out.writeMap(this.mostAvailableSpaceUsage, (o, v) -> v.writeTo(o));
+        out.writeMap(this.leastAvailableSpaceUsage, StreamOutput::writeWriteable);
+        out.writeMap(this.mostAvailableSpaceUsage, StreamOutput::writeWriteable);
         out.writeMap(this.shardSizes, (o, v) -> o.writeLong(v == null ? -1 : v));
         if (out.getTransportVersion().onOrAfter(DATA_SET_SIZE_SIZE_VERSION)) {
-            out.writeMap(this.shardDataSetSizes, (o, s) -> s.writeTo(o), StreamOutput::writeLong);
+            out.writeMap(this.shardDataSetSizes, StreamOutput::writeWriteable, StreamOutput::writeLong);
         }
         if (out.getTransportVersion().onOrAfter(DATA_PATH_NEW_KEY_VERSION)) {
-            out.writeMap(this.dataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
+            out.writeMap(this.dataPath, StreamOutput::writeWriteable, StreamOutput::writeString);
         } else {
             out.writeMap(this.dataPath, (o, k) -> createFakeShardRoutingFromNodeAndShard(k).writeTo(o), StreamOutput::writeString);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -378,7 +378,7 @@ public class ClusterFormationFailureHelper {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeStringCollection(initialMasterNodesSetting);
             localNode.writeTo(out);
-            out.writeMap(masterEligibleNodes, (streamOutput, node) -> node.writeTo(streamOutput));
+            out.writeMap(masterEligibleNodes, StreamOutput::writeWriteable);
             out.writeLong(clusterStateVersion);
             out.writeLong(acceptedTerm);
             lastAcceptedConfiguration.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -92,7 +92,7 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.componentTemplates, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.componentTemplates, StreamOutput::writeWriteable);
     }
 
     public static ComponentTemplateMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -97,7 +97,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.indexTemplates, (outstream, val) -> val.writeTo(outstream));
+        out.writeMap(this.indexTemplates, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -399,7 +399,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         out.writeStringCollection(dataStreams);
         out.writeOptionalString(writeDataStream);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-            out.writeMap(dataStreamToFilterMap, (out1, filter) -> filter.writeTo(out1));
+            out.writeMap(dataStreamToFilterMap, StreamOutput::writeWriteable);
         } else {
             if (dataStreamToFilterMap.isEmpty()) {
                 out.writeBoolean(false);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -419,7 +419,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeOptionalCollection(rounds, (o, v) -> v.writeTo(o));
+            out.writeOptionalCollection(rounds, StreamOutput::writeWriteable);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -221,8 +221,8 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.dataStreams, (stream, val) -> val.writeTo(stream));
-        out.writeMap(this.dataStreamAliases, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.dataStreams, StreamOutput::writeWriteable);
+        out.writeMap(this.dataStreamAliases, StreamOutput::writeWriteable);
     }
 
     public static DataStreamMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1714,7 +1714,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
         }
         out.writeCollection(aliases.values());
-        out.writeMap(customData, (o, v) -> v.writeTo(o));
+        out.writeMap(customData, StreamOutput::writeWriteable);
         out.writeMap(
             inSyncAllocationIds,
             StreamOutput::writeVInt,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -206,7 +206,7 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
         out.writeInt(order);
         out.writeStringCollection(patterns);
         settings.writeTo(out);
-        out.writeMap(mappings, (o, v) -> v.writeTo(o));
+        out.writeMap(mappings, StreamOutput::writeWriteable);
         out.writeCollection(aliases.values());
         out.writeOptionalVInt(version);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -79,7 +79,7 @@ public class NodesShutdownMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(nodes, (outStream, v) -> v.writeTo(outStream));
+        out.writeMap(nodes, StreamOutput::writeWriteable);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -173,7 +173,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeMap(this.aliases, (stream, aliasMetadata) -> aliasMetadata.writeTo(stream));
+            out.writeMap(this.aliases, StreamOutput::writeWriteable);
         }
         if (out.getTransportVersion().onOrAfter(DataStreamLifecycle.ADDED_ENABLED_FLAG_VERSION)) {
             out.writeOptionalWriteable(lifecycle);

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
@@ -125,7 +125,7 @@ public final class ClusterApplierRecordingService {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(recordings, (out1, value) -> value.writeTo(out1));
+            out.writeMap(recordings, StreamOutput::writeWriteable);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -46,7 +47,7 @@ import java.util.zip.Inflater;
  * memory. Note that the compressed string might still sometimes need to be
  * decompressed in order to perform equality checks or to compute hash codes.
  */
-public final class CompressedXContent {
+public final class CompressedXContent implements Writeable {
 
     private static final ThreadLocal<InflaterAndBuffer> inflater = ThreadLocal.withInitial(InflaterAndBuffer::new);
 
@@ -215,6 +216,7 @@ public final class CompressedXContent {
         return new CompressedXContent(compressedData, sha256);
     }
 
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)) {
             out.writeString(sha256);

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -575,7 +575,7 @@ public abstract class StreamOutput extends OutputStream {
      * Writes values of a map as a collection
      */
     public final <V extends Writeable> void writeMapValues(final Map<?, V> map) throws IOException {
-        writeMapValues(map, (o, v) -> v.writeTo(o));
+        writeMapValues(map, StreamOutput::writeWriteable);
     }
 
     /**
@@ -602,7 +602,7 @@ public abstract class StreamOutput extends OutputStream {
      * Write a {@link Map} of {@code K}-type keys to {@code V}-type.
      */
     public final <K extends Writeable, V extends Writeable> void writeMap(final Map<K, V> map) throws IOException {
-        writeMap(map, (o, k) -> k.writeTo(o), (o, v) -> v.writeTo(o));
+        writeMap(map, StreamOutput::writeWriteable, StreamOutput::writeWriteable);
     }
 
     /**
@@ -955,7 +955,7 @@ public abstract class StreamOutput extends OutputStream {
      * integer is first written to the stream, and then the elements of the array are written to the stream.
      */
     public <T extends Writeable> void writeArray(T[] array) throws IOException {
-        writeArray((out, value) -> value.writeTo(out), array);
+        writeArray(StreamOutput::writeWriteable, array);
     }
 
     /**
@@ -963,7 +963,7 @@ public abstract class StreamOutput extends OutputStream {
      * serialized to indicate whether the array was null or not.
      */
     public <T extends Writeable> void writeOptionalArray(@Nullable T[] array) throws IOException {
-        writeOptionalArray((out, value) -> value.writeTo(out), array);
+        writeOptionalArray(StreamOutput::writeWriteable, array);
     }
 
     public void writeOptionalWriteable(@Nullable Writeable writeable) throws IOException {
@@ -1042,7 +1042,7 @@ public abstract class StreamOutput extends OutputStream {
      * @throws IOException if an I/O exception occurs writing the collection
      */
     public void writeCollection(final Collection<? extends Writeable> collection) throws IOException {
-        writeCollection(collection, (o, v) -> v.writeTo(o));
+        writeCollection(collection, StreamOutput::writeWriteable);
     }
 
     /**
@@ -1074,7 +1074,7 @@ public abstract class StreamOutput extends OutputStream {
      * {@link StreamInput#readOptionalList(Writeable.Reader)}.
      */
     public <T extends Writeable> void writeOptionalCollection(final Collection<T> collection) throws IOException {
-        writeOptionalCollection(collection, (o, v) -> v.writeTo(o));
+        writeOptionalCollection(collection, StreamOutput::writeWriteable);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -637,7 +637,7 @@ public class KeyStoreWrapper implements SecureSettings {
         out.writeBoolean(hasPassword);
         out.writeOptionalByteArray(dataBytes);
         var entriesMap = entries.get();
-        out.writeMap((entriesMap == null) ? Map.of() : entriesMap, (o, v) -> v.writeTo(o));
+        out.writeMap((entriesMap == null) ? Map.of() : entriesMap, StreamOutput::writeWriteable);
         out.writeBoolean(closed);
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/node/HealthInfo.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthInfo.java
@@ -28,6 +28,6 @@ public record HealthInfo(Map<String, DiskHealthInfo> diskInfoByNode) implements 
 
     @Override
     public void writeTo(StreamOutput output) throws IOException {
-        output.writeMap(diskInfoByNode, (out, diskHealthInfo) -> diskHealthInfo.writeTo(out));
+        output.writeMap(diskInfoByNode, StreamOutput::writeWriteable);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
@@ -57,7 +57,7 @@ public class FieldUsageStats implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(stats, (o, v) -> v.writeTo(o));
+        out.writeMap(stats, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -398,7 +398,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeMap(groupStats, (stream, stats) -> stats.writeTo(stream));
+            out.writeMap(groupStats, StreamOutput::writeWriteable);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1602,7 +1602,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(clusterStateVersion);
-            out.writeMap(checkpoints, (streamOutput, cps) -> cps.writeTo(streamOutput));
+            out.writeMap(checkpoints, StreamOutput::writeWriteable);
             IndexShardRoutingTable.Builder.writeTo(routingTable, out);
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -206,7 +206,7 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         stats.writeTo(out);
-        out.writeMap(statsByShard, (o, k) -> k.writeTo(o), StreamOutput::writeCollection);
+        out.writeMap(statsByShard, StreamOutput::writeWriteable, StreamOutput::writeCollection);
         if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_STATS_BY_INDEX)) {
             out.writeMap(statsByIndex);
         }

--- a/server/src/main/java/org/elasticsearch/node/AdaptiveSelectionStats.java
+++ b/server/src/main/java/org/elasticsearch/node/AdaptiveSelectionStats.java
@@ -49,7 +49,7 @@ public class AdaptiveSelectionStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(this.clientOutgoingConnections, StreamOutput::writeLong);
-        out.writeMap(this.nodeComputedStats, (stream, stats) -> stats.writeTo(stream));
+        out.writeMap(this.nodeComputedStats, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -542,7 +542,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             .stream()
             .filter(t -> VersionedNamedWriteable.shouldSerialize(out, t.getParams()))
             .collect(Collectors.toMap(PersistentTask::getId, Function.identity()));
-        out.writeMap(filteredTasks, (stream, value) -> value.writeTo(stream));
+        out.writeMap(filteredTasks, StreamOutput::writeWriteable);
     }
 
     public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java
@@ -42,7 +42,7 @@ public class RepositoriesStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_011)) {
-            out.writeMap(repositoryThrottlingStats, (o, v) -> v.writeTo(o));
+            out.writeMap(repositoryThrottlingStats, StreamOutput::writeWriteable);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
@@ -258,7 +258,7 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(scripts, (o, v) -> v.writeTo(o));
+        out.writeMap(scripts, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -264,8 +264,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             writeExplanation(out, explanation);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_8_0)) {
-            out.writeMap(documentFields, (stream, documentField) -> documentField.writeTo(stream));
-            out.writeMap(metaFields, (stream, documentField) -> documentField.writeTo(stream));
+            out.writeMap(documentFields, StreamOutput::writeWriteable);
+            out.writeMap(metaFields, StreamOutput::writeWriteable);
         } else {
             writeFields(out, this.getFields());
         }
@@ -285,7 +285,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (innerHits == null) {
             out.writeVInt(0);
         } else {
-            out.writeMap(innerHits, (o, v) -> v.writeTo(o));
+            out.writeMap(innerHits, StreamOutput::writeWriteable);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -120,7 +120,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         }
         out.writeIntArray(reverseMuls);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-            out.writeArray((o, order) -> order.writeTo(o), missingOrders);
+            out.writeArray(missingOrders);
         }
         out.writeCollection(buckets);
         out.writeOptionalWriteable(afterKey);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
@@ -132,7 +132,7 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeBoolean(keyed);
-        out.writeCollection(filters, keyed ? (o, v) -> v.writeTo(o) : (o, v) -> o.writeNamedWriteable(v.filter()));
+        out.writeCollection(filters, keyed ? StreamOutput::writeWriteable : (o, v) -> o.writeNamedWriteable(v.filter()));
         out.writeBoolean(otherBucket);
         out.writeString(otherBucketKey);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -104,7 +104,7 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
 
     @Override
     protected final void doWriteTo(StreamOutput out) throws IOException {
-        out.writeMap(fields, (o, value) -> value.writeTo(o));
+        out.writeMap(fields, StreamOutput::writeWriteable);
         out.writeOptionalWriteable(userValueTypeHint);
         out.writeOptionalString(format);
         innerWriteTo(out);

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
@@ -67,7 +67,7 @@ public final class SearchProfileResults implements Writeable, ToXContentFragment
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-            out.writeMap(shardResults, (o, r) -> r.writeTo(o));
+            out.writeMap(shardResults, StreamOutput::writeWriteable);
         } else {
             // Before 8.0.0 we only send the query phase
             out.writeMap(shardResults, (o, r) -> r.getQueryPhase().writeTo(o));

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -1044,7 +1044,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         out.writeStringCollection(dataStreams);
         out.writeCollection(featureStates);
 
-        out.writeMap(indexSnapshotDetails, (stream, value) -> value.writeTo(stream));
+        out.writeMap(indexSnapshotDetails, StreamOutput::writeWriteable);
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -74,7 +74,7 @@ public class FeatureMigrationResults implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(featureStatuses, (outStream, featureStatus) -> featureStatus.writeTo(outStream));
+        out.writeMap(featureStatuses, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotFeatureInfo;
@@ -60,7 +61,7 @@ public class GetSnapshotsResponseTests extends ESTestCase {
         return copyInstance(
             instance,
             new NamedWriteableRegistry(Collections.emptyList()),
-            (out, value) -> value.writeTo(out),
+            StreamOutput::writeWriteable,
             GetSnapshotsResponse::new,
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponseSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponseSerializationTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.shard.ShardId;
@@ -54,7 +55,7 @@ public class GetShardSnapshotResponseSerializationTests extends ESTestCase {
         return copyInstance(
             instance,
             new NamedWriteableRegistry(Collections.emptyList()),
-            (out, value) -> value.writeTo(out),
+            StreamOutput::writeWriteable,
             GetShardSnapshotResponse::new,
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
@@ -169,7 +169,7 @@ public class DelayableWriteableTests extends ESTestCase {
         DelayableWriteable<T> delayed = copyInstance(
             original,
             writableRegistry(),
-            (out, d) -> d.writeTo(out),
+            StreamOutput::writeWriteable,
             in -> DelayableWriteable.delayed(reader, in),
             version
         );
@@ -178,7 +178,7 @@ public class DelayableWriteableTests extends ESTestCase {
         DelayableWriteable<T> referencing = copyInstance(
             original,
             writableRegistry(),
-            (out, d) -> d.writeTo(out),
+            StreamOutput::writeWriteable,
             in -> DelayableWriteable.referencing(reader, in),
             version
         );

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.util;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -46,7 +47,7 @@ public class BytesRefArrayTests extends ESTestCase {
             BytesRefArray copy = copyInstance(
                 array,
                 writableRegistry(),
-                (out, value) -> value.writeTo(out),
+                StreamOutput::writeWriteable,
                 in -> new BytesRefArray(in, mockBigArrays()),
                 TransportVersion.current()
             );
@@ -95,7 +96,7 @@ public class BytesRefArrayTests extends ESTestCase {
                 array = copyInstance(
                     inArray,
                     writableRegistry(),
-                    (out, value) -> value.writeTo(out),
+                    StreamOutput::writeWriteable,
                     in -> new BytesRefArray(in, mockBigArrays()),
                     TransportVersion.current()
                 );

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Releasables;
@@ -392,7 +393,7 @@ public class BytesRefHashTests extends ESTestCase {
             BytesRefArray refArrayCopy = copyInstance(
                 refArray,
                 writableRegistry(),
-                (out, value) -> value.writeTo(out),
+                StreamOutput::writeWriteable,
                 in -> new BytesRefArray(in, mockBigArrays()),
                 TransportVersion.current()
             );

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1522,7 +1522,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         Writeable.Reader<T> reader,
         TransportVersion version
     ) throws IOException {
-        return copyInstance(original, namedWriteableRegistry, (out, value) -> value.writeTo(out), reader, version);
+        return copyInstance(original, namedWriteableRegistry, StreamOutput::writeWriteable, reader, version);
     }
 
     /**

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
@@ -90,7 +90,7 @@ public class GetAutoscalingCapacityAction extends ActionType<GetAutoscalingCapac
 
         @Override
         public void writeTo(final StreamOutput out) throws IOException {
-            out.writeMap(results, (o, decision) -> decision.writeTo(o));
+            out.writeMap(results, StreamOutput::writeWriteable);
         }
 
         public SortedMap<String, AutoscalingDeciderResults> results() {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
@@ -71,7 +71,7 @@ public class AutoscalingDeciderResults implements ToXContentObject, Writeable {
     public void writeTo(final StreamOutput out) throws IOException {
         currentCapacity.writeTo(out);
         out.writeCollection(currentNodes);
-        out.writeMap(results, (output, result) -> result.writeTo(output));
+        out.writeMap(results, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
@@ -52,7 +52,7 @@ public class DataTiersFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(tierStats, (o, v) -> v.writeTo(o));
+        out.writeMap(tierStats, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -142,7 +142,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(patterns, (out1, value) -> value.writeTo(out1));
+        out.writeMap(patterns, StreamOutput::writeWriteable);
         out.writeMapOfLists(followedLeaderIndexUUIDs, StreamOutput::writeString, StreamOutput::writeString);
         out.writeMap(headers, (valOut, header) -> valOut.writeMap(header, StreamOutput::writeString));
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowStats.java
@@ -137,7 +137,7 @@ public class AutoFollowStats implements Writeable, ToXContentObject {
             out1.writeZLong(value.v1());
             out1.writeException(value.v2());
         });
-        out.writeMap(autoFollowedClusters, (out1, value) -> value.writeTo(out1));
+        out.writeMap(autoFollowedClusters, StreamOutput::writeWriteable);
     }
 
     public long getNumberOfFailedFollowIndices() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
@@ -93,7 +93,7 @@ public class GetAutoFollowPatternAction extends ActionType<GetAutoFollowPatternA
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(autoFollowPatterns, (out1, value) -> value.writeTo(out1));
+            out.writeMap(autoFollowPatterns, StreamOutput::writeWriteable);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
@@ -93,7 +93,7 @@ public final class EnrichMetadata extends AbstractNamedDiffable<Metadata.Custom>
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(policies, (out1, value) -> value.writeTo(out1));
+        out.writeMap(policies, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -111,7 +111,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(phaseStats, (o, p) -> p.writeTo(o));
+            out.writeMap(phaseStats, StreamOutput::writeWriteable);
             out.writeVInt(indicesManaged);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -75,7 +75,7 @@ public class IndexLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(policyMetadatas, (o, v) -> v.writeTo(o));
+        out.writeMap(policyMetadatas, StreamOutput::writeWriteable);
         out.writeEnum(operationMode);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -135,7 +135,7 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
     public void writeTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(type);
         out.writeString(name);
-        out.writeMap(phases, (o, val) -> val.writeTo(o));
+        out.writeMap(phases, StreamOutput::writeWriteable);
         out.writeGenericMap(this.metadata);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
@@ -180,7 +180,7 @@ public class GetDatafeedRunningStateAction extends ActionType<GetDatafeedRunning
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeMap(datafeedRunningState, (o, w) -> w.writeTo(o));
+            out.writeMap(datafeedRunningState, StreamOutput::writeWriteable);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -306,7 +306,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         taskParams.writeTo(out);
-        out.writeMap(nodeRoutingTable, (o, w) -> w.writeTo(o));
+        out.writeMap(nodeRoutingTable, StreamOutput::writeWriteable);
         out.writeEnum(assignmentState);
         out.writeOptionalString(reason);
         out.writeInstant(startTime);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
@@ -73,7 +73,7 @@ public class RuleScope implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(scope, (out1, value) -> value.writeTo(out1));
+        out.writeMap(scope, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
@@ -125,7 +125,7 @@ public class GetRollupCapsAction extends ActionType<GetRollupCapsAction.Response
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(jobs, (out1, value) -> value.writeTo(out1));
+            out.writeMap(jobs, StreamOutput::writeWriteable);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -154,7 +154,7 @@ public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsActio
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeMap(jobs, (out1, value) -> value.writeTo(out1));
+            out.writeMap(jobs, StreamOutput::writeWriteable);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
@@ -94,7 +94,7 @@ public class RollupJobCaps implements Writeable, ToXContentObject {
         out.writeString(jobID);
         out.writeString(rollupIndex);
         out.writeString(indexPattern);
-        out.writeMap(fieldCapLookup, (o, value) -> value.writeTo(o));
+        out.writeMap(fieldCapLookup, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -136,7 +136,7 @@ public class SnapshotLifecycleMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.snapshotConfigurations, (out1, value) -> value.writeTo(out1));
+        out.writeMap(this.snapshotConfigurations, StreamOutput::writeWriteable);
         out.writeEnum(this.operationMode);
         this.slmStats.writeTo(out);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java
@@ -210,7 +210,7 @@ public class SnapshotLifecycleStats implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(policyStats, (v, o) -> o.writeTo(v));
+        out.writeMap(policyStats, StreamOutput::writeWriteable);
         out.writeVLong(retentionRunCount.count());
         out.writeVLong(retentionFailedCount.count());
         out.writeVLong(retentionTimedOut.count());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -296,7 +296,7 @@ public class TextStructure implements ToXContentObject, Writeable {
             out.writeBoolean(true);
             out.writeGenericMap(ingestPipeline);
         }
-        out.writeMap(fieldStats, (out1, value) -> value.writeTo(out1));
+        out.writeMap(fieldStats, StreamOutput::writeWriteable);
         out.writeStringCollection(explanation);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealthIssueTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealthIssueTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.transform.transforms;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
@@ -50,8 +51,8 @@ public class TransformHealthIssueTests extends AbstractWireSerializingTestCase<T
         TransformHealthIssue deserializedIssue = copyInstance(
             originalIssue,
             getNamedWriteableRegistry(),
-            (out, value) -> value.writeTo(out),
-            in -> new TransformHealthIssue(in),
+            StreamOutput::writeWriteable,
+            TransformHealthIssue::new,
             TransportVersion.V_8_7_0
         );
         assertThat(deserializedIssue.getType(), is(equalTo("unknown")));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -203,11 +203,11 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(clusterSettingsIssues);
             out.writeCollection(nodeSettingsIssues);
-            out.writeMapOfLists(indexSettingsIssues, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+            out.writeMap(indexSettingsIssues, StreamOutput::writeCollection);
             if (out.getTransportVersion().before(TransportVersion.V_7_11_0)) {
                 out.writeCollection(pluginSettingsIssues.getOrDefault("ml_settings", Collections.emptyList()));
             } else {
-                out.writeMapOfLists(pluginSettingsIssues, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+                out.writeMap(pluginSettingsIssues, StreamOutput::writeCollection);
             }
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -301,7 +301,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
                 out.writeBoolean(fetchFields != null);
                 if (fetchFields != null) {
-                    out.writeMap(fetchFields, (stream, documentField) -> documentField.writeTo(stream));
+                    out.writeMap(fetchFields, StreamOutput::writeWriteable);
                 }
             }
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_038)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
@@ -117,7 +117,7 @@ public class ModelAliasMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(this.modelAliases, (stream, val) -> val.writeTo(stream));
+        out.writeMap(this.modelAliases, StreamOutput::writeWriteable);
     }
 
     public String getModelId(String modelAlias) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -160,7 +160,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(deploymentRoutingEntries, (o, w) -> w.writeTo(o));
+        out.writeMap(deploymentRoutingEntries, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionStoreTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionStoreTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
@@ -141,7 +142,7 @@ public class TransactionStoreTests extends ESTestCase {
             storeCopy = copyInstance(
                 store,
                 writableRegistry(),
-                (out, value) -> value.writeTo(out),
+                StreamOutput::writeWriteable,
                 in -> new HashBasedTransactionStore(in, mockBigArraysWithThrowingCircuitBreaker()),
                 TransportVersion.current()
             );
@@ -165,7 +166,7 @@ public class TransactionStoreTests extends ESTestCase {
         HashBasedTransactionStore storeCopy = copyInstance(
             store,
             writableRegistry(),
-            (out, value) -> value.writeTo(out),
+            StreamOutput::writeWriteable,
             in -> new HashBasedTransactionStore(in, mockBigArrays()),
             TransportVersion.current()
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSourceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSourceTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
@@ -90,6 +91,6 @@ public class ItemSetMapReduceValueSourceTests extends ESTestCase {
     }
 
     private Field copyField(Field field) throws IOException {
-        return copyInstance(field, writableRegistry(), (out, value) -> value.writeTo(out), Field::new, TransportVersion.current());
+        return copyInstance(field, writableRegistry(), StreamOutput::writeWriteable, Field::new, TransportVersion.current());
     }
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -270,10 +270,9 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
         NamedWriteableRegistry namedWriteableRegistry,
         Writeable.Reader<SearchSourceBuilder> reader
     ) throws IOException {
-        Writeable.Writer<SearchSourceBuilder> writer = (out, value) -> value.writeTo(out);
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setTransportVersion(TransportVersion.current());
-            writer.write(output, original);
+            original.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
                 in.setTransportVersion(TransportVersion.current());
                 return reader.read(in);


### PR DESCRIPTION
No need to duplicate the lambda all over the place. Follow-up to #99087
