### PR TITLE
Align collection de/serialization API naming

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -224,7 +224,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
         super(in);
         bucketInfo = new BucketInfo(in);
         format = in.readNamedWriteable(DocValueFormat.class);
-        buckets = in.readList(stream -> new Bucket(stream, format));
+        buckets = in.readCollectionAsList(stream -> new Bucket(stream, format));
         this.targetBuckets = in.readVInt();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
             bucketInnerInterval = in.readVLong();

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSortPipelineAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSortPipelineAggregationBuilder.java
@@ -92,7 +92,7 @@ public class BucketSortPipelineAggregationBuilder extends AbstractPipelineAggreg
      */
     public BucketSortPipelineAggregationBuilder(StreamInput in) throws IOException {
         super(in, NAME);
-        sorts = in.readList(FieldSortBuilder::new);
+        sorts = in.readCollectionAsList(FieldSortBuilder::new);
         from = in.readVInt();
         size = in.readOptionalVInt();
         gapPolicy = GapPolicy.readFrom(in);

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/ExplainDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/ExplainDataStreamLifecycleAction.java
@@ -151,7 +151,7 @@ public class ExplainDataStreamLifecycleAction extends ActionType<ExplainDataStre
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.indices = in.readList(ExplainIndexDataStreamLifecycle::new);
+            this.indices = in.readCollectionAsList(ExplainIndexDataStreamLifecycle::new);
             this.rolloverConfiguration = in.readOptionalWriteable(RolloverConfiguration::new);
         }
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/GetDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/GetDataStreamLifecycleAction.java
@@ -191,7 +191,7 @@ public class GetDataStreamLifecycleAction extends ActionType<GetDataStreamLifecy
         }
 
         public Response(StreamInput in) throws IOException {
-            this(in.readList(Response.DataStreamLifecycle::new), in.readOptionalWriteable(RolloverConfiguration::new));
+            this(in.readCollectionAsList(Response.DataStreamLifecycle::new), in.readOptionalWriteable(RolloverConfiguration::new));
         }
 
         public List<DataStreamLifecycle> getDataStreamLifecycles() {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
@@ -98,7 +98,7 @@ public class GeoIpDownloaderStatsAction extends ActionType<GeoIpDownloaderStatsA
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override
@@ -164,10 +164,10 @@ public class GeoIpDownloaderStatsAction extends ActionType<GeoIpDownloaderStatsA
         protected NodeResponse(StreamInput in) throws IOException {
             super(in);
             stats = in.readBoolean() ? new GeoIpDownloaderStats(in) : null;
-            databases = in.readImmutableSet(StreamInput::readString);
-            filesInTemp = in.readImmutableSet(StreamInput::readString);
+            databases = in.readCollectionAsImmutableSet(StreamInput::readString);
+            filesInTemp = in.readCollectionAsImmutableSet(StreamInput::readString);
             configDatabases = in.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)
-                ? in.readImmutableSet(StreamInput::readString)
+                ? in.readCollectionAsImmutableSet(StreamInput::readString)
                 : null;
         }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
@@ -41,7 +41,7 @@ public class MultiSearchTemplateRequest extends ActionRequest implements Composi
     MultiSearchTemplateRequest(StreamInput in) throws IOException {
         super(in);
         maxConcurrentSearchRequests = in.readVInt();
-        requests = in.readList(SearchTemplateRequest::new);
+        requests = in.readCollectionAsList(SearchTemplateRequest::new);
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextAction.java
@@ -112,7 +112,7 @@ public class PainlessContextAction extends ActionType<PainlessContextAction.Resp
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            scriptContextNames = in.readStringList();
+            scriptContextNames = in.readStringCollectionAsList();
             painlessContextInfo = in.readOptionalWriteable(PainlessContextInfo::new);
         }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassBindingInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassBindingInfo.java
@@ -77,7 +77,7 @@ public class PainlessContextClassBindingInfo implements Writeable, ToXContentObj
         name = in.readString();
         rtn = in.readString();
         readOnly = in.readInt();
-        parameters = in.readImmutableList(StreamInput::readString);
+        parameters = in.readCollectionAsImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassInfo.java
@@ -124,11 +124,11 @@ public class PainlessContextClassInfo implements Writeable, ToXContentObject {
     public PainlessContextClassInfo(StreamInput in) throws IOException {
         name = in.readString();
         imported = in.readBoolean();
-        constructors = in.readImmutableList(PainlessContextConstructorInfo::new);
-        staticMethods = in.readImmutableList(PainlessContextMethodInfo::new);
-        methods = in.readImmutableList(PainlessContextMethodInfo::new);
-        staticFields = in.readImmutableList(PainlessContextFieldInfo::new);
-        fields = in.readImmutableList(PainlessContextFieldInfo::new);
+        constructors = in.readCollectionAsImmutableList(PainlessContextConstructorInfo::new);
+        staticMethods = in.readCollectionAsImmutableList(PainlessContextMethodInfo::new);
+        methods = in.readCollectionAsImmutableList(PainlessContextMethodInfo::new);
+        staticFields = in.readCollectionAsImmutableList(PainlessContextFieldInfo::new);
+        fields = in.readCollectionAsImmutableList(PainlessContextFieldInfo::new);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextConstructorInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextConstructorInfo.java
@@ -62,7 +62,7 @@ public class PainlessContextConstructorInfo implements Writeable, ToXContentObje
 
     public PainlessContextConstructorInfo(StreamInput in) throws IOException {
         declaring = in.readString();
-        parameters = in.readImmutableList(StreamInput::readString);
+        parameters = in.readCollectionAsImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInfo.java
@@ -148,10 +148,10 @@ public class PainlessContextInfo implements Writeable, ToXContentObject {
 
     public PainlessContextInfo(StreamInput in) throws IOException {
         name = in.readString();
-        classes = in.readImmutableList(PainlessContextClassInfo::new);
-        importedMethods = in.readImmutableList(PainlessContextMethodInfo::new);
-        classBindings = in.readImmutableList(PainlessContextClassBindingInfo::new);
-        instanceBindings = in.readImmutableList(PainlessContextInstanceBindingInfo::new);
+        classes = in.readCollectionAsImmutableList(PainlessContextClassInfo::new);
+        importedMethods = in.readCollectionAsImmutableList(PainlessContextMethodInfo::new);
+        classBindings = in.readCollectionAsImmutableList(PainlessContextClassBindingInfo::new);
+        instanceBindings = in.readCollectionAsImmutableList(PainlessContextInstanceBindingInfo::new);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInstanceBindingInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInstanceBindingInfo.java
@@ -72,7 +72,7 @@ public class PainlessContextInstanceBindingInfo implements Writeable, ToXContent
         declaring = in.readString();
         name = in.readString();
         rtn = in.readString();
-        parameters = in.readImmutableList(StreamInput::readString);
+        parameters = in.readCollectionAsImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextMethodInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextMethodInfo.java
@@ -71,7 +71,7 @@ public class PainlessContextMethodInfo implements Writeable, ToXContentObject {
         declaring = in.readString();
         name = in.readString();
         rtn = in.readString();
-        parameters = in.readImmutableList(StreamInput::readString);
+        parameters = in.readCollectionAsImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -233,7 +233,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         } else {
             indexedDocumentVersion = null;
         }
-        documents = in.readImmutableList(StreamInput::readBytesReference);
+        documents = in.readCollectionAsImmutableList(StreamInput::readBytesReference);
         if (documents.isEmpty() == false) {
             documentXContentType = in.readEnum(XContentType.class);
         } else {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvalQueryQuality.java
@@ -43,7 +43,7 @@ public class EvalQueryQuality implements ToXContentFragment, Writeable {
     public EvalQueryQuality(StreamInput in) throws IOException {
         this.queryId = in.readString();
         this.metricScore = in.readDouble();
-        this.ratedHits = in.readList(RatedSearchHit::new);
+        this.ratedHits = in.readCollectionAsList(RatedSearchHit::new);
         this.optionalMetricDetails = in.readOptionalNamedWriteable(MetricDetail.class);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -434,7 +434,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
             super(in);
             this.id = in.readInt();
             this.node = new DiscoveryNode(in);
-            this.subRequests = in.readList(TestRequest::new);
+            this.subRequests = in.readCollectionAsList(TestRequest::new);
             this.timeout = in.readBoolean();
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -159,7 +159,7 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
     public record DesiredShards(List<ShardView> current, ShardAssignmentView desired) implements Writeable, ChunkedToXContentObject {
 
         public static DesiredShards from(StreamInput in) throws IOException {
-            return new DesiredShards(in.readList(ShardView::from), ShardAssignmentView.from(in));
+            return new DesiredShards(in.readCollectionAsList(ShardView::from), ShardAssignmentView.from(in));
         }
 
         @Override
@@ -226,7 +226,9 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
             if (in.getTransportVersion().onOrAfter(ADD_FORECASTS_VERSION) == false) {
                 in.readOptionalWriteable(AllocationId::new);
             }
-            List<String> tierPreference = in.getTransportVersion().onOrAfter(ADD_TIER_PREFERENCE) ? in.readStringList() : List.of();
+            List<String> tierPreference = in.getTransportVersion().onOrAfter(ADD_TIER_PREFERENCE)
+                ? in.readStringCollectionAsList()
+                : List.of();
             return new ShardView(
                 state,
                 primary,
@@ -290,7 +292,7 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
         public static final ShardAssignmentView EMPTY = new ShardAssignmentView(Set.of(), 0, 0, 0);
 
         public static ShardAssignmentView from(StreamInput in) throws IOException {
-            final var nodeIds = in.readSet(StreamInput::readString);
+            final var nodeIds = in.readCollectionAsSet(StreamInput::readString);
             final var total = in.readVInt();
             final var unassigned = in.readVInt();
             final var ignored = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequest.java
@@ -58,7 +58,7 @@ public class UpdateDesiredNodesRequest extends AcknowledgedRequest<UpdateDesired
         super(in);
         this.historyID = in.readString();
         this.version = in.readLong();
-        this.nodes = in.readList(DesiredNode::readFrom);
+        this.nodes = in.readCollectionAsList(DesiredNode::readFrom);
         if (in.getTransportVersion().onOrAfter(DRY_RUN_VERSION)) {
             this.dryRun = in.readBoolean();
         } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
@@ -48,7 +48,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
      */
     public GetFeatureUpgradeStatusResponse(StreamInput in) throws IOException {
         super(in);
-        this.featureUpgradeStatuses = in.readImmutableList(FeatureUpgradeStatus::new);
+        this.featureUpgradeStatuses = in.readCollectionAsImmutableList(FeatureUpgradeStatus::new);
         this.upgradeStatus = in.readEnum(UpgradeStatus.class);
     }
 
@@ -154,7 +154,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
             this.featureName = in.readString();
             this.minimumIndexVersion = IndexVersion.readVersion(in);
             this.upgradeStatus = in.readEnum(UpgradeStatus.class);
-            this.indexInfos = in.readImmutableList(IndexInfo::new);
+            this.indexInfos = in.readCollectionAsImmutableList(IndexInfo::new);
         }
 
         public String getFeatureName() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeResponse.java
@@ -59,7 +59,7 @@ public class PostFeatureUpgradeResponse extends ActionResponse implements ToXCon
     public PostFeatureUpgradeResponse(StreamInput in) throws IOException {
         super(in);
         this.accepted = in.readBoolean();
-        this.features = in.readImmutableList(Feature::new);
+        this.features = in.readCollectionAsImmutableList(Feature::new);
         this.reason = in.readOptionalString();
         this.elasticsearchException = in.readOptionalWriteable(ElasticsearchException::new);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
@@ -47,7 +47,7 @@ public class NodesHotThreadsResponse extends BaseNodesResponse<NodeHotThreads> {
 
     @Override
     protected List<NodeHotThreads> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeHotThreads::new);
+        return in.readCollectionAsList(NodeHotThreads::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -44,7 +44,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
 
     @Override
     protected List<NodeInfo> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeInfo::new);
+        return in.readCollectionAsList(NodeInfo::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -35,8 +35,8 @@ public class PluginsAndModules implements ReportingService.Info {
     }
 
     public PluginsAndModules(StreamInput in) throws IOException {
-        this.plugins = in.readImmutableList(PluginRuntimeInfo::new);
-        this.modules = in.readImmutableList(PluginDescriptor::new);
+        this.plugins = in.readCollectionAsImmutableList(PluginRuntimeInfo::new);
+        this.modules = in.readCollectionAsImmutableList(PluginDescriptor::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
@@ -40,7 +40,7 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
 
     @Override
     protected List<NodesReloadSecureSettingsResponse.NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeResponse::new);
+        return in.readCollectionAsList(NodeResponse::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathRequest.java
@@ -31,7 +31,7 @@ public class NodePrevalidateShardPathRequest extends TransportRequest {
 
     public NodePrevalidateShardPathRequest(StreamInput in) throws IOException {
         super(in);
-        this.shardIds = in.readImmutableSet(ShardId::new);
+        this.shardIds = in.readCollectionAsImmutableSet(ShardId::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathResponse.java
@@ -29,7 +29,7 @@ public class NodePrevalidateShardPathResponse extends BaseNodeResponse {
 
     protected NodePrevalidateShardPathResponse(StreamInput in) throws IOException {
         super(in);
-        shardIds = in.readImmutableSet(ShardId::new);
+        shardIds = in.readCollectionAsImmutableSet(ShardId::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodesRemovalPrevalidation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodesRemovalPrevalidation.java
@@ -45,7 +45,7 @@ public record NodesRemovalPrevalidation(boolean isSafe, String message, List<Nod
     }
 
     public static NodesRemovalPrevalidation readFrom(final StreamInput in) throws IOException {
-        return new NodesRemovalPrevalidation(in.readBoolean(), in.readString(), in.readList(NodeResult::readFrom));
+        return new NodesRemovalPrevalidation(in.readBoolean(), in.readString(), in.readCollectionAsList(NodeResult::readFrom));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateShardPathRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateShardPathRequest.java
@@ -29,7 +29,7 @@ public class PrevalidateShardPathRequest extends BaseNodesRequest<PrevalidateSha
 
     public PrevalidateShardPathRequest(StreamInput in) throws IOException {
         super(in);
-        this.shardIds = in.readImmutableSet(ShardId::new);
+        this.shardIds = in.readCollectionAsImmutableSet(ShardId::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateShardPathResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateShardPathResponse.java
@@ -33,7 +33,7 @@ public class PrevalidateShardPathResponse extends BaseNodesResponse<NodePrevalid
 
     @Override
     protected List<NodePrevalidateShardPathResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodePrevalidateShardPathResponse::new);
+        return in.readCollectionAsList(NodePrevalidateShardPathResponse::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -43,7 +43,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
 
         indices = new CommonStatsFlags(in);
         requestedMetrics.clear();
-        requestedMetrics.addAll(in.readStringList());
+        requestedMetrics.addAll(in.readStringCollectionAsList());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -34,7 +34,7 @@ public class NodesStatsResponse extends BaseNodesXContentResponse<NodeStats> {
 
     @Override
     protected List<NodeStats> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeStats::new);
+        return in.readCollectionAsList(NodeStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -60,7 +60,7 @@ public class ListTasksResponse extends BaseTasksResponse {
 
     public ListTasksResponse(StreamInput in) throws IOException {
         super(in);
-        tasks = in.readImmutableList(TaskInfo::from);
+        tasks = in.readCollectionAsImmutableList(TaskInfo::from);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
@@ -36,7 +36,7 @@ public class NodesUsageResponse extends BaseNodesResponse<NodeUsage> implements 
 
     @Override
     protected List<NodeUsage> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeUsage::new);
+        return in.readCollectionAsList(NodeUsage::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
@@ -79,7 +79,7 @@ public class RemoteClusterNodesAction extends ActionType<RemoteClusterNodesActio
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.nodes = in.readList(DiscoveryNode::new);
+            this.nodes = in.readCollectionAsList(DiscoveryNode::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoResponse.java
@@ -25,7 +25,7 @@ public final class RemoteInfoResponse extends ActionResponse implements ToXConte
 
     RemoteInfoResponse(StreamInput in) throws IOException {
         super(in);
-        infos = in.readImmutableList(RemoteConnectionInfo::new);
+        infos = in.readCollectionAsImmutableList(RemoteConnectionInfo::new);
     }
 
     public RemoteInfoResponse(Collection<RemoteConnectionInfo> infos) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -117,7 +117,7 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
 
     public VerifyRepositoryResponse(StreamInput in) throws IOException {
         super(in);
-        this.nodes = in.readList(NodeView::new);
+        this.nodes = in.readCollectionAsList(NodeView::new);
     }
 
     public VerifyRepositoryResponse(DiscoveryNode[] nodes) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/GetSnapshottableFeaturesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/GetSnapshottableFeaturesResponse.java
@@ -29,7 +29,7 @@ public class GetSnapshottableFeaturesResponse extends ActionResponse implements 
 
     public GetSnapshottableFeaturesResponse(StreamInput in) throws IOException {
         super(in);
-        snapshottableFeatures = in.readImmutableList(SnapshottableFeature::new);
+        snapshottableFeatures = in.readCollectionAsImmutableList(SnapshottableFeature::new);
     }
 
     public List<SnapshottableFeature> getSnapshottableFeatures() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/ResetFeatureStateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/ResetFeatureStateResponse.java
@@ -43,7 +43,7 @@ public class ResetFeatureStateResponse extends ActionResponse implements ToXCont
 
     public ResetFeatureStateResponse(StreamInput in) throws IOException {
         super(in);
-        this.resetFeatureStateStatusList = in.readList(ResetFeatureStateStatus::new);
+        this.resetFeatureStateStatusList = in.readCollectionAsList(ResetFeatureStateStatus::new);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -92,7 +92,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     }
 
     public GetSnapshotsResponse(StreamInput in) throws IOException {
-        this.snapshots = in.readImmutableList(SnapshotInfo::readFrom);
+        this.snapshots = in.readCollectionAsImmutableList(SnapshotInfo::readFrom);
         if (in.getTransportVersion().onOrAfter(GetSnapshotsRequest.MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
             final Map<String, ElasticsearchException> failedResponses = in.readMap(StreamInput::readException);
             this.failures = Collections.unmodifiableMap(failedResponses);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotRequest.java
@@ -38,7 +38,7 @@ public class GetShardSnapshotRequest extends MasterNodeRequest<GetShardSnapshotR
 
     public GetShardSnapshotRequest(StreamInput in) throws IOException {
         super(in);
-        this.repositories = in.readStringList();
+        this.repositories = in.readStringCollectionAsList();
         this.shardId = new ShardId(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -63,7 +63,7 @@ public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
     SnapshotStatus(StreamInput in) throws IOException {
         snapshot = new Snapshot(in);
         state = State.fromValue(in.readByte());
-        shards = in.readImmutableList(SnapshotIndexShardStatus::new);
+        shards = in.readCollectionAsImmutableList(SnapshotIndexShardStatus::new);
         includeGlobalState = in.readOptionalBoolean();
         final long startTime = in.readLong();
         final long time = in.readLong();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -34,7 +34,7 @@ public class SnapshotsStatusResponse extends ActionResponse implements ChunkedTo
 
     public SnapshotsStatusResponse(StreamInput in) throws IOException {
         super(in);
-        snapshots = in.readImmutableList(SnapshotStatus::new);
+        snapshots = in.readCollectionAsImmutableList(SnapshotStatus::new);
     }
 
     SnapshotsStatusResponse(List<SnapshotStatus> snapshots) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -159,7 +159,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
 
         @Override
         protected List<NodeSnapshotStatus> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeSnapshotStatus::new);
+            return in.readCollectionAsList(NodeSnapshotStatus::new);
         }
 
         @Override
@@ -174,7 +174,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
-            snapshots = in.readList(Snapshot::new);
+            snapshots = in.readCollectionAsList(Snapshot::new);
         }
 
         NodeRequest(TransportNodesSnapshotsStatus.Request request) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/AnalysisStats.java
@@ -275,14 +275,14 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
     }
 
     public AnalysisStats(StreamInput input) throws IOException {
-        usedCharFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedTokenizers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedTokenFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedAnalyzers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedBuiltInCharFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedBuiltInTokenizers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedBuiltInTokenFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
-        usedBuiltInAnalyzers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readList(IndexFeatureStats::new)));
+        usedCharFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedTokenizers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedTokenFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedAnalyzers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedBuiltInCharFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedBuiltInTokenizers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedBuiltInTokenFilters = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
+        usedBuiltInAnalyzers = Collections.unmodifiableSet(new LinkedHashSet<>(input.readCollectionAsList(IndexFeatureStats::new)));
         if (input.getTransportVersion().onOrAfter(SYNONYM_SETS_VERSION)) {
             usedSynonyms = input.readImmutableMap(SynonymsStats::new);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -125,7 +125,7 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
 
     @Override
     protected List<ClusterStatsNodeResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(ClusterStatsNodeResponse::readNodeResponse);
+        return in.readCollectionAsList(ClusterStatsNodeResponse::readNodeResponse);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/FieldStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/FieldStats.java
@@ -34,7 +34,7 @@ public class FieldStats extends IndexFeatureStats {
     FieldStats(StreamInput in) throws IOException {
         super(in);
         scriptCount = in.readVInt();
-        scriptLangs = in.readSet(StreamInput::readString);
+        scriptLangs = in.readCollectionAsSet(StreamInput::readString);
         fieldScriptStats = new FieldScriptStats(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -216,8 +216,8 @@ public final class MappingStats implements ToXContentFragment, Writeable {
             totalDeduplicatedFieldCount = null;
             totalMappingSizeBytes = null;
         }
-        fieldTypeStats = in.readImmutableList(FieldStats::new);
-        runtimeFieldStats = in.readImmutableList(RuntimeFieldStats::new);
+        fieldTypeStats = in.readCollectionAsImmutableList(FieldStats::new);
+        runtimeFieldStats = in.readCollectionAsImmutableList(RuntimeFieldStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/RuntimeFieldStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/RuntimeFieldStats.java
@@ -38,7 +38,7 @@ public final class RuntimeFieldStats implements Writeable, ToXContentObject {
         this.type = in.readString();
         this.count = in.readInt();
         this.indexCount = in.readInt();
-        this.scriptLangs = in.readSet(StreamInput::readString);
+        this.scriptLangs = in.readCollectionAsSet(StreamInput::readString);
         this.scriptLessCount = in.readLong();
         this.shadowedCount = in.readLong();
         this.fieldScriptStats = new FieldScriptStats(in);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/VersionStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/VersionStats.java
@@ -99,7 +99,7 @@ public final class VersionStats implements ToXContentFragment, Writeable {
     }
 
     VersionStats(StreamInput in) throws IOException {
-        this.versionStats = Collections.unmodifiableSet(new TreeSet<>(in.readList(SingleVersionStats::new)));
+        this.versionStats = Collections.unmodifiableSet(new TreeSet<>(in.readCollectionAsList(SingleVersionStats::new)));
     }
 
     public Set<SingleVersionStats> versionStats() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -26,7 +26,7 @@ public class PendingClusterTasksResponse extends ActionResponse implements Chunk
 
     public PendingClusterTasksResponse(StreamInput in) throws IOException {
         super(in);
-        pendingTasks = in.readList(PendingClusterTask::new);
+        pendingTasks = in.readCollectionAsList(PendingClusterTask::new);
     }
 
     PendingClusterTasksResponse(List<PendingClusterTask> pendingTasks) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -61,7 +61,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
     public IndicesAliasesRequest(StreamInput in) throws IOException {
         super(in);
-        allAliasActions = in.readList(AliasActions::new);
+        allAliasActions = in.readCollectionAsList(AliasActions::new);
         origin = in.readOptionalString();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -31,8 +31,8 @@ public class GetAliasesResponse extends ActionResponse {
 
     public GetAliasesResponse(StreamInput in) throws IOException {
         super(in);
-        aliases = in.readImmutableOpenMap(StreamInput::readString, i -> i.readList(AliasMetadata::new));
-        dataStreamAliases = in.readMap(in1 -> in1.readList(DataStreamAlias::new));
+        aliases = in.readImmutableOpenMap(StreamInput::readString, i -> i.readCollectionAsList(AliasMetadata::new));
+        dataStreamAliases = in.readMap(in1 -> in1.readCollectionAsList(DataStreamAlias::new));
     }
 
     public Map<String, List<AliasMetadata>> getAliases() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -78,8 +78,8 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
             text = in.readStringArray();
             analyzer = in.readOptionalString();
             tokenizer = in.readOptionalWriteable(NameOrDefinition::new);
-            tokenFilters.addAll(in.readList(NameOrDefinition::new));
-            charFilters.addAll(in.readList(NameOrDefinition::new));
+            tokenFilters.addAll(in.readCollectionAsList(NameOrDefinition::new));
+            charFilters.addAll(in.readCollectionAsList(NameOrDefinition::new));
             field = in.readOptionalString();
             explain = in.readBoolean();
             attributes = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
@@ -159,8 +159,8 @@ public class ReloadAnalyzersResponse extends BroadcastResponse {
 
         ReloadDetails(StreamInput in) throws IOException {
             this.indexName = in.readString();
-            this.reloadedIndicesNodes = new HashSet<>(in.readList(StreamInput::readString));
-            this.reloadedAnalyzers = new HashSet<>(in.readList(StreamInput::readString));
+            this.reloadedIndicesNodes = new HashSet<>(in.readCollectionAsList(StreamInput::readString));
+            this.reloadedAnalyzers = new HashSet<>(in.readCollectionAsList(StreamInput::readString));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportReloadAnalyzersAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportReloadAnalyzersAction.java
@@ -144,7 +144,7 @@ public class TransportReloadAnalyzersAction extends TransportBroadcastByNodeActi
         private ReloadResult(StreamInput in) throws IOException {
             this.index = in.readString();
             this.nodeId = in.readString();
-            this.reloadedSearchAnalyzers = in.readStringList();
+            this.reloadedSearchAnalyzers = in.readStringCollectionAsList();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
@@ -32,7 +32,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
 
     CloseIndexResponse(StreamInput in) throws IOException {
         super(in, true);
-        indices = in.readImmutableList(IndexResult::new);
+        indices = in.readCollectionAsImmutableList(IndexResult::new);
     }
 
     public CloseIndexResponse(final boolean acknowledged, final boolean shardsAcknowledged, final List<IndexResult> indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/FindDanglingIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/FindDanglingIndexResponse.java
@@ -37,7 +37,7 @@ public class FindDanglingIndexResponse extends BaseNodesResponse<NodeFindDanglin
 
     @Override
     protected List<NodeFindDanglingIndexResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeFindDanglingIndexResponse::new);
+        return in.readCollectionAsList(NodeFindDanglingIndexResponse::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/NodeFindDanglingIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/NodeFindDanglingIndexResponse.java
@@ -40,7 +40,7 @@ public class NodeFindDanglingIndexResponse extends BaseNodeResponse {
 
     protected NodeFindDanglingIndexResponse(StreamInput in) throws IOException {
         super(in);
-        this.danglingIndexInfo = in.readList(IndexMetadata::readFrom);
+        this.danglingIndexInfo = in.readCollectionAsList(IndexMetadata::readFrom);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
@@ -94,7 +94,7 @@ public class ListDanglingIndicesResponse extends BaseNodesResponse<NodeListDangl
 
     @Override
     protected List<NodeListDanglingIndicesResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeListDanglingIndicesResponse::new);
+        return in.readCollectionAsList(NodeListDanglingIndicesResponse::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/NodeListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/NodeListDanglingIndicesResponse.java
@@ -34,7 +34,7 @@ public class NodeListDanglingIndicesResponse extends BaseNodeResponse {
 
     protected NodeListDanglingIndicesResponse(StreamInput in) throws IOException {
         super(in);
-        this.indexMetaData = in.readList(DanglingIndexInfo::new);
+        this.indexMetaData = in.readCollectionAsList(DanglingIndexInfo::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -87,7 +87,7 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
             }
         } : i -> i.readBoolean() ? new MappingMetadata(i) : MappingMetadata.EMPTY_MAPPINGS);
 
-        aliases = in.readImmutableOpenMap(StreamInput::readString, i -> i.readList(AliasMetadata::new));
+        aliases = in.readImmutableOpenMap(StreamInput::readString, i -> i.readCollectionAsList(AliasMetadata::new));
         settings = in.readImmutableOpenMap(StreamInput::readString, Settings::readSettingsFromStream);
         defaultSettings = in.readImmutableOpenMap(StreamInput::readString, Settings::readSettingsFromStream);
         dataStreams = in.readImmutableOpenMap(StreamInput::readString, StreamInput::readOptionalString);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockResponse.java
@@ -33,7 +33,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
 
     AddIndexBlockResponse(StreamInput in) throws IOException {
         super(in, true);
-        indices = in.readImmutableList(AddBlockResult::new);
+        indices = in.readCollectionAsImmutableList(AddBlockResult::new);
     }
 
     public AddIndexBlockResponse(final boolean acknowledged, final boolean shardsAcknowledged, final List<AddBlockResult> indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -390,9 +390,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
 
         public Response(StreamInput in) throws IOException {
-            this.indices = in.readList(ResolvedIndex::new);
-            this.aliases = in.readList(ResolvedAlias::new);
-            this.dataStreams = in.readList(ResolvedDataStream::new);
+            this.indices = in.readCollectionAsList(ResolvedIndex::new);
+            this.aliases = in.readCollectionAsList(ResolvedAlias::new);
+            this.dataStreams = in.readCollectionAsList(ResolvedDataStream::new);
         }
 
         public List<ResolvedIndex> getIndices() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverConfiguration.java
@@ -65,7 +65,7 @@ public class RolloverConfiguration implements Writeable, ToXContentObject {
     }
 
     public RolloverConfiguration(StreamInput in) throws IOException {
-        this(new RolloverConditions(in), in.readSet(StreamInput::readString));
+        this(new RolloverConditions(in), in.readCollectionAsSet(StreamInput::readString));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
@@ -61,7 +61,7 @@ public class RolloverInfo implements SimpleDiffable<RolloverInfo>, Writeable, To
     public RolloverInfo(StreamInput in) throws IOException {
         this.alias = in.readString();
         this.time = in.readVLong();
-        this.metConditions = (List) in.readNamedWriteableList(Condition.class);
+        this.metConditions = (List) in.readNamedWriteableCollectionAsList(Condition.class);
     }
 
     public static RolloverInfo parse(XContentParser parser, String alias) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
@@ -31,7 +31,7 @@ public class ShardSegments implements Writeable, Iterable<Segment> {
 
     ShardSegments(StreamInput in) throws IOException {
         shardRouting = new ShardRouting(in);
-        segments = in.readList(Segment::new);
+        segments = in.readCollectionAsList(Segment::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -245,8 +245,10 @@ public class IndicesShardStoresResponse extends ActionResponse implements Chunke
 
     public IndicesShardStoresResponse(StreamInput in) throws IOException {
         super(in);
-        storeStatuses = in.readImmutableMap(i -> i.readImmutableMap(StreamInput::readInt, j -> j.readImmutableList(StoreStatus::new)));
-        failures = in.readImmutableList(Failure::readFailure);
+        storeStatuses = in.readImmutableMap(
+            i -> i.readImmutableMap(StreamInput::readInt, j -> j.readCollectionAsImmutableList(StoreStatus::new))
+        );
+        failures = in.readCollectionAsImmutableList(Failure::readFailure);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
@@ -35,7 +35,7 @@ public class FieldUsageStatsResponse extends ChunkedBroadcastResponse {
 
     FieldUsageStatsResponse(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap(i -> i.readList(FieldUsageShardResponse::new));
+        stats = in.readMap(i -> i.readCollectionAsList(FieldUsageShardResponse::new));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
@@ -29,7 +29,7 @@ public class GetIndexTemplatesResponse extends ActionResponse implements ToXCont
 
     public GetIndexTemplatesResponse(StreamInput in) throws IOException {
         super(in);
-        indexTemplates = in.readList(IndexTemplateMetadata::readFrom);
+        indexTemplates = in.readCollectionAsList(IndexTemplateMetadata::readFrom);
     }
 
     public GetIndexTemplatesResponse(List<IndexTemplateMetadata> indexTemplates) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -68,7 +68,7 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
             overlappingTemplates = Maps.newMapWithExpectedSize(overlappingTemplatesCount);
             for (int i = 0; i < overlappingTemplatesCount; i++) {
                 String templateName = in.readString();
-                overlappingTemplates.put(templateName, in.readStringList());
+                overlappingTemplates.put(templateName, in.readStringCollectionAsList());
             }
         } else {
             this.overlappingTemplates = null;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -72,7 +72,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         super(in);
         cause = in.readString();
         name = in.readString();
-        indexPatterns = in.readStringList();
+        indexPatterns = in.readStringCollectionAsList();
         order = in.readInt();
         create = in.readBoolean();
         settings = readSettingsFromStream(in);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
@@ -65,7 +65,7 @@ public class ValidateQueryResponse extends BroadcastResponse {
     ValidateQueryResponse(StreamInput in) throws IOException {
         super(in);
         valid = in.readBoolean();
-        queryExplanations = in.readList(QueryExplanation::new);
+        queryExplanations = in.readCollectionAsList(QueryExplanation::new);
     }
 
     ValidateQueryResponse(

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -83,7 +83,7 @@ public class BulkRequest extends ActionRequest
     public BulkRequest(StreamInput in) throws IOException {
         super(in);
         waitForActiveShards = ActiveShardCount.readFrom(in);
-        requests.addAll(in.readList(i -> DocWriteRequest.readDocumentRequest(null, i)));
+        requests.addAll(in.readCollectionAsList(i -> DocWriteRequest.readDocumentRequest(null, i)));
         refreshPolicy = RefreshPolicy.readFrom(in);
         timeout = in.readTimeValue();
     }

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -301,7 +301,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
         public record TimeSeries(List<Tuple<Instant, Instant>> temporalRanges) implements Writeable {
 
             TimeSeries(StreamInput in) throws IOException {
-                this(in.readList(in1 -> new Tuple<>(in1.readInstant(), in1.readInstant())));
+                this(in.readCollectionAsList(in1 -> new Tuple<>(in1.readInstant(), in1.readInstant())));
             }
 
             @Override
@@ -341,7 +341,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
 
         public Response(StreamInput in) throws IOException {
             this(
-                in.readList(DataStreamInfo::new),
+                in.readCollectionAsList(DataStreamInfo::new),
                 in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)
                     ? in.readOptionalWriteable(RolloverConfiguration::new)
                     : null

--- a/server/src/main/java/org/elasticsearch/action/datastreams/ModifyDataStreamsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/ModifyDataStreamsAction.java
@@ -60,7 +60,7 @@ public class ModifyDataStreamsAction extends ActionType<AcknowledgedResponse> {
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            actions = in.readList(DataStreamAction::new);
+            actions = in.readCollectionAsList(DataStreamAction::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -243,7 +243,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             this.nonDimensionIndices = null;
             this.metricConflictsIndices = null;
         }
-        meta = in.readMap(i -> i.readSet(StreamInput::readString));
+        meta = in.readMap(i -> i.readCollectionAsSet(StreamInput::readString));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFailure.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFailure.java
@@ -38,7 +38,7 @@ public class FieldCapabilitiesFailure implements Writeable, ToXContentObject {
     }
 
     public FieldCapabilitiesFailure(StreamInput in) throws IOException {
-        this.indices = in.readStringList();
+        this.indices = in.readStringCollectionAsList();
         this.exception = in.readException();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -71,7 +71,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
         implements
             Writeable {
         GroupByMappingHash(StreamInput in) throws IOException {
-            this(in.readStringList(), in.readString(), in.readMap(IndexFieldCapabilities::new));
+            this(in.readStringCollectionAsList(), in.readString(), in.readMap(IndexFieldCapabilities::new));
         }
 
         @Override
@@ -88,10 +88,10 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
 
     static List<FieldCapabilitiesIndexResponse> readList(StreamInput input) throws IOException {
         if (input.getTransportVersion().before(MAPPING_HASH_VERSION)) {
-            return input.readList(FieldCapabilitiesIndexResponse::new);
+            return input.readCollectionAsList(FieldCapabilitiesIndexResponse::new);
         }
-        final List<FieldCapabilitiesIndexResponse> ungroupedList = input.readList(FieldCapabilitiesIndexResponse::new);
-        final List<GroupByMappingHash> groups = input.readList(GroupByMappingHash::new);
+        final List<FieldCapabilitiesIndexResponse> ungroupedList = input.readCollectionAsList(FieldCapabilitiesIndexResponse::new);
+        final List<GroupByMappingHash> groups = input.readCollectionAsList(GroupByMappingHash::new);
         return Stream.concat(ungroupedList.stream(), groups.stream().flatMap(GroupByMappingHash::getResponses)).toList();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -42,7 +42,7 @@ class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesReque
 
     FieldCapabilitiesNodeRequest(StreamInput in) throws IOException {
         super(in);
-        shardIds = in.readList(ShardId::new);
+        shardIds = in.readCollectionAsList(ShardId::new);
         fields = in.readStringArray();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_2_0)) {
             filters = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
@@ -39,7 +39,7 @@ class FieldCapabilitiesNodeResponse extends ActionResponse implements Writeable 
         super(in);
         this.indexResponses = FieldCapabilitiesIndexResponse.readList(in);
         this.failures = in.readMap(ShardId::new, StreamInput::readException);
-        this.unmatchedShardIds = in.readSet(ShardId::new);
+        this.unmatchedShardIds = in.readCollectionAsSet(ShardId::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -78,7 +78,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
         indices = in.readStringArray();
         this.responseMap = in.readMap(FieldCapabilitiesResponse::readField);
         this.indexResponses = FieldCapabilitiesIndexResponse.readList(in);
-        this.failures = in.readList(FieldCapabilitiesFailure::new);
+        this.failures = in.readCollectionAsList(FieldCapabilitiesFailure::new);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -262,7 +262,7 @@ public class MultiGetRequest extends ActionRequest
         preference = in.readOptionalString();
         refresh = in.readBoolean();
         realtime = in.readBoolean();
-        items = in.readList(Item::new);
+        items = in.readCollectionAsList(Item::new);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_4_0)) {
             forceSyntheticSource = in.readBoolean();
         } else {

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
@@ -167,7 +167,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
         nowInMillis = in.readVLong();
         clusterAlias = in.readOptionalString();
         waitForCheckpointsTimeout = in.readTimeValue();
-        shards = in.readList(Shard::new);
+        shards = in.readCollectionAsList(Shard::new);
         indices = shards.stream().map(Shard::getOriginalIndices).flatMap(Arrays::stream).distinct().toArray(String[]::new);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeResponse.java
@@ -24,7 +24,7 @@ public class CanMatchNodeResponse extends TransportResponse {
 
     public CanMatchNodeResponse(StreamInput in) throws IOException {
         super(in);
-        responses = in.readList(ResponseOrFailure::new);
+        responses = in.readCollectionAsList(ResponseOrFailure::new);
     }
 
     public CanMatchNodeResponse(List<ResponseOrFailure> responses) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -538,7 +538,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.successful = in.readVInt();
             this.skipped = in.readVInt();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_053)) {
-                List<Cluster> clusterList = in.readList(Cluster::new);
+                List<Cluster> clusterList = in.readCollectionAsList(Cluster::new);
                 if (clusterList.isEmpty()) {
                     this.clusterInfo = Collections.emptyMap();
                 } else {
@@ -884,7 +884,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
                 this.took = new TimeValue(took);
             }
             this.timedOut = in.readBoolean();
-            this.failures = Collections.unmodifiableList(in.readList(ShardSearchFailure::readShardSearchFailure));
+            this.failures = Collections.unmodifiableList(in.readCollectionAsList(ShardSearchFailure::readShardSearchFailure));
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_066)) {
                 this.skipUnavailable = in.readBoolean();
             } else {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsGroup.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsGroup.java
@@ -49,7 +49,7 @@ public class SearchShardsGroup implements Writeable {
 
     public SearchShardsGroup(StreamInput in) throws IOException {
         this.shardId = new ShardId(in);
-        this.allocatedNodes = in.readStringList();
+        this.allocatedNodes = in.readStringCollectionAsList();
         this.skipped = in.readBoolean();
         this.preFiltered = true;
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
@@ -47,8 +47,8 @@ public final class SearchShardsResponse extends ActionResponse {
 
     public SearchShardsResponse(StreamInput in) throws IOException {
         super(in);
-        this.groups = in.readList(SearchShardsGroup::new);
-        this.nodes = in.readList(DiscoveryNode::new);
+        this.groups = in.readCollectionAsList(SearchShardsGroup::new);
+        this.nodes = in.readCollectionAsList(DiscoveryNode::new);
         this.aliasFilters = in.readMap(AliasFilter::readFrom);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -469,7 +469,7 @@ public abstract class TransportBroadcastByNodeAction<
         NodeRequest(StreamInput in) throws IOException {
             super(in);
             indicesLevelRequest = readRequestFrom(in);
-            shards = in.readList(ShardRouting::new);
+            shards = in.readCollectionAsList(ShardRouting::new);
             nodeId = in.readString();
         }
 
@@ -552,9 +552,9 @@ public abstract class TransportBroadcastByNodeAction<
             super(in);
             nodeId = in.readString();
             totalShards = in.readVInt();
-            results = in.readList((stream) -> stream.readBoolean() ? readShardResult(stream) : null);
+            results = in.readCollectionAsList((stream) -> stream.readBoolean() ? readShardResult(stream) : null);
             if (in.readBoolean()) {
-                exceptions = in.readList(BroadcastShardOperationFailedException::new);
+                exceptions = in.readCollectionAsList(BroadcastShardOperationFailedException::new);
             } else {
                 exceptions = null;
             }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -31,7 +31,7 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
         super(in);
         clusterName = new ClusterName(in);
         nodes = readNodesFrom(in);
-        failures = in.readList(FailedNodeException::new);
+        failures = in.readCollectionAsList(FailedNodeException::new);
     }
 
     protected BaseNodesResponse(ClusterName clusterName, List<TNodeResponse> nodes, List<FailedNodeException> failures) {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -358,7 +358,7 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
         public static final ReservedSpace EMPTY = new ReservedSpace(0, new HashSet<>());
 
         ReservedSpace(StreamInput in) throws IOException {
-            this(in.readVLong(), in.readSet(ShardId::new));
+            this(in.readVLong(), in.readCollectionAsSet(ShardId::new));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterSnapshotStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterSnapshotStats.java
@@ -184,7 +184,7 @@ public record ClusterSnapshotStats(
             in.readVInt(),
             in.readVInt(),
             in.readVInt(),
-            in.readList(PerRepositoryStats::readFrom)
+            in.readCollectionAsList(PerRepositoryStats::readFrom)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -302,7 +302,7 @@ public final class DiffableUtils {
         ) throws IOException {
             this.keySerializer = keySerializer;
             this.valueSerializer = valueSerializer;
-            deletes = in.readList(keySerializer::readKey);
+            deletes = in.readCollectionAsList(keySerializer::readKey);
             int diffsCount = in.readVInt();
             diffs = diffsCount == 0 ? List.of() : new ArrayList<>(diffsCount);
             for (int i = 0; i < diffsCount; i++) {

--- a/server/src/main/java/org/elasticsearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RepositoryCleanupInProgress.java
@@ -37,7 +37,7 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
     }
 
     RepositoryCleanupInProgress(StreamInput in) throws IOException {
-        this.entries = in.readList(Entry::new);
+        this.entries = in.readCollectionAsList(Entry::new);
     }
 
     public static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
@@ -371,7 +371,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
                 // Backwards compatibility: previously there was no logging of the start or completion of a snapshot restore
                 quiet = true;
             }
-            List<String> indices = in.readImmutableList(StreamInput::readString);
+            List<String> indices = in.readCollectionAsImmutableList(StreamInput::readString);
             entriesBuilder.put(
                 uuid,
                 new Entry(

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -56,7 +56,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
     }
 
     public SnapshotDeletionsInProgress(StreamInput in) throws IOException {
-        this(in.readImmutableList(Entry::new));
+        this(in.readCollectionAsImmutableList(Entry::new));
     }
 
     private static boolean assertNoConcurrentDeletionsForSameRepository(List<Entry> entries) {
@@ -228,7 +228,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
         public Entry(StreamInput in) throws IOException {
             this.repoName = in.readString();
-            this.snapshots = in.readImmutableList(SnapshotId::new);
+            this.snapshots = in.readCollectionAsImmutableList(SnapshotId::new);
             this.startTime = in.readVLong();
             this.repositoryStateId = in.readLong();
             this.state = State.readFrom(in);

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -838,13 +838,13 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             final String failure = in.readOptionalString();
             final Map<String, Object> userMetadata = in.readMap();
             final IndexVersion version = IndexVersion.readVersion(in);
-            final List<String> dataStreams = in.readImmutableStringList();
+            final List<String> dataStreams = in.readStringCollectionAsImmutableList();
             final SnapshotId source = in.readOptionalWriteable(SnapshotId::new);
             final Map<RepositoryShardId, ShardSnapshotStatus> clones = in.readImmutableMap(
                 RepositoryShardId::readFrom,
                 ShardSnapshotStatus::readFrom
             );
-            final List<SnapshotFeatureInfo> featureStates = in.readImmutableList(SnapshotFeatureInfo::new);
+            final List<SnapshotFeatureInfo> featureStates = in.readCollectionAsImmutableList(SnapshotFeatureInfo::new);
             if (source == null) {
                 return snapshot(
                     snapshot,
@@ -1431,7 +1431,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             this.indexByIndexNameDiff = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(), INDEX_ID_VALUE_SERIALIZER);
             this.updatedState = State.fromValue(in.readByte());
             this.updatedRepositoryStateId = in.readLong();
-            this.updatedDataStreams = in.readOptionalStringList();
+            this.updatedDataStreams = in.readOptionalStringCollectionAsList();
             this.updatedFailure = in.readOptionalString();
             this.shardsByShardIdDiff = DiffableUtils.readJdkMapDiff(
                 in,
@@ -1598,7 +1598,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             this.mapDiff = DiffableUtils.readJdkMapDiff(
                 in,
                 DiffableUtils.getStringKeySerializer(),
-                i -> new ByRepo(i.readImmutableList(Entry::readFrom)),
+                i -> new ByRepo(i.readCollectionAsImmutableList(Entry::readFrom)),
                 i -> new ByRepo.ByRepoDiff(
                     DiffableUtils.readJdkMapDiff(i, DiffableUtils.getStringKeySerializer(), Entry::readFrom, EntryDiff::new),
                     DiffableUtils.readJdkMapDiff(i, DiffableUtils.getStringKeySerializer(), ByRepo.INT_DIFF_VALUE_SERIALIZER)

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlockException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlockException.java
@@ -35,7 +35,7 @@ public class ClusterBlockException extends ElasticsearchException {
 
     public ClusterBlockException(StreamInput in) throws IOException {
         super(in);
-        this.blocks = in.readImmutableSet(ClusterBlock::new);
+        this.blocks = in.readCollectionAsImmutableSet(ClusterBlock::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -294,7 +294,7 @@ public class ClusterBlocks implements SimpleDiffable<ClusterBlocks> {
     }
 
     private static Set<ClusterBlock> readBlockSet(StreamInput in) throws IOException {
-        return in.readImmutableSet(ClusterBlock::new);
+        return in.readCollectionAsImmutableSet(ClusterBlock::new);
     }
 
     public static Diff<ClusterBlocks> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -204,19 +204,19 @@ public class ClusterFormationFailureHelper {
 
         public ClusterFormationState(StreamInput in) throws IOException {
             this(
-                in.readStringList(),
+                in.readStringCollectionAsList(),
                 new DiscoveryNode(in),
                 in.readMap(DiscoveryNode::new),
                 in.readLong(),
                 in.readLong(),
                 new VotingConfiguration(in),
                 new VotingConfiguration(in),
-                in.readImmutableList(TransportAddress::new),
-                in.readImmutableList(DiscoveryNode::new),
+                in.readCollectionAsImmutableList(TransportAddress::new),
+                in.readCollectionAsImmutableList(DiscoveryNode::new),
                 in.readLong(),
                 in.readBoolean(),
                 new StatusInfo(in),
-                in.readList(JoinStatus::new)
+                in.readCollectionAsList(JoinStatus::new)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1285,7 +1285,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
             boolean hasRecentMasters = in.readBoolean();
             List<DiscoveryNode> recentMasters;
             if (hasRecentMasters) {
-                recentMasters = in.readImmutableList(DiscoveryNode::new);
+                recentMasters = in.readCollectionAsImmutableList(DiscoveryNode::new);
             } else {
                 recentMasters = null;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -98,7 +98,7 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
         term = in.readLong();
         lastCommittedConfiguration = new VotingConfiguration(in);
         lastAcceptedConfiguration = new VotingConfiguration(in);
-        votingConfigExclusions = in.readImmutableSet(VotingConfigExclusion::new);
+        votingConfigExclusions = in.readCollectionAsImmutableSet(VotingConfigExclusion::new);
     }
 
     public static Builder builder() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PeersResponse.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PeersResponse.java
@@ -32,7 +32,7 @@ public class PeersResponse extends TransportResponse {
 
     public PeersResponse(StreamInput in) throws IOException {
         masterNode = Optional.ofNullable(in.readOptionalWriteable(DiscoveryNode::new));
-        knownPeers = in.readImmutableList(DiscoveryNode::new);
+        knownPeers = in.readCollectionAsImmutableList(DiscoveryNode::new);
         term = in.readLong();
         assert masterNode.isPresent() == false || knownPeers.isEmpty();
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -161,20 +161,20 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
     }
 
     public ComposableIndexTemplate(StreamInput in) throws IOException {
-        this.indexPatterns = in.readStringList();
+        this.indexPatterns = in.readStringCollectionAsList();
         if (in.readBoolean()) {
             this.template = new Template(in);
         } else {
             this.template = null;
         }
-        this.componentTemplates = in.readOptionalStringList();
+        this.componentTemplates = in.readOptionalStringCollectionAsList();
         this.priority = in.readOptionalVLong();
         this.version = in.readOptionalVLong();
         this.metadata = in.readMap();
         this.dataStreamTemplate = in.readOptionalWriteable(DataStreamTemplate::new);
         this.allowAutoCreate = in.readOptionalBoolean();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-            this.ignoreMissingComponentTemplates = in.readOptionalStringList();
+            this.ignoreMissingComponentTemplates = in.readOptionalStringCollectionAsList();
         } else {
             this.ignoreMissingComponentTemplates = null;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -794,7 +794,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
 
     static List<Index> readIndices(StreamInput in) throws IOException {
         in.readString(); // timestamp field, which is always @timestamp
-        return in.readImmutableList(Index::new);
+        return in.readCollectionAsImmutableList(Index::new);
     }
 
     public static Diff<DataStream> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -165,7 +165,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
 
     public DataStreamAlias(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.dataStreams = in.readStringList();
+        this.dataStreams = in.readStringCollectionAsList();
         this.writeDataStream = in.readOptionalString();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
             this.dataStreamToFilterMap = in.readMap(CompressedXContent::readCompressedString);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -414,7 +414,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         }
 
         public static Downsampling read(StreamInput in) throws IOException {
-            return new Downsampling(in.readOptionalList(Round::read));
+            return new Downsampling(in.readOptionalCollectionAsList(Round::read));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodes.java
@@ -163,7 +163,7 @@ public class DesiredNodes implements Writeable, ToXContentObject, Iterable<Desir
     public static DesiredNodes readFrom(StreamInput in) throws IOException {
         final var historyId = in.readString();
         final var version = in.readLong();
-        final var nodesWithStatus = in.readList(DesiredNodeWithStatus::readFrom);
+        final var nodesWithStatus = in.readCollectionAsList(DesiredNodeWithStatus::readFrom);
         return create(historyId, version, nodesWithStatus);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -88,7 +88,7 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
     }
 
     public static Diff<DiffableStringMap> readDiffFrom(StreamInput in) throws IOException {
-        final List<String> deletes = in.readStringList();
+        final List<String> deletes = in.readStringCollectionAsList();
         final Map<String, String> upserts = in.readMap(StreamInput::readString);
         return getDiff(deletes, upserts);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -78,7 +78,7 @@ public final class IndexGraveyard implements Metadata.Custom {
     }
 
     public IndexGraveyard(final StreamInput in) throws IOException {
-        this.tombstones = in.readImmutableList(Tombstone::new);
+        this.tombstones = in.readCollectionAsImmutableList(Tombstone::new);
     }
 
     @Override
@@ -255,7 +255,7 @@ public final class IndexGraveyard implements Metadata.Custom {
         private final int removedCount;
 
         IndexGraveyardDiff(final StreamInput in) throws IOException {
-            added = in.readImmutableList(Tombstone::new);
+            added = in.readCollectionAsImmutableList(Tombstone::new);
             removedCount = in.readVInt();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -181,7 +181,7 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
     public static IndexTemplateMetadata readFrom(StreamInput in) throws IOException {
         Builder builder = new Builder(in.readString());
         builder.order(in.readInt());
-        builder.patterns(in.readStringList());
+        builder.patterns(in.readStringCollectionAsList());
         builder.settings(Settings.readSettingsFromStream(in));
         int mappingsSize = in.readVInt();
         for (int i = 0; i < mappingsSize; i++) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ItemUsage.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ItemUsage.java
@@ -47,17 +47,17 @@ public class ItemUsage implements Writeable, ToXContentObject {
 
     public ItemUsage(StreamInput in) throws IOException {
         if (in.readBoolean()) {
-            this.indices = in.readSet(StreamInput::readString);
+            this.indices = in.readCollectionAsSet(StreamInput::readString);
         } else {
             this.indices = null;
         }
         if (in.readBoolean()) {
-            this.dataStreams = in.readSet(StreamInput::readString);
+            this.dataStreams = in.readCollectionAsSet(StreamInput::readString);
         } else {
             this.dataStreams = null;
         }
         if (in.readBoolean()) {
-            this.composableTemplates = in.readSet(StreamInput::readString);
+            this.composableTemplates = in.readCollectionAsSet(StreamInput::readString);
         } else {
             this.composableTemplates = null;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
@@ -178,7 +178,7 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Custom> implemen
     }
 
     public RepositoriesMetadata(StreamInput in) throws IOException {
-        this.repositories = in.readImmutableList(RepositoryMetadata::new);
+        this.repositories = in.readCollectionAsImmutableList(RepositoryMetadata::new);
     }
 
     public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateErrorMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateErrorMetadata.java
@@ -62,7 +62,11 @@ public record ReservedStateErrorMetadata(Long version, ErrorKind errorKind, List
      * @throws IOException
      */
     public static ReservedStateErrorMetadata readFrom(StreamInput in) throws IOException {
-        return new ReservedStateErrorMetadata(in.readLong(), ErrorKind.of(in.readString()), in.readList(StreamInput::readString));
+        return new ReservedStateErrorMetadata(
+            in.readLong(),
+            ErrorKind.of(in.readString()),
+            in.readCollectionAsList(StreamInput::readString)
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateHandlerMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateHandlerMetadata.java
@@ -53,7 +53,7 @@ public record ReservedStateHandlerMetadata(String name, Set<String> keys)
      * @throws IOException
      */
     public static ReservedStateHandlerMetadata readFrom(StreamInput in) throws IOException {
-        return new ReservedStateHandlerMetadata(in.readString(), in.readSet(StreamInput::readString));
+        return new ReservedStateHandlerMetadata(in.readString(), in.readCollectionAsSet(StreamInput::readString));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -306,7 +306,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         this.failure = in.readException();
         this.failedAllocations = in.readVInt();
         this.lastAllocationStatus = AllocationStatus.readFrom(in);
-        this.failedNodeIds = in.readImmutableSet(StreamInput::readString);
+        this.failedNodeIds = in.readCollectionAsImmutableSet(StreamInput::readString);
         if (in.getTransportVersion().onOrAfter(VERSION_LAST_ALLOCATED_NODE_ADDED)) {
             this.lastAllocatedNodeId = in.readOptionalString();
         } else {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AbstractAllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AbstractAllocationDecision.java
@@ -40,7 +40,7 @@ public abstract class AbstractAllocationDecision implements ToXContentFragment, 
 
     protected AbstractAllocationDecision(StreamInput in) throws IOException {
         targetNode = in.readOptionalWriteable(DiscoveryNode::new);
-        nodeDecisions = in.readBoolean() ? in.readImmutableList(NodeAllocationResult::new) : null;
+        nodeDecisions = in.readBoolean() ? in.readCollectionAsImmutableList(NodeAllocationResult::new) : null;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
@@ -211,7 +211,7 @@ public record ClusterBalanceStats(Map<String, TierBalanceStats> tiers, Map<Strin
         public static NodeBalanceStats readFrom(StreamInput in) throws IOException {
             return new NodeBalanceStats(
                 in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0) ? in.readString() : UNKNOWN_NODE_ID,
-                in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0) ? in.readStringList() : List.of(),
+                in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0) ? in.readStringCollectionAsList() : List.of(),
                 in.readInt(),
                 in.readDouble(),
                 in.readLong(),

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -43,14 +43,14 @@ public class DocumentField implements Writeable, Iterable<Object> {
 
     public DocumentField(StreamInput in) throws IOException {
         name = in.readString();
-        values = in.readList(StreamInput::readGenericValue);
+        values = in.readCollectionAsList(StreamInput::readGenericValue);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-            ignoredValues = in.readList(StreamInput::readGenericValue);
+            ignoredValues = in.readCollectionAsList(StreamInput::readGenericValue);
         } else {
             ignoredValues = Collections.emptyList();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_2_0)) {
-            lookupFields = in.readList(LookupField::new);
+            lookupFields = in.readCollectionAsList(LookupField::new);
         } else {
             lookupFields = List.of();
         }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
@@ -33,7 +33,7 @@ public class NamedWriteableAwareStreamInput extends FilterStreamInput {
     }
 
     @Override
-    public <T extends NamedWriteable> List<T> readNamedWriteableList(Class<T> categoryClass) throws IOException {
+    public <T extends NamedWriteable> List<T> readNamedWriteableCollectionAsList(Class<T> categoryClass) throws IOException {
         int count = readArraySize();
         if (count == 0) {
             return Collections.emptyList();

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -663,7 +663,7 @@ public abstract class StreamInput extends InputStream {
      * @return Never {@code null}.
      */
     public <V> Map<String, List<V>> readMapOfLists(final Writeable.Reader<V> valueReader) throws IOException {
-        return readMap(i -> i.readList(valueReader));
+        return readMap(i -> i.readCollectionAsList(valueReader));
     }
 
     /**
@@ -1070,19 +1070,127 @@ public abstract class StreamInput extends InputStream {
      *
      * @return the list of objects
      * @throws IOException if an I/O exception occurs reading the list
+     * @deprecated use {@link #readCollectionAsList}.
      */
+    @Deprecated(forRemoval = true)
     public <T> List<T> readList(final Writeable.Reader<T> reader) throws IOException {
+        return readCollectionAsList(reader);
+    }
+
+    /**
+     * Reads a list of objects. The list is expected to have been written using {@link StreamOutput#writeCollection}.
+     * The returned list is immutable.
+     *
+     * @return the list of objects
+     * @throws IOException if an I/O exception occurs reading the list
+     * @deprecated use {@link #readCollectionAsImmutableList}.
+     */
+    @Deprecated(forRemoval = true)
+    public <T> List<T> readImmutableList(final Writeable.Reader<T> reader) throws IOException {
+        return readCollectionAsImmutableList(reader);
+    }
+
+    /**
+     * Same as {@link #readStringList()} but always returns an immutable list.
+     *
+     * @return immutable list of strings
+     * @throws IOException on failure
+     * @deprecated use {@link #readStringCollectionAsImmutableList}.
+     */
+    @Deprecated(forRemoval = true)
+    public List<String> readImmutableStringList() throws IOException {
+        return readStringCollectionAsImmutableList();
+    }
+
+    /**
+     * Reads a list of strings. The list is expected to have been written using {@link StreamOutput#writeStringCollection(Collection)}.
+     * If the returned list contains any entries it will be mutable. If it is empty it might be immutable.
+     *
+     * @return the list of strings
+     * @throws IOException if an I/O exception occurs reading the list
+     * @deprecated use {@link #readStringCollectionAsList}.
+     */
+    @Deprecated(forRemoval = true)
+    public List<String> readStringList() throws IOException {
+        return readStringCollectionAsList();
+    }
+
+    /**
+     * Reads an optional list. The list is expected to have been written using
+     * {@link StreamOutput#writeOptionalCollection(Collection)}. If the returned list contains any entries it will be mutable.
+     * If it is empty it might be immutable.
+     * @deprecated use {@link #readOptionalCollectionAsList}.
+     */
+    @Deprecated(forRemoval = true)
+    public <T> List<T> readOptionalList(final Writeable.Reader<T> reader) throws IOException {
+        return readOptionalCollectionAsList(reader);
+    }
+
+    /**
+     * Reads an optional list of strings. The list is expected to have been written using
+     * {@link StreamOutput#writeOptionalStringCollection(Collection)}. If the returned list contains any entries it will be mutable.
+     * If it is empty it might be immutable.
+     *
+     * @return the list of strings
+     * @throws IOException if an I/O exception occurs reading the list
+     * @deprecated use {@link #readOptionalStringCollectionAsList}.
+     */
+    @Deprecated(forRemoval = true)
+    public List<String> readOptionalStringList() throws IOException {
+        return readOptionalStringCollectionAsList();
+    }
+
+    /**
+     * Reads a set of objects. If the returned set contains any entries it will be mutable. If it is empty it might be immutable.
+     * @deprecated use {@link #readCollectionAsSet}.
+     */
+    @Deprecated(forRemoval = true)
+    public <T> Set<T> readSet(Writeable.Reader<T> reader) throws IOException {
+        return readCollectionAsSet(reader);
+    }
+
+    /**
+     * Reads a set of objects. The set is expected to have been written using {@link StreamOutput#writeCollection(Collection)}} with
+     * a collection that contains no duplicates. The returned set is immutable.
+     *
+     * @return the set of objects
+     * @throws IOException if an I/O exception occurs reading the set
+     * @deprecated use {@link #readCollectionAsImmutableSet}.
+     */
+    @Deprecated(forRemoval = true)
+    public <T> Set<T> readImmutableSet(final Writeable.Reader<T> reader) throws IOException {
+        return readCollectionAsImmutableSet(reader);
+    }
+
+    /**
+     * Reads a list of {@link NamedWriteable}s. If the returned list contains any entries it will be mutable.
+     * If it is empty it might be immutable.
+     * @deprecated use {@link #readNamedWriteableCollectionAsList}.
+     */
+    @Deprecated(forRemoval = true)
+    public <T extends NamedWriteable> List<T> readNamedWriteableList(Class<T> categoryClass) throws IOException {
+        return readNamedWriteableCollectionAsList(categoryClass);
+    }
+
+    /**
+     * Reads a list of objects. The list is expected to have been written using {@link StreamOutput#writeCollection}.
+     * If the returned list contains any entries it will be mutable. If it is empty it might be immutable.
+     *
+     * @return the list of objects
+     * @throws IOException if an I/O exception occurs reading the list
+     */
+    public <T> List<T> readCollectionAsList(final Writeable.Reader<T> reader) throws IOException {
         return readCollection(reader, ArrayList::new, Collections.emptyList());
     }
 
     /**
-     * Reads an list of objects. The list is expected to have been written using {@link StreamOutput#writeCollection}.
+     * Reads a list of objects. The list is expected to have been written using {@link StreamOutput#writeCollection}.
      * The returned list is immutable.
      *
      * @return the list of objects
      * @throws IOException if an I/O exception occurs reading the list
      */
-    public <T> List<T> readImmutableList(final Writeable.Reader<T> reader) throws IOException {
+    public <T> List<T> readCollectionAsImmutableList(final Writeable.Reader<T> reader) throws IOException {
         int count = readArraySize();
         // special cases small arrays, just like in java.util.List.of(...)
         return switch (count) {
@@ -1102,13 +1210,13 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Same as {@link #readStringList()} but always returns an immutable list.
+     * Same as {@link #readStringCollectionAsList()} but always returns an immutable list.
      *
      * @return immutable list of strings
      * @throws IOException on failure
      */
-    public List<String> readImmutableStringList() throws IOException {
-        return readImmutableList(StreamInput::readString);
+    public List<String> readStringCollectionAsImmutableList() throws IOException {
+        return readCollectionAsImmutableList(StreamInput::readString);
     }
 
     /**
@@ -1118,8 +1226,8 @@ public abstract class StreamInput extends InputStream {
      * @return the list of strings
      * @throws IOException if an I/O exception occurs reading the list
      */
-    public List<String> readStringList() throws IOException {
-        return readList(StreamInput::readString);
+    public List<String> readStringCollectionAsList() throws IOException {
+        return readCollectionAsList(StreamInput::readString);
     }
 
     /**
@@ -1127,9 +1235,9 @@ public abstract class StreamInput extends InputStream {
      * {@link StreamOutput#writeOptionalCollection(Collection)}. If the returned list contains any entries it will be mutable.
      * If it is empty it might be immutable.
      */
-    public <T> List<T> readOptionalList(final Writeable.Reader<T> reader) throws IOException {
+    public <T> List<T> readOptionalCollectionAsList(final Writeable.Reader<T> reader) throws IOException {
         final boolean isPresent = readBoolean();
-        return isPresent ? readList(reader) : null;
+        return isPresent ? readCollectionAsList(reader) : null;
     }
 
     /**
@@ -1140,25 +1248,26 @@ public abstract class StreamInput extends InputStream {
      * @return the list of strings
      * @throws IOException if an I/O exception occurs reading the list
      */
-    public List<String> readOptionalStringList() throws IOException {
-        return readOptionalList(StreamInput::readString);
+    public List<String> readOptionalStringCollectionAsList() throws IOException {
+        return readOptionalCollectionAsList(StreamInput::readString);
     }
 
     /**
-     * Reads a set of objects. If the returned set contains any entries it will be mutable. If it is empty it might be immutable.
+     * Reads a set of objects. The set is expected to have been written using {@link StreamOutput#writeCollection(Collection)}}. If the
+     * returned set contains any entries it will be mutable. If it is empty it might be immutable.
      */
-    public <T> Set<T> readSet(Writeable.Reader<T> reader) throws IOException {
+    public <T> Set<T> readCollectionAsSet(Writeable.Reader<T> reader) throws IOException {
         return readCollection(reader, Sets::newHashSetWithExpectedSize, Collections.emptySet());
     }
 
     /**
-     * Reads a set of objects. The set is expected to have been written using {@link StreamOutput#writeCollection(Collection)}} with
-     * a collection that contains no duplicates. The returned set is immutable.
+     * Reads a set of objects. The set is expected to have been written using {@link StreamOutput#writeCollection(Collection)}}. The
+     * returned set is immutable.
      *
      * @return the set of objects
      * @throws IOException if an I/O exception occurs reading the set
      */
-    public <T> Set<T> readImmutableSet(final Writeable.Reader<T> reader) throws IOException {
+    public <T> Set<T> readCollectionAsImmutableSet(final Writeable.Reader<T> reader) throws IOException {
         int count = readArraySize();
         // special cases small arrays, just like in java.util.Set.of(...)
         return switch (count) {
@@ -1178,10 +1287,10 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Reads a list of {@link NamedWriteable}s. If the returned list contains any entries it will be mutable.
-     * If it is empty it might be immutable.
+     * Reads a list of {@link NamedWriteable}s, as written by {@link StreamOutput#writeNamedWriteableCollection}. If the returned list
+     * contains any entries it will be mutable. If it is empty it might be immutable.
      */
-    public <T extends NamedWriteable> List<T> readNamedWriteableList(Class<T> categoryClass) throws IOException {
+    public <T extends NamedWriteable> List<T> readNamedWriteableCollectionAsList(Class<T> categoryClass) throws IOException {
         throw new UnsupportedOperationException("can't read named writeable from StreamInput");
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1036,7 +1036,7 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes a collection to this stream. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readList(Writeable.Reader)}.
+     * {@link StreamInput#readCollectionAsList(Writeable.Reader)}.
      *
      * @param collection the collection to write to this stream
      * @throws IOException if an I/O exception occurs writing the collection
@@ -1060,7 +1060,7 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes a collection of a strings. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readList(Writeable.Reader)}.
+     * {@link StreamInput#readCollectionAsList(Writeable.Reader)}.
      *
      * @param collection the collection of strings
      * @throws IOException if an I/O exception occurs writing the collection
@@ -1071,7 +1071,7 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes an optional collection. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readOptionalList(Writeable.Reader)}.
+     * {@link StreamInput#readOptionalCollectionAsList(Writeable.Reader)}.
      */
     public <T extends Writeable> void writeOptionalCollection(final Collection<T> collection) throws IOException {
         writeOptionalCollection(collection, StreamOutput::writeWriteable);
@@ -1079,7 +1079,7 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes an optional collection via {@link Writer}. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readOptionalList(Writeable.Reader)}.
+     * {@link StreamInput#readOptionalCollectionAsList(Writeable.Reader)}.
      */
     public <T> void writeOptionalCollection(final Collection<T> collection, final Writer<T> writer) throws IOException {
         if (collection != null) {
@@ -1092,7 +1092,7 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes an optional collection of a strings. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readList(Writeable.Reader)}.
+     * {@link StreamInput#readCollectionAsList(Writeable.Reader)}.
      *
      * @param collection the collection of strings
      * @throws IOException if an I/O exception occurs writing the collection
@@ -1102,10 +1102,10 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a list of {@link NamedWriteable} objects.
+     * Writes a collection of {@link NamedWriteable} objects.
      */
-    public void writeNamedWriteableCollection(Collection<? extends NamedWriteable> collection) throws IOException {
-        writeCollection(collection, StreamOutput::writeNamedWriteable);
+    public void writeNamedWriteableCollection(Collection<? extends NamedWriteable> list) throws IOException {
+        writeCollection(list, StreamOutput::writeNamedWriteable);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1035,21 +1035,16 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a collection to this stream. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readCollectionAsList(Writeable.Reader)}.
-     *
-     * @param collection the collection to write to this stream
-     * @throws IOException if an I/O exception occurs writing the collection
+     * Writes a collection which can then be read using {@link StreamInput#readCollectionAsList} or another {@code readCollectionAs*}
+     * method. Make sure to read the collection back into the same type as was originally written.
      */
     public void writeCollection(final Collection<? extends Writeable> collection) throws IOException {
         writeCollection(collection, StreamOutput::writeWriteable);
     }
 
     /**
-     * Writes a collection of objects via a {@link Writer}.
-     *
-     * @param collection the collection of objects
-     * @throws IOException if an I/O exception occurs writing the collection
+     * Writes a collection which can then be read using {@link StreamInput#readCollectionAsList} or another {@code readCollectionAs*}
+     * method. Make sure to read the collection back into the same type as was originally written.
      */
     public <T> void writeCollection(final Collection<T> collection, final Writer<T> writer) throws IOException {
         writeVInt(collection.size());
@@ -1059,29 +1054,24 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes a collection of a strings. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readCollectionAsList(Writeable.Reader)}.
-     *
-     * @param collection the collection of strings
-     * @throws IOException if an I/O exception occurs writing the collection
+     * Writes a collection of strings which can then be read using {@link StreamInput#readStringCollectionAsList} or another {@code
+     * readStringCollectionAs*} method. Make sure to read the collection back into the same type as was originally written.
      */
     public void writeStringCollection(final Collection<String> collection) throws IOException {
         writeCollection(collection, StreamOutput::writeString);
     }
 
     /**
-     * Writes an optional collection. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readOptionalCollectionAsList(Writeable.Reader)}.
+     * Writes a possibly-{@code null} collection which can then be read using {@link StreamInput#readOptionalCollectionAsList}.
      */
-    public <T extends Writeable> void writeOptionalCollection(final Collection<T> collection) throws IOException {
+    public <T extends Writeable> void writeOptionalCollection(@Nullable final Collection<T> collection) throws IOException {
         writeOptionalCollection(collection, StreamOutput::writeWriteable);
     }
 
     /**
-     * Writes an optional collection via {@link Writer}. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readOptionalCollectionAsList(Writeable.Reader)}.
+     * Writes a possibly-{@code null} collection which can then be read using {@link StreamInput#readOptionalCollectionAsList}.
      */
-    public <T> void writeOptionalCollection(final Collection<T> collection, final Writer<T> writer) throws IOException {
+    public <T> void writeOptionalCollection(@Nullable final Collection<T> collection, final Writer<T> writer) throws IOException {
         if (collection != null) {
             writeBoolean(true);
             writeCollection(collection, writer);
@@ -1091,18 +1081,16 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
-     * Writes an optional collection of a strings. The corresponding collection can be read from a stream input using
-     * {@link StreamInput#readCollectionAsList(Writeable.Reader)}.
-     *
-     * @param collection the collection of strings
-     * @throws IOException if an I/O exception occurs writing the collection
+     * Writes a possibly-{@code null} collection of strings which can then be read using
+     * {@link StreamInput#readOptionalStringCollectionAsList}.
      */
-    public void writeOptionalStringCollection(final Collection<String> collection) throws IOException {
+    public void writeOptionalStringCollection(@Nullable final Collection<String> collection) throws IOException {
         writeOptionalCollection(collection, StreamOutput::writeString);
     }
 
     /**
-     * Writes a collection of {@link NamedWriteable} objects.
+     * Writes a collection of {@link NamedWriteable} objects which can then be read using {@link
+     * StreamInput#readNamedWriteableCollectionAsList}.
      */
     public void writeNamedWriteableCollection(Collection<? extends NamedWriteable> list) throws IOException {
         writeCollection(list, StreamOutput::writeNamedWriteable);

--- a/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
@@ -111,9 +111,9 @@ public class SetBackedScalingCuckooFilter implements Writeable {
         this.fpp = in.readDouble();
 
         if (isSetMode) {
-            this.hashes = in.readSet(StreamInput::readZLong);
+            this.hashes = in.readCollectionAsSet(StreamInput::readZLong);
         } else {
-            this.filters = in.readList(in12 -> new CuckooFilter(in12, rng));
+            this.filters = in.readCollectionAsList(in12 -> new CuckooFilter(in12, rng));
             this.numBuckets = filters.get(0).getNumBuckets();
             this.fingerprintMask = filters.get(0).getFingerprintMask();
             this.bitsPerEntry = filters.get(0).getBitsPerEntry();

--- a/server/src/main/java/org/elasticsearch/discovery/PeersRequest.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeersRequest.java
@@ -30,7 +30,7 @@ public class PeersRequest extends TransportRequest {
     public PeersRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
-        knownPeers = in.readList(DiscoveryNode::new);
+        knownPeers = in.readCollectionAsList(DiscoveryNode::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -243,7 +243,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
 
         @Override
         protected List<NodeGatewayStartedShards> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeGatewayStartedShards::new);
+            return in.readCollectionAsList(NodeGatewayStartedShards::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/health/stats/HealthApiStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/health/stats/HealthApiStatsAction.java
@@ -89,7 +89,7 @@ public class HealthApiStatsAction extends ActionType<HealthApiStatsAction.Respon
 
         @Override
         protected List<Node> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(Node::new);
+            return in.readCollectionAsList(Node::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -31,7 +31,7 @@ public record HttpStats(long serverOpen, long totalOpen, List<ClientStats> clien
     }
 
     public HttpStats(StreamInput in) throws IOException {
-        this(in.readVLong(), in.readVLong(), in.readList(ClientStats::new));
+        this(in.readVLong(), in.readVLong(), in.readCollectionAsList(ClientStats::new));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -267,7 +267,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     }
 
     protected static List<QueryBuilder> readQueries(StreamInput in) throws IOException {
-        return in.readNamedWriteableList(QueryBuilder.class);
+        return in.readNamedWriteableCollectionAsList(QueryBuilder.class);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -170,7 +170,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         seqNoAndPrimaryTerm = in.readBoolean();
         trackScores = in.readBoolean();
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
-        docValueFields = in.readBoolean() ? in.readList(FieldAndFormat::new) : null;
+        docValueFields = in.readBoolean() ? in.readCollectionAsList(FieldAndFormat::new) : null;
         if (in.readBoolean()) {
             int size = in.readVInt();
             scriptFields = Sets.newHashSetWithExpectedSize(size);
@@ -191,7 +191,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
 
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_10_0)) {
             if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
+                fetchFields = in.readCollectionAsList(FieldAndFormat::new);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -288,7 +288,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         public Disjunction(StreamInput in) throws IOException {
-            this.subSources = in.readNamedWriteableList(IntervalsSourceProvider.class);
+            this.subSources = in.readNamedWriteableCollectionAsList(IntervalsSourceProvider.class);
             this.filter = in.readOptionalWriteable(IntervalFilter::new);
         }
 
@@ -398,7 +398,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
 
         public Combine(StreamInput in) throws IOException {
             this.ordered = in.readBoolean();
-            this.subSources = in.readNamedWriteableList(IntervalsSourceProvider.class);
+            this.subSources = in.readNamedWriteableCollectionAsList(IntervalsSourceProvider.class);
             this.maxGaps = in.readInt();
             this.filter = in.readOptionalWriteable(IntervalFilter::new);
         }

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollResponse.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollResponse.java
@@ -68,8 +68,8 @@ public class BulkByScrollResponse extends ActionResponse implements ToXContentFr
         super(in);
         took = in.readTimeValue();
         status = new BulkByScrollTask.Status(in);
-        bulkFailures = in.readList(Failure::new);
-        searchFailures = in.readList(ScrollableHitSource.SearchFailure::new);
+        bulkFailures = in.readCollectionAsList(Failure::new);
+        searchFailures = in.readCollectionAsList(ScrollableHitSource.SearchFailure::new);
         timedOut = in.readBoolean();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -537,7 +537,7 @@ public class BulkByScrollTask extends CancellableTask {
             requestsPerSecond = in.readFloat();
             reasonCancelled = in.readOptionalString();
             throttledUntil = in.readTimeValue();
-            sliceStatuses = in.readList(stream -> stream.readOptionalWriteable(StatusOrException::new));
+            sliceStatuses = in.readCollectionAsList(stream -> stream.readOptionalWriteable(StatusOrException::new));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryResponse.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryResponse.java
@@ -59,10 +59,10 @@ public final class RecoveryResponse extends TransportResponse {
 
     RecoveryResponse(StreamInput in) throws IOException {
         super(in);
-        phase1FileNames = in.readStringList();
-        phase1FileSizes = in.readList(StreamInput::readVLong);
-        phase1ExistingFileNames = in.readStringList();
-        phase1ExistingFileSizes = in.readList(StreamInput::readVLong);
+        phase1FileNames = in.readStringCollectionAsList();
+        phase1FileSizes = in.readCollectionAsList(StreamInput::readVLong);
+        phase1ExistingFileNames = in.readStringCollectionAsList();
+        phase1ExistingFileSizes = in.readCollectionAsList(StreamInput::readVLong);
         phase1TotalSize = in.readVLong();
         phase1ExistingTotalSize = in.readVLong();
         phase1Time = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -207,7 +207,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
                 new ShardId(in);
             }
             final var metadataSnapshot = Store.MetadataSnapshot.readFrom(in);
-            final var peerRecoveryRetentionLeases = in.readImmutableList(RetentionLease::new);
+            final var peerRecoveryRetentionLeases = in.readCollectionAsImmutableList(RetentionLease::new);
             if (metadataSnapshot == Store.MetadataSnapshot.EMPTY && peerRecoveryRetentionLeases.isEmpty()) {
                 return EMPTY;
             } else {
@@ -329,7 +329,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
 
         @Override
         protected List<NodeStoreFilesMetadata> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeStoreFilesMetadata::readListShardStoreNodeOperationResponse);
+            return in.readCollectionAsList(NodeStoreFilesMetadata::readListShardStoreNodeOperationResponse);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -167,7 +167,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
         mem = new Mem(in);
         threads = new Threads(in);
         gc = new GarbageCollectors(in);
-        bufferPools = in.readList(BufferPool::new);
+        bufferPools = in.readCollectionAsList(BufferPool::new);
         classes = new Classes(in);
     }
 
@@ -506,7 +506,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
             nonHeapCommitted = in.readVLong();
             nonHeapUsed = in.readVLong();
             heapMax = in.readVLong();
-            pools = in.readList(MemoryPool::new);
+            pools = in.readCollectionAsList(MemoryPool::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/plugins/PluginApiInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginApiInfo.java
@@ -26,7 +26,7 @@ import java.util.List;
 public record PluginApiInfo(List<String> legacyInterfaces, List<String> legacyMethods) implements Writeable, ToXContentFragment {
 
     public PluginApiInfo(StreamInput in) throws IOException {
-        this(in.readImmutableList(StreamInput::readString), in.readImmutableList(StreamInput::readString));
+        this(in.readCollectionAsImmutableList(StreamInput::readString), in.readCollectionAsImmutableList(StreamInput::readString));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
@@ -124,7 +124,7 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         } else {
             this.moduleName = null;
         }
-        extendedPlugins = in.readStringList();
+        extendedPlugins = in.readStringCollectionAsList();
         hasNativeController = in.readBoolean();
 
         if (in.getTransportVersion().onOrAfter(LICENSED_PLUGINS_SUPPORT)) {

--- a/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
@@ -82,8 +82,8 @@ public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
     }
 
     public ScriptLanguagesInfo(StreamInput in) throws IOException {
-        typesAllowed = in.readImmutableSet(StreamInput::readString);
-        languageContexts = in.readImmutableMap(sin -> sin.readImmutableSet(StreamInput::readString));
+        typesAllowed = in.readCollectionAsImmutableSet(StreamInput::readString);
+        languageContexts = in.readImmutableMap(sin -> sin.readCollectionAsImmutableSet(StreamInput::readString));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -140,7 +140,7 @@ public record ScriptStats(
             cacheEvictionsHistory = new TimeSeries(cacheEvictions);
         }
         var compilationLimitTriggered = in.readVLong();
-        var contextStats = in.readList(ScriptContextStats::read);
+        var contextStats = in.readCollectionAsList(ScriptContextStats::read);
         return new ScriptStats(
             contextStats,
             compilations,

--- a/server/src/main/java/org/elasticsearch/search/RescoreDocIds.java
+++ b/server/src/main/java/org/elasticsearch/search/RescoreDocIds.java
@@ -31,7 +31,7 @@ public final class RescoreDocIds implements Writeable {
     }
 
     public RescoreDocIds(StreamInput in) throws IOException {
-        docIds = in.readMap(StreamInput::readVInt, i -> i.readSet(StreamInput::readVInt));
+        docIds = in.readMap(StreamInput::readVInt, i -> i.readCollectionAsSet(StreamInput::readVInt));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -59,7 +59,7 @@ public final class InternalAggregations extends Aggregations implements Writeabl
     }
 
     public static InternalAggregations readFrom(StreamInput in) throws IOException {
-        return from(in.readList(stream -> stream.readNamedWriteable(InternalAggregation.class)));
+        return from(in.readCollectionAsList(stream -> stream.readNamedWriteable(InternalAggregation.class)));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -94,7 +94,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
     public InternalComposite(StreamInput in) throws IOException {
         super(in);
         this.size = in.readVInt();
-        this.sourceNames = in.readStringList();
+        this.sourceNames = in.readStringCollectionAsList();
         this.formats = new ArrayList<>(sourceNames.size());
         for (int i = 0; i < sourceNames.size(); i++) {
             formats.add(in.readNamedWriteable(DocValueFormat.class));
@@ -106,7 +106,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             this.missingOrders = new MissingOrder[reverseMuls.length];
             Arrays.fill(missingOrders, MissingOrder.DEFAULT);
         }
-        this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls, missingOrders));
+        this.buckets = in.readCollectionAsList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls, missingOrders));
         this.afterKey = in.readOptionalWriteable(CompositeKey::new);
         this.earlyTerminated = in.getTransportVersion().onOrAfter(TransportVersion.V_7_6_0) ? in.readBoolean() : false;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
@@ -55,7 +55,7 @@ public abstract class InternalGeoGrid<B extends InternalGeoGridBucket> extends I
     public InternalGeoGrid(StreamInput in) throws IOException {
         super(in);
         requiredSize = readSize(in);
-        buckets = (List<InternalGeoGridBucket>) in.readList(getBucketReader());
+        buckets = (List<InternalGeoGridBucket>) in.readCollectionAsList(getBucketReader());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -243,7 +243,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         offset = in.readLong();
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
-        buckets = in.readList(stream -> new Bucket(stream, keyed, format));
+        buckets = in.readCollectionAsList(stream -> new Bucket(stream, keyed, format));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -238,7 +238,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
         }
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
-        buckets = in.readList(stream -> new Bucket(stream, keyed, format));
+        buckets = in.readCollectionAsList(stream -> new Bucket(stream, keyed, format));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -260,7 +260,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
         super(in);
         emptyBucketInfo = new EmptyBucketInfo(in);
         format = in.readNamedWriteable(DocValueFormat.class);
-        buckets = in.readList(stream -> new Bucket(stream, format));
+        buckets = in.readCollectionAsList(stream -> new Bucket(stream, format));
         targetNumBuckets = in.readVInt();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -203,7 +203,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
         minDocCount = in.readVLong();
-        buckets = in.readList(stream -> new Bucket(stream, format, keyed));
+        buckets = in.readCollectionAsList(stream -> new Bucket(stream, format, keyed));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
@@ -55,7 +55,7 @@ public abstract class AbstractRangeBuilder<AB extends AbstractRangeBuilder<AB, R
         throws IOException {
         super(in);
         this.rangeFactory = rangeFactory;
-        ranges = in.readList(rangeReader);
+        ranges = in.readCollectionAsList(rangeReader);
         keyed = in.readBoolean();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -216,7 +216,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         super(in);
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
-        buckets = in.readList(stream -> Bucket.createFromStream(stream, format, keyed));
+        buckets = in.readCollectionAsList(stream -> Bucket.createFromStream(stream, format, keyed));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
@@ -72,7 +72,7 @@ public abstract class InternalMappedRareTerms<A extends InternalRareTerms<A, B>,
     InternalMappedRareTerms(StreamInput in, Bucket.Reader<B> bucketReader) throws IOException {
         super(in);
         format = in.readNamedWriteable(DocValueFormat.class);
-        buckets = in.readList(stream -> bucketReader.read(stream, format));
+        buckets = in.readCollectionAsList(stream -> bucketReader.read(stream, format));
         filter = new SetBackedScalingCuckooFilter(in, Randomness.get());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -58,7 +58,7 @@ public abstract class InternalMappedSignificantTerms<
         subsetSize = in.readVLong();
         supersetSize = in.readVLong();
         significanceHeuristic = in.readNamedWriteable(SignificanceHeuristic.class);
-        buckets = in.readList(stream -> bucketReader.read(stream, subsetSize, supersetSize, format));
+        buckets = in.readCollectionAsList(stream -> bucketReader.read(stream, subsetSize, supersetSize, format));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
@@ -76,7 +76,7 @@ public abstract class InternalMappedTerms<A extends InternalTerms<A, B>, B exten
         shardSize = readSize(in);
         showTermDocCountError = in.readBoolean();
         otherDocCount = in.readVLong();
-        buckets = in.readList(stream -> bucketReader.read(stream, format, showTermDocCountError));
+        buckets = in.readCollectionAsList(stream -> bucketReader.read(stream, format, showTermDocCountError));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -48,7 +48,7 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
         if (in.getTransportVersion().before(TransportVersion.V_7_8_0)) {
             aggregations = singletonList(in.readGenericValue());
         } else {
-            aggregations = in.readList(StreamInput::readGenericValue);
+            aggregations = in.readCollectionAsList(StreamInput::readGenericValue);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -131,7 +131,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         seqNoAndPrimaryTerm = in.readBoolean();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_10_0)) {
             if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
+                fetchFields = in.readCollectionAsList(FieldAndFormat::new);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -206,18 +206,18 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         explain = in.readOptionalBoolean();
         fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         if (in.readBoolean()) {
-            docValueFields = in.readList(FieldAndFormat::new);
+            docValueFields = in.readCollectionAsList(FieldAndFormat::new);
         } else {
             docValueFields = null;
         }
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
         from = in.readVInt();
         highlightBuilder = in.readOptionalWriteable(HighlightBuilder::new);
-        indexBoosts = in.readList(IndexBoost::new);
+        indexBoosts = in.readCollectionAsList(IndexBoost::new);
         minScore = in.readOptionalFloat();
         postQueryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_013)) {
-            subSearchSourceBuilders = in.readList(SubSearchSourceBuilder::new);
+            subSearchSourceBuilders = in.readCollectionAsList(SubSearchSourceBuilder::new);
         } else {
             QueryBuilder queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
             if (queryBuilder != null) {
@@ -225,10 +225,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             }
         }
         if (in.readBoolean()) {
-            rescoreBuilders = in.readNamedWriteableList(RescorerBuilder.class);
+            rescoreBuilders = in.readNamedWriteableCollectionAsList(RescorerBuilder.class);
         }
         if (in.readBoolean()) {
-            scriptFields = in.readList(ScriptField::new);
+            scriptFields = in.readCollectionAsList(ScriptField::new);
         }
         size = in.readVInt();
         if (in.readBoolean()) {
@@ -239,7 +239,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             }
         }
         if (in.readBoolean()) {
-            stats = in.readStringList();
+            stats = in.readStringCollectionAsList();
         }
         suggestBuilder = in.readOptionalWriteable(SuggestBuilder::new);
         terminateAfter = in.readVInt();
@@ -247,7 +247,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         trackScores = in.readBoolean();
         version = in.readOptionalBoolean();
         seqNoAndPrimaryTerm = in.readOptionalBoolean();
-        extBuilders = in.readNamedWriteableList(SearchExtBuilder.class);
+        extBuilders = in.readNamedWriteableCollectionAsList(SearchExtBuilder.class);
         profile = in.readBoolean();
         searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
         sliceBuilder = in.readOptionalWriteable(SliceBuilder::new);
@@ -255,7 +255,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         trackTotalHitsUpTo = in.readOptionalInt();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_10_0)) {
             if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
+                fetchFields = in.readCollectionAsList(FieldAndFormat::new);
             }
             pointInTimeBuilder = in.readOptionalWriteable(PointInTimeBuilder::new);
         }
@@ -267,7 +267,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 KnnSearchBuilder searchBuilder = in.readOptionalWriteable(KnnSearchBuilder::new);
                 knnSearch = searchBuilder != null ? List.of(searchBuilder) : List.of();
             } else {
-                knnSearch = in.readList(KnnSearchBuilder::new);
+                knnSearch = in.readCollectionAsList(KnnSearchBuilder::new);
             }
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -78,7 +78,7 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
     public CollapseBuilder(StreamInput in) throws IOException {
         this.field = in.readString();
         this.maxConcurrentGroupRequests = in.readVInt();
-        this.innerHits = in.readList(InnerHitBuilder::new);
+        this.innerHits = in.readCollectionAsList(InnerHitBuilder::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
@@ -58,7 +58,7 @@ public class DfsSearchResult extends SearchPhaseResult {
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_4_0)) {
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-                knnResults = in.readOptionalList(DfsKnnResults::new);
+                knnResults = in.readOptionalCollectionAsList(DfsKnnResults::new);
             } else {
                 DfsKnnResults results = in.readOptionalWriteable(DfsKnnResults::new);
                 knnResults = results != null ? List.of(results) : List.of();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/LookupField.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/LookupField.java
@@ -28,7 +28,7 @@ import java.util.List;
 public record LookupField(String targetIndex, QueryBuilder query, List<FieldAndFormat> fetchFields, int size) implements Writeable {
 
     public LookupField(StreamInput in) throws IOException {
-        this(in.readString(), in.readNamedWriteable(QueryBuilder.class), in.readList(FieldAndFormat::new), in.readVInt());
+        this(in.readString(), in.readNamedWriteable(QueryBuilder.class), in.readCollectionAsList(FieldAndFormat::new), in.readVInt());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -128,7 +128,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         super(in);
         encoder(in.readOptionalString());
         useExplicitFieldOrder(in.readBoolean());
-        this.fields = in.readList(Field::new);
+        this.fields = in.readCollectionAsList(Field::new);
         assert this.equals(new HighlightBuilder(this, highlightQuery, fields)) : "copy constructor is broken";
     }
 

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -281,7 +281,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             // to deserialize between the 8.8 and 8.500.013 version we need to translate
             // the rank queries into sub searches if we are ranking; if there are no rank queries
             // we deserialize the empty list and do nothing
-            List<QueryBuilder> rankQueryBuilders = in.readNamedWriteableList(QueryBuilder.class);
+            List<QueryBuilder> rankQueryBuilders = in.readNamedWriteableCollectionAsList(QueryBuilder.class);
             // if we are in the dfs phase in 8.8, we can have no rank queries
             // and if we are in the query/fetch phase we can have either no rank queries
             // for a standard query or hybrid search or 2+ rank queries, but we cannot have

--- a/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -80,7 +80,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         } else {
             debug = Map.of();
         }
-        children = in.readList(ProfileResult::new);
+        children = in.readCollectionAsList(ProfileResult::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResult.java
@@ -46,7 +46,7 @@ public class SearchProfileDfsPhaseResult implements Writeable, ToXContentObject 
     public SearchProfileDfsPhaseResult(StreamInput in) throws IOException {
         dfsShardResult = in.readOptionalWriteable(ProfileResult::new);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-            queryProfileShardResult = in.readOptionalList(QueryProfileShardResult::new);
+            queryProfileShardResult = in.readOptionalCollectionAsList(QueryProfileShardResult::new);
         } else {
             QueryProfileShardResult singleResult = in.readOptionalWriteable(QueryProfileShardResult::new);
             queryProfileShardResult = singleResult != null ? List.of(singleResult) : null;

--- a/server/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -56,7 +56,7 @@ public class CollectorResult extends ProfilerCollectorResult implements ToXConte
      * Read from a stream.
      */
     public CollectorResult(StreamInput in) throws IOException {
-        super(in.readString(), in.readString(), in.readLong(), in.readList(CollectorResult::new));
+        super(in.readString(), in.readString(), in.readLong(), in.readCollectionAsList(CollectorResult::new));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -72,7 +72,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public Suggest(StreamInput in) throws IOException {
-        suggestions = (List) in.readNamedWriteableList(Suggestion.class);
+        suggestions = (List) in.readNamedWriteableCollectionAsList(Suggestion.class);
         hasScoreDocs = filter(CompletionSuggestion.class).stream().anyMatch(CompletionSuggestion::hasScoreDocs);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -206,7 +206,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         this.k = in.readVInt();
         this.numCands = in.readVInt();
         this.queryVector = in.readFloatArray();
-        this.filterQueries = in.readNamedWriteableList(QueryBuilder.class);
+        this.filterQueries = in.readNamedWriteableCollectionAsList(QueryBuilder.class);
         this.boost = in.readFloat();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
             this.queryVectorBuilder = in.readOptionalNamedWriteable(QueryVectorBuilder.class);

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreInfo.java
@@ -39,7 +39,7 @@ public class RestoreInfo implements ToXContentObject, Writeable {
 
     public RestoreInfo(StreamInput in) throws IOException {
         name = in.readString();
-        indices = in.readImmutableStringList();
+        indices = in.readStringCollectionAsImmutableList();
         totalShards = in.readVInt();
         successfulShards = in.readVInt();
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotFeatureInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotFeatureInfo.java
@@ -48,7 +48,7 @@ public class SnapshotFeatureInfo implements Writeable, ToXContentObject {
     }
 
     public SnapshotFeatureInfo(final StreamInput in) throws IOException {
-        this(in.readString(), in.readImmutableStringList());
+        this(in.readString(), in.readStringCollectionAsImmutableList());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -502,19 +502,19 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         } else {
             snapshot = new Snapshot(UNKNOWN_REPO_NAME, new SnapshotId(in));
         }
-        final List<String> indices = in.readImmutableStringList();
+        final List<String> indices = in.readStringCollectionAsImmutableList();
         final SnapshotState state = in.readBoolean() ? SnapshotState.fromValue(in.readByte()) : null;
         final String reason = in.readOptionalString();
         final long startTime = in.readVLong();
         final long endTime = in.readVLong();
         final int totalShards = in.readVInt();
         final int successfulShards = in.readVInt();
-        final List<SnapshotShardFailure> shardFailures = in.readImmutableList(SnapshotShardFailure::new);
+        final List<SnapshotShardFailure> shardFailures = in.readCollectionAsImmutableList(SnapshotShardFailure::new);
         final IndexVersion version = in.readBoolean() ? IndexVersion.readVersion(in) : null;
         final Boolean includeGlobalState = in.readOptionalBoolean();
         final Map<String, Object> userMetadata = in.readMap();
-        final List<String> dataStreams = in.readImmutableStringList();
-        final List<SnapshotFeatureInfo> featureStates = in.readImmutableList(SnapshotFeatureInfo::new);
+        final List<String> dataStreams = in.readStringCollectionAsImmutableList();
+        final List<SnapshotFeatureInfo> featureStates = in.readCollectionAsImmutableList(SnapshotFeatureInfo::new);
         final Map<String, IndexSnapshotDetails> indexSnapshotDetails = in.readImmutableMap(IndexSnapshotDetails::new);
         return new SnapshotInfo(
             snapshot,

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolInfo.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolInfo.java
@@ -26,7 +26,7 @@ public class ThreadPoolInfo implements ReportingService.Info, Iterable<ThreadPoo
     }
 
     public ThreadPoolInfo(StreamInput in) throws IOException {
-        this.infos = in.readImmutableList(ThreadPool.Info::new);
+        this.infos = in.readCollectionAsImmutableList(ThreadPool.Info::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
@@ -136,7 +136,7 @@ public record ThreadPoolStats(Collection<Stats> stats) implements Writeable, Chu
     }
 
     public ThreadPoolStats(StreamInput in) throws IOException {
-        this(in.readList(Stats::new));
+        this(in.readCollectionAsList(Stats::new));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -119,7 +119,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -141,7 +141,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -384,7 +384,7 @@ public class TransportNodesActionTests extends ESTestCase {
 
         @Override
         protected List<TestNodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(TestNodeResponse::new);
+            return in.readCollectionAsList(TestNodeResponse::new);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -368,32 +368,42 @@ public abstract class AbstractStreamTests extends ESTestCase {
         runWriteReadCollectionTest(
             () -> new FooBar(randomInt(), randomInt()),
             StreamOutput::writeCollection,
-            in -> in.readList(FooBar::new)
+            in -> in.readCollectionAsList(FooBar::new)
         );
 
         runWriteReadCollectionTest(
             () -> new FooBar(randomInt(), randomInt()),
             StreamOutput::writeOptionalCollection,
-            in -> in.readOptionalList(FooBar::new)
+            in -> in.readOptionalCollectionAsList(FooBar::new)
         );
 
-        runWriteReadOptionalCollectionWithNullInput(out -> out.writeOptionalCollection(null), in -> in.readOptionalList(FooBar::new));
+        runWriteReadOptionalCollectionWithNullInput(
+            out -> out.writeOptionalCollection(null),
+            in -> in.readOptionalCollectionAsList(FooBar::new)
+        );
     }
 
     public void testStringCollection() throws IOException {
-        runWriteReadCollectionTest(() -> randomUnicodeOfLength(16), StreamOutput::writeStringCollection, StreamInput::readStringList);
+        runWriteReadCollectionTest(
+            () -> randomUnicodeOfLength(16),
+            StreamOutput::writeStringCollection,
+            StreamInput::readStringCollectionAsList
+        );
     }
 
     public void testOptionalStringCollection() throws IOException {
         runWriteReadCollectionTest(
             () -> randomUnicodeOfLength(16),
             StreamOutput::writeOptionalStringCollection,
-            StreamInput::readOptionalStringList
+            StreamInput::readOptionalStringCollectionAsList
         );
     }
 
     public void testOptionalStringCollectionWithNullInput() throws IOException {
-        runWriteReadOptionalCollectionWithNullInput(out -> out.writeOptionalStringCollection(null), StreamInput::readOptionalStringList);
+        runWriteReadOptionalCollectionWithNullInput(
+            out -> out.writeOptionalStringCollection(null),
+            StreamInput::readOptionalStringCollectionAsList
+        );
     }
 
     private <T> void runWriteReadCollectionTest(
@@ -437,7 +447,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         out.writeCollection(sourceSet, StreamOutput::writeLong);
 
-        final Set<Long> targetSet = getStreamInput(out.bytes()).readSet(StreamInput::readLong);
+        final Set<Long> targetSet = getStreamInput(out.bytes()).readCollectionAsSet(StreamInput::readLong);
         assertThat(targetSet, equalTo(sourceSet));
     }
 
@@ -683,7 +693,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
         final BytesReference bytesReference = output.bytes();
 
         final StreamInput input = getStreamInput(bytesReference);
-        List<T> got = input.readImmutableList(reader);
+        List<T> got = input.readCollectionAsImmutableList(reader);
         assertThat(got, equalTo(expected));
 
         expectThrows(UnsupportedOperationException.class, got::clear);

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -388,7 +388,7 @@ public class BytesStreamsTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeNamedWriteableCollection(expected);
             try (StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), namedWriteableRegistry)) {
-                assertEquals(expected, in.readNamedWriteableList(BaseNamedWriteable.class));
+                assertEquals(expected, in.readNamedWriteableCollectionAsList(BaseNamedWriteable.class));
                 assertEquals(0, in.available());
             }
         }
@@ -480,7 +480,7 @@ public class BytesStreamsTests extends ESTestCase {
 
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
 
-        final List<TestWriteable> loaded = in.readList(TestWriteable::new);
+        final List<TestWriteable> loaded = in.readCollectionAsList(TestWriteable::new);
 
         assertThat(loaded, hasSize(expected.size()));
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -428,7 +428,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         try (RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler)) {
             out.writeNamedWriteableCollection(expected);
             try (StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), namedWriteableRegistry)) {
-                assertEquals(expected, in.readNamedWriteableList(BaseNamedWriteable.class));
+                assertEquals(expected, in.readNamedWriteableCollectionAsList(BaseNamedWriteable.class));
                 assertEquals(0, in.available());
             }
         }
@@ -520,7 +520,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
 
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
 
-        final List<TestWriteable> loaded = in.readList(TestWriteable::new);
+        final List<TestWriteable> loaded = in.readCollectionAsList(TestWriteable::new);
 
         assertThat(loaded, hasSize(expected.size()));
 

--- a/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
@@ -513,7 +513,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
 
         public TestTasksResponse(StreamInput in) throws IOException {
             super(in);
-            tasks = in.readList(TestTaskResponse::new);
+            tasks = in.readCollectionAsList(TestTaskResponse::new);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/TestQueryVectorBuilderPlugin.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/TestQueryVectorBuilderPlugin.java
@@ -58,7 +58,7 @@ class TestQueryVectorBuilderPlugin implements SearchPlugin {
         }
 
         TestQueryVectorBuilder(StreamInput in) throws IOException {
-            this.vectorToBuild = in.readList(StreamInput::readFloat);
+            this.vectorToBuild = in.readCollectionAsList(StreamInput::readFloat);
         }
 
         @Override

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
@@ -90,7 +90,7 @@ public class ErrorQueryBuilder extends AbstractQueryBuilder<ErrorQueryBuilder> {
 
     public ErrorQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        this.indices = in.readList(IndexError::new);
+        this.indices = in.readCollectionAsList(IndexError::new);
     }
 
     @Override

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
@@ -31,7 +31,7 @@ public class NodeSeekStats extends BaseNodeResponse implements ToXContentFragmen
 
     public NodeSeekStats(StreamInput in) throws IOException {
         super(in);
-        this.seeks = in.readMap(s -> s.readList(ShardSeekStats::new));
+        this.seeks = in.readMap(s -> s.readCollectionAsList(ShardSeekStats::new));
     }
 
     @Override

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekStatsResponse.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekStatsResponse.java
@@ -36,7 +36,7 @@ public class SeekStatsResponse extends BaseNodesResponse<NodeSeekStats> implemen
 
     @Override
     protected List<NodeSeekStats> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeSeekStats::new);
+        return in.readCollectionAsList(NodeSeekStats::new);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -67,7 +67,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
         protected Bucket(StreamInput in, List<DocValueFormat> formats, List<KeyConverter> keyConverters, boolean showDocCountError)
             throws IOException {
-            terms = in.readList(StreamInput::readGenericValue);
+            terms = in.readCollectionAsList(StreamInput::readGenericValue);
             docCount = in.readVLong();
             aggregations = InternalAggregations.readFrom(in);
             this.showDocCountError = showDocCountError;
@@ -329,9 +329,9 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         shardSize = readSize(in);
         showTermDocCountError = in.readBoolean();
         otherDocCount = in.readVLong();
-        formats = in.readList(in1 -> in1.readNamedWriteable(DocValueFormat.class));
-        keyConverters = in.readList(in1 -> in1.readEnum(KeyConverter.class));
-        buckets = in.readList(stream -> new Bucket(stream, formats, keyConverters, showTermDocCountError));
+        formats = in.readCollectionAsList(in1 -> in1.readNamedWriteable(DocValueFormat.class));
+        keyConverters = in.readCollectionAsList(in1 -> in1.readEnum(KeyConverter.class));
+        buckets = in.readCollectionAsList(stream -> new Bucket(stream, formats, keyConverters, showTermDocCountError));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java
@@ -140,7 +140,7 @@ public class MultiTermsAggregationBuilder extends AbstractAggregationBuilder<Mul
 
     public MultiTermsAggregationBuilder(StreamInput in) throws IOException {
         super(in);
-        terms = in.readList(MultiValuesSourceFieldConfig::new);
+        terms = in.readCollectionAsList(MultiValuesSourceFieldConfig::new);
         order = InternalOrder.Streams.readOrder(in);
         collectMode = in.readOptionalWriteable(Aggregator.SubAggCollectionMode::readFromStream);
         bucketCountThresholds = new TermsAggregator.BucketCountThresholds(in);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
@@ -177,7 +177,7 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
      */
     static List<Object> unpackTerms(BytesRef termsBytes) {
         try (StreamInput input = new BytesArray(termsBytes).streamInput()) {
-            return input.readList(StreamInput::readGenericValue);
+            return input.readCollectionAsList(StreamInput::readGenericValue);
         } catch (IOException ex) {
             throw ExceptionsHelper.convertToRuntime(ex);
         }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -67,9 +67,9 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
     public InternalTopMetrics(StreamInput in) throws IOException {
         super(in);
         sortOrder = SortOrder.readFromStream(in);
-        metricNames = in.readStringList();
+        metricNames = in.readStringCollectionAsList();
         size = in.readVInt();
-        topMetrics = in.readList(TopMetric::new);
+        topMetrics = in.readCollectionAsList(TopMetric::new);
     }
 
     @Override
@@ -268,7 +268,7 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
         TopMetric(StreamInput in) throws IOException {
             sortFormat = in.readNamedWriteable(DocValueFormat.class);
             sortValue = in.readNamedWriteable(SortValue.class);
-            metricValues = in.readList(s -> s.readOptionalWriteable(MetricValue::new));
+            metricValues = in.readCollectionAsList(s -> s.readOptionalWriteable(MetricValue::new));
         }
 
         @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -152,10 +152,10 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
     public TopMetricsAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         @SuppressWarnings({ "unchecked", "HiddenField" })
-        List<SortBuilder<?>> sortBuilders = (List<SortBuilder<?>>) (List<?>) in.readNamedWriteableList(SortBuilder.class);
+        List<SortBuilder<?>> sortBuilders = (List<SortBuilder<?>>) (List<?>) in.readNamedWriteableCollectionAsList(SortBuilder.class);
         this.sortBuilders = sortBuilders;
         this.size = in.readVInt();
-        this.metricFields = in.readList(MultiValuesSourceFieldConfig::new);
+        this.metricFields = in.readCollectionAsList(MultiValuesSourceFieldConfig::new);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
@@ -87,7 +87,7 @@ public class PutAutoscalingPolicyAction extends ActionType<AcknowledgedResponse>
             super(in);
             this.name = in.readString();
             if (in.readBoolean()) {
-                this.roles = in.readSet(StreamInput::readString).stream().collect(Sets.toUnmodifiableSortedSet());
+                this.roles = in.readCollectionAsSet(StreamInput::readString).stream().collect(Sets.toUnmodifiableSortedSet());
             } else {
                 this.roles = null;
             }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
@@ -61,7 +61,7 @@ public class AutoscalingDeciderResults implements ToXContentObject, Writeable {
 
     public AutoscalingDeciderResults(final StreamInput in) throws IOException {
         this.currentCapacity = new AutoscalingCapacity(in);
-        this.currentNodes = in.readSet(DiscoveryNode::new)
+        this.currentNodes = in.readCollectionAsSet(DiscoveryNode::new)
             .stream()
             .collect(Collectors.toCollection(() -> new TreeSet<>(DISCOVERY_NODE_COMPARATOR)));
         this.results = new TreeMap<>(in.readMap(AutoscalingDeciderResult::new));

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderService.java
@@ -85,7 +85,7 @@ public class FrozenExistenceDeciderService implements AutoscalingDeciderService 
         }
 
         public FrozenExistenceReason(StreamInput in) throws IOException {
-            this.indices = in.readStringList();
+            this.indices = in.readStringCollectionAsList();
         }
 
         @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
@@ -87,7 +87,7 @@ public class AutoscalingPolicy implements SimpleDiffable<AutoscalingPolicy>, ToX
 
     public AutoscalingPolicy(final StreamInput in) throws IOException {
         this.name = in.readString();
-        this.roles = in.readSet(StreamInput::readString).stream().collect(Sets.toUnmodifiableSortedSet());
+        this.roles = in.readCollectionAsSet(StreamInput::readString).stream().collect(Sets.toUnmodifiableSortedSet());
         int deciderCount = in.readInt();
         SortedMap<String, Settings> decidersMap = new TreeMap<>();
         for (int i = 0; i < deciderCount; ++i) {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/NodeDecisions.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/NodeDecisions.java
@@ -29,7 +29,7 @@ class NodeDecisions implements ToXContentObject, Writeable {
     }
 
     NodeDecisions(StreamInput in) throws IOException {
-        canAllocateDecisions = in.readList(NodeDecision::new);
+        canAllocateDecisions = in.readCollectionAsList(NodeDecision::new);
         canRemainDecision = in.readOptionalWriteable(NodeDecision::new);
     }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -1008,8 +1008,8 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             this.unassigned = in.readLong();
             this.assigned = in.readLong();
             if (in.getTransportVersion().onOrAfter(SHARD_IDS_OUTPUT_VERSION)) {
-                unassignedShardIds = Collections.unmodifiableSortedSet(new TreeSet<>(in.readSet(ShardId::new)));
-                assignedShardIds = Collections.unmodifiableSortedSet(new TreeSet<>(in.readSet(ShardId::new)));
+                unassignedShardIds = Collections.unmodifiableSortedSet(new TreeSet<>(in.readCollectionAsSet(ShardId::new)));
+                assignedShardIds = Collections.unmodifiableSortedSet(new TreeSet<>(in.readCollectionAsSet(ShardId::new)));
             } else {
                 unassignedShardIds = Collections.emptySortedSet();
                 assignedShardIds = Collections.emptySortedSet();

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsRequest.java
@@ -28,7 +28,7 @@ public final class BulkShardOperationsRequest extends ReplicatedWriteRequest<Bul
         super(in);
         historyUUID = in.readString();
         maxSeqNoOfUpdatesOrDeletes = in.readZLong();
-        operations = in.readList(Translog.Operation::readOperation);
+        operations = in.readCollectionAsList(Translog.Operation::readOperation);
     }
 
     public BulkShardOperationsRequest(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageResponse.java
@@ -104,7 +104,7 @@ public class GetFeatureUsageResponse extends ActionResponse implements ToXConten
     }
 
     public GetFeatureUsageResponse(StreamInput in) throws IOException {
-        this.features = in.readList(FeatureUsageInfo::new);
+        this.features = in.readCollectionAsList(FeatureUsageInfo::new);
     }
 
     public List<FeatureUsageInfo> getFeatures() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
@@ -60,13 +60,13 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
     public MigrateToDataTiersResponse(StreamInput in) throws IOException {
         super(in);
         removedIndexTemplateName = in.readOptionalString();
-        migratedPolicies = in.readStringList();
-        migratedIndices = in.readStringList();
+        migratedPolicies = in.readStringCollectionAsList();
+        migratedIndices = in.readStringCollectionAsList();
         dryRun = in.readBoolean();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_17_0)) {
-            migratedLegacyTemplates = in.readStringList();
-            migratedComposableTemplates = in.readStringList();
-            migratedComponentTemplates = in.readStringList();
+            migratedLegacyTemplates = in.readStringCollectionAsList();
+            migratedComposableTemplates = in.readStringCollectionAsList();
+            migratedComponentTemplates = in.readStringCollectionAsList();
         } else {
             migratedLegacyTemplates = List.of();
             migratedComposableTemplates = List.of();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/RemoteClusterFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/RemoteClusterFeatureSetUsage.java
@@ -23,7 +23,7 @@ public class RemoteClusterFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public RemoteClusterFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        this.remoteConnectionInfos = in.readImmutableList(RemoteConnectionInfo::new);
+        this.remoteConnectionInfos = in.readCollectionAsImmutableList(RemoteConnectionInfo::new);
     }
 
     public RemoteClusterFeatureSetUsage(List<RemoteConnectionInfo> remoteConnectionInfos) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -24,7 +24,7 @@ public class XPackUsageResponse extends ActionResponse {
     }
 
     public XPackUsageResponse(final StreamInput in) throws IOException {
-        usages = in.readNamedWriteableList(XPackFeatureSet.Usage.class);
+        usages = in.readNamedWriteableCollectionAsList(XPackFeatureSet.Usage.class);
     }
 
     public List<XPackFeatureSet.Usage> getUsages() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/QueryPage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/QueryPage.java
@@ -43,7 +43,7 @@ public final class QueryPage<T extends ToXContent & Writeable> implements ToXCon
 
     public QueryPage(StreamInput in, Reader<T> hitReader) throws IOException {
         resultsField = new ParseField(in.readString());
-        results = in.readList(hitReader);
+        results = in.readCollectionAsList(hitReader);
         count = in.readLong();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
@@ -107,7 +107,7 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -260,7 +260,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
 
         public static AutoFollowPattern readFrom(StreamInput in) throws IOException {
             final String remoteCluster = in.readString();
-            final List<String> leaderIndexPatterns = in.readStringList();
+            final List<String> leaderIndexPatterns = in.readStringCollectionAsList();
             final String followIndexPattern = in.readOptionalString();
             final Settings settings;
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_9_0)) {
@@ -289,7 +289,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
                 this.active = true;
             }
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_14_0)) {
-                this.leaderIndexExclusionPatterns = in.readStringList();
+                this.leaderIndexExclusionPatterns = in.readStringCollectionAsList();
             } else {
                 this.leaderIndexExclusionPatterns = Collections.emptyList();
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
@@ -97,7 +97,7 @@ public class FollowInfoAction extends ActionType<FollowInfoAction.Response> {
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            followInfos = in.readList(FollowerInfo::new);
+            followInfos = in.readCollectionAsList(FollowerInfo::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
@@ -64,7 +64,7 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
 
         public StatsResponses(StreamInput in) throws IOException {
             super(in);
-            statsResponse = in.readList(StatsResponse::new);
+            statsResponse = in.readCollectionAsList(StatsResponse::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutAutoFollowPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutAutoFollowPatternAction.java
@@ -183,14 +183,14 @@ public class PutAutoFollowPatternAction extends ActionType<AcknowledgedResponse>
             super(in);
             name = in.readString();
             remoteCluster = in.readString();
-            leaderIndexPatterns = in.readStringList();
+            leaderIndexPatterns = in.readStringCollectionAsList();
             followIndexNamePattern = in.readOptionalString();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_9_0)) {
                 settings = Settings.readSettingsFromStream(in);
             }
             parameters = new FollowParameters(in);
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_14_0)) {
-                leaderIndexExclusionPatterns = in.readStringList();
+                leaderIndexExclusionPatterns = in.readStringCollectionAsList();
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -114,9 +114,9 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         this(
             in.readString(),
             in.readOptionalWriteable(QuerySource::new),
-            in.readStringList(),
+            in.readStringCollectionAsList(),
             in.readString(),
-            in.readStringList(),
+            in.readStringCollectionAsList(),
             Version.readVersion(in)
         );
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -60,9 +60,9 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            executingPolicies = in.readList(ExecutingPolicy::new);
-            coordinatorStats = in.readList(CoordinatorStats::new);
-            cacheStats = in.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0) ? in.readList(CacheStats::new) : null;
+            executingPolicies = in.readCollectionAsList(ExecutingPolicy::new);
+            coordinatorStats = in.readCollectionAsList(CoordinatorStats::new);
+            cacheStats = in.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0) ? in.readCollectionAsList(CacheStats::new) : null;
         }
 
         public List<ExecutingPolicy> getExecutingPolicies() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/GetEnrichPolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/GetEnrichPolicyAction.java
@@ -48,7 +48,7 @@ public class GetEnrichPolicyAction extends ActionType<GetEnrichPolicyAction.Resp
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.names = in.readStringList();
+            this.names = in.readStringCollectionAsList();
         }
 
         @Override
@@ -94,7 +94,7 @@ public class GetEnrichPolicyAction extends ActionType<GetEnrichPolicyAction.Resp
         }
 
         public Response(StreamInput in) throws IOException {
-            policies = in.readList(EnrichPolicy.NamedPolicy::new);
+            policies = in.readCollectionAsList(EnrichPolicy.NamedPolicy::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -33,7 +33,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
     public IndexLifecycleFeatureSetUsage(StreamInput input) throws IOException {
         super(input);
         if (input.readBoolean()) {
-            policyStats = input.readList(PolicyStats::new);
+            policyStats = input.readCollectionAsList(PolicyStats::new);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
@@ -45,7 +45,7 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.policies = in.readList(LifecyclePolicyResponseItem::new);
+            this.policies = in.readCollectionAsList(LifecyclePolicyResponseItem::new);
         }
 
         public Response(List<LifecyclePolicyResponseItem> policies) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyAction.java
@@ -52,7 +52,7 @@ public class RemoveIndexLifecyclePolicyAction extends ActionType<RemoveIndexLife
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            failedIndexes = in.readStringList();
+            failedIndexes = in.readStringCollectionAsList();
         }
 
         public Response(List<String> failedIndexes) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
@@ -194,7 +194,7 @@ public class EvaluateDataFrameAction extends ActionType<EvaluateDataFrameAction.
         public Response(StreamInput in) throws IOException {
             super(in);
             this.evaluationName = in.readString();
-            this.metrics = in.readNamedWriteableList(EvaluationMetricResult.class);
+            this.metrics = in.readNamedWriteableCollectionAsList(EvaluationMetricResult.class);
         }
 
         public Response(String evaluationName, List<EvaluationMetricResult> metrics) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ExplainDataFrameAnalyticsAction.java
@@ -185,7 +185,7 @@ public class ExplainDataFrameAnalyticsAction extends ActionType<ExplainDataFrame
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.fieldSelection = in.readList(FieldSelection::new);
+            this.fieldSelection = in.readCollectionAsList(FieldSelection::new);
             this.memoryEstimation = new MemoryEstimation(in);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsStatsAction.java
@@ -75,7 +75,7 @@ public class GetDataFrameAnalyticsStatsAction extends ActionType<GetDataFrameAna
             id = in.readString();
             allowNoMatch = in.readBoolean();
             pageParams = in.readOptionalWriteable(PageParams::new);
-            expandedIds = in.readStringList();
+            expandedIds = in.readStringCollectionAsList();
         }
 
         public void setExpandedIds(List<String> expandedIds) {
@@ -207,7 +207,7 @@ public class GetDataFrameAnalyticsStatsAction extends ActionType<GetDataFrameAna
                 id = in.readString();
                 state = DataFrameAnalyticsState.fromStream(in);
                 failureReason = in.readOptionalString();
-                progress = in.readList(PhaseProgress::new);
+                progress = in.readCollectionAsList(PhaseProgress::new);
                 dataCounts = new DataCounts(in);
                 memoryUsage = new MemoryUsage(in);
                 analysisStats = in.readOptionalNamedWriteable(AnalysisStats.class);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
@@ -54,7 +54,7 @@ public class GetDatafeedRunningStateAction extends ActionType<GetDatafeedRunning
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.datafeedTaskIds = in.readSet(StreamInput::readString);
+            this.datafeedTaskIds = in.readCollectionAsSet(StreamInput::readString);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
@@ -50,7 +50,7 @@ public class GetDeploymentStatsAction extends ActionType<GetDeploymentStatsActio
         public Request(StreamInput in) throws IOException {
             super(in);
             this.deploymentId = in.readString();
-            this.expandedIds = in.readStringList();
+            this.expandedIds = in.readStringCollectionAsList();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java
@@ -78,7 +78,7 @@ public class GetJobsStatsAction extends ActionType<GetJobsStatsAction.Response> 
         public Request(StreamInput in) throws IOException {
             super(in);
             jobId = in.readString();
-            expandedJobsIds = in.readStringList();
+            expandedJobsIds = in.readStringCollectionAsList();
             allowNoMatch = in.readBoolean();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -81,7 +81,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
         }
 
         public Includes(StreamInput in) throws IOException {
-            this.includes = in.readSet(StreamInput::readString);
+            this.includes = in.readCollectionAsSet(StreamInput::readString);
         }
 
         @Override
@@ -146,7 +146,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
         public Request(StreamInput in) throws IOException {
             super(in);
             this.includes = new Includes(in);
-            this.tags = in.readStringList();
+            this.tags = in.readStringCollectionAsList();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -147,7 +147,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.id = in.readString();
-            this.objectsToInfer = in.readImmutableList(StreamInput::readMap);
+            this.objectsToInfer = in.readCollectionAsImmutableList(StreamInput::readMap);
             this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readBoolean();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
@@ -156,7 +156,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
                 this.inferenceTimeout = TimeValue.MAX_VALUE;
             }
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-                textInput = in.readOptionalStringList();
+                textInput = in.readOptionalStringCollectionAsList();
             } else {
                 textInput = null;
             }
@@ -316,7 +316,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.inferenceResults = Collections.unmodifiableList(in.readNamedWriteableList(InferenceResults.class));
+            this.inferenceResults = Collections.unmodifiableList(in.readNamedWriteableCollectionAsList(InferenceResults.class));
             this.isLicensed = in.readBoolean();
             this.id = in.readOptionalString();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -145,14 +145,14 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public Request(StreamInput in) throws IOException {
             super(in);
             id = in.readString();
-            docs = in.readImmutableList(StreamInput::readMap);
+            docs = in.readCollectionAsImmutableList(StreamInput::readMap);
             update = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
             inferenceTimeout = in.readOptionalTimeValue();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
                 highPriority = in.readBoolean();
             }
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-                textInput = in.readOptionalStringList();
+                textInput = in.readOptionalStringCollectionAsList();
             } else {
                 textInput = null;
             }
@@ -321,7 +321,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
 
             // Multiple results added in 8.6.1
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_6_1)) {
-                results = in.readNamedWriteableList(InferenceResults.class);
+                results = in.readNamedWriteableCollectionAsList(InferenceResults.class);
             } else {
                 results = List.of(in.readNamedWriteable(InferenceResults.class));
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlMemoryAction.java
@@ -318,7 +318,7 @@ public class MlMemoryAction extends ActionType<MlMemoryAction.Response> {
 
         @Override
         protected List<MlMemoryStats> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(MlMemoryStats::new);
+            return in.readCollectionAsList(MlMemoryStats::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
@@ -68,7 +68,7 @@ public class PostCalendarEventsAction extends ActionType<PostCalendarEventsActio
         public Request(StreamInput in) throws IOException {
             super(in);
             calendarId = in.readString();
-            scheduledEvents = in.readList(ScheduledEvent::new);
+            scheduledEvents = in.readCollectionAsList(ScheduledEvent::new);
         }
 
         public Request(String calendarId, List<ScheduledEvent> scheduledEvents) {
@@ -124,7 +124,7 @@ public class PostCalendarEventsAction extends ActionType<PostCalendarEventsActio
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            in.readList(ScheduledEvent::new);
+            in.readCollectionAsList(ScheduledEvent::new);
         }
 
         public Response(List<ScheduledEvent> scheduledEvents) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDataFrameAnalyticsAction.java
@@ -143,7 +143,7 @@ public class PreviewDataFrameAnalyticsAction extends ActionType<PreviewDataFrame
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.featureValues = in.readList(StreamInput::readMap);
+            this.featureValues = in.readCollectionAsList(StreamInput::readMap);
         }
 
         public List<Map<String, Object>> getFeatureValues() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelVocabularyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelVocabularyAction.java
@@ -80,14 +80,14 @@ public class PutTrainedModelVocabularyAction extends ActionType<AcknowledgedResp
         public Request(StreamInput in) throws IOException {
             super(in);
             this.modelId = in.readString();
-            this.vocabulary = in.readStringList();
+            this.vocabulary = in.readStringCollectionAsList();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_2_0)) {
-                this.merges = in.readStringList();
+                this.merges = in.readStringCollectionAsList();
             } else {
                 this.merges = List.of();
             }
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
-                this.scores = in.readList(StreamInput::readDouble);
+                this.scores = in.readCollectionAsList(StreamInput::readDouble);
             } else {
                 this.scores = List.of();
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -202,7 +202,7 @@ public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
             endTime = in.readOptionalLong();
             timeout = TimeValue.timeValueMillis(in.readVLong());
             jobId = in.readOptionalString();
-            datafeedIndices = in.readStringList();
+            datafeedIndices = in.readStringCollectionAsList();
             indicesOptions = IndicesOptions.readIndicesOptions(in);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
@@ -126,7 +126,7 @@ public class TrainedModelCacheInfoAction extends ActionType<TrainedModelCacheInf
 
         @Override
         protected List<CacheInfo> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(CacheInfo::new);
+            return in.readCollectionAsList(CacheInfo::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateProcessAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateProcessAction.java
@@ -101,7 +101,7 @@ public class UpdateProcessAction extends ActionType<UpdateProcessAction.Response
             modelPlotConfig = in.readOptionalWriteable(ModelPlotConfig::new);
             perPartitionCategorizationConfig = in.readOptionalWriteable(PerPartitionCategorizationConfig::new);
             if (in.readBoolean()) {
-                detectorUpdates = in.readList(JobUpdate.DetectorUpdate::new);
+                detectorUpdates = in.readCollectionAsList(JobUpdate.DetectorUpdate::new);
             }
             filter = in.readOptionalWriteable(MlFilter::new);
             updateScheduledEvents = in.readBoolean();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -279,7 +279,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         this.queryDelay = in.readOptionalTimeValue();
         this.frequency = in.readOptionalTimeValue();
         if (in.readBoolean()) {
-            this.indices = in.readImmutableList(StreamInput::readString);
+            this.indices = in.readCollectionAsImmutableList(StreamInput::readString);
         } else {
             this.indices = null;
         }
@@ -289,7 +289,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         this.aggProvider = in.readOptionalWriteable(AggProvider::fromStream);
 
         if (in.readBoolean()) {
-            this.scriptFields = in.readImmutableList(SearchSourceBuilder.ScriptField::new);
+            this.scriptFields = in.readCollectionAsImmutableList(SearchSourceBuilder.ScriptField::new);
         } else {
             this.scriptFields = null;
         }
@@ -792,7 +792,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             this.queryDelay = in.readOptionalTimeValue();
             this.frequency = in.readOptionalTimeValue();
             if (in.readBoolean()) {
-                this.indices = in.readImmutableList(StreamInput::readString);
+                this.indices = in.readCollectionAsImmutableList(StreamInput::readString);
             } else {
                 this.indices = null;
             }
@@ -802,7 +802,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             this.aggProvider = in.readOptionalWriteable(AggProvider::fromStream);
 
             if (in.readBoolean()) {
-                this.scriptFields = in.readImmutableList(SearchSourceBuilder.ScriptField::new);
+                this.scriptFields = in.readCollectionAsImmutableList(SearchSourceBuilder.ScriptField::new);
             } else {
                 this.scriptFields = null;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -148,7 +148,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
         this.queryDelay = in.readOptionalTimeValue();
         this.frequency = in.readOptionalTimeValue();
         if (in.readBoolean()) {
-            this.indices = in.readStringList();
+            this.indices = in.readStringCollectionAsList();
         } else {
             this.indices = null;
         }
@@ -157,7 +157,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
         this.aggProvider = in.readOptionalWriteable(AggProvider::fromStream);
 
         if (in.readBoolean()) {
-            this.scriptFields = in.readList(SearchSourceBuilder.ScriptField::new);
+            this.scriptFields = in.readCollectionAsList(SearchSourceBuilder.ScriptField::new);
         } else {
             this.scriptFields = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -223,7 +223,7 @@ public class Classification implements DataFrameAnalysis {
         numTopClasses = in.readOptionalVInt();
         trainingPercent = in.readDouble();
         randomizeSeed = in.readOptionalLong();
-        featureProcessors = Collections.unmodifiableList(in.readNamedWriteableList(PreProcessor.class));
+        featureProcessors = Collections.unmodifiableList(in.readNamedWriteableCollectionAsList(PreProcessor.class));
         earlyStoppingEnabled = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -183,7 +183,7 @@ public class Regression implements DataFrameAnalysis {
         randomizeSeed = in.readOptionalLong();
         lossFunction = in.readEnum(LossFunction.class);
         lossFunctionParameter = in.readOptionalDouble();
-        featureProcessors = Collections.unmodifiableList(in.readNamedWriteableList(PreProcessor.class));
+        featureProcessors = Collections.unmodifiableList(in.readNamedWriteableCollectionAsList(PreProcessor.class));
         earlyStoppingEnabled = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
@@ -239,7 +239,7 @@ public class Accuracy implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.classes = in.readImmutableList(PerClassSingleValue::new);
+            this.classes = in.readCollectionAsImmutableList(PerClassSingleValue::new);
             this.overallAccuracy = in.readDouble();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
@@ -110,7 +110,7 @@ public class Classification implements Evaluation {
             in.readOptionalString(),
             true
         );
-        this.metrics = in.readNamedWriteableList(EvaluationMetric.class);
+        this.metrics = in.readNamedWriteableCollectionAsList(EvaluationMetric.class);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
@@ -286,7 +286,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.actualClasses = in.readImmutableList(ActualClass::new);
+            this.actualClasses = in.readCollectionAsImmutableList(ActualClass::new);
             this.otherActualClassCount = in.readVLong();
         }
 
@@ -382,7 +382,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
         public ActualClass(StreamInput in) throws IOException {
             this.actualClass = in.readString();
             this.actualClassDocCount = in.readVLong();
-            this.predictedClasses = in.readImmutableList(PredictedClass::new);
+            this.predictedClasses = in.readCollectionAsImmutableList(PredictedClass::new);
             this.otherPredictedClassDocCount = in.readVLong();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
@@ -232,7 +232,7 @@ public class Precision implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.classes = in.readImmutableList(PerClassSingleValue::new);
+            this.classes = in.readCollectionAsImmutableList(PerClassSingleValue::new);
             this.avgPrecision = in.readDouble();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
@@ -202,7 +202,7 @@ public class Recall implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.classes = in.readImmutableList(PerClassSingleValue::new);
+            this.classes = in.readCollectionAsImmutableList(PerClassSingleValue::new);
             this.avgRecall = in.readDouble();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/common/AbstractAucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/common/AbstractAucRoc.java
@@ -298,7 +298,7 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
 
         public Result(StreamInput in) throws IOException {
             this.value = in.readDouble();
-            this.curve = in.readList(AucRocPoint::new);
+            this.curve = in.readCollectionAsList(AucRocPoint::new);
         }
 
         public double getValue() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
@@ -98,7 +98,7 @@ public class OutlierDetection implements Evaluation {
 
     public OutlierDetection(StreamInput in) throws IOException {
         this.fields = new EvaluationFields(in.readString(), null, null, null, in.readString(), false);
-        this.metrics = in.readNamedWriteableList(EvaluationMetric.class);
+        this.metrics = in.readNamedWriteableCollectionAsList(EvaluationMetric.class);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
@@ -87,7 +87,7 @@ public class Regression implements Evaluation {
 
     public Regression(StreamInput in) throws IOException {
         this.fields = new EvaluationFields(in.readString(), in.readString(), null, null, null, false);
-        this.metrics = in.readNamedWriteableList(EvaluationMetric.class);
+        this.metrics = in.readNamedWriteableCollectionAsList(EvaluationMetric.class);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/explain/FieldSelection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/explain/FieldSelection.java
@@ -101,7 +101,7 @@ public class FieldSelection implements ToXContentObject, Writeable {
 
     public FieldSelection(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.mappingTypes = in.readImmutableSet(StreamInput::readString);
+        this.mappingTypes = in.readCollectionAsImmutableSet(StreamInput::readString);
         this.isIncluded = in.readBoolean();
         this.isRequired = in.readBoolean();
         boolean hasFeatureType = in.readBoolean();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ValidationLoss.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ValidationLoss.java
@@ -57,7 +57,7 @@ public class ValidationLoss implements ToXContentObject, Writeable {
 
     public ValidationLoss(StreamInput in) throws IOException {
         lossType = in.readString();
-        foldValues = in.readList(FoldValues::new);
+        foldValues = in.readCollectionAsList(FoldValues::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/ValidationLoss.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/ValidationLoss.java
@@ -57,7 +57,7 @@ public class ValidationLoss implements ToXContentObject, Writeable {
 
     public ValidationLoss(StreamInput in) throws IOException {
         lossType = in.readString();
-        foldValues = in.readList(FoldValues::new);
+        foldValues = in.readCollectionAsList(FoldValues::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -255,7 +255,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         description = in.readOptionalString();
         createTime = in.readInstant();
         definition = in.readOptionalWriteable(LazyModelDefinition::fromStreamInput);
-        tags = in.readImmutableList(StreamInput::readString);
+        tags = in.readCollectionAsImmutableList(StreamInput::readString);
         metadata = in.readMap();
         input = new TrainedModelInput(in);
         modelSize = in.readVLong();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinition.java
@@ -84,7 +84,7 @@ public class TrainedModelDefinition implements ToXContentObject, Writeable, Acco
 
     public TrainedModelDefinition(StreamInput in) throws IOException {
         this.trainedModel = in.readNamedWriteable(TrainedModel.class);
-        this.preProcessors = in.readNamedWriteableList(PreProcessor.class);
+        this.preProcessors = in.readNamedWriteableCollectionAsList(PreProcessor.class);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelInput.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelInput.java
@@ -35,7 +35,7 @@ public class TrainedModelInput implements ToXContentObject, Writeable {
     }
 
     public TrainedModelInput(StreamInput in) throws IOException {
-        this.fieldNames = in.readImmutableList(StreamInput::readString);
+        this.fieldNames = in.readCollectionAsImmutableList(StreamInput::readString);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -460,7 +460,7 @@ public class AssignmentStats implements ToXContentObject, Writeable {
         numberOfAllocations = in.readOptionalVInt();
         queueCapacity = in.readOptionalVInt();
         startTime = in.readInstant();
-        nodeStats = in.readList(AssignmentStats.NodeStats::new);
+        nodeStats = in.readCollectionAsList(AssignmentStats.NodeStats::new);
         state = in.readOptionalEnum(AssignmentState.class);
         reason = in.readOptionalString();
         allocationStatus = in.readOptionalWriteable(AllocationStatus::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/Multi.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/Multi.java
@@ -122,7 +122,7 @@ public class Multi implements LenientlyParsedPreProcessor, StrictlyParsedPreProc
     }
 
     public Multi(StreamInput in) throws IOException {
-        this.processors = in.readNamedWriteableList(PreProcessor.class).toArray(PreProcessor[]::new);
+        this.processors = in.readNamedWriteableCollectionAsList(PreProcessor.class).toArray(PreProcessor[]::new);
         this.custom = in.readBoolean();
         this.outputFields = in.readOrderedMap(StreamInput::readString, StreamInput::readString);
         this.inputFields = in.readStringArray();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationFeatureImportance.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationFeatureImportance.java
@@ -62,7 +62,7 @@ public class ClassificationFeatureImportance extends AbstractFeatureImportance {
 
     public ClassificationFeatureImportance(StreamInput in) throws IOException {
         this.featureName = in.readString();
-        this.classImportance = in.readList(ClassImportance::new);
+        this.classImportance = in.readCollectionAsList(ClassImportance::new);
     }
 
     public List<ClassImportance> getClassImportance() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -118,9 +118,9 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
 
     public ClassificationInferenceResults(StreamInput in) throws IOException {
         super(in);
-        this.featureImportance = in.readList(ClassificationFeatureImportance::new);
+        this.featureImportance = in.readCollectionAsList(ClassificationFeatureImportance::new);
         this.classificationLabel = in.readOptionalString();
-        this.topClasses = in.readImmutableList(TopClassEntry::new);
+        this.topClasses = in.readCollectionAsImmutableList(TopClassEntry::new);
         this.topNumClassesField = in.readString();
         this.resultsField = in.readString();
         this.predictionFieldType = in.readEnum(PredictionFieldType.class);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NerResults.java
@@ -40,7 +40,7 @@ public class NerResults extends NlpInferenceResults {
 
     public NerResults(StreamInput in) throws IOException {
         super(in);
-        entityGroups = in.readList(EntityGroup::new);
+        entityGroups = in.readCollectionAsList(EntityGroup::new);
         resultsField = in.readString();
         annotatedResult = in.readString();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NlpClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NlpClassificationInferenceResults.java
@@ -45,7 +45,7 @@ public class NlpClassificationInferenceResults extends NlpInferenceResults {
     public NlpClassificationInferenceResults(StreamInput in) throws IOException {
         super(in);
         this.classificationLabel = in.readString();
-        this.topClasses = in.readImmutableList(TopClassEntry::new);
+        this.topClasses = in.readCollectionAsImmutableList(TopClassEntry::new);
         this.resultsField = in.readString();
         this.predictionProbability = in.readOptionalDouble();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/QuestionAnsweringInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/QuestionAnsweringInferenceResults.java
@@ -62,7 +62,7 @@ public class QuestionAnsweringInferenceResults extends NlpInferenceResults {
         this.answer = in.readString();
         this.startOffset = in.readVInt();
         this.endOffset = in.readVInt();
-        this.topClasses = in.readImmutableList(TopAnswerEntry::fromStream);
+        this.topClasses = in.readCollectionAsImmutableList(TopAnswerEntry::fromStream);
         this.resultsField = in.readString();
         this.score = in.readDouble();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
@@ -74,7 +74,7 @@ public class RegressionInferenceResults extends SingleValueInferenceResults {
 
     public RegressionInferenceResults(StreamInput in) throws IOException {
         super(in);
-        this.featureImportance = in.readList(RegressionFeatureImportance::new);
+        this.featureImportance = in.readCollectionAsList(RegressionFeatureImportance::new);
         this.resultsField = in.readString();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
@@ -64,7 +64,7 @@ public class TextExpansionResults extends NlpInferenceResults {
     public TextExpansionResults(StreamInput in) throws IOException {
         super(in);
         this.resultsField = in.readString();
-        this.weightedTokens = in.readList(WeightedToken::new);
+        this.weightedTokens = in.readCollectionAsList(WeightedToken::new);
     }
 
     public List<WeightedToken> getWeightedTokens() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
@@ -80,7 +80,7 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
 
     public LearnToRankConfig(StreamInput in) throws IOException {
         super(in);
-        this.featureExtractorBuilders = in.readNamedWriteableList(LearnToRankFeatureExtractorBuilder.class);
+        this.featureExtractorBuilders = in.readNamedWriteableCollectionAsList(LearnToRankFeatureExtractorBuilder.class);
     }
 
     public List<LearnToRankFeatureExtractorBuilder> getFeatureExtractorBuilders() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfigUpdate.java
@@ -92,7 +92,7 @@ public class LearnToRankConfigUpdate implements InferenceConfigUpdate, NamedXCon
 
     public LearnToRankConfigUpdate(StreamInput in) throws IOException {
         this.numTopFeatureImportanceValues = in.readOptionalVInt();
-        this.featureExtractorBuilderList = in.readNamedWriteableList(LearnToRankFeatureExtractorBuilder.class);
+        this.featureExtractorBuilderList = in.readNamedWriteableCollectionAsList(LearnToRankFeatureExtractorBuilder.class);
     }
 
     public Integer getNumTopFeatureImportanceValues() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
@@ -160,7 +160,7 @@ public class ModelPackageConfig implements ToXContentObject, Writeable {
         this.inferenceConfigSource = in.readMap();
         this.metadata = in.readMap();
         this.modelType = in.readOptionalString();
-        this.tags = in.readOptionalList(StreamInput::readString);
+        this.tags = in.readOptionalCollectionAsList(StreamInput::readString);
         this.vocabularyFile = in.readOptionalString();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfig.java
@@ -119,7 +119,7 @@ public class NerConfig implements NlpConfig {
     public NerConfig(StreamInput in) throws IOException {
         vocabularyConfig = new VocabularyConfig(in);
         tokenization = in.readNamedWriteable(Tokenization.class);
-        classificationLabels = in.readStringList();
+        classificationLabels = in.readStringCollectionAsList();
         resultsField = in.readOptionalString();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfig.java
@@ -94,7 +94,7 @@ public class TextClassificationConfig implements NlpConfig {
     public TextClassificationConfig(StreamInput in) throws IOException {
         vocabularyConfig = new VocabularyConfig(in);
         tokenization = in.readNamedWriteable(Tokenization.class);
-        classificationLabels = in.readStringList();
+        classificationLabels = in.readStringCollectionAsList();
         numTopClasses = in.readInt();
         resultsField = in.readOptionalString();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdate.java
@@ -82,7 +82,7 @@ public class TextClassificationConfigUpdate extends NlpConfigUpdate implements N
 
     public TextClassificationConfigUpdate(StreamInput in) throws IOException {
         super(in);
-        classificationLabels = in.readOptionalStringList();
+        classificationLabels = in.readOptionalStringCollectionAsList();
         numTopClasses = in.readOptionalVInt();
         resultsField = in.readOptionalString();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfig.java
@@ -151,10 +151,10 @@ public class ZeroShotClassificationConfig implements NlpConfig {
     public ZeroShotClassificationConfig(StreamInput in) throws IOException {
         vocabularyConfig = new VocabularyConfig(in);
         tokenization = in.readNamedWriteable(Tokenization.class);
-        classificationLabels = in.readStringList();
+        classificationLabels = in.readStringCollectionAsList();
         isMultiLabel = in.readBoolean();
         hypothesisTemplate = in.readString();
-        labels = in.readOptionalStringList();
+        labels = in.readOptionalStringCollectionAsList();
         resultsField = in.readOptionalString();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
@@ -88,7 +88,7 @@ public class ZeroShotClassificationConfigUpdate extends NlpConfigUpdate implemen
 
     public ZeroShotClassificationConfigUpdate(StreamInput in) throws IOException {
         super(in);
-        labels = in.readOptionalStringList();
+        labels = in.readOptionalStringCollectionAsList();
         isMultiLabel = in.readOptionalBoolean();
         resultsField = in.readOptionalString();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -114,12 +114,12 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
     }
 
     public Ensemble(StreamInput in) throws IOException {
-        this.featureNames = in.readImmutableList(StreamInput::readString);
-        this.models = Collections.unmodifiableList(in.readNamedWriteableList(TrainedModel.class));
+        this.featureNames = in.readCollectionAsImmutableList(StreamInput::readString);
+        this.models = Collections.unmodifiableList(in.readNamedWriteableCollectionAsList(TrainedModel.class));
         this.outputAggregator = in.readNamedWriteable(OutputAggregator.class);
         this.targetType = TargetType.fromStream(in);
         if (in.readBoolean()) {
-            this.classificationLabels = in.readStringList();
+            this.classificationLabels = in.readStringCollectionAsList();
         } else {
             this.classificationLabels = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/FeatureImportanceBaseline.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/FeatureImportanceBaseline.java
@@ -61,7 +61,7 @@ public class FeatureImportanceBaseline implements ToXContentObject, Writeable {
 
     public FeatureImportanceBaseline(StreamInput in) throws IOException {
         this.baseline = in.readOptionalDouble();
-        this.classBaselines = in.readList(ClassBaseline::new);
+        this.classBaselines = in.readCollectionAsList(ClassBaseline::new);
     }
 
     public FeatureImportanceBaseline(Double baseline, List<ClassBaseline> classBaselines) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TotalFeatureImportance.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TotalFeatureImportance.java
@@ -73,7 +73,7 @@ public class TotalFeatureImportance implements ToXContentObject, Writeable {
     public TotalFeatureImportance(StreamInput in) throws IOException {
         this.featureName = in.readString();
         this.importance = in.readOptionalWriteable(Importance::new);
-        this.classImportances = in.readList(ClassImportance::new);
+        this.classImportances = in.readCollectionAsList(ClassImportance::new);
     }
 
     TotalFeatureImportance(String featureName, @Nullable Importance importance, @Nullable List<ClassImportance> classImportances) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TrainedModelMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TrainedModelMetadata.java
@@ -86,9 +86,9 @@ public class TrainedModelMetadata implements ToXContentObject, Writeable {
 
     public TrainedModelMetadata(StreamInput in) throws IOException {
         this.modelId = in.readString();
-        this.totalFeatureImportances = in.readList(TotalFeatureImportance::new);
+        this.totalFeatureImportances = in.readCollectionAsList(TotalFeatureImportance::new);
         this.featureImportanceBaselines = in.readOptionalWriteable(FeatureImportanceBaseline::new);
-        this.hyperparameters = in.readList(Hyperparameters::new);
+        this.hyperparameters = in.readCollectionAsList(Hyperparameters::new);
     }
 
     public TrainedModelMetadata(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
@@ -81,11 +81,11 @@ public class Tree implements LenientlyParsedTrainedModel, StrictlyParsedTrainedM
     }
 
     public Tree(StreamInput in) throws IOException {
-        this.featureNames = in.readImmutableList(StreamInput::readString);
-        this.nodes = in.readImmutableList(TreeNode::new);
+        this.featureNames = in.readCollectionAsImmutableList(StreamInput::readString);
+        this.nodes = in.readCollectionAsImmutableList(TreeNode::new);
         this.targetType = TargetType.fromStream(in);
         if (in.readBoolean()) {
-            this.classificationLabels = in.readImmutableList(StreamInput::readString);
+            this.classificationLabels = in.readCollectionAsImmutableList(StreamInput::readString);
         } else {
             this.classificationLabels = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -174,13 +174,13 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
     public AnalysisConfig(StreamInput in) throws IOException {
         bucketSpan = in.readTimeValue();
         categorizationFieldName = in.readOptionalString();
-        categorizationFilters = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
+        categorizationFilters = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
         categorizationAnalyzerConfig = in.readOptionalWriteable(CategorizationAnalyzerConfig::new);
         perPartitionCategorizationConfig = new PerPartitionCategorizationConfig(in);
         latency = in.readOptionalTimeValue();
         summaryCountFieldName = in.readOptionalString();
-        detectors = in.readImmutableList(Detector::new);
-        influencers = in.readImmutableList(StreamInput::readString);
+        detectors = in.readCollectionAsImmutableList(Detector::new);
+        influencers = in.readCollectionAsImmutableList(StreamInput::readString);
 
         multivariateByFields = in.readOptionalBoolean();
         modelPruneWindow = in.readOptionalTimeValue();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/CategorizationAnalyzerConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/CategorizationAnalyzerConfig.java
@@ -229,9 +229,9 @@ public class CategorizationAnalyzerConfig implements ToXContentFragment, Writeab
 
     public CategorizationAnalyzerConfig(StreamInput in) throws IOException {
         analyzer = in.readOptionalString();
-        charFilters = in.readList(NameOrDefinition::new);
+        charFilters = in.readCollectionAsList(NameOrDefinition::new);
         tokenizer = in.readOptionalWriteable(NameOrDefinition::new);
-        tokenFilters = in.readList(NameOrDefinition::new);
+        tokenFilters = in.readCollectionAsList(NameOrDefinition::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DetectionRule.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/DetectionRule.java
@@ -62,7 +62,7 @@ public class DetectionRule implements ToXContentObject, Writeable {
     public DetectionRule(StreamInput in) throws IOException {
         actions = in.readEnumSet(RuleAction.class);
         scope = new RuleScope(in);
-        conditions = in.readList(RuleCondition::new);
+        conditions = in.readCollectionAsList(RuleCondition::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
@@ -224,7 +224,7 @@ public class Detector implements ToXContentObject, Writeable {
         partitionFieldName = in.readOptionalString();
         useNull = in.readBoolean();
         excludeFrequent = in.readBoolean() ? ExcludeFrequent.readFromStream(in) : null;
-        rules = in.readImmutableList(DetectionRule::new);
+        rules = in.readCollectionAsImmutableList(DetectionRule::new);
         detectorIndex = in.readInt();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -278,7 +278,7 @@ public class Job implements SimpleDiffable<Job>, Writeable, ToXContentObject {
         jobId = in.readString();
         jobType = in.readString();
         jobVersion = in.readBoolean() ? MlConfigVersion.readVersion(in) : null;
-        groups = in.readImmutableList(StreamInput::readString);
+        groups = in.readCollectionAsImmutableList(StreamInput::readString);
         description = in.readOptionalString();
         createTime = new Date(in.readVLong());
         finishedTime = in.readBoolean() ? new Date(in.readVLong()) : null;
@@ -830,7 +830,7 @@ public class Job implements SimpleDiffable<Job>, Writeable, ToXContentObject {
             id = in.readOptionalString();
             jobType = in.readString();
             jobVersion = in.readBoolean() ? MlConfigVersion.readVersion(in) : null;
-            groups = in.readStringList();
+            groups = in.readStringCollectionAsList();
             description = in.readOptionalString();
             createTime = in.readBoolean() ? new Date(in.readVLong()) : null;
             finishedTime = in.readBoolean() ? new Date(in.readVLong()) : null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -161,7 +161,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         groups = groupsArray == null ? null : Arrays.asList(groupsArray);
         description = in.readOptionalString();
         if (in.readBoolean()) {
-            detectorUpdates = in.readList(DetectorUpdate::new);
+            detectorUpdates = in.readCollectionAsList(DetectorUpdate::new);
         } else {
             detectorUpdates = null;
         }
@@ -173,7 +173,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
         if (in.readBoolean()) {
-            categorizationFilters = in.readStringList();
+            categorizationFilters = in.readStringCollectionAsList();
         } else {
             categorizationFilters = null;
         }
@@ -701,7 +701,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
             detectorIndex = in.readInt();
             description = in.readOptionalString();
             if (in.readBoolean()) {
-                rules = in.readList(DetectionRule::new);
+                rules = in.readCollectionAsList(DetectionRule::new);
             } else {
                 rules = null;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyCause.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyCause.java
@@ -126,7 +126,7 @@ public class AnomalyCause implements ToXContentObject, Writeable {
         overFieldName = in.readOptionalString();
         overFieldValue = in.readOptionalString();
         if (in.readBoolean()) {
-            influencers = in.readList(Influence::new);
+            influencers = in.readCollectionAsList(Influence::new);
         }
         geoResults = in.readOptionalWriteable(GeoResults::new);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
@@ -207,14 +207,14 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
         }
         isInterim = in.readBoolean();
         if (in.readBoolean()) {
-            causes = in.readList(AnomalyCause::new);
+            causes = in.readCollectionAsList(AnomalyCause::new);
         }
         recordScore = in.readDouble();
         initialRecordScore = in.readDouble();
         timestamp = new Date(in.readLong());
         bucketSpan = in.readLong();
         if (in.readBoolean()) {
-            influences = in.readList(Influence::new);
+            influences = in.readCollectionAsList(Influence::new);
         }
         geoResults = in.readOptionalWriteable(GeoResults::new);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_6_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
@@ -143,12 +143,12 @@ public class Bucket implements ToXContentObject, Writeable {
         anomalyScore = in.readDouble();
         bucketSpan = in.readLong();
         initialAnomalyScore = in.readDouble();
-        records = in.readList(AnomalyRecord::new);
+        records = in.readCollectionAsList(AnomalyRecord::new);
         eventCount = in.readLong();
         isInterim = in.readBoolean();
-        bucketInfluencers = in.readList(BucketInfluencer::new);
+        bucketInfluencers = in.readCollectionAsList(BucketInfluencer::new);
         processingTimeMs = in.readLong();
-        scheduledEvents = in.readStringList();
+        scheduledEvents = in.readStringCollectionAsList();
         if (scheduledEvents.isEmpty()) {
             scheduledEvents = Collections.emptyList();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/CategoryDefinition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/CategoryDefinition.java
@@ -97,7 +97,7 @@ public class CategoryDefinition implements ToXContentObject, Writeable {
         terms = in.readString();
         regex = in.readString();
         maxMatchingLength = in.readLong();
-        examples = new TreeSet<>(in.readStringList());
+        examples = new TreeSet<>(in.readStringCollectionAsList());
         grokPattern = in.readOptionalString();
         this.preferredToCategories = in.readVLongArray();
         this.numMatches = in.readVLong();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
@@ -152,7 +152,7 @@ public class ForecastRequestStats implements ToXContentObject, Writeable {
         forecastId = in.readString();
         recordCount = in.readLong();
         if (in.readBoolean()) {
-            messages = in.readStringList();
+            messages = in.readStringCollectionAsList();
         } else {
             messages = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/OverallBucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/OverallBucket.java
@@ -55,7 +55,7 @@ public class OverallBucket implements ToXContentObject, Writeable {
         timestamp = new Date(in.readLong());
         bucketSpan = in.readLong();
         overallScore = in.readDouble();
-        jobs = in.readList(JobInfo::new);
+        jobs = in.readCollectionAsList(JobInfo::new);
         isInterim = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkRequest.java
@@ -38,7 +38,7 @@ public class MonitoringBulkRequest extends ActionRequest {
 
     public MonitoringBulkRequest(StreamInput in) throws IOException {
         super(in);
-        docs.addAll(in.readList(MonitoringBulkDoc::new));
+        docs.addAll(in.readCollectionAsList(MonitoringBulkDoc::new));
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringMigrateAlertsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringMigrateAlertsResponse.java
@@ -31,7 +31,7 @@ public class MonitoringMigrateAlertsResponse extends ActionResponse implements T
 
     public MonitoringMigrateAlertsResponse(StreamInput in) throws IOException {
         super(in);
-        this.exporters = in.readList(ExporterMigrationResult::new);
+        this.exporters = in.readCollectionAsList(ExporterMigrationResult::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupJobsAction.java
@@ -143,7 +143,7 @@ public class GetRollupJobsAction extends ActionType<GetRollupJobsAction.Response
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            jobs = in.readList(JobWrapper::new);
+            jobs = in.readCollectionAsList(JobWrapper::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollableIndexCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollableIndexCaps.java
@@ -38,7 +38,7 @@ public class RollableIndexCaps implements Writeable, ToXContentObject {
 
     public RollableIndexCaps(StreamInput in) throws IOException {
         this.indexName = in.readString();
-        this.jobCaps = in.readList(RollupJobCaps::new);
+        this.jobCaps = in.readCollectionAsList(RollupJobCaps::new);
     }
 
     public String getIndexName() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/MetricConfig.java
@@ -89,7 +89,7 @@ public class MetricConfig implements Writeable, ToXContentObject {
 
     public MetricConfig(final StreamInput in) throws IOException {
         field = in.readString();
-        metrics = in.readStringList();
+        metrics = in.readStringCollectionAsList();
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobConfig.java
@@ -148,7 +148,7 @@ public class RollupJobConfig implements NamedWriteable, ToXContentObject {
         rollupIndex = in.readString();
         cron = in.readString();
         groupConfig = in.readOptionalWriteable(GroupConfig::new);
-        metricsConfig = in.readList(MetricConfig::new);
+        metricsConfig = in.readCollectionAsList(MetricConfig::new);
         timeout = in.readTimeValue();
         pageSize = in.readInt();
         indices = Strings.splitStringByCommaToArray(indexPattern);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
@@ -48,7 +48,7 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
         this.shardRouting = new ShardRouting(in);
         this.snapshotId = new SnapshotId(in);
         this.indexId = new IndexId(in);
-        this.inputStats = in.readList(CacheIndexInputStats::new);
+        this.inputStats = in.readCollectionAsList(CacheIndexInputStats::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/ClearSecurityCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/ClearSecurityCacheResponse.java
@@ -32,7 +32,7 @@ public class ClearSecurityCacheResponse extends BaseNodesResponse<ClearSecurityC
 
     @Override
     protected List<Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::new);
+        return in.readCollectionAsList(Node::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/DelegatePkiAuthenticationRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/DelegatePkiAuthenticationRequest.java
@@ -74,7 +74,7 @@ public final class DelegatePkiAuthenticationRequest extends ActionRequest implem
         super(input);
         try {
             final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-            certificateChain = input.readImmutableList(in -> {
+            certificateChain = input.readCollectionAsImmutableList(in -> {
                 try (ByteArrayInputStream bis = new ByteArrayInputStream(in.readByteArray())) {
                     return (X509Certificate) certificateFactory.generateCertificate(bis);
                 } catch (CertificateException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
@@ -184,7 +184,7 @@ public final class ApiKey implements ToXContentObject, Writeable {
             this.metadata = Map.of();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_5_0)) {
-            final List<RoleDescriptor> roleDescriptors = in.readOptionalList(RoleDescriptor::new);
+            final List<RoleDescriptor> roleDescriptors = in.readOptionalCollectionAsList(RoleDescriptor::new);
             this.roleDescriptors = roleDescriptors != null ? List.copyOf(roleDescriptors) : null;
             this.limitedBy = in.readOptionalWriteable(RoleDescriptorsIntersection::new);
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseBulkUpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseBulkUpdateApiKeyRequest.java
@@ -35,7 +35,7 @@ public abstract class BaseBulkUpdateApiKeyRequest extends BaseUpdateApiKeyReques
 
     public BaseBulkUpdateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        this.ids = in.readStringList();
+        this.ids = in.readStringCollectionAsList();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseUpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseUpdateApiKeyRequest.java
@@ -36,7 +36,7 @@ public abstract class BaseUpdateApiKeyRequest extends ActionRequest {
 
     public BaseUpdateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        this.roleDescriptors = in.readOptionalList(RoleDescriptor::new);
+        this.roleDescriptors = in.readOptionalCollectionAsList(RoleDescriptor::new);
         this.metadata = in.readMap();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyResponse.java
@@ -35,8 +35,8 @@ public final class BulkUpdateApiKeyResponse extends ActionResponse implements To
 
     public BulkUpdateApiKeyResponse(StreamInput in) throws IOException {
         super(in);
-        this.updated = in.readStringList();
-        this.noops = in.readStringList();
+        this.updated = in.readStringCollectionAsList();
+        this.noops = in.readStringCollectionAsList();
         this.errorDetails = in.readMap(StreamInput::readException);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
@@ -63,7 +63,7 @@ public final class CreateApiKeyRequest extends AbstractCreateApiKeyRequest {
             this.name = in.readString();
         }
         this.expiration = in.readOptionalTimeValue();
-        this.roleDescriptors = in.readImmutableList(RoleDescriptor::new);
+        this.roleDescriptors = in.readCollectionAsImmutableList(RoleDescriptor::new);
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)) {
             this.metadata = in.readMap();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCrossClusterApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCrossClusterApiKeyRequest.java
@@ -41,7 +41,7 @@ public final class CreateCrossClusterApiKeyRequest extends AbstractCreateApiKeyR
         super(in);
         this.name = in.readString();
         this.expiration = in.readOptionalTimeValue();
-        this.roleDescriptors = in.readImmutableList(RoleDescriptor::new);
+        this.roleDescriptors = in.readCollectionAsImmutableList(RoleDescriptor::new);
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
         this.metadata = in.readMap();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/InvalidateApiKeyResponse.java
@@ -45,9 +45,9 @@ public final class InvalidateApiKeyResponse extends ActionResponse implements To
 
     public InvalidateApiKeyResponse(StreamInput in) throws IOException {
         super(in);
-        this.invalidatedApiKeys = in.readList(StreamInput::readString);
-        this.previouslyInvalidatedApiKeys = in.readList(StreamInput::readString);
-        this.errors = in.readList(StreamInput::readException);
+        this.invalidatedApiKeys = in.readCollectionAsList(StreamInput::readString);
+        this.previouslyInvalidatedApiKeys = in.readCollectionAsList(StreamInput::readString);
+        this.errors = in.readCollectionAsList(StreamInput::readException);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
@@ -67,7 +67,7 @@ public final class QueryApiKeyRequest extends ActionRequest {
         this.from = in.readOptionalVInt();
         this.size = in.readOptionalVInt();
         if (in.readBoolean()) {
-            this.fieldSortBuilders = in.readList(FieldSortBuilder::new);
+            this.fieldSortBuilders = in.readCollectionAsList(FieldSortBuilder::new);
         } else {
             this.fieldSortBuilders = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/enrollment/NodeEnrollmentResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/enrollment/NodeEnrollmentResponse.java
@@ -42,7 +42,7 @@ public final class NodeEnrollmentResponse extends ActionResponse implements ToXC
         transportCaCert = in.readString();
         transportKey = in.readString();
         transportCert = in.readString();
-        nodesAddresses = in.readStringList();
+        nodesAddresses = in.readStringCollectionAsList();
     }
 
     public NodeEnrollmentResponse(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/ClearPrivilegesCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/ClearPrivilegesCacheResponse.java
@@ -32,7 +32,7 @@ public class ClearPrivilegesCacheResponse extends BaseNodesResponse<ClearPrivile
 
     @Override
     protected List<Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::new);
+        return in.readCollectionAsList(Node::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponse.java
@@ -26,7 +26,7 @@ public final class DeletePrivilegesResponse extends ActionResponse implements To
 
     public DeletePrivilegesResponse(StreamInput in) throws IOException {
         super(in);
-        this.found = in.readImmutableSet(StreamInput::readString);
+        this.found = in.readCollectionAsImmutableSet(StreamInput::readString);
     }
 
     public DeletePrivilegesResponse(Collection<String> found) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
@@ -34,7 +34,7 @@ public final class PutPrivilegesRequest extends ActionRequest implements Applica
 
     public PutPrivilegesRequest(StreamInput in) throws IOException {
         super(in);
-        privileges = in.readImmutableList(ApplicationPrivilegeDescriptor::new);
+        privileges = in.readCollectionAsImmutableList(ApplicationPrivilegeDescriptor::new);
         refreshPolicy = RefreshPolicy.readFrom(in);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -27,7 +27,7 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     public PutPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
-        this.created = in.readImmutableMap(StreamInput::readStringList);
+        this.created = in.readImmutableMap(StreamInput::readStringCollectionAsList);
     }
 
     public PutPrivilegesResponse(Map<String, List<String>> created) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesRequest.java
@@ -32,8 +32,8 @@ public class GetProfilesRequest extends ActionRequest {
 
     public GetProfilesRequest(StreamInput in) throws IOException {
         super(in);
-        this.uids = in.readStringList();
-        this.dataKeys = in.readSet(StreamInput::readString);
+        this.uids = in.readStringCollectionAsList();
+        this.dataKeys = in.readCollectionAsSet(StreamInput::readString);
     }
 
     public GetProfilesRequest(String uid, Set<String> dataKeys) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
@@ -31,7 +31,7 @@ public class GetProfilesResponse extends ActionResponse implements ToXContentObj
 
     public GetProfilesResponse(StreamInput in) throws IOException {
         super(in);
-        this.profiles = in.readImmutableList(Profile::new);
+        this.profiles = in.readCollectionAsImmutableList(Profile::new);
         this.errors = in.readMap(StreamInput::readException);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
@@ -43,7 +43,7 @@ public record Profile(
         public ProfileUser(StreamInput in) throws IOException {
             this(
                 in.readString(),
-                in.readStringList(),
+                in.readStringCollectionAsList(),
                 in.readString(),
                 in.readOptionalString(),
                 in.readOptionalString(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SuggestProfilesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SuggestProfilesRequest.java
@@ -50,7 +50,7 @@ public class SuggestProfilesRequest extends ActionRequest {
 
     public SuggestProfilesRequest(StreamInput in) throws IOException {
         super(in);
-        this.dataKeys = in.readSet(StreamInput::readString);
+        this.dataKeys = in.readCollectionAsSet(StreamInput::readString);
         this.name = in.readOptionalString();
         this.size = in.readVInt();
         this.hint = in.readOptionalWriteable(Hint::new);
@@ -139,7 +139,7 @@ public class SuggestProfilesRequest extends ActionRequest {
         }
 
         public Hint(StreamInput in) throws IOException {
-            this.uids = in.readStringList();
+            this.uids = in.readStringCollectionAsList();
             this.labels = in.readMapOfLists(StreamInput::readString);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheResponse.java
@@ -32,7 +32,7 @@ public class ClearRealmCacheResponse extends BaseNodesResponse<ClearRealmCacheRe
 
     @Override
     protected List<ClearRealmCacheResponse.Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::new);
+        return in.readCollectionAsList(Node::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheResponse.java
@@ -35,7 +35,7 @@ public class ClearRolesCacheResponse extends BaseNodesResponse<ClearRolesCacheRe
 
     @Override
     protected List<ClearRolesCacheResponse.Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::new);
+        return in.readCollectionAsList(Node::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -54,13 +54,13 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
         for (int i = 0; i < indicesSize; i++) {
             indicesPrivileges.add(new RoleDescriptor.IndicesPrivileges(in));
         }
-        applicationPrivileges = in.readList(RoleDescriptor.ApplicationResourcePrivileges::new);
+        applicationPrivileges = in.readCollectionAsList(RoleDescriptor.ApplicationResourcePrivileges::new);
         configurableClusterPrivileges = ConfigurableClusterPrivileges.readArray(in);
         runAs = in.readStringArray();
         refreshPolicy = RefreshPolicy.readFrom(in);
         metadata = in.readMap();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            remoteIndicesPrivileges = in.readList(RoleDescriptor.RemoteIndicesPrivileges::new);
+            remoteIndicesPrivileges = in.readCollectionAsList(RoleDescriptor.RemoteIndicesPrivileges::new);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
@@ -46,9 +46,9 @@ public class PutRoleMappingRequest extends ActionRequest implements WriteRequest
         super(in);
         this.name = in.readString();
         this.enabled = in.readBoolean();
-        this.roles = in.readStringList();
+        this.roles = in.readStringCollectionAsList();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_2_0)) {
-            this.roleTemplates = in.readList(TemplateRoleName::new);
+            this.roleTemplates = in.readCollectionAsList(TemplateRoleName::new);
         }
         this.rules = ExpressionParser.readExpression(in);
         this.metadata = in.readMap();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsNodesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsNodesResponse.java
@@ -45,7 +45,7 @@ public class GetServiceAccountCredentialsNodesResponse extends BaseNodesResponse
 
     @Override
     protected List<GetServiceAccountCredentialsNodesResponse.Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(GetServiceAccountCredentialsNodesResponse.Node::new);
+        return in.readCollectionAsList(GetServiceAccountCredentialsNodesResponse.Node::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsResponse.java
@@ -37,7 +37,7 @@ public class GetServiceAccountCredentialsResponse extends ActionResponse impleme
     public GetServiceAccountCredentialsResponse(StreamInput in) throws IOException {
         super(in);
         this.principal = in.readString();
-        this.indexTokenInfos = in.readList(TokenInfo::new);
+        this.indexTokenInfos = in.readCollectionAsList(TokenInfo::new);
         this.nodesResponse = new GetServiceAccountCredentialsNodesResponse(in);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/TokenInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/TokenInfo.java
@@ -36,7 +36,7 @@ public class TokenInfo implements Writeable, ToXContentObject, Comparable<TokenI
 
     public TokenInfo(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.nodeNames = in.readOptionalStringList();
+        this.nodeNames = in.readOptionalStringCollectionAsList();
     }
 
     public String getName() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
@@ -43,13 +43,13 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
 
     public GetUserPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
-        cluster = in.readImmutableSet(StreamInput::readString);
-        configurableClusterPrivileges = in.readImmutableSet(ConfigurableClusterPrivileges.READER);
-        index = in.readImmutableSet(Indices::new);
-        application = in.readImmutableSet(RoleDescriptor.ApplicationResourcePrivileges::new);
-        runAs = in.readImmutableSet(StreamInput::readString);
+        cluster = in.readCollectionAsImmutableSet(StreamInput::readString);
+        configurableClusterPrivileges = in.readCollectionAsImmutableSet(ConfigurableClusterPrivileges.READER);
+        index = in.readCollectionAsImmutableSet(Indices::new);
+        application = in.readCollectionAsImmutableSet(RoleDescriptor.ApplicationResourcePrivileges::new);
+        runAs = in.readCollectionAsImmutableSet(StreamInput::readString);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            remoteIndex = in.readImmutableSet(RemoteIndices::new);
+            remoteIndex = in.readCollectionAsImmutableSet(RemoteIndices::new);
         } else {
             remoteIndex = Set.of();
         }
@@ -144,7 +144,7 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
     public record RemoteIndices(Indices indices, Set<String> remoteClusters) implements ToXContentObject, Writeable {
 
         public RemoteIndices(StreamInput in) throws IOException {
-            this(new Indices(in), Collections.unmodifiableSet(new TreeSet<>(in.readSet(StreamInput::readString))));
+            this(new Indices(in), Collections.unmodifiableSet(new TreeSet<>(in.readCollectionAsSet(StreamInput::readString))));
         }
 
         @Override
@@ -190,14 +190,14 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
 
         public Indices(StreamInput in) throws IOException {
             // The use of TreeSet is to provide a consistent order that can be relied upon in tests
-            indices = Collections.unmodifiableSet(new TreeSet<>(in.readSet(StreamInput::readString)));
-            privileges = Collections.unmodifiableSet(new TreeSet<>(in.readSet(StreamInput::readString)));
-            fieldSecurity = in.readImmutableSet(input -> {
+            indices = Collections.unmodifiableSet(new TreeSet<>(in.readCollectionAsSet(StreamInput::readString)));
+            privileges = Collections.unmodifiableSet(new TreeSet<>(in.readCollectionAsSet(StreamInput::readString)));
+            fieldSecurity = in.readCollectionAsImmutableSet(input -> {
                 final String[] grant = input.readOptionalStringArray();
                 final String[] exclude = input.readOptionalStringArray();
                 return new FieldPermissionsDefinition.FieldGrantExcludeGroup(grant, exclude);
             });
-            queries = in.readImmutableSet(StreamInput::readBytesReference);
+            queries = in.readCollectionAsImmutableSet(StreamInput::readBytesReference);
             this.allowRestrictedIndices = in.readBoolean();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesRequest.java
@@ -56,7 +56,7 @@ public class ProfileHasPrivilegesRequest extends ActionRequest {
 
     public ProfileHasPrivilegesRequest(StreamInput in) throws IOException {
         super(in);
-        this.uids = in.readStringList();
+        this.uids = in.readStringCollectionAsList();
         this.privilegesToCheck = PrivilegesToCheck.readFrom(in);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesResponse.java
@@ -26,7 +26,7 @@ public class ProfileHasPrivilegesResponse extends ActionResponse implements ToXC
 
     public ProfileHasPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
-        this.hasPrivilegeUids = in.readSet(StreamInput::readString);
+        this.hasPrivilegeUids = in.readCollectionAsSet(StreamInput::readString);
         this.errors = in.readMap(StreamInput::readException);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -742,7 +742,7 @@ public final class Authentication implements ToXContentObject {
         CROSS_CLUSTER_ACCESS_AUTHENTICATION_KEY,
         Authentication::new,
         CROSS_CLUSTER_ACCESS_ROLE_DESCRIPTORS_KEY,
-        in -> in.readList(RoleDescriptorsBytes::new)
+        in -> in.readCollectionAsList(RoleDescriptorsBytes::new)
     );
 
     private static Map<String, Object> readMetadata(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/CrossClusterAccessSubjectInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/CrossClusterAccessSubjectInfo.java
@@ -169,7 +169,7 @@ public final class CrossClusterAccessSubjectInfo {
         final TransportVersion version = TransportVersion.readVersion(in);
         in.setTransportVersion(version);
         final Authentication authentication = new Authentication(in);
-        final List<RoleDescriptorsBytes> roleDescriptorsBytesList = in.readImmutableList(RoleDescriptorsBytes::new);
+        final List<RoleDescriptorsBytes> roleDescriptorsBytesList = in.readCollectionAsImmutableList(RoleDescriptorsBytes::new);
         return new CrossClusterAccessSubjectInfo(authentication, roleDescriptorsBytesList);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmDomain.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmDomain.java
@@ -33,7 +33,7 @@ public record RealmDomain(String name, Set<RealmConfig.RealmIdentifier> realms) 
 
     static RealmDomain readFrom(StreamInput in) throws IOException {
         String domainName = in.readString();
-        Set<RealmConfig.RealmIdentifier> realms = in.readSet(RealmConfig.RealmIdentifier::new);
+        Set<RealmConfig.RealmIdentifier> realms = in.readCollectionAsSet(RealmConfig.RealmIdentifier::new);
         return new RealmDomain(domainName, realms);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
@@ -46,7 +46,7 @@ public final class TokenMetadata extends AbstractNamedDiffable<ClusterState.Cust
 
     public TokenMetadata(StreamInput input) throws IOException {
         currentKeyHash = input.readByteArray();
-        keys = input.readImmutableList(KeyAndTimestamp::new);
+        keys = input.readCollectionAsImmutableList(KeyAndTimestamp::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/TokensInvalidationResult.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/TokensInvalidationResult.java
@@ -56,9 +56,9 @@ public class TokensInvalidationResult implements ToXContentObject, Writeable {
     }
 
     public TokensInvalidationResult(StreamInput in) throws IOException {
-        this.invalidatedTokens = in.readStringList();
-        this.previouslyInvalidatedTokens = in.readStringList();
-        this.errors = in.readList(StreamInput::readException);
+        this.invalidatedTokens = in.readStringCollectionAsList();
+        this.previouslyInvalidatedTokens = in.readStringCollectionAsList();
+        this.errors = in.readCollectionAsList(StreamInput::readException);
         if (in.getTransportVersion().before(TransportVersion.V_7_2_0)) {
             in.readVInt();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
@@ -96,9 +96,9 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
     public ExpressionRoleMapping(StreamInput in) throws IOException {
         this.name = in.readString();
         this.enabled = in.readBoolean();
-        this.roles = in.readStringList();
+        this.roles = in.readStringCollectionAsList();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_2_0)) {
-            this.roleTemplates = in.readList(TemplateRoleName::new);
+            this.roleTemplates = in.readCollectionAsList(TemplateRoleName::new);
         } else {
             this.roleTemplates = Collections.emptyList();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionParser.java
@@ -36,7 +36,7 @@ public final class ExpressionParser {
     }
 
     static List<RoleMapperExpression> readExpressionList(StreamInput in) throws IOException {
-        return in.readNamedWriteableList(RoleMapperExpression.class);
+        return in.readNamedWriteableCollectionAsList(RoleMapperExpression.class);
     }
 
     static void writeExpressionList(List<RoleMapperExpression> list, StreamOutput out) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/FieldExpression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/FieldExpression.java
@@ -45,7 +45,7 @@ public final class FieldExpression implements RoleMapperExpression {
     }
 
     public FieldExpression(StreamInput in) throws IOException {
-        this(in.readString(), in.readList(FieldValue::readFrom));
+        this(in.readString(), in.readCollectionAsList(FieldValue::readFrom));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersection.java
@@ -31,7 +31,7 @@ public record RoleDescriptorsIntersection(Collection<Set<RoleDescriptor>> roleDe
     }
 
     public RoleDescriptorsIntersection(StreamInput in) throws IOException {
-        this(in.readImmutableList(inner -> inner.readSet(RoleDescriptor::new)));
+        this(in.readCollectionAsImmutableList(inner -> inner.readCollectionAsSet(RoleDescriptor::new)));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
@@ -65,7 +65,7 @@ public class ApplicationPrivilegeDescriptor implements ToXContentObject, Writeab
     public ApplicationPrivilegeDescriptor(StreamInput input) throws IOException {
         this.application = input.readString();
         this.name = input.readString();
-        this.actions = input.readImmutableSet(StreamInput::readString);
+        this.actions = input.readCollectionAsImmutableSet(StreamInput::readString);
         this.metadata = Collections.unmodifiableMap(input.readMap());
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
@@ -192,7 +192,7 @@ public final class ConfigurableClusterPrivileges {
         }
 
         public static WriteProfileDataPrivileges createFrom(StreamInput in) throws IOException {
-            final Set<String> applications = in.readSet(StreamInput::readString);
+            final Set<String> applications = in.readCollectionAsSet(StreamInput::readString);
             return new WriteProfileDataPrivileges(applications);
         }
 
@@ -301,7 +301,7 @@ public final class ConfigurableClusterPrivileges {
         }
 
         public static ManageApplicationPrivileges createFrom(StreamInput in) throws IOException {
-            final Set<String> applications = in.readSet(StreamInput::readString);
+            final Set<String> applications = in.readCollectionAsSet(StreamInput::readString);
             return new ManageApplicationPrivileges(applications);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/GetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/GetSnapshotLifecycleAction.java
@@ -92,7 +92,7 @@ public class GetSnapshotLifecycleAction extends ActionType<GetSnapshotLifecycleA
         }
 
         public Response(StreamInput in) throws IOException {
-            this.lifecycles = in.readList(SnapshotLifecyclePolicyItem::new);
+            this.lifecycles = in.readCollectionAsList(SnapshotLifecyclePolicyItem::new);
         }
 
         public List<SnapshotLifecyclePolicyItem> getPolicies() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/action/SpatialStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/action/SpatialStatsAction.java
@@ -101,7 +101,7 @@ public class SpatialStatsAction extends ActionType<SpatialStatsAction.Response> 
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/NodeTermsEnumResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/NodeTermsEnumResponse.java
@@ -32,13 +32,13 @@ class NodeTermsEnumResponse extends TransportResponse {
     NodeTermsEnumResponse(StreamInput in) throws IOException {
         super(in);
         if (in.getTransportVersion().before(TransportVersion.V_8_2_0)) {
-            terms = in.readList(r -> {
+            terms = in.readCollectionAsList(r -> {
                 String term = r.readString();
                 in.readLong(); // obsolete docCount field
                 return term;
             });
         } else {
-            terms = in.readStringList();
+            terms = in.readStringCollectionAsList();
         }
         error = in.readOptionalString();
         complete = in.readBoolean();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumResponse.java
@@ -59,7 +59,7 @@ public class TermsEnumResponse extends BroadcastResponse {
 
     TermsEnumResponse(StreamInput in) throws IOException {
         super(in);
-        terms = in.readStringList();
+        terms = in.readStringCollectionAsList();
         complete = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
@@ -140,7 +140,7 @@ public class FindStructureAction extends ActionType<FindStructureAction.Response
             timeout = in.readOptionalTimeValue();
             charset = in.readOptionalString();
             format = in.readBoolean() ? in.readEnum(TextStructure.Format.class) : null;
-            columnNames = in.readBoolean() ? in.readStringList() : null;
+            columnNames = in.readBoolean() ? in.readStringCollectionAsList() : null;
             hasHeaderRow = in.readOptionalBoolean();
             delimiter = in.readBoolean() ? (char) in.readVInt() : null;
             quote = in.readBoolean() ? (char) in.readVInt() : null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/FieldStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/FieldStats.java
@@ -123,7 +123,7 @@ public class FieldStats implements ToXContentObject, Writeable {
         medianValue = in.readOptionalDouble();
         earliestTimestamp = in.readOptionalString();
         latestTimestamp = in.readOptionalString();
-        topHits = in.readList(StreamInput::readMap);
+        topHits = in.readCollectionAsList(StreamInput::readMap);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -220,7 +220,7 @@ public class TextStructure implements ToXContentObject, Writeable {
         format = in.readEnum(Format.class);
         multilineStartPattern = in.readOptionalString();
         excludeLinesPattern = in.readOptionalString();
-        columnNames = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
+        columnNames = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
         hasHeaderRow = in.readOptionalBoolean();
         delimiter = in.readBoolean() ? (char) in.readVInt() : null;
         quote = in.readBoolean() ? (char) in.readVInt() : null;
@@ -231,14 +231,14 @@ public class TextStructure implements ToXContentObject, Writeable {
         } else {
             ecsCompatibility = getNonNullEcsCompatibilityString(null);
         }
-        jodaTimestampFormats = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
-        javaTimestampFormats = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
+        jodaTimestampFormats = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
+        javaTimestampFormats = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
         timestampField = in.readOptionalString();
         needClientTimezone = in.readBoolean();
         mappings = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap()));
         ingestPipeline = in.readBoolean() ? Collections.unmodifiableMap(in.readMap()) : null;
         fieldStats = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap(FieldStats::new)));
-        explanation = in.readImmutableList(StreamInput::readString);
+        explanation = in.readCollectionAsImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointNodeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetCheckpointNodeAction.java
@@ -94,7 +94,7 @@ public class GetCheckpointNodeAction extends ActionType<GetCheckpointNodeAction.
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.shards = in.readImmutableSet(ShardId::new);
+            this.shards = in.readCollectionAsImmutableSet(ShardId::new);
             this.originalIndices = OriginalIndices.readOriginalIndices(in);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -138,7 +138,7 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
             super(in);
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0)) {
                 if (in.readBoolean()) {
-                    this.errors = in.readList(Error::new);
+                    this.errors = in.readCollectionAsList(Error::new);
                 } else {
                     this.errors = null;
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -71,7 +71,7 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
         public Request(StreamInput in) throws IOException {
             super(in);
             id = in.readString();
-            expandedIds = in.readImmutableList(StreamInput::readString);
+            expandedIds = in.readCollectionAsImmutableList(StreamInput::readString);
             pageParams = new PageParams(in);
             allowNoMatch = in.readBoolean();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/DestConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/DestConfig.java
@@ -65,7 +65,7 @@ public class DestConfig implements Writeable, ToXContentObject {
     public DestConfig(final StreamInput in) throws IOException {
         index = in.readString();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            aliases = in.readOptionalList(DestAlias::new);
+            aliases = in.readOptionalCollectionAsList(DestAlias::new);
         } else {
             aliases = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettings.java
@@ -77,7 +77,7 @@ public class TransformDestIndexSettings implements SimpleDiffable<TransformDestI
     public TransformDestIndexSettings(StreamInput in) throws IOException {
         mappings = in.readMap();
         settings = Settings.readSettingsFromStream(in);
-        aliases = new HashSet<>(in.readList(Alias::new));
+        aliases = new HashSet<>(in.readCollectionAsList(Alias::new));
     }
 
     public Map<String, Object> getMappings() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealth.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealth.java
@@ -38,7 +38,7 @@ public class TransformHealth implements Writeable, ToXContentObject {
 
     public TransformHealth(StreamInput in) throws IOException {
         this.status = in.readEnum(HealthStatus.class);
-        this.issues = in.readOptionalList(TransformHealthIssue::new);
+        this.issues = in.readOptionalCollectionAsList(TransformHealthIssue::new);
     }
 
     public HealthStatus getStatus() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/latest/LatestConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/latest/LatestConfig.java
@@ -71,7 +71,7 @@ public class LatestConfig implements Writeable, ToXContentObject {
     }
 
     public LatestConfig(StreamInput in) throws IOException {
-        this.uniqueKey = in.readStringList();
+        this.uniqueKey = in.readStringCollectionAsList();
         this.sort = in.readString();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/QueryWatchesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/QueryWatchesAction.java
@@ -106,7 +106,7 @@ public class QueryWatchesAction extends ActionType<QueryWatchesAction.Response> 
             size = in.readOptionalVInt();
             query = in.readOptionalNamedWriteable(QueryBuilder.class);
             if (in.readBoolean()) {
-                sorts = in.readList(FieldSortBuilder::new);
+                sorts = in.readCollectionAsList(FieldSortBuilder::new);
             } else {
                 sorts = null;
             }
@@ -216,7 +216,7 @@ public class QueryWatchesAction extends ActionType<QueryWatchesAction.Response> 
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            watches = in.readList(Item::new);
+            watches = in.readCollectionAsList(Item::new);
             watchTotalCount = in.readVLong();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
@@ -54,7 +54,7 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
 
     @Override
     protected List<Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::new);
+        return in.readCollectionAsList(Node::new);
     }
 
     @Override
@@ -105,10 +105,10 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
             watcherState = WatcherState.fromId(in.readByte());
 
             if (in.readBoolean()) {
-                snapshots = in.readList(WatchExecutionSnapshot::new);
+                snapshots = in.readCollectionAsList(WatchExecutionSnapshot::new);
             }
             if (in.readBoolean()) {
-                queuedWatches = in.readList(QueuedWatch::new);
+                queuedWatches = in.readCollectionAsList(QueuedWatch::new);
             }
             if (in.readBoolean()) {
                 stats = new Counters(in);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockAction.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockAction.java
@@ -45,7 +45,7 @@ public class MockAction implements LifecycleAction {
     }
 
     public MockAction(StreamInput in) throws IOException {
-        this.steps = in.readList(MockStep::new);
+        this.steps = in.readCollectionAsList(MockStep::new);
         this.safe = in.readBoolean();
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -151,11 +151,11 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            clusterSettingsIssues = in.readList(DeprecationIssue::new);
-            nodeSettingsIssues = in.readList(DeprecationIssue::new);
+            clusterSettingsIssues = in.readCollectionAsList(DeprecationIssue::new);
+            nodeSettingsIssues = in.readCollectionAsList(DeprecationIssue::new);
             indexSettingsIssues = in.readMapOfLists(DeprecationIssue::new);
             if (in.getTransportVersion().before(TransportVersion.V_7_11_0)) {
-                List<DeprecationIssue> mlIssues = in.readList(DeprecationIssue::new);
+                List<DeprecationIssue> mlIssues = in.readCollectionAsList(DeprecationIssue::new);
                 pluginSettingsIssues = new HashMap<>();
                 pluginSettingsIssues.put("ml_settings", mlIssues);
             } else {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckAction.java
@@ -58,7 +58,7 @@ public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationChec
 
         public NodeResponse(StreamInput in) throws IOException {
             super(in);
-            deprecationIssues = in.readList(DeprecationIssue::new);
+            deprecationIssues = in.readCollectionAsList(DeprecationIssue::new);
         }
 
         public NodeResponse(DiscoveryNode node, List<DeprecationIssue> deprecationIssues) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckResponse.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckResponse.java
@@ -33,7 +33,7 @@ public class NodesDeprecationCheckResponse extends BaseNodesResponse<NodesDeprec
 
     @Override
     protected List<NodesDeprecationCheckAction.NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodesDeprecationCheckAction.NodeResponse::new);
+        return in.readCollectionAsList(NodesDeprecationCheckAction.NodeResponse::new);
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationCacheResetAction.java
@@ -81,7 +81,7 @@ public class DeprecationCacheResetAction extends ActionType<DeprecationCacheRese
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -79,7 +79,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeResponse::new);
+            return in.readCollectionAsList(NodeResponse::new);
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
@@ -109,7 +109,7 @@ public class GetAnalyticsCollectionAction extends ActionType<GetAnalyticsCollect
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.collections = in.readList(AnalyticsCollection::new);
+            this.collections = in.readCollectionAsList(AnalyticsCollection::new);
         }
 
         public Response(List<AnalyticsCollection> collections) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -94,7 +94,7 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
             this.eventTime = in.readLong();
             this.xContentType = in.readEnum(XContentType.class);
             this.payload = in.readBytesReference();
-            this.headers = in.readMap(StreamInput::readStringList);
+            this.headers = in.readMap(StreamInput::readStringCollectionAsList);
             this.clientAddress = in.readOptionalString();
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -111,7 +111,7 @@ public class QueryRule implements Writeable, ToXContentObject {
     public QueryRule(StreamInput in) throws IOException {
         this.id = in.readString();
         this.type = QueryRuleType.queryRuleType(in.readString());
-        this.criteria = in.readList(QueryRuleCriteria::new);
+        this.criteria = in.readCollectionAsList(QueryRuleCriteria::new);
         this.actions = in.readMap();
 
         validate();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -74,7 +74,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         this.criteriaType = in.readEnum(QueryRuleCriteriaType.class);
         if (in.getTransportVersion().onOrAfter(CRITERIA_METADATA_VALUES_TRANSPORT_VERSION)) {
             this.criteriaMetadata = in.readOptionalString();
-            this.criteriaValues = in.readOptionalList(StreamInput::readGenericValue);
+            this.criteriaValues = in.readOptionalCollectionAsList(StreamInput::readGenericValue);
         } else {
             this.criteriaMetadata = in.readString();
             this.criteriaValues = List.of(in.readGenericValue());

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleset.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleset.java
@@ -56,7 +56,7 @@ public class QueryRuleset implements Writeable, ToXContentObject {
 
     public QueryRuleset(StreamInput in) throws IOException {
         this.id = in.readString();
-        this.rules = in.readList(QueryRule::new);
+        this.rules = in.readCollectionAsList(QueryRule::new);
     }
 
     private static final ConstructingObjectParser<QueryRuleset, String> PARSER = new ConstructingObjectParser<>(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -84,9 +84,9 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
         organicQuery = in.readNamedWriteable(QueryBuilder.class);
         matchCriteria = in.readMap();
         rulesetId = in.readString();
-        pinnedIds = in.readOptionalStringList();
+        pinnedIds = in.readOptionalStringCollectionAsList();
         pinnedIdsSupplier = null;
-        pinnedDocs = in.readOptionalList(Item::new);
+        pinnedDocs = in.readOptionalCollectionAsList(Item::new);
         pinnedDocsSupplier = null;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -126,7 +126,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
             if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
+                fetchFields = in.readCollectionAsList(FieldAndFormat::new);
             }
             runtimeMappings = in.readMap();
         } else {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -439,7 +439,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         @SuppressWarnings("unchecked")
         public Sequence(StreamInput in) throws IOException {
             this.joinKeys = (List<Object>) in.readGenericValue();
-            this.events = in.readList(Event::readFrom);
+            this.events = in.readCollectionAsList(Event::readFrom);
         }
 
         public static Sequence fromXContent(XContentParser parser) {
@@ -521,8 +521,8 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
             } else {
                 totalHits = null;
             }
-            events = in.readBoolean() ? in.readList(Event::readFrom) : null;
-            sequences = in.readBoolean() ? in.readList(Sequence::new) : null;
+            events = in.readBoolean() ? in.readCollectionAsList(Event::readFrom) : null;
+            sequences = in.readBoolean() ? in.readCollectionAsList(Sequence::new) : null;
         }
 
         @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionProcessor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/CIDRMatchFunctionProcessor.java
@@ -32,7 +32,7 @@ public class CIDRMatchFunctionProcessor implements Processor {
 
     public CIDRMatchFunctionProcessor(StreamInput in) throws IOException {
         source = in.readNamedWriteable(Processor.class);
-        addresses = in.readNamedWriteableList(Processor.class);
+        addresses = in.readNamedWriteableCollectionAsList(Processor.class);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlStatsResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlStatsResponse.java
@@ -33,7 +33,7 @@ public class EqlStatsResponse extends BaseNodesResponse<EqlStatsResponse.NodeSta
 
     @Override
     protected List<NodeStatsResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeStatsResponse::readNodeResponse);
+        return in.readCollectionAsList(NodeStatsResponse::readNodeResponse);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -280,7 +280,7 @@ public class CircuitBreakerTests extends ESTestCase {
                     }
 
                     @Override
-                    public List<String> readStringList() throws IOException {
+                    public List<String> readStringCollectionAsList() throws IOException {
                         return emptyList();
                     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverStatus.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverStatus.java
@@ -59,7 +59,7 @@ public class DriverStatus implements Task.Status {
     }
 
     DriverStatus(StreamInput in) throws IOException {
-        this(in.readString(), in.readLong(), Status.valueOf(in.readString()), in.readImmutableList(OperatorStatus::new));
+        this(in.readString(), in.readLong(), Status.valueOf(in.readString()), in.readCollectionAsImmutableList(OperatorStatus::new));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -185,7 +185,7 @@ public class BasicPageTests extends SerializationTestCase {
         out.writeCollection(origPages);
         StreamInput in = new NamedWriteableAwareStreamInput(ByteBufferStreamInput.wrap(BytesReference.toBytes(out.bytes())), registry);
 
-        List<Page> deserPages = in.readList(new Page.PageReader());
+        List<Page> deserPages = in.readCollectionAsList(new Page.PageReader());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(origPages, unused -> deserPages);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -80,8 +80,8 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
 
     public EsqlQueryResponse(StreamInput in) throws IOException {
         super(in);
-        this.columns = in.readList(ColumnInfo::new);
-        this.pages = in.readList(Page::new);
+        this.columns = in.readCollectionAsList(ColumnInfo::new);
+        this.pages = in.readCollectionAsList(Page::new);
         this.columnar = in.readBoolean();
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -292,7 +292,7 @@ public class EnrichLookupService {
             this.matchField = in.readString();
             this.inputPage = new Page(in);
             PlanStreamInput planIn = new PlanStreamInput(in, PlanNameRegistry.INSTANCE, in.namedWriteableRegistry(), null);
-            this.extractFields = planIn.readList(readerFromPlanReader(PlanStreamInput::readNamedExpression));
+            this.extractFields = planIn.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readNamedExpression));
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -384,7 +384,7 @@ public final class PlanNamedTypes {
         return new AggregateExec(
             Source.EMPTY,
             in.readPhysicalPlanNode(),
-            in.readList(readerFromPlanReader(PlanStreamInput::readExpression)),
+            in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression)),
             readNamedExpressions(in),
             in.readEnum(AggregateExec.Mode.class),
             in.readOptionalVInt()
@@ -417,7 +417,7 @@ public final class PlanNamedTypes {
             readAttributes(in),
             in.readOptionalNamedWriteable(QueryBuilder.class),
             in.readOptionalNamed(Expression.class),
-            in.readOptionalList(readerFromPlanReader(PlanNamedTypes::readFieldSort)),
+            in.readOptionalCollectionAsList(readerFromPlanReader(PlanNamedTypes::readFieldSort)),
             in.readOptionalVInt()
         );
     }
@@ -569,7 +569,11 @@ public final class PlanNamedTypes {
     }
 
     static OrderExec readOrderExec(PlanStreamInput in) throws IOException {
-        return new OrderExec(Source.EMPTY, in.readPhysicalPlanNode(), in.readList(readerFromPlanReader(PlanNamedTypes::readOrder)));
+        return new OrderExec(
+            Source.EMPTY,
+            in.readPhysicalPlanNode(),
+            in.readCollectionAsList(readerFromPlanReader(PlanNamedTypes::readOrder))
+        );
     }
 
     static void writeOrderExec(PlanStreamOutput out, OrderExec orderExec) throws IOException {
@@ -609,7 +613,7 @@ public final class PlanNamedTypes {
         return new TopNExec(
             Source.EMPTY,
             in.readPhysicalPlanNode(),
-            in.readList(readerFromPlanReader(PlanNamedTypes::readOrder)),
+            in.readCollectionAsList(readerFromPlanReader(PlanNamedTypes::readOrder)),
             in.readNamed(Expression.class),
             in.readOptionalVInt()
         );
@@ -627,7 +631,7 @@ public final class PlanNamedTypes {
         return new Aggregate(
             Source.EMPTY,
             in.readLogicalPlanNode(),
-            in.readList(readerFromPlanReader(PlanStreamInput::readExpression)),
+            in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression)),
             readNamedExpressions(in)
         );
     }
@@ -725,7 +729,11 @@ public final class PlanNamedTypes {
     }
 
     static OrderBy readOrderBy(PlanStreamInput in) throws IOException {
-        return new OrderBy(Source.EMPTY, in.readLogicalPlanNode(), in.readList(readerFromPlanReader(PlanNamedTypes::readOrder)));
+        return new OrderBy(
+            Source.EMPTY,
+            in.readLogicalPlanNode(),
+            in.readCollectionAsList(readerFromPlanReader(PlanNamedTypes::readOrder))
+        );
     }
 
     static void writeOrderBy(PlanStreamOutput out, OrderBy order) throws IOException {
@@ -746,7 +754,7 @@ public final class PlanNamedTypes {
         return new TopN(
             Source.EMPTY,
             in.readLogicalPlanNode(),
-            in.readList(readerFromPlanReader(PlanNamedTypes::readOrder)),
+            in.readCollectionAsList(readerFromPlanReader(PlanNamedTypes::readOrder)),
             in.readNamed(Expression.class)
         );
     }
@@ -762,7 +770,7 @@ public final class PlanNamedTypes {
     //
 
     private static List<Attribute> readAttributes(PlanStreamInput in) throws IOException {
-        return in.readList(readerFromPlanReader(PlanStreamInput::readAttribute));
+        return in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readAttribute));
     }
 
     static void writeAttributes(PlanStreamOutput out, List<Attribute> attributes) throws IOException {
@@ -770,7 +778,7 @@ public final class PlanNamedTypes {
     }
 
     private static List<NamedExpression> readNamedExpressions(PlanStreamInput in) throws IOException {
-        return in.readList(readerFromPlanReader(PlanStreamInput::readNamedExpression));
+        return in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readNamedExpression));
     }
 
     static void writeNamedExpressions(PlanStreamOutput out, List<? extends NamedExpression> namedExpressions) throws IOException {
@@ -778,7 +786,7 @@ public final class PlanNamedTypes {
     }
 
     private static List<Alias> readAliases(PlanStreamInput in) throws IOException {
-        return in.readList(readerFromPlanReader(PlanNamedTypes::readAlias));
+        return in.readCollectionAsList(readerFromPlanReader(PlanNamedTypes::readAlias));
     }
 
     static void writeAliases(PlanStreamOutput out, List<Alias> aliases) throws IOException {
@@ -994,7 +1002,7 @@ public final class PlanNamedTypes {
     // -- InComparison
 
     static In readInComparison(PlanStreamInput in) throws IOException {
-        return new In(Source.EMPTY, in.readExpression(), in.readList(readerFromPlanReader(PlanStreamInput::readExpression)));
+        return new In(Source.EMPTY, in.readExpression(), in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression)));
     }
 
     static void writeInComparison(PlanStreamOutput out, In in) throws IOException {
@@ -1161,7 +1169,7 @@ public final class PlanNamedTypes {
 
     static ScalarFunction readVarag(PlanStreamInput in, String name) throws IOException {
         return VARARG_CTORS.get(name)
-            .apply(Source.EMPTY, in.readExpression(), in.readList(readerFromPlanReader(PlanStreamInput::readExpression)));
+            .apply(Source.EMPTY, in.readExpression(), in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression)));
     }
 
     static void writeVararg(PlanStreamOutput out, ScalarFunction vararg) throws IOException {
@@ -1306,7 +1314,11 @@ public final class PlanNamedTypes {
     }
 
     static CIDRMatch readCIDRMatch(PlanStreamInput in) throws IOException {
-        return new CIDRMatch(Source.EMPTY, in.readExpression(), in.readList(readerFromPlanReader(PlanStreamInput::readExpression)));
+        return new CIDRMatch(
+            Source.EMPTY,
+            in.readExpression(),
+            in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression))
+        );
     }
 
     static void writeCIDRMatch(PlanStreamOutput out, CIDRMatch cidrMatch) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequest.java
@@ -57,7 +57,7 @@ final class DataNodeRequest extends TransportRequest implements IndicesRequest {
         super(in);
         this.sessionId = in.readString();
         this.configuration = new EsqlConfiguration(in);
-        this.shardIds = in.readList(ShardId::new);
+        this.shardIds = in.readCollectionAsList(ShardId::new);
         this.aliasFilters = in.readMap(Index::new, AliasFilter::readFrom);
         this.plan = new PlanStreamInput(in, planNameRegistry, in.namedWriteableRegistry(), configuration).readPhysicalPlanNode();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlStatsResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlStatsResponse.java
@@ -33,7 +33,7 @@ public class EsqlStatsResponse extends BaseNodesResponse<EsqlStatsResponse.NodeS
 
     @Override
     protected List<NodeStatsResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeStatsResponse::readNodeResponse);
+        return in.readCollectionAsList(NodeStatsResponse::readNodeResponse);
     }
 
     @Override

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocument.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocument.java
@@ -256,16 +256,16 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         authenticationExpiryMillis = in.readOptionalVLong();
 
         privileges.resource = in.readString();
-        privileges.rolePatterns = new TreeSet<>(in.readSet(StreamInput::readString));
+        privileges.rolePatterns = new TreeSet<>(in.readCollectionAsSet(StreamInput::readString));
 
         attributeNames.principal = in.readString();
         attributeNames.email = in.readOptionalString();
         attributeNames.name = in.readOptionalString();
         attributeNames.roles = in.readOptionalString();
 
-        certificates.serviceProviderSigning = in.readStringList();
-        certificates.identityProviderSigning = in.readStringList();
-        certificates.identityProviderMetadataSigning = in.readStringList();
+        certificates.serviceProviderSigning = in.readStringCollectionAsList();
+        certificates.identityProviderSigning = in.readStringCollectionAsList();
+        certificates.identityProviderMetadataSigning = in.readStringCollectionAsList();
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -588,7 +588,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         }
 
         public static ObservableAction readObservableAction(StreamInput in) throws IOException {
-            List<Step> steps = in.readList(ObservableClusterStateWaitStep::new);
+            List<Step> steps = in.readCollectionAsList(ObservableClusterStateWaitStep::new);
             boolean safe = in.readBoolean();
             return new ObservableAction(steps, safe);
         }

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineRequest.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineRequest.java
@@ -26,7 +26,7 @@ public class GetPipelineRequest extends ActionRequest {
 
     public GetPipelineRequest(StreamInput in) throws IOException {
         super(in);
-        ids = in.readStringList();
+        ids = in.readStringCollectionAsList();
     }
 
     public List<String> ids() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -248,7 +248,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
             );
         }
         this.similarityThreshold = in.readVInt();
-        this.buckets = in.readList(Bucket::new);
+        this.buckets = in.readCollectionAsList(Bucket::new);
         this.requiredSize = readSize(in);
         this.minDocCount = in.readVLong();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -160,7 +160,7 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
 
     public FrequentItemSetsAggregationBuilder(StreamInput in) throws IOException {
         super(in);
-        this.fields = in.readList(MultiValuesSourceFieldConfig::new);
+        this.fields = in.readCollectionAsList(MultiValuesSourceFieldConfig::new);
         this.minimumSupport = in.readDouble();
         this.minimumSetSize = in.readVInt();
         this.size = in.readVInt();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregation.java
@@ -87,7 +87,7 @@ public final class InternalItemSetMapReduceAggregation<
             this.mapReduceResult = this.mapReducer.readResult(in, bigArraysForMapReduce);
         }
 
-        this.fields = in.readList(Field::new);
+        this.fields = in.readCollectionAsList(Field::new);
         this.profiling = in.readBoolean();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -46,11 +46,11 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
     private final String simpleReason;
 
     public MlScalingReason(StreamInput in) throws IOException {
-        this.waitingAnalyticsJobs = in.readStringList();
-        this.waitingAnomalyJobs = in.readStringList();
-        this.waitingSnapshotUpgrades = in.readStringList();
+        this.waitingAnalyticsJobs = in.readStringCollectionAsList();
+        this.waitingAnomalyJobs = in.readStringCollectionAsList();
+        this.waitingSnapshotUpgrades = in.readStringCollectionAsList();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)) {
-            this.waitingModels = in.readStringList();
+            this.waitingModels = in.readStringCollectionAsList();
         } else {
             this.waitingModels = List.of();
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/Vocabulary.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/Vocabulary.java
@@ -62,15 +62,15 @@ public class Vocabulary implements Writeable, ToXContentObject {
     }
 
     public Vocabulary(StreamInput in) throws IOException {
-        vocab = in.readStringList();
+        vocab = in.readStringCollectionAsList();
         modelId = in.readString();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_2_0)) {
-            merges = in.readStringList();
+            merges = in.readStringCollectionAsList();
         } else {
             merges = List.of();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_010)) {
-            scores = in.readList(StreamInput::readDouble);
+            scores = in.readCollectionAsList(StreamInput::readDouble);
         } else {
             scores = List.of();
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
@@ -139,12 +139,12 @@ public class AutodetectResult implements ToXContentObject, Writeable {
             this.bucket = null;
         }
         if (in.readBoolean()) {
-            this.records = in.readList(AnomalyRecord::new);
+            this.records = in.readCollectionAsList(AnomalyRecord::new);
         } else {
             this.records = null;
         }
         if (in.readBoolean()) {
-            this.influencers = in.readList(Influencer::new);
+            this.influencers = in.readCollectionAsList(Influencer::new);
         } else {
             this.influencers = null;
         }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
@@ -38,20 +38,20 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
         this.stackTraces = in.readBoolean()
             ? in.readMap(
                 i -> new StackTrace(
-                    i.readList(StreamInput::readInt),
-                    i.readList(StreamInput::readString),
-                    i.readList(StreamInput::readString),
-                    i.readList(StreamInput::readInt)
+                    i.readCollectionAsList(StreamInput::readInt),
+                    i.readCollectionAsList(StreamInput::readString),
+                    i.readCollectionAsList(StreamInput::readString),
+                    i.readCollectionAsList(StreamInput::readInt)
                 )
             )
             : null;
         this.stackFrames = in.readBoolean()
             ? in.readMap(
                 i -> new StackFrame(
-                    i.readList(StreamInput::readString),
-                    i.readList(StreamInput::readString),
-                    i.readList(StreamInput::readInt),
-                    i.readList(StreamInput::readInt)
+                    i.readCollectionAsList(StreamInput::readString),
+                    i.readCollectionAsList(StreamInput::readString),
+                    i.readCollectionAsList(StreamInput::readInt),
+                    i.readCollectionAsList(StreamInput::readInt)
                 )
             )
             : null;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/InProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/InProcessor.java
@@ -26,7 +26,7 @@ public class InProcessor implements Processor {
     }
 
     public InProcessor(StreamInput in) throws IOException {
-        processsors = in.readNamedWriteableList(Processor.class);
+        processsors = in.readNamedWriteableCollectionAsList(Processor.class);
     }
 
     @Override

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesMeteringResponse.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesMeteringResponse.java
@@ -34,7 +34,7 @@ public final class RepositoriesMeteringResponse extends BaseNodesResponse<Reposi
 
     @Override
     protected List<RepositoriesNodeMeteringResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(RepositoriesNodeMeteringResponse::new);
+        return in.readCollectionAsList(RepositoriesNodeMeteringResponse::new);
     }
 
     @Override

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesNodeMeteringResponse.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesNodeMeteringResponse.java
@@ -30,7 +30,7 @@ public final class RepositoriesNodeMeteringResponse extends BaseNodeResponse imp
 
     public RepositoriesNodeMeteringResponse(StreamInput in) throws IOException {
         super(in);
-        this.repositoryStatsSnapshots = in.readList(RepositoryStatsSnapshot::new);
+        this.repositoryStatsSnapshots = in.readCollectionAsList(RepositoryStatsSnapshot::new);
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/RollupIndexCaps.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/RollupIndexCaps.java
@@ -135,7 +135,7 @@ public class RollupIndexCaps implements Writeable, ToXContentFragment {
 
     RollupIndexCaps(StreamInput in) throws IOException {
         this.rollupIndexName = in.readString();
-        this.jobCaps = in.readList(RollupJobCaps::new);
+        this.jobCaps = in.readCollectionAsList(RollupJobCaps::new);
     }
 
     protected List<RollupJobCaps> getJobCaps() {

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
@@ -220,11 +220,11 @@ public class PinnedQueryBuilder extends AbstractQueryBuilder<PinnedQueryBuilder>
     public PinnedQueryBuilder(StreamInput in) throws IOException {
         super(in);
         if (in.getTransportVersion().before(TransportVersion.V_7_15_0)) {
-            ids = in.readStringList();
+            ids = in.readStringCollectionAsList();
             docs = null;
         } else {
-            ids = in.readOptionalStringList();
-            docs = in.readBoolean() ? in.readList(Item::new) : null;
+            ids = in.readOptionalStringCollectionAsList();
+            docs = in.readBoolean() ? in.readCollectionAsList(Item::new) : null;
         }
         organicQuery = in.readNamedWriteable(QueryBuilder.class);
     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponse.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponse.java
@@ -35,7 +35,7 @@ public class SearchableSnapshotsStatsResponse extends BroadcastResponse {
 
     SearchableSnapshotsStatsResponse(StreamInput in) throws IOException {
         super(in);
-        this.stats = in.readList(SearchableSnapshotShardStats::new);
+        this.stats = in.readCollectionAsList(SearchableSnapshotShardStats::new);
     }
 
     SearchableSnapshotsStatsResponse(

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
@@ -181,7 +181,7 @@ public class TransportSearchableSnapshotCacheStoresAction extends TransportNodes
 
         @Override
         protected List<NodeCacheFilesMetadata> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeCacheFilesMetadata::new);
+            return in.readCollectionAsList(NodeCacheFilesMetadata::new);
         }
 
         @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -289,7 +289,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
 
         @Override
         protected List<NodeCachesStatsResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readList(NodeCachesStatsResponse::new);
+            return in.readCollectionAsList(NodeCachesStatsResponse::new);
         }
 
         @Override

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusAction.java
@@ -79,7 +79,7 @@ public class GetShutdownStatusAction extends ActionType<GetShutdownStatusAction.
         }
 
         public Response(StreamInput in) throws IOException {
-            this.shutdownStatuses = in.readList(SingleNodeShutdownStatus::new);
+            this.shutdownStatuses = in.readCollectionAsList(SingleNodeShutdownStatus::new);
         }
 
         public List<SingleNodeShutdownStatus> getShutdownStatuses() {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -694,7 +694,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
             blobName = in.readString();
             targetLength = in.readVLong();
             seed = in.readLong();
-            nodes = in.readList(DiscoveryNode::new);
+            nodes = in.readCollectionAsList(DiscoveryNode::new);
             readNodeCount = in.readVInt();
             earlyReadNodeCount = in.readVInt();
             readEarly = in.readBoolean();
@@ -841,7 +841,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
             writeElapsedNanos = in.readVLong();
             overwriteElapsedNanos = in.readVLong();
             writeThrottledNanos = in.readVLong();
-            readDetails = in.readList(ReadDetail::new);
+            readDetails = in.readCollectionAsList(ReadDetail::new);
         }
 
         @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -1082,7 +1082,7 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
             rareActionProbability = in.readDouble();
             blobPath = in.readString();
             summary = new RepositoryPerformanceSummary(in);
-            blobResponses = in.readList(BlobAnalyzeAction.Response::new);
+            blobResponses = in.readCollectionAsList(BlobAnalyzeAction.Response::new);
             listingTimeNanos = in.readVLong();
             deleteTimeNanos = in.readVLong();
         }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -427,7 +427,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
     public AbstractSqlQueryRequest(StreamInput in) throws IOException {
         super(in);
         query = in.readString();
-        params = in.readList(AbstractSqlQueryRequest::readSqlTypedParamValue);
+        params = in.readCollectionAsList(AbstractSqlQueryRequest::readSqlTypedParamValue);
         zoneId = in.readZoneId();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
             catalog = in.readOptionalString();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggCursor.java
@@ -80,7 +80,7 @@ public class CompositeAggCursor implements Cursor {
         nextQuery = new SearchSourceBuilder(in);
         limit = in.readVInt();
 
-        extractors = in.readNamedWriteableList(BucketExtractor.class);
+        extractors = in.readNamedWriteableCollectionAsList(BucketExtractor.class);
         mask = BitSet.valueOf(in.readByteArray());
         includeFrozen = in.readBoolean();
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
@@ -66,7 +66,7 @@ public class SearchHitCursor implements Cursor {
         nextQuery = new SearchSourceBuilder(in);
         limit = in.readVInt();
 
-        extractors = in.readNamedWriteableList(HitExtractor.class);
+        extractors = in.readNamedWriteableCollectionAsList(HitExtractor.class);
         mask = BitSet.valueOf(in.readByteArray());
         includeFrozen = in.readBoolean();
         allowPartialSearchResults = in.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0) && in.readBoolean();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/CaseProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/CaseProcessor.java
@@ -25,7 +25,7 @@ public class CaseProcessor implements Processor {
     }
 
     public CaseProcessor(StreamInput in) throws IOException {
-        processors = in.readNamedWriteableList(Processor.class);
+        processors = in.readNamedWriteableCollectionAsList(Processor.class);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalProcessor.java
@@ -59,7 +59,7 @@ public class ConditionalProcessor implements Processor {
     }
 
     public ConditionalProcessor(StreamInput in) throws IOException {
-        processors = in.readNamedWriteableList(Processor.class);
+        processors = in.readNamedWriteableCollectionAsList(Processor.class);
         operation = in.readEnum(ConditionalOperation.class);
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
@@ -33,7 +33,7 @@ public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeSta
 
     @Override
     protected List<NodeStatsResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeStatsResponse::readNodeResponse);
+        return in.readCollectionAsList(NodeStatsResponse::readNodeResponse);
     }
 
     @Override


### PR DESCRIPTION
The `StreamOutput` and `StreamInput` APIs are designed so that code
which serializes objects to the transport protocol aligns closely with
the corresponding deserialization code. However today
`StreamOutput#writeCollection` pairs up with a variety of methods on
`StreamInput`, including `readList`, `readSet`, and so on. These methods
are not obviously compatible with `writeCollection` unless you look at
the implementation, and that makes verifying transport protocol code
harder than it needs to be.

This commit renames these methods to `readCollectionAsList`,
`readCollectionAsSet`, and so on, to clarify that they are compatible
with `writeCollection`.

Relates https://github.com/elastic/elasticsearch/pull/98971#issuecomment-1697289815