### PR TITLE
Close index readers in tests.

### DIFF
--- a/server/src/test/java/org/elasticsearch/deps/lucene/VectorHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/deps/lucene/VectorHighlighterTests.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.vectorhighlight.FastVectorHighlighter;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.lucene.search.vectorhighlight.CustomFieldQuery;
 import org.elasticsearch.test.ESTestCase;
 
@@ -64,6 +65,7 @@ public class VectorHighlighterTests extends ESTestCase {
         );
         assertThat(fragment, notNullValue());
         assertThat(fragment, equalTo("the big <b>bad</b> dog"));
+        IOUtils.close(reader, indexWriter, dir);
     }
 
     public void testVectorHighlighterPrefixQuery() throws Exception {
@@ -120,6 +122,7 @@ public class VectorHighlighterTests extends ESTestCase {
             30
         );
         assertThat(fragment, notNullValue());
+        IOUtils.close(indexReader, indexWriter, dir);
     }
 
     public void testVectorHighlighterNoStore() throws Exception {
@@ -150,6 +153,7 @@ public class VectorHighlighterTests extends ESTestCase {
             30
         );
         assertThat(fragment, nullValue());
+        IOUtils.close(reader, indexWriter, dir);
     }
 
     public void testVectorHighlighterNoTermVector() throws Exception {
@@ -176,5 +180,6 @@ public class VectorHighlighterTests extends ESTestCase {
             30
         );
         assertThat(fragment, nullValue());
+        IOUtils.close(reader, indexWriter, dir);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/similarity/ScriptedSimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/ScriptedSimilarityTests.java
@@ -146,6 +146,7 @@ public class ScriptedSimilarityTests extends ESTestCase {
         assertEquals(1, topDocs.totalHits.value);
         assertTrue(called.get());
         assertEquals(42, topDocs.scoreDocs[0].score, 0);
+        r.close();
         w.close();
         dir.close();
     }
@@ -238,6 +239,7 @@ public class ScriptedSimilarityTests extends ESTestCase {
         assertTrue(initCalled.get());
         assertTrue(called.get());
         assertEquals(42, topDocs.scoreDocs[0].score, 0);
+        r.close();
         w.close();
         dir.close();
     }


### PR DESCRIPTION
This is important because when the Lucene test framework randomly enables search concurrency, it registers the shutdown of the threadpool as a close listener on the index reader.