### PR TITLE
[IdP] Fix Idp Builder using method calls

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProviderBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProviderBuilder.java
@@ -168,6 +168,10 @@ public class SamlIdentityProviderBuilder {
             ex.addValidationError("Service provider defaults must be specified");
         }
 
+        if (allowedNameIdFormats == null || allowedNameIdFormats.isEmpty()) {
+            ex.addValidationError("At least 1 allowed NameID format must be specified");
+        }
+
         if (ex.validationErrors().isEmpty() == false) {
             throw ex;
         }
@@ -260,6 +264,9 @@ public class SamlIdentityProviderBuilder {
     }
 
     public SamlIdentityProviderBuilder allowedNameIdFormat(String nameIdFormat) {
+        if (this.allowedNameIdFormats == null) {
+            this.allowedNameIdFormats = new HashSet<>();
+        }
         this.allowedNameIdFormats.add(nameIdFormat);
         return this;
     }


### PR DESCRIPTION
The `SamlIdentityProviderBuilder` has mechanisms for building an object using direct method calls, or from a `Settings` object. Due to a lack of tests there was a bug that prevented the direct method call approach from working correctly.
