### PR TITLE
Execute aggregations in its own thread in AggregatorTestCase

### DIFF
--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -740,7 +740,7 @@ The API returns the following result:
                     "time_in_nanos": 22577
                   },
                   {
-                    "name": "BucketCollectorWrapper: [BucketCollectorWrapper[bucketCollector=[my_scoped_agg, my_global_agg]]]",
+                    "name": "AggregatorCollector: [my_scoped_agg, my_global_agg]",
                     "reason": "aggregation",
                     "time_in_nanos": 867617
                   }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorCollector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.search.internal.TwoPhaseCollector;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/** Collector that controls the life cycle of an aggregation document collection. */
+public class AggregatorCollector implements TwoPhaseCollector {
+    final Aggregator[] aggregators;
+    final BucketCollector bucketCollector;
+
+    public AggregatorCollector(Aggregator[] aggregators, BucketCollector bucketCollector) {
+        this.aggregators = aggregators;
+        this.bucketCollector = bucketCollector;
+    }
+
+    @Override
+    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+        return bucketCollector.getLeafCollector(new AggregationExecutionContext(context, null, null, null));
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+        return bucketCollector.scoreMode();
+    }
+
+    @Override
+    public void doPostCollection() throws IOException {
+        bucketCollector.postCollection();
+    }
+
+    @Override
+    public String toString() {
+        String[] aggNames = new String[aggregators.length];
+        for (int i = 0; i < aggregators.length; i++) {
+            aggNames[i] = aggregators[i].name();
+        }
+        return Arrays.toString(aggNames);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorCollectorManager.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorCollectorManager.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.apache.lucene.search.CollectorManager;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+/** Collector manager that produces {@link AggregatorCollector}. */
+public class AggregatorCollectorManager implements CollectorManager<AggregatorCollector, Void> {
+
+    private final Supplier<AggregatorCollector> collectorSupplier;
+
+    public AggregatorCollectorManager(Supplier<AggregatorCollector> collectorSupplier) {
+        this.collectorSupplier = collectorSupplier;
+    }
+
+    @Override
+    public AggregatorCollector newCollector() throws IOException {
+        return collectorSupplier.get();
+    }
+
+    @Override
+    public Void reduce(Collection<AggregatorCollector> collectors) throws IOException {
+        // we cannot run Aggregator#buildTopLevel here because we need to do it after the optional timeout
+        // has been removed from the index searcher. Therefore, we delay this processing to the
+        // AggregationPhase#execute method.
+        return null;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/SearchContextAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/SearchContextAggregations.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.search.aggregations;
 
-import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 
 import java.util.ArrayList;
@@ -22,7 +21,7 @@ public class SearchContextAggregations {
     private final AggregatorFactories factories;
     private final Supplier<AggregationReduceContext.Builder> toAggregationReduceContextBuilder;
     private final List<Aggregator[]> aggregators;
-    private CollectorManager<Collector, Void> aggCollectorManager;
+    private CollectorManager<AggregatorCollector, Void> aggCollectorManager;
 
     /**
      * Creates a new aggregation context with the parsed aggregator factories
@@ -56,14 +55,14 @@ public class SearchContextAggregations {
     /**
      * Registers the collector to be run for the aggregations phase
      */
-    public void registerAggsCollectorManager(CollectorManager<Collector, Void> aggCollectorManager) {
+    public void registerAggsCollectorManager(CollectorManager<AggregatorCollector, Void> aggCollectorManager) {
         this.aggCollectorManager = aggCollectorManager;
     }
 
     /**
      * Returns the collector to be run for the aggregations phase
      */
-    public CollectorManager<Collector, Void> getAggsCollectorManager() {
+    public CollectorManager<AggregatorCollector, Void> getAggsCollectorManager() {
         return aggCollectorManager;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollector.java
@@ -63,7 +63,7 @@ public class InternalProfileCollector extends ProfilerCollector implements TwoPh
 
         // Aggregation collector toString()'s include the user-defined agg name
         if (getReason().equals(CollectorResult.REASON_AGGREGATION) || getReason().equals(CollectorResult.REASON_AGGREGATION_GLOBAL)) {
-            s += ": [" + c + "]";
+            s += ": " + c;
         }
         return s;
     }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/98204, the way queries are executed changed. From now one there are two threadpools, one that coordinates the searches and another to actually execute them. This change was not reflected in the `AggregatorTestCase` where everything is done on a single thread. 

This PR modifies modifies the test to reflect the new execution strategy by introducing an AggregatorCollectorManager that is used to execute aggregations.

Unfortunately test are failing with this change, in particular for Composite and frequent items aggregations. This aggregations are now accessing doc values from different threads, something that lucene is not happy about and complains. I guess there are no Integration tests that is exercising this logic for those aggregations.