### PR TITLE
[7.17] Fix Painless method lookup over unknown super interfaces (#97062)

### DIFF
--- a/docs/changelog/97062.yaml
+++ b/docs/changelog/97062.yaml
@@ -1,0 +1,6 @@
+pr: 97062
+summary: Fix Painless method lookup over unknown super interfaces
+area: Infra/Scripting
+type: bug
+issues:
+ - 97022

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # java homes resolved by environment variables
 org.gradle.java.installations.auto-detect=false
-org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA20_HOME,JAVA19_HOME,JAVA18_HOME,JAVA17_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA21_HOME,JAVA20_HOME,JAVA19_HOME,JAVA18_HOME,JAVA17_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
 
 # log some dependency verification info to console
 org.gradle.dependency.verification.console=verbose

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
@@ -370,9 +370,8 @@ public final class PainlessLookup {
                         if (painlessObject != null) {
                             return painlessObject;
                         }
-
-                        targetInterfaces.addAll(Arrays.asList(targetInterface.getInterfaces()));
                     }
+                    targetInterfaces.addAll(Arrays.asList(targetInterface.getInterfaces()));
                 }
             }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix Painless method lookup over unknown super interfaces (#97062)](https://github.com/elastic/elasticsearch/pull/97062)

fixes java 21 compatibility tests https://elasticsearch-ci.elastic.co/view/Elasticsearch%207.17/job/elastic+elasticsearch+7.17+periodic+java-matrix/1258/

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)