### PR TITLE
Use NamedWritable to enable GeoBoundingBox serialisation

### DIFF
--- a/docs/changelog/99163.yaml
+++ b/docs/changelog/99163.yaml
@@ -1,0 +1,6 @@
+pr: 99163
+summary: Use `NamedWritable` to enable `GeoBoundingBox` serialisation
+area: Geo
+type: bug
+issues:
+ - 99089

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -182,6 +182,8 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_067 = registerTransportVersion(8_500_067, "a7c86604-a917-4aff-9a1b-a4d44c3dbe02");
     public static final TransportVersion V_8_500_068 = registerTransportVersion(8_500_068, "2683c8b4-5372-4a6a-bb3a-d61aa679089a");
     public static final TransportVersion V_8_500_069 = registerTransportVersion(8_500_069, "5b804027-d8a0-421b-9970-1f53d766854b");
+    public static final TransportVersion V_8_500_070 = registerTransportVersion(8_500_070, "6BADC9CD-3C9D-4381-8BD9-B305CAA93F86");
+
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _
@@ -219,7 +221,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
      */
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_069);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_070);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -183,7 +183,6 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     public static final TransportVersion V_8_500_068 = registerTransportVersion(8_500_068, "2683c8b4-5372-4a6a-bb3a-d61aa679089a");
     public static final TransportVersion V_8_500_069 = registerTransportVersion(8_500_069, "5b804027-d8a0-421b-9970-1f53d766854b");
     public static final TransportVersion V_8_500_070 = registerTransportVersion(8_500_070, "6BADC9CD-3C9D-4381-8BD9-B305CAA93F86");
-
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
@@ -8,7 +8,8 @@
 package org.elasticsearch.common.geo;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.ShapeType;
@@ -27,7 +28,7 @@ import java.util.Objects;
  * A class representing a Bounding-Box for use by Geo and Cartesian queries and aggregations
  * that deal with extents/rectangles representing rectangular areas of interest.
  */
-public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentFragment, NamedWriteable {
+public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentFragment, GenericNamedWriteable {
     static final ParseField TOP_RIGHT_FIELD = new ParseField("top_right");
     static final ParseField BOTTOM_LEFT_FIELD = new ParseField("bottom_left");
     static final ParseField TOP_FIELD = new ParseField("top");
@@ -193,5 +194,10 @@ public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentF
     @Override
     public String toString() {
         return "BBOX (" + left() + ", " + right() + ", " + top() + ", " + bottom() + ")";
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.V_8_500_070;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.common.geo;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Rectangle;
@@ -194,10 +193,5 @@ public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentF
     @Override
     public String toString() {
         return "BBOX (" + left() + ", " + right() + ", " + top() + ", " + bottom() + ")";
-    }
-
-    @Override
-    public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.V_8_500_070;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.common.geo;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.ShapeType;
@@ -27,7 +27,7 @@ import java.util.Objects;
  * A class representing a Bounding-Box for use by Geo and Cartesian queries and aggregations
  * that deal with extents/rectangles representing rectangular areas of interest.
  */
-public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentFragment, Writeable {
+public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentFragment, NamedWriteable {
     static final ParseField TOP_RIGHT_FIELD = new ParseField("top_right");
     static final ParseField BOTTOM_LEFT_FIELD = new ParseField("bottom_left");
     static final ParseField TOP_FIELD = new ParseField("top");

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.common.geo;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ParseField;
@@ -92,8 +93,13 @@ public class GeoBoundingBox extends BoundingBox<GeoPoint> {
     }
 
     @Override
-    public String getWriteableName() {
+    public final String getWriteableName() {
         return "GeoBoundingBox";
+    }
+
+    @Override
+    public final TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.V_8_500_070;
     }
 
     protected static class GeoBoundsParser extends BoundsParser<GeoBoundingBox> {

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
@@ -91,6 +91,11 @@ public class GeoBoundingBox extends BoundingBox<GeoPoint> {
         out.writeGeoPoint(bottomRight);
     }
 
+    @Override
+    public String getWriteableName() {
+        return "GeoBoundingBox";
+    }
+
     protected static class GeoBoundsParser extends BoundsParser<GeoBoundingBox> {
         GeoBoundsParser(XContentParser parser) {
             super(parser);

--- a/server/src/main/java/org/elasticsearch/common/io/stream/GenericNamedWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/GenericNamedWriteable.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+/**
+ * Marker interface that allows specific NamedWritable objects to be serialized as part of the
+ * generic serialization in StreamOutput and StreamInput.
+ */
+public interface GenericNamedWriteable extends VersionedNamedWriteable {
+}

--- a/server/src/main/java/org/elasticsearch/common/io/stream/GenericNamedWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/GenericNamedWriteable.java
@@ -12,5 +12,4 @@ package org.elasticsearch.common.io.stream;
  * Marker interface that allows specific NamedWritable objects to be serialized as part of the
  * generic serialization in StreamOutput and StreamInput.
  */
-public interface GenericNamedWriteable extends VersionedNamedWriteable {
-}
+public interface GenericNamedWriteable extends VersionedNamedWriteable {}

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -790,7 +790,7 @@ public abstract class StreamInput extends InputStream {
             case 27 -> readOffsetTime();
             case 28 -> readDuration();
             case 29 -> readPeriod();
-            case 30 -> readNamedWriteable(NamedWriteable.class);
+            case 30 -> readNamedWriteable(GenericNamedWriteable.class);
             default -> throw new IOException("Can't read unknown type [" + type + "]");
         };
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -790,6 +790,7 @@ public abstract class StreamInput extends InputStream {
             case 27 -> readOffsetTime();
             case 28 -> readDuration();
             case 29 -> readPeriod();
+            case 30 -> readNamedWriteable(NamedWriteable.class);
             default -> throw new IOException("Can't read unknown type [" + type + "]");
         };
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -763,23 +763,18 @@ public abstract class StreamOutput extends OutputStream {
             o.writeInt(period.getDays());
         }),
         entry(GenericNamedWriteable.class, (o, v) -> {
+            // Note that we do not rely on the checks in VersionCheckingStreamOutput because that only applies to CCS
             final var genericNamedWriteable = (GenericNamedWriteable) v;
-            final var minSupportedVersion = TransportVersion.max(
-                TransportVersion.V_8_500_069,
-                genericNamedWriteable.getMinimalSupportedVersion()
-            );
-
-            if (o.getTransportVersion().before(minSupportedVersion)) {
+            if (o.getTransportVersion().before(genericNamedWriteable.getMinimalSupportedVersion())) {
                 final var message = Strings.format(
                     "[%s] requires minimal transport version [%s] and cannot be sent using transport version [%s]",
-                    genericNamedWriteable,
-                    minSupportedVersion,
+                    genericNamedWriteable.getWriteableName(),
+                    genericNamedWriteable.getMinimalSupportedVersion(),
                     o.getTransportVersion()
                 );
                 assert false : message;
                 throw new IllegalStateException(message);
             }
-
             o.writeByte((byte) 30);
             o.writeNamedWriteable(genericNamedWriteable);
         })

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -761,9 +761,9 @@ public abstract class StreamOutput extends OutputStream {
             o.writeInt(period.getMonths());
             o.writeInt(period.getDays());
         }),
-        entry(NamedWriteable.class, (o, v) -> {
+        entry(GenericNamedWriteable.class, (o, v) -> {
             o.writeByte((byte) 30);
-            NamedWriteable w = (NamedWriteable) v;
+            GenericNamedWriteable w = (GenericNamedWriteable) v;
             o.writeNamedWriteable(w);
         })
     );
@@ -795,8 +795,8 @@ public abstract class StreamOutput extends OutputStream {
             return Set.class;
         } else if (value instanceof BytesReference) {
             return BytesReference.class;
-        } else if (value instanceof NamedWriteable) {
-            return NamedWriteable.class;
+        } else if (value instanceof GenericNamedWriteable) {
+            return GenericNamedWriteable.class;
         } else {
             return value.getClass();
         }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -760,6 +760,11 @@ public abstract class StreamOutput extends OutputStream {
             o.writeInt(period.getYears());
             o.writeInt(period.getMonths());
             o.writeInt(period.getDays());
+        }),
+        entry(NamedWriteable.class, (o, v) -> {
+            o.writeByte((byte) 30);
+            NamedWriteable w = (NamedWriteable) v;
+            o.writeNamedWriteable(w);
         })
     );
 
@@ -790,6 +795,8 @@ public abstract class StreamOutput extends OutputStream {
             return Set.class;
         } else if (value instanceof BytesReference) {
             return BytesReference.class;
+        } else if (value instanceof NamedWriteable) {
+            return NamedWriteable.class;
         } else {
             return value.getClass();
         }

--- a/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -10,6 +10,7 @@ package org.elasticsearch.plugins;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -144,6 +145,13 @@ public interface SearchPlugin {
      * The new {@link Rescorer}s added by this plugin.
      */
     default List<RescorerSpec<?>> getRescorers() {
+        return emptyList();
+    }
+
+    /**
+     * Additional GenericNamedWriteable classes added by this plugin.
+     */
+    default List<GenericNamedWriteableSpec> getGenericNamedWriteables() {
         return emptyList();
     }
 
@@ -634,4 +642,9 @@ public interface SearchPlugin {
             super(name, reader, parser);
         }
     }
+
+    /**
+     * Specification of GenericNamedWriteable classes that can be serialized/deserialized as generic objects in search results.
+     */
+    record GenericNamedWriteableSpec(String name, Writeable.Reader<? extends GenericNamedWriteable> reader) {}
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -10,6 +10,8 @@ package org.elasticsearch.search;
 
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.NamedRegistry;
+import org.elasticsearch.common.geo.GeoBoundingBox;
+import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -315,6 +317,9 @@ public class SearchModule {
         registerIntervalsSourceProviders();
         requestCacheKeyDifferentiator = registerRequestCacheKeyDifferentiator(plugins);
         namedWriteables.addAll(SortValue.namedWriteables());
+        namedWriteables.add(
+            new NamedWriteableRegistry.Entry(NamedWriteable.class, GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new)
+        );
     }
 
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -317,8 +317,8 @@ public class SearchModule {
         registerIntervalsSourceProviders();
         requestCacheKeyDifferentiator = registerRequestCacheKeyDifferentiator(plugins);
         namedWriteables.addAll(SortValue.namedWriteables());
-        namedWriteables.add(
-            new NamedWriteableRegistry.Entry(GenericNamedWriteable.class, GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new)
+        registerGenericNamedWriteable(
+            new SearchPlugin.GenericNamedWriteableSpec(GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new)
         );
     }
 
@@ -657,6 +657,9 @@ public class SearchModule {
             }
         });
 
+        // Register GenericNamedWriteable classes for use in StreamOutput/StreamInput as generic types in query hits
+        registerFromPlugin(plugins, SearchPlugin::getGenericNamedWriteables, this::registerGenericNamedWriteable);
+
         return builder.build();
     }
 
@@ -681,6 +684,10 @@ public class SearchModule {
             // have to register usage explicitly here.
             builder.registerUsage(spec.getName().getPreferredName());
         }
+    }
+
+    private void registerGenericNamedWriteable(SearchPlugin.GenericNamedWriteableSpec spec) {
+        namedWriteables.add(new NamedWriteableRegistry.Entry(GenericNamedWriteable.class, spec.name(), spec.reader()));
     }
 
     private void registerPipelineAggregations(List<SearchPlugin> plugins) {

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -11,7 +11,7 @@ package org.elasticsearch.search;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.NamedRegistry;
 import org.elasticsearch.common.geo.GeoBoundingBox;
-import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -318,7 +318,7 @@ public class SearchModule {
         requestCacheKeyDifferentiator = registerRequestCacheKeyDifferentiator(plugins);
         namedWriteables.addAll(SortValue.namedWriteables());
         namedWriteables.add(
-            new NamedWriteableRegistry.Entry(NamedWriteable.class, GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new)
+            new NamedWriteableRegistry.Entry(GenericNamedWriteable.class, GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -284,6 +285,7 @@ public class SearchModuleTests extends ESTestCase {
             1,
             module.getNamedWriteables().stream().filter(e -> e.categoryClass.equals(Suggestion.class) && e.name.equals("test")).count()
         );
+        assertEquals(1, module.getNamedWriteables().stream().filter(e -> e.categoryClass.equals(GenericNamedWriteable.class)).count());
     }
 
     public void testRegisterHighlighter() {

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
@@ -51,22 +51,11 @@ public class GeoBoundsGenericWriteableTests extends AbstractNamedWriteableTestCa
 
     @Override
     protected GenericNamedWriteable copyInstance(GenericNamedWriteable original, TransportVersion version) throws IOException {
-        return copyInstance(original, version, version);
-    }
-
-    /**
-     * Read and write with different serialization versions
-     */
-    protected GenericNamedWriteable copyInstance(
-        GenericNamedWriteable original,
-        TransportVersion writeVersion,
-        TransportVersion readVersion
-    ) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setTransportVersion(writeVersion);
+            output.setTransportVersion(version);
             output.writeGenericValue(original);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), getNamedWriteableRegistry())) {
-                in.setTransportVersion(readVersion);
+                in.setTransportVersion(version);
                 return readGenericValue(in);
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.geo;
+
+import org.apache.lucene.geo.Rectangle;
+import org.apache.lucene.tests.geo.GeoTestUtil;
+import org.elasticsearch.common.geo.GeoBoundingBox;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.test.AbstractNamedWriteableTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+public class GeoBoundsGenericWriteableTests extends AbstractNamedWriteableTestCase<GenericNamedWriteable> {
+    NamedWriteableRegistry registry = new NamedWriteableRegistry(
+        List.of(new NamedWriteableRegistry.Entry(GenericNamedWriteable.class, GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new))
+    );
+
+    @Override
+    protected GeoBoundingBox createTestInstance() {
+        Rectangle box = GeoTestUtil.nextBox();
+        return new GeoBoundingBox(new GeoPoint(box.maxLat, box.minLon), new GeoPoint(box.minLat, box.maxLon));
+    }
+
+    @Override
+    protected GeoBoundingBox mutateInstance(GenericNamedWriteable instance) throws IOException {
+        assert instance instanceof GeoBoundingBox : "Expected GeoBoundingBox";
+        GeoBoundingBox geoBoundingBox = (GeoBoundingBox) instance;
+        double width = geoBoundingBox.right() - geoBoundingBox.left();
+        double height = geoBoundingBox.top() - geoBoundingBox.bottom();
+        double top = geoBoundingBox.top() - height / 4;
+        double left = geoBoundingBox.left() + width / 4;
+        double bottom = geoBoundingBox.bottom() + height / 4;
+        double right = geoBoundingBox.right() - width / 4;
+        return new GeoBoundingBox(new GeoPoint(top, left), new GeoPoint(bottom, right));
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return registry;
+    }
+
+    @Override
+    protected Class<GenericNamedWriteable> categoryClass() {
+        return GenericNamedWriteable.class;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoBoundsGenericWriteableTests.java
@@ -15,88 +15,76 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.GenericNamedWriteable;
-import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.test.AbstractNamedWriteableTestCase;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.search.geo.GeoBoundsGenericWriteableTests.GenericWriteableWrapper;
+import org.elasticsearch.test.AbstractWireTestCase;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
-public class GeoBoundsGenericWriteableTests extends AbstractNamedWriteableTestCase<GenericNamedWriteable> {
-    NamedWriteableRegistry registry = new NamedWriteableRegistry(
+public class GeoBoundsGenericWriteableTests extends AbstractWireTestCase<GenericWriteableWrapper> {
+
+    /**
+     * Wrapper around a GeoBoundingBox to verify that it round-trips via {@code writeGenericValue} and {@code readGenericValue}
+     */
+    public record GenericWriteableWrapper(GeoBoundingBox geoBoundingBox) implements Writeable {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeGenericValue(geoBoundingBox);
+        }
+
+        public static GenericWriteableWrapper readFrom(StreamInput in) throws IOException {
+            return new GenericWriteableWrapper((GeoBoundingBox) in.readGenericValue());
+        }
+    }
+
+    private static final NamedWriteableRegistry NAMED_WRITEABLE_REGISTRY = new NamedWriteableRegistry(
         List.of(new NamedWriteableRegistry.Entry(GenericNamedWriteable.class, GeoBoundingBox.class.getSimpleName(), GeoBoundingBox::new))
     );
 
     @Override
-    protected GeoBoundingBox createTestInstance() {
-        Rectangle box = GeoTestUtil.nextBox();
-        return new GeoBoundingBox(new GeoPoint(box.maxLat, box.minLon), new GeoPoint(box.minLat, box.maxLon));
+    protected NamedWriteableRegistry writableRegistry() {
+        return NAMED_WRITEABLE_REGISTRY;
     }
 
     @Override
-    protected GeoBoundingBox mutateInstance(GenericNamedWriteable instance) throws IOException {
-        assert instance instanceof GeoBoundingBox : "Expected GeoBoundingBox";
-        GeoBoundingBox geoBoundingBox = (GeoBoundingBox) instance;
+    protected GenericWriteableWrapper createTestInstance() {
+        Rectangle box = GeoTestUtil.nextBox();
+        return new GenericWriteableWrapper(new GeoBoundingBox(new GeoPoint(box.maxLat, box.minLon), new GeoPoint(box.minLat, box.maxLon)));
+    }
+
+    @Override
+    protected GenericWriteableWrapper mutateInstance(GenericWriteableWrapper instance) throws IOException {
+        GeoBoundingBox geoBoundingBox = instance.geoBoundingBox;
         double width = geoBoundingBox.right() - geoBoundingBox.left();
         double height = geoBoundingBox.top() - geoBoundingBox.bottom();
         double top = geoBoundingBox.top() - height / 4;
         double left = geoBoundingBox.left() + width / 4;
         double bottom = geoBoundingBox.bottom() + height / 4;
         double right = geoBoundingBox.right() - width / 4;
-        return new GeoBoundingBox(new GeoPoint(top, left), new GeoPoint(bottom, right));
+        return new GenericWriteableWrapper(new GeoBoundingBox(new GeoPoint(top, left), new GeoPoint(bottom, right)));
     }
 
     @Override
-    protected GenericNamedWriteable copyInstance(GenericNamedWriteable original, TransportVersion version) throws IOException {
-        try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setTransportVersion(version);
-            output.writeGenericValue(original);
-            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), getNamedWriteableRegistry())) {
-                in.setTransportVersion(version);
-                return readGenericValue(in);
-            }
-        }
+    protected GenericWriteableWrapper copyInstance(GenericWriteableWrapper instance, TransportVersion version) throws IOException {
+        return copyInstance(instance, writableRegistry(), StreamOutput::writeWriteable, GenericWriteableWrapper::readFrom, version);
     }
 
-    private GenericNamedWriteable readGenericValue(StreamInput in) throws IOException {
-        Object obj = in.readGenericValue();
-        if (obj instanceof GenericNamedWriteable result) {
-            return result;
-        }
-        throw new IllegalStateException("Read result of wrong type: " + obj.getClass().getSimpleName());
-    }
-
-    @Override
-    protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        return registry;
-    }
-
-    @Override
-    protected Class<GenericNamedWriteable> categoryClass() {
-        return GenericNamedWriteable.class;
-    }
-
-    public void testSerializationFailsWithOlderVersion() throws IOException {
+    public void testSerializationFailsWithOlderVersion() {
         TransportVersion older = TransportVersion.V_8_500_069;
         assert older.before(TransportVersion.V_8_500_070);
-        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
-            GenericNamedWriteable testInstance = createTestInstance();
-            try {
-                try (BytesStreamOutput output = new BytesStreamOutput()) {
-                    output.setTransportVersion(older);
-                    output.writeGenericValue(testInstance);
-                }
-                fail("Expected exception to be thrown when writing with older TransportVersion");
-            } catch (Throwable e) {
-                assertThat(
-                    "Writing with older TransportVersion",
-                    e.getMessage(),
-                    containsString("[GeoBoundingBox] requires minimal transport version")
-                );
-            }
+        final var testInstance = createTestInstance().geoBoundingBox();
+        try (var output = new BytesStreamOutput()) {
+            output.setTransportVersion(older);
+            assertThat(
+                expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
+                containsString("[GeoBoundingBox] requires minimal transport version")
+            );
         }
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.spatial.action.SpatialStatsAction;
 import org.elasticsearch.xpack.spatial.action.SpatialInfoTransportAction;
 import org.elasticsearch.xpack.spatial.action.SpatialStatsTransportAction;
 import org.elasticsearch.xpack.spatial.action.SpatialUsageTransportAction;
+import org.elasticsearch.xpack.spatial.common.CartesianBoundingBox;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
 import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
@@ -189,6 +190,11 @@ public class SpatialPlugin extends Plugin implements ActionPlugin, MapperPlugin,
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         return Map.of(CircleProcessor.TYPE, new CircleProcessor.Factory(), GeoGridProcessor.TYPE, new GeoGridProcessor.Factory());
+    }
+
+    @Override
+    public List<GenericNamedWriteableSpec> getGenericNamedWriteables() {
+        return List.of(new GenericNamedWriteableSpec(CartesianBoundingBox.class.getSimpleName(), CartesianBoundingBox::new));
     }
 
     private static void registerGeoShapeBoundsAggregator(ValuesSourceRegistry.Builder builder) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianBoundingBox.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianBoundingBox.java
@@ -56,6 +56,11 @@ public class CartesianBoundingBox extends BoundingBox<CartesianPoint> {
         out.writeDouble(bottomRight.getY());
     }
 
+    @Override
+    public String getWriteableName() {
+        return "CartesianBoundingBox";
+    }
+
     protected static class CartesianBoundsParser extends BoundsParser<CartesianBoundingBox> {
         CartesianBoundsParser(XContentParser parser) {
             super(parser);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianBoundingBox.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianBoundingBox.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.spatial.common;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.geo.BoundingBox;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.SpatialPoint;
@@ -57,8 +58,13 @@ public class CartesianBoundingBox extends BoundingBox<CartesianPoint> {
     }
 
     @Override
-    public String getWriteableName() {
+    public final String getWriteableName() {
         return "CartesianBoundingBox";
+    }
+
+    @Override
+    public final TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.V_8_500_070;
     }
 
     protected static class CartesianBoundsParser extends BoundsParser<CartesianBoundingBox> {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
@@ -7,11 +7,14 @@
 package org.elasticsearch.xpack.spatial;
 
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.internal.XPackLicenseStatus;
 import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGridAggregationBuilder;
@@ -33,7 +36,9 @@ import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValue
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -127,6 +132,16 @@ public class SpatialPluginTests extends ESTestCase {
                 fail("Unexpected exception: " + e.getMessage());
             }
         }, "cartesian_bounds", "shape");
+    }
+
+    public void testGenericNamedWriteables() {
+        SearchModule module = new SearchModule(Settings.EMPTY, List.of(new SpatialPlugin()));
+        Set<String> names = module.getNamedWriteables()
+            .stream()
+            .filter(e -> e.categoryClass.equals(GenericNamedWriteable.class))
+            .map(e -> e.name)
+            .collect(Collectors.toSet());
+        assertThat("Expect both Geo and Cartesian BoundingBox", names, equalTo(Set.of("GeoBoundingBox", "CartesianBoundingBox")));
     }
 
     private SpatialPlugin getPluginWithOperationMode(License.OperationMode operationMode) {


### PR DESCRIPTION
`BoundingBox` allows inter-node serialisation only within aggs results as components of aggregations that themselves use `NamedWritable`. However, if a `GeoBoundingBox` is added to search `hits`, serialisation fails as this type is not explicitly supported by `StreamOuput/StreamInput`. This was never noticed before because the only way to get a `BoundingBox` into the `hits` is through a painless script, something that appears to have not been used by customers, and is only tested internally using a single-node, single-shard yaml test, which does not touch this code path. We only found this issue due to recent effort to run all yaml tests in a serverless environment, which appears to always require serialisation from backend data nodes to a coordinator node.

Having said that, it is a surface API that could be used by users, and so should be fixed. While the missing type could be added explicitly, a much more flexible approach is to allow named classes to encapsulate their own serialization/deserialization logic. Here we use `NamedWritable` for that purpose.

Tasks:

- [x] Implement GenericNamedWriteable with version checking capabilities (based on VersionedNamedWriteable)
- [x] Manual testing with a multi-node cluster to verify this fixes #99089
- [x] Unit tests for version checking
- [x] Unit tests for serialization of GeoBoundingBox
- [x] Support CartesianBoundingBox by registering the named writable in SpatialPlugin

Fixes #99089
