### PR TITLE
Fork response-sending in OpenPointInTimeAction

### DIFF
--- a/docs/changelog/99222.yaml
+++ b/docs/changelog/99222.yaml
@@ -1,0 +1,5 @@
+pr: 99222
+summary: Fork response-sending in `OpenPointInTimeAction`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -21,7 +21,7 @@ import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
@@ -167,10 +167,29 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                 @Override
                 protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
                     return new SearchPhase(getName()) {
+
+                        private void onExecuteFailure(Exception e) {
+                            onPhaseFailure(this, "sending response failed", e);
+                        }
+
                         @Override
                         public void run() {
-                            final AtomicArray<SearchPhaseResult> atomicArray = results.getAtomicArray();
-                            sendSearchResponse(InternalSearchResponse.EMPTY_WITH_TOTAL_HITS, atomicArray);
+                            execute(new AbstractRunnable() {
+                                @Override
+                                public void onFailure(Exception e) {
+                                    onExecuteFailure(e);
+                                }
+
+                                @Override
+                                protected void doRun() {
+                                    sendSearchResponse(InternalSearchResponse.EMPTY_WITH_TOTAL_HITS, results.getAtomicArray());
+                                }
+
+                                @Override
+                                public boolean isForceExecution() {
+                                    return true; // we already created the PIT, no sense in rejecting the task that sends the response.
+                                }
+                            });
                         }
                     };
                 }


### PR DESCRIPTION
Creating the response after opening a PIT involves O(#shards) work and
has been observed to block transport worker threads which disrupts the
cluster. This commit forks this work onto a more appropriate thread.