### PR TITLE
[7.17] Set explicit file permissions in NoticeTask (#99206)

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -431,9 +431,13 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
           from buildServerNoticeTaskProvider
         } else {
          if (jdk) {
-            from buildDefaultNoticeTaskProvider
+            from(buildDefaultNoticeTaskProvider)  {
+              fileMode = 0644
+            }
           } else {
-            from buildDefaultNoJdkNoticeTaskProvider
+            from(buildDefaultNoJdkNoticeTaskProvider) {
+             fileMode = 0644
+            }
           }
         }
       }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Set explicit file permissions in NoticeTask (#99206)](https://github.com/elastic/elasticsearch/pull/99206)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)