### PR TITLE
ESQL: Improve detection of @timestamp inside query

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -180,7 +180,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
         }
     }
 
-    private static class PushFiltersToSource extends OptimizerRule<FilterExec> {
+    public static class PushFiltersToSource extends OptimizerRule<FilterExec> {
         @Override
         protected PhysicalPlan rule(FilterExec filterExec) {
             PhysicalPlan plan = filterExec;
@@ -213,7 +213,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             return plan;
         }
 
-        private static boolean canPushToSource(Expression exp) {
+        public static boolean canPushToSource(Expression exp) {
             if (exp instanceof BinaryComparison bc) {
                 return isAttributePushable(bc.left(), bc) && bc.right().foldable();
             } else if (exp instanceof BinaryLogic bl) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -62,7 +62,7 @@ import static org.elasticsearch.xpack.ql.expression.predicate.Predicates.splitAn
 import static org.elasticsearch.xpack.ql.optimizer.OptimizerRules.TransformDirection.UP;
 
 public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPlan, LocalPhysicalOptimizerContext> {
-    private static final QlTranslatorHandler TRANSLATOR_HANDLER = new EsqlTranslatorHandler();
+    public static final QlTranslatorHandler TRANSLATOR_HANDLER = new EsqlTranslatorHandler();
 
     private final PhysicalVerifier verifier = new PhysicalVerifier();
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -24,14 +24,23 @@ import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
+import org.elasticsearch.xpack.ql.expression.AttributeSet;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.ql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.ql.plan.logical.Filter;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.util.Holder;
+import org.elasticsearch.xpack.ql.util.Queries;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer.TRANSLATOR_HANDLER;
+import static org.elasticsearch.xpack.ql.util.Queries.Clause.FILTER;
 
 public class PlannerUtils {
 
@@ -72,7 +81,7 @@ public class PlannerUtils {
         plan.forEachUp(
             FragmentExec.class,
             f -> f.fragment()
-                .forEachUp(EsRelation.class, r -> indices.addAll(Arrays.asList(Strings.commaDelimitedListToStringArray(r.index().name()))))
+                .forEachUp(EsRelation.class, r -> indices.addAll(asList(Strings.commaDelimitedListToStringArray(r.index().name()))))
         );
         return indices.toArray(String[]::new);
     }
@@ -116,8 +125,41 @@ public class PlannerUtils {
      * Extracts the ES query provided by the filter parameter
      */
     public static QueryBuilder requestFilter(PhysicalPlan plan) {
-        var filter = new Holder<QueryBuilder>(null);
-        plan.forEachDown(FragmentExec.class, es -> filter.set(es.esFilter()));
-        return filter.get();
+        return detectFilter(plan, "@timestamp");
+    }
+
+    static QueryBuilder detectFilter(PhysicalPlan plan, String fieldName) {
+        // first position is the REST filter, the second the query filter
+        var requestFilter = new QueryBuilder[] { null, null };
+
+        plan.forEachDown(FragmentExec.class, fe -> {
+            requestFilter[0] = fe.esFilter();
+            // detect filter inside the query
+            fe.fragment().forEachUp(Filter.class, f -> {
+                // the only filter that can be pushed down is that on top of the relation
+                // similar to OptimizerRule#PushDownAndCombineFilters and
+                // LocalPhysicalPlanOptimizer#PushFiltersToSource
+                // but get executed on the logical plan
+                List<Expression> matches = new ArrayList<>();
+                if (f.child() instanceof EsRelation relation) {
+                    var conjunctions = Predicates.splitAnd(f.condition());
+                    // look only at expressions that contain literals and the target field
+                    for (var exp : conjunctions) {
+                        var refs = new AttributeSet(exp.references());
+                        // remove literals or attributes that match by name
+                        boolean matchesField = refs.removeIf(e -> fieldName.equals(e.name()));
+                        // the expression only contains the target reference
+                        if (matchesField && refs.isEmpty()) {
+                            matches.add(exp);
+                        }
+                    }
+                }
+                if (matches.size() > 0) {
+                    requestFilter[1] = TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(matches)).asBuilder();
+                }
+            });
+        });
+
+        return Queries.combine(FILTER, asList(requestFilter));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -140,6 +140,9 @@ public class ComputeService {
             return;
         }
         QueryBuilder requestFilter = PlannerUtils.requestFilter(dataNodePlan);
+
+        LOGGER.info("Sending data node plan\n{}\n with filter [{}]", dataNodePlan, requestFilter);
+
         String[] originalIndices = PlannerUtils.planOriginalIndices(physicalPlan);
         computeTargetNodes(
             rootTask,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.planner;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.SerializationTestUtils;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
+import org.elasticsearch.xpack.esql.analysis.Verifier;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.parser.EsqlParser;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
+import org.elasticsearch.xpack.esql.stats.Metrics;
+import org.elasticsearch.xpack.ql.index.EsIndex;
+import org.elasticsearch.xpack.ql.index.IndexResolution;
+import org.elasticsearch.xpack.ql.type.EsField;
+import org.elasticsearch.xpack.ql.util.Queries;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.SerializationTestUtils.assertSerialization;
+import static org.elasticsearch.xpack.ql.util.Queries.Clause.FILTER;
+import static org.elasticsearch.xpack.ql.util.Queries.Clause.MUST;
+import static org.elasticsearch.xpack.ql.util.Queries.Clause.SHOULD;
+import static org.hamcrest.Matchers.nullValue;
+
+public class FilterTests extends ESTestCase {
+
+    // use a field that already exists in the mapping
+    private static final String AT_TIMESTAMP = "emp_no";
+    private static final String OTHER_FIELD = "salary";
+
+    private static EsqlParser parser;
+    private static Analyzer analyzer;
+    private static LogicalPlanOptimizer logicalOptimizer;
+    private static PhysicalPlanOptimizer physicalPlanOptimizer;
+    private static Map<String, EsField> mapping;
+    private static Mapper mapper;
+
+    @BeforeClass
+    public static void init() {
+        parser = new EsqlParser();
+
+        mapping = loadMapping("mapping-basic.json");
+        EsIndex test = new EsIndex("test", mapping);
+        IndexResolution getIndexResult = IndexResolution.valid(test);
+        logicalOptimizer = new LogicalPlanOptimizer();
+        physicalPlanOptimizer = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(EsqlTestUtils.TEST_CFG));
+        mapper = new Mapper(false);
+
+        analyzer = new Analyzer(
+            new AnalyzerContext(EsqlTestUtils.TEST_CFG, new EsqlFunctionRegistry(), getIndexResult, EsqlTestUtils.emptyPolicyResolution()),
+            new Verifier(new Metrics())
+        );
+    }
+
+    public void testTimestampRequestFilterNoQueryFilter() {
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > 10
+            """.formatted(OTHER_FIELD), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        assertEquals(restFilter.toString(), filter.toString());
+    }
+
+    public void testTimestampNoRequestFilterQueryFilter() {
+        var value = 10;
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > %s
+            """.formatted(AT_TIMESTAMP, value), null);
+
+        var filter = filterForTransportNodes(plan);
+        var expected = sv(rangeQuery(AT_TIMESTAMP).gt(value), AT_TIMESTAMP);
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampRequestFilterQueryFilter() {
+        var value = 10;
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > 10
+            """.formatted(AT_TIMESTAMP, value), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        var queryFilter = sv(rangeQuery(AT_TIMESTAMP).gt(value).includeUpper(false), AT_TIMESTAMP);
+        var expected = Queries.combine(FILTER, asList(restFilter, queryFilter));
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampRequestFilterQueryFilterWithConjunction() {
+        var lowValue = 10;
+        var highValue = 100;
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > %s AND %s < %s
+            """.formatted(AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var right = sv(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
+        var must = Queries.combine(MUST, asList(left, right));
+        var expected = Queries.combine(FILTER, asList(restFilter, must));
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampRequestFilterQueryFilterWithDisjunctionOnDifferentFields() {
+        var lowValue = 10;
+        var highValue = 100;
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > %s OR %s < %s
+            """.formatted(OTHER_FIELD, lowValue, AT_TIMESTAMP, highValue), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        var expected = restFilter;
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampRequestFilterQueryFilterWithDisjunctionOnSameField() {
+        var lowValue = 10;
+        var highValue = 100;
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > %s OR %s < %s
+            """.formatted(AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var right = sv(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
+        var should = Queries.combine(SHOULD, asList(left, right));
+        var expected = Queries.combine(FILTER, asList(restFilter, should));
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampRequestFilterQueryFilterWithMultiConjunction() {
+        var lowValue = 10;
+        var highValue = 100;
+        var eqValue = 1234;
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > %s AND %s == %s AND %s < %s
+            """.formatted(AT_TIMESTAMP, lowValue, OTHER_FIELD, eqValue, AT_TIMESTAMP, highValue), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var right = sv(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
+        var must = Queries.combine(MUST, asList(left, right));
+        var expected = Queries.combine(FILTER, asList(restFilter, must));
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampRequestFilterQueryMultipleFilters() {
+        var lowValue = 10;
+        var eqValue = 1234;
+        var highValue = 100;
+
+        var restFilter = restFilter(AT_TIMESTAMP);
+
+        var plan = plan("""
+             FROM test
+            |WHERE %s > %s
+            |EVAL %s = %s
+            |WHERE %s > %s
+            """.formatted(AT_TIMESTAMP, lowValue, AT_TIMESTAMP, eqValue, AT_TIMESTAMP, highValue), restFilter);
+
+        var filter = filterForTransportNodes(plan);
+        var queryFilter = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var expected = Queries.combine(FILTER, asList(restFilter, queryFilter));
+        assertEquals(expected.toString(), filter.toString());
+    }
+
+    public void testTimestampOverridenFilterFilter() {
+        var eqValue = 1234;
+
+        var plan = plan("""
+             FROM test
+            |EVAL %s = %s
+            |WHERE %s > %s
+            """.formatted(AT_TIMESTAMP, OTHER_FIELD, AT_TIMESTAMP, eqValue), null);
+
+        var filter = filterForTransportNodes(plan);
+        assertThat(filter, nullValue());
+    }
+
+    /**
+     * Ugly hack to create a QueryBuilder for SingleValueQuery.
+     * For some reason however the queryName is set to null on range queries when deserializing.
+     */
+    public static QueryBuilder sv(QueryBuilder inner, String field) {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            // emulate SingleValueQuery writeTo
+            out.writeFloat(AbstractQueryBuilder.DEFAULT_BOOST);
+            out.writeOptionalString(null);
+            out.writeNamedWriteable(inner);
+            out.writeString(field);
+
+            StreamInput in = new NamedWriteableAwareStreamInput(
+                ByteBufferStreamInput.wrap(BytesReference.toBytes(out.bytes())),
+                SerializationTestUtils.writableRegistry()
+            );
+
+            Object obj = SingleValueQuery.ENTRY.reader.read(in);
+            return (QueryBuilder) obj;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private PhysicalPlan plan(String query, QueryBuilder restFilter) {
+        var logical = logicalOptimizer.optimize(analyzer.analyze(parser.createStatement(query)));
+        // System.out.println("Logical\n" + logical);
+        var physical = mapper.map(logical);
+        // System.out.println("physical\n" + physical);
+        physical = physical.transformUp(
+            FragmentExec.class,
+            f -> new FragmentExec(f.source(), f.fragment(), restFilter, f.estimatedRowSize())
+        );
+        physical = physicalPlanOptimizer.optimize(physical);
+        // System.out.println("optimized\n" + physical);
+        assertSerialization(physical);
+        return physical;
+    }
+
+    private QueryBuilder restFilter(String field) {
+        return rangeQuery(field).lt("2020-12-34");
+    }
+
+    private QueryBuilder filterForTransportNodes(PhysicalPlan plan) {
+        return PlannerUtils.detectFilter(plan, AT_TIMESTAMP);
+    }
+
+    // for some reason by default the range query include upper is set to true
+    // while the RangeQuery in QL translator defaults to false
+    // hence why the comparisons are done through strings
+    private static void assertQueries(QueryBuilder filter, QueryBuilder query) {
+        var left = filter != null ? filter.toString() : null;
+        var right = query != null ? sv(query, AT_TIMESTAMP).toString() : null;
+        assertEquals(left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
@@ -80,14 +80,14 @@ public class FilterTests extends ESTestCase {
     }
 
     public void testTimestampRequestFilterNoQueryFilter() {
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
             |WHERE {} > 10
             """, OTHER_FIELD), restFilter);
 
-        var filter = filterForTransportNodes(plan);
+        var filter = filterQueryForTransportNodes(plan);
         assertEquals(restFilter.toString(), filter.toString());
     }
 
@@ -99,22 +99,22 @@ public class FilterTests extends ESTestCase {
             |WHERE {} > {}
             """, AT_TIMESTAMP, value), null);
 
-        var filter = filterForTransportNodes(plan);
-        var expected = sv(rangeQuery(AT_TIMESTAMP).gt(value), AT_TIMESTAMP);
+        var filter = filterQueryForTransportNodes(plan);
+        var expected = singleValueQuery(rangeQuery(AT_TIMESTAMP).gt(value), AT_TIMESTAMP);
         assertEquals(expected.toString(), filter.toString());
     }
 
     public void testTimestampRequestFilterQueryFilter() {
         var value = 10;
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
             |WHERE {} > 10
             """, AT_TIMESTAMP, value), restFilter);
 
-        var filter = filterForTransportNodes(plan);
-        var queryFilter = sv(rangeQuery(AT_TIMESTAMP).gt(value).includeUpper(false), AT_TIMESTAMP);
+        var filter = filterQueryForTransportNodes(plan);
+        var queryFilter = singleValueQuery(rangeQuery(AT_TIMESTAMP).gt(value).includeUpper(false), AT_TIMESTAMP);
         var expected = Queries.combine(FILTER, asList(restFilter, queryFilter));
         assertEquals(expected.toString(), filter.toString());
     }
@@ -122,16 +122,16 @@ public class FilterTests extends ESTestCase {
     public void testTimestampRequestFilterQueryFilterWithConjunction() {
         var lowValue = 10;
         var highValue = 100;
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
             |WHERE {} > {} AND {} < {}
             """, AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
 
-        var filter = filterForTransportNodes(plan);
-        var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
-        var right = sv(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
+        var filter = filterQueryForTransportNodes(plan);
+        var left = singleValueQuery(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var right = singleValueQuery(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
         var must = Queries.combine(MUST, asList(left, right));
         var expected = Queries.combine(FILTER, asList(restFilter, must));
         assertEquals(expected.toString(), filter.toString());
@@ -140,14 +140,14 @@ public class FilterTests extends ESTestCase {
     public void testTimestampRequestFilterQueryFilterWithDisjunctionOnDifferentFields() {
         var lowValue = 10;
         var highValue = 100;
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
             |WHERE {} > {} OR {} < {}
             """, OTHER_FIELD, lowValue, AT_TIMESTAMP, highValue), restFilter);
 
-        var filter = filterForTransportNodes(plan);
+        var filter = filterQueryForTransportNodes(plan);
         var expected = restFilter;
         assertEquals(expected.toString(), filter.toString());
     }
@@ -155,16 +155,16 @@ public class FilterTests extends ESTestCase {
     public void testTimestampRequestFilterQueryFilterWithDisjunctionOnSameField() {
         var lowValue = 10;
         var highValue = 100;
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
             |WHERE {} > {} OR {} < {}
             """, AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
 
-        var filter = filterForTransportNodes(plan);
-        var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
-        var right = sv(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
+        var filter = filterQueryForTransportNodes(plan);
+        var left = singleValueQuery(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var right = singleValueQuery(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
         var should = Queries.combine(SHOULD, asList(left, right));
         var expected = Queries.combine(FILTER, asList(restFilter, should));
         assertEquals(expected.toString(), filter.toString());
@@ -174,16 +174,16 @@ public class FilterTests extends ESTestCase {
         var lowValue = 10;
         var highValue = 100;
         var eqValue = 1234;
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
             |WHERE {} > {} AND {} == {} AND {} < {}
             """, AT_TIMESTAMP, lowValue, OTHER_FIELD, eqValue, AT_TIMESTAMP, highValue), restFilter);
 
-        var filter = filterForTransportNodes(plan);
-        var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
-        var right = sv(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
+        var filter = filterQueryForTransportNodes(plan);
+        var left = singleValueQuery(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var right = singleValueQuery(rangeQuery(AT_TIMESTAMP).lt(highValue), AT_TIMESTAMP);
         var must = Queries.combine(MUST, asList(left, right));
         var expected = Queries.combine(FILTER, asList(restFilter, must));
         assertEquals(expected.toString(), filter.toString());
@@ -194,7 +194,7 @@ public class FilterTests extends ESTestCase {
         var eqValue = 1234;
         var highValue = 100;
 
-        var restFilter = restFilter(AT_TIMESTAMP);
+        var restFilter = restFilterQuery(AT_TIMESTAMP);
 
         var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
@@ -203,13 +203,13 @@ public class FilterTests extends ESTestCase {
             |WHERE {} > {}
             """, AT_TIMESTAMP, lowValue, AT_TIMESTAMP, eqValue, AT_TIMESTAMP, highValue), restFilter);
 
-        var filter = filterForTransportNodes(plan);
-        var queryFilter = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
+        var filter = filterQueryForTransportNodes(plan);
+        var queryFilter = singleValueQuery(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
         var expected = Queries.combine(FILTER, asList(restFilter, queryFilter));
         assertEquals(expected.toString(), filter.toString());
     }
 
-    public void testTimestampOverridenFilterFilter() {
+    public void testTimestampOverriddenFilterFilter() {
         var eqValue = 1234;
 
         var plan = plan(LoggerMessageFormat.format(null, """
@@ -218,7 +218,31 @@ public class FilterTests extends ESTestCase {
             |WHERE {} > {}
             """, AT_TIMESTAMP, OTHER_FIELD, AT_TIMESTAMP, eqValue), null);
 
-        var filter = filterForTransportNodes(plan);
+        var filter = filterQueryForTransportNodes(plan);
+        assertThat(filter, nullValue());
+    }
+
+    public void testTimestampAsFunctionArgument() {
+        var eqValue = 1234;
+
+        var plan = plan(LoggerMessageFormat.format(null, """
+             FROM test
+            |WHERE to_int(to_string({})) == {}
+            """, AT_TIMESTAMP, eqValue), null);
+
+        var filter = filterQueryForTransportNodes(plan);
+        assertThat(filter, nullValue());
+    }
+
+    public void testTimestampAsFunctionArgumentInsideExpression() {
+        var eqValue = 1234;
+
+        var plan = plan(LoggerMessageFormat.format(null, """
+             FROM test
+            |WHERE to_int(to_string({})) + 987 == {}
+            """, AT_TIMESTAMP, eqValue), null);
+
+        var filter = filterQueryForTransportNodes(plan);
         assertThat(filter, nullValue());
     }
 
@@ -226,7 +250,7 @@ public class FilterTests extends ESTestCase {
      * Ugly hack to create a QueryBuilder for SingleValueQuery.
      * For some reason however the queryName is set to null on range queries when deserializing.
      */
-    public static QueryBuilder sv(QueryBuilder inner, String field) {
+    public static QueryBuilder singleValueQuery(QueryBuilder inner, String field) {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             // emulate SingleValueQuery writeTo
             out.writeFloat(AbstractQueryBuilder.DEFAULT_BOOST);
@@ -261,20 +285,11 @@ public class FilterTests extends ESTestCase {
         return physical;
     }
 
-    private QueryBuilder restFilter(String field) {
+    private QueryBuilder restFilterQuery(String field) {
         return rangeQuery(field).lt("2020-12-34");
     }
 
-    private QueryBuilder filterForTransportNodes(PhysicalPlan plan) {
+    private QueryBuilder filterQueryForTransportNodes(PhysicalPlan plan) {
         return PlannerUtils.detectFilter(plan, AT_TIMESTAMP);
-    }
-
-    // for some reason by default the range query include upper is set to true
-    // while the RangeQuery in QL translator defaults to false
-    // hence why the comparisons are done through strings
-    private static void assertQueries(QueryBuilder filter, QueryBuilder query) {
-        var left = filter != null ? filter.toString() : null;
-        var right = query != null ? sv(query, AT_TIMESTAMP).toString() : null;
-        assertEquals(left, right);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/FilterTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.test.ESTestCase;
@@ -81,10 +82,10 @@ public class FilterTests extends ESTestCase {
     public void testTimestampRequestFilterNoQueryFilter() {
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > 10
-            """.formatted(OTHER_FIELD), restFilter);
+            |WHERE {} > 10
+            """, OTHER_FIELD), restFilter);
 
         var filter = filterForTransportNodes(plan);
         assertEquals(restFilter.toString(), filter.toString());
@@ -93,10 +94,10 @@ public class FilterTests extends ESTestCase {
     public void testTimestampNoRequestFilterQueryFilter() {
         var value = 10;
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > %s
-            """.formatted(AT_TIMESTAMP, value), null);
+            |WHERE {} > {}
+            """, AT_TIMESTAMP, value), null);
 
         var filter = filterForTransportNodes(plan);
         var expected = sv(rangeQuery(AT_TIMESTAMP).gt(value), AT_TIMESTAMP);
@@ -107,10 +108,10 @@ public class FilterTests extends ESTestCase {
         var value = 10;
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > 10
-            """.formatted(AT_TIMESTAMP, value), restFilter);
+            |WHERE {} > 10
+            """, AT_TIMESTAMP, value), restFilter);
 
         var filter = filterForTransportNodes(plan);
         var queryFilter = sv(rangeQuery(AT_TIMESTAMP).gt(value).includeUpper(false), AT_TIMESTAMP);
@@ -123,10 +124,10 @@ public class FilterTests extends ESTestCase {
         var highValue = 100;
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > %s AND %s < %s
-            """.formatted(AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
+            |WHERE {} > {} AND {} < {}
+            """, AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
 
         var filter = filterForTransportNodes(plan);
         var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
@@ -141,10 +142,10 @@ public class FilterTests extends ESTestCase {
         var highValue = 100;
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > %s OR %s < %s
-            """.formatted(OTHER_FIELD, lowValue, AT_TIMESTAMP, highValue), restFilter);
+            |WHERE {} > {} OR {} < {}
+            """, OTHER_FIELD, lowValue, AT_TIMESTAMP, highValue), restFilter);
 
         var filter = filterForTransportNodes(plan);
         var expected = restFilter;
@@ -156,10 +157,10 @@ public class FilterTests extends ESTestCase {
         var highValue = 100;
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > %s OR %s < %s
-            """.formatted(AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
+            |WHERE {} > {} OR {} < {}
+            """, AT_TIMESTAMP, lowValue, AT_TIMESTAMP, highValue), restFilter);
 
         var filter = filterForTransportNodes(plan);
         var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
@@ -175,10 +176,10 @@ public class FilterTests extends ESTestCase {
         var eqValue = 1234;
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > %s AND %s == %s AND %s < %s
-            """.formatted(AT_TIMESTAMP, lowValue, OTHER_FIELD, eqValue, AT_TIMESTAMP, highValue), restFilter);
+            |WHERE {} > {} AND {} == {} AND {} < {}
+            """, AT_TIMESTAMP, lowValue, OTHER_FIELD, eqValue, AT_TIMESTAMP, highValue), restFilter);
 
         var filter = filterForTransportNodes(plan);
         var left = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
@@ -195,12 +196,12 @@ public class FilterTests extends ESTestCase {
 
         var restFilter = restFilter(AT_TIMESTAMP);
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |WHERE %s > %s
-            |EVAL %s = %s
-            |WHERE %s > %s
-            """.formatted(AT_TIMESTAMP, lowValue, AT_TIMESTAMP, eqValue, AT_TIMESTAMP, highValue), restFilter);
+            |WHERE {} > {}
+            |EVAL {} = {}
+            |WHERE {} > {}
+            """, AT_TIMESTAMP, lowValue, AT_TIMESTAMP, eqValue, AT_TIMESTAMP, highValue), restFilter);
 
         var filter = filterForTransportNodes(plan);
         var queryFilter = sv(rangeQuery(AT_TIMESTAMP).gt(lowValue), AT_TIMESTAMP);
@@ -211,11 +212,11 @@ public class FilterTests extends ESTestCase {
     public void testTimestampOverridenFilterFilter() {
         var eqValue = 1234;
 
-        var plan = plan("""
+        var plan = plan(LoggerMessageFormat.format(null, """
              FROM test
-            |EVAL %s = %s
-            |WHERE %s > %s
-            """.formatted(AT_TIMESTAMP, OTHER_FIELD, AT_TIMESTAMP, eqValue), null);
+            |EVAL {} = {}
+            |WHERE {} > {}
+            """, AT_TIMESTAMP, OTHER_FIELD, AT_TIMESTAMP, eqValue), null);
 
         var filter = filterForTransportNodes(plan);
         assertThat(filter, nullValue());


### PR DESCRIPTION
For better selectivity of canMatch, detect if the given query has any
 filters on @timestamp that can be pushed down before sending requests
 to the cluster node.
 This should help eliminate more nodes that do not match the criteria

Related #99073