### PR TITLE
[7.17] [DOCS] Fix double-slash in link (#99205)

### DIFF
--- a/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
@@ -38,8 +38,8 @@ PUT _watcher/watch/cluster_health_watch
     Since this watch runs so frequently, don't forget to <<health-delete, delete the watch>>
     when you're done experimenting.
 
-To get the status of your cluster, you can call the Elasticsearch
-{ref}//cluster-health.html[cluster health] API:
+To get the status of your cluster, you can call the <<cluster-health,cluster
+health API>>:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[DOCS] Fix double-slash in link (#99205)](https://github.com/elastic/elasticsearch/pull/99205)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)