### PR TITLE
Fix sparse_vector tests for serverlesss

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -9,8 +9,6 @@
       indices.create:
           index: test
           body:
-            settings:
-              number_of_replicas: 0
             mappings:
               properties:
                 text:
@@ -112,8 +110,6 @@
       indices.create:
         index: test
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               text:
@@ -133,8 +129,6 @@
       indices.create:
         index: test
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               text:


### PR DESCRIPTION
Remove `number_of_replicas: 0` from `sparse_vector` tests as it doesn't work on serverless.

See https://github.com/elastic/elasticsearch/issues/99238#issuecomment-1708220010 and https://github.com/elastic/elasticsearch-serverless/pull/866