### PR TITLE
Mute failing QueryFeatureExtractorTests test

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/rescorer/QueryFeatureExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/rescorer/QueryFeatureExtractorTests.java
@@ -62,6 +62,7 @@ public class QueryFeatureExtractorTests extends AbstractBuilderTestCase {
         searcher.setSimilarity(new ClassicSimilarity());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99167")
     public void testQueryExtractor() throws IOException {
         addDocs(
             new String[] { "the quick brown fox", "the slow brown fox", "the grey dog", "yet another string" },


### PR DESCRIPTION
Mutes failing test `QueryFeatureExtractorTests/testQueryExtractor`

See https://github.com/elastic/elasticsearch/issues/99167