### PR TITLE
[8.10] [DOCS] Fine-tunes the reindexing step of the ELSER tutorial. (#99155)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -173,7 +173,7 @@ GET _tasks/<task_id>
 // TEST[skip:TBD]
 
 You can also open the Trained Models UI, select the Pipelines tab under ELSER to 
-follow the progress. It may take a couple of minutes to complete the process.
+follow the progress.
 
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOCS] Fine-tunes the reindexing step of the ELSER tutorial. (#99155)