### PR TITLE
Set explicit file permissions in NoticeTask

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/NoticeTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/NoticeTask.java
@@ -167,6 +167,10 @@ public class NoticeTask extends DefaultTask {
         }
 
         FileUtils.write(outputFile, output.toString(), "UTF-8");
+        // i.e. 0644
+        outputFile.setReadable(true);
+        outputFile.setWritable(false, false);
+        outputFile.setWritable(true, true);
     }
 
     @InputFiles

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/NoticeTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/NoticeTask.java
@@ -167,10 +167,6 @@ public class NoticeTask extends DefaultTask {
         }
 
         FileUtils.write(outputFile, output.toString(), "UTF-8");
-        // i.e. 0644
-        outputFile.setReadable(true);
-        outputFile.setWritable(false, false);
-        outputFile.setWritable(true, true);
     }
 
     @InputFiles

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -411,7 +411,9 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         if (testDistro) {
           from buildServerNoticeTaskProvider
         } else {
-          from buildDefaultNoticeTaskProvider
+          from (buildDefaultNoticeTaskProvider) {
+            fileMode = 0644
+          }
         }
       }
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
@@ -47,7 +47,6 @@ public class CertGenCliTests extends PackagingTestCase {
         FileUtils.rm(instancesFile, certificatesFile);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99153")
     public void test10Install() throws Exception {
         install();
         // Disable security auto-configuration as we want to generate keys/certificates manually here

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
@@ -54,13 +54,11 @@ public class CertGenCliTests extends PackagingTestCase {
         ServerUtils.disableSecurityAutoConfiguration(installation);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99153")
     public void test20Help() {
         Shell.Result result = installation.executables().certgenTool.run("--help");
         assertThat(result.stdout(), containsString("Simplifies certificate creation"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99153")
     public void test30Generate() throws Exception {
         final List<String> lines = new ArrayList<>();
         lines.add("instances:");
@@ -75,7 +73,6 @@ public class CertGenCliTests extends PackagingTestCase {
         assertThat(certificatesFile, file(File, owner, owner, p600));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99153")
     public void test31ExtractCerts() throws Exception {
         // windows 2012 r2 has powershell 4.0, which lacks Expand-Archive
         assumeFalse(Platforms.OS_NAME.equals("Windows Server 2012 R2"));
@@ -94,7 +91,6 @@ public class CertGenCliTests extends PackagingTestCase {
         FileUtils.cp(certsDir, installation.config("certs"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99153")
     public void test40RunWithCert() throws Exception {
         // windows 2012 r2 has powershell 4.0, which lacks Expand-Archive
         assumeFalse(Platforms.OS_NAME.equals("Windows Server 2012 R2"));


### PR DESCRIPTION
Fixes #99153

This error is due to a build cache object that got populated with a `NOTICE.txt` with an unexpected set of permissions (`664` instead of `644`).

A Buildkite agent for another project with a different `umask` generated a `NOTICE.txt` file with different permissions. The other project shares a build cache with `elasticsearch`, and was recently allowed to populate the cache as well as read from it.

Anywhere that we care enough to test permissions on files, we should set those permissions at file creation time, so that the files are correct regardless of what OS they get created on / etc. So, that's what I'm doing in this PR.