### PR TITLE
[8.10] Set explicit file permissions in NoticeTask (#99206)

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -411,7 +411,9 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         if (testDistro) {
           from buildServerNoticeTaskProvider
         } else {
-          from buildDefaultNoticeTaskProvider
+          from (buildDefaultNoticeTaskProvider) {
+            fileMode = 0644
+          }
         }
       }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Set explicit file permissions in NoticeTask (#99206)](https://github.com/elastic/elasticsearch/pull/99206)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)