### PR TITLE
Cleanup some array writing spots in StreamOutput

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -109,7 +109,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringArray(requestedMetrics.toArray(String[]::new));
+        out.writeStringCollection(requestedMetrics);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -173,7 +173,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         indices.writeTo(out);
-        out.writeStringArray(requestedMetrics.toArray(String[]::new));
+        out.writeStringCollection(requestedMetrics);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
@@ -72,7 +72,7 @@ public class ClearScrollRequest extends ActionRequest implements ToXContentObjec
         if (scrollIds == null) {
             out.writeVInt(0);
         } else {
-            out.writeStringArray(scrollIds.toArray(new String[scrollIds.size()]));
+            out.writeStringCollection(scrollIds);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -502,10 +502,7 @@ public abstract class StreamOutput extends OutputStream {
         if (array == null) {
             writeVInt(0);
         } else {
-            writeVInt(array.length);
-            for (String s : array) {
-                writeString(s);
-            }
+            writeStringArray(array);
         }
     }
 
@@ -682,10 +679,7 @@ public abstract class StreamOutput extends OutputStream {
         entry(Object[].class, (o, v) -> {
             o.writeByte((byte) 8);
             final Object[] list = (Object[]) v;
-            o.writeVInt(list.length);
-            for (Object item : list) {
-                o.writeGenericValue(item);
-            }
+            o.writeArray(StreamOutput::writeGenericValue, list);
         }),
         entry(Map.class, (o, v) -> {
             if (v instanceof LinkedHashMap) {

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -69,7 +69,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
             // types not supported so send an empty array to previous versions
             out.writeStringArray(Strings.EMPTY_ARRAY);
         }
-        out.writeStringArray(ids.toArray(new String[ids.size()]));
+        out.writeStringCollection(ids);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/ScriptException.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptException.java
@@ -88,7 +88,7 @@ public class ScriptException extends ElasticsearchException {
     @Override
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
-        out.writeStringArray(scriptStack.toArray(new String[0]));
+        out.writeStringCollection(scriptStack);
         out.writeString(script);
         out.writeString(lang);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_7_0)) {

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -279,7 +279,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
             out.writeMap(matchedQueries, StreamOutput::writeFloat);
         } else {
-            out.writeStringArray(matchedQueries.keySet().toArray(new String[0]));
+            out.writeStringCollection(matchedQueries.keySet());
         }
         out.writeOptionalWriteable(shard);
         if (innerHits == null) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
@@ -96,7 +96,7 @@ public final class RemoteConnectionInfo implements ToXContentFragment, Writeable
         } else {
             if (modeInfo.modeType() == RemoteConnectionStrategy.ConnectionStrategy.SNIFF) {
                 SniffConnectionStrategy.SniffModeInfo sniffInfo = (SniffConnectionStrategy.SniffModeInfo) this.modeInfo;
-                out.writeStringArray(sniffInfo.seedNodes.toArray(new String[0]));
+                out.writeStringCollection(sniffInfo.seedNodes);
                 out.writeVInt(sniffInfo.maxConnectionsPerCluster);
                 out.writeTimeValue(initialConnectionTimeout);
                 out.writeVInt(sniffInfo.numNodesConnected);

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -606,7 +606,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeStringArray(seedNodes.toArray(new String[0]));
+            out.writeStringCollection(seedNodes);
             out.writeVInt(maxConnectionsPerCluster);
             out.writeVInt(numNodesConnected);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
@@ -146,7 +146,7 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
             out.writeString(id);
             out.writeBoolean(allowNoMatch);
             out.writeBoolean(force);
-            out.writeStringArray(expandedIds.toArray(new String[0]));
+            out.writeStringCollection(expandedIds);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
@@ -128,8 +128,8 @@ public class UpdateFilterAction extends ActionType<PutFilterAction.Response> {
             super.writeTo(out);
             out.writeString(filterId);
             out.writeOptionalString(description);
-            out.writeStringArray(addItems.toArray(new String[addItems.size()]));
-            out.writeStringArray(removeItems.toArray(new String[removeItems.size()]));
+            out.writeStringCollection(addItems);
+            out.writeStringCollection(removeItems);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/Calendar.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/Calendar.java
@@ -100,7 +100,7 @@ public class Calendar implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
-        out.writeStringArray(jobIds.toArray(new String[jobIds.size()]));
+        out.writeStringCollection(jobIds);
         out.writeOptionalString(description);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/MlFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/MlFilter.java
@@ -84,7 +84,7 @@ public class MlFilter implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
         out.writeOptionalString(description);
-        out.writeStringArray(items.toArray(new String[items.size()]));
+        out.writeStringCollection(items);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Influence.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Influence.java
@@ -64,7 +64,7 @@ public class Influence implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
-        out.writeStringArray(fieldValues.toArray(new String[fieldValues.size()]));
+        out.writeStringCollection(fieldValues);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
@@ -121,7 +121,7 @@ public class StopTransformAction extends ActionType<StopTransformAction.Response
             boolean hasExpandedIds = expandedIds != null;
             out.writeBoolean(hasExpandedIds);
             if (hasExpandedIds) {
-                out.writeStringArray(expandedIds.toArray(new String[0]));
+                out.writeStringCollection(expandedIds);
             }
             out.writeBoolean(allowNoMatch);
             out.writeBoolean(waitForCheckpoint);


### PR DESCRIPTION
No need to convert collections to strings before writing, also a few obvious dry-up spots.
