### PR TITLE
Build bwc without es runtime 7x

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -74,6 +74,9 @@ public class BwcSetupExtension {
                     String[] versionArray = readFromFile(new File(checkoutDir.get(), compilerVersionInfoPath)).split("\\.");
                     String minimumCompilerVersion = versionArray[versionArray.length - 1];
                     loggedExec.environment("JAVA_HOME", getJavaHome(Integer.parseInt(minimumCompilerVersion)));
+                    // the bwc related builds should not require es java runtime as we only build artifacts.
+                    // This is to avoids breaking old builds that are incompatible with current `ES_JAVA_RUNTIME`.
+                    loggedExec.getEnvironment().remove("ES_JAVA_RUNTIME");
                 }
             });
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -74,7 +74,7 @@ public class BwcSetupExtension {
                     String[] versionArray = readFromFile(new File(checkoutDir.get(), compilerVersionInfoPath)).split("\\.");
                     String minimumCompilerVersion = versionArray[versionArray.length - 1];
                     loggedExec.environment("JAVA_HOME", getJavaHome(Integer.parseInt(minimumCompilerVersion)));
-                    // the bwc related builds should not require es java runtime as we only build artifacts.
+                    // The bwc related builds should not require es java runtime as we only build artifacts.
                     // This is to avoids breaking old builds that are incompatible with current `ES_JAVA_RUNTIME`.
                     loggedExec.getEnvironment().remove("RUNTIME_JAVA_HOME");
                 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -76,7 +76,7 @@ public class BwcSetupExtension {
                     loggedExec.environment("JAVA_HOME", getJavaHome(Integer.parseInt(minimumCompilerVersion)));
                     // the bwc related builds should not require es java runtime as we only build artifacts.
                     // This is to avoids breaking old builds that are incompatible with current `ES_JAVA_RUNTIME`.
-                    loggedExec.getEnvironment().remove("ES_JAVA_RUNTIME");
+                    loggedExec.getEnvironment().remove("RUNTIME_JAVA_HOME");
                 }
             });
 


### PR DESCRIPTION
This removes the runtime java information to build bwc artefacts from earlier elasticsearch versions.
It reduces the risk of breaking the build due to incompatiblities between gradle and potential java runtime versions.
