### PR TITLE
Add "manage" permission for fleet managed threat intel indices

### DIFF
--- a/docs/changelog/99231.yaml
+++ b/docs/changelog/99231.yaml
@@ -1,0 +1,5 @@
+pr: 99231
+summary: Add manage permission for fleet managed threat intel indices
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -281,8 +281,6 @@ class KibanaOwnedReservedRoleDescriptors {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs-ti_*_latest.*")
                     .privileges(
-                        // Require "create_index", "delete_index", "read", "index", "delete", IndicesAliasesAction.NAME, and
-                        // UpdateSettingsAction.NAME for transform
                         "create_index",
                         "delete_index",
                         "read",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -288,6 +288,7 @@ class KibanaOwnedReservedRoleDescriptors {
                         "read",
                         "index",
                         "delete",
+                        "manage",
                         IndicesAliasesAction.NAME,
                         UpdateSettingsAction.NAME
                     )


### PR DESCRIPTION
Adds [manage](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html#:~:text=manage%20the%20index.-,manage,-All%20monitor%20privileges) privilege to `kibana_system` to support creating and managing aliases for threat intel latest indices created by the [transform with `move_on_creation` feature](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html#:~:text=of%20the%20alias.-,move_on_creation,-(Optional%2C%20boolean)%20Whether)


More context in this comment: https://github.com/elastic/elasticsearch/pull/99231#discussion_r1319677614