### PR TITLE
[8.9] [buildkite] Migrate DRA workflows (#99132)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -43,3 +43,29 @@ export GRADLE_BUILD_CACHE_USERNAME
 
 GRADLE_BUILD_CACHE_PASSWORD=$(vault read -field=password secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
 export GRADLE_BUILD_CACHE_PASSWORD
+
+BUILDKITE_API_TOKEN=$(vault read -field=token secret/ci/elastic-elasticsearch/buildkite-api-token)
+export BUILDKITE_API_TOKEN
+
+if [[ "${USE_LUCENE_SNAPSHOT_CREDS:-}" == "true" ]]; then
+  data=$(.buildkite/scripts/lucene-snapshot/get-credentials.sh)
+
+  AWS_ACCESS_KEY_ID=$(echo "$data" | jq -r .data.access_key)
+  export AWS_ACCESS_KEY_ID
+
+  AWS_SECRET_ACCESS_KEY=$(echo "$data" | jq -r .data.secret_key)
+  export AWS_SECRET_ACCESS_KEY
+
+  unset data
+fi
+
+if [[ "${USE_DRA_CREDENTIALS:-}" == "true" ]]; then
+  DRA_VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
+  export DRA_VAULT_ROLE_ID_SECRET
+
+  DRA_VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
+  export DRA_VAULT_SECRET_ID_SECRET
+
+  DRA_VAULT_ADDR=https://secrets.elastic.co:8200
+  export DRA_VAULT_ADDR
+fi

--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -1,0 +1,9 @@
+steps:
+  - command: .buildkite/scripts/dra-workflow.sh
+    env:
+      USE_DRA_CREDENTIALS: "true"
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2204
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/dra-update-staging.sh
+++ b/.buildkite/scripts/dra-update-staging.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source .buildkite/scripts/branches.sh
+
+for BRANCH in "${BRANCHES[@]}"; do
+  # Don't publish main branch to staging
+  if [[ "$BRANCH" == "main" ]]; then
+    continue
+  fi
+
+  echo "--- Checking $BRANCH"
+
+  BEATS_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/beats/latest/${BRANCH}.json" | jq -r '.manifest_url')
+  ML_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/ml-cpp/latest/${BRANCH}.json" | jq -r '.manifest_url')
+  ES_MANIFEST=$(curl -sS "https://artifacts-staging.elastic.co/elasticsearch/latest/${BRANCH}.json" | jq -r '.manifest_url')
+
+  ES_BEATS_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "beats") | .build_uri')
+  ES_ML_DEPENDENCY=$(curl -sS "$ES_MANIFEST" | jq -r '.projects.elasticsearch.dependencies[] | select(.prefix == "ml-cpp") | .build_uri')
+
+  SHOULD_TRIGGER=""
+
+  if [ "$BEATS_MANIFEST" = "$ES_BEATS_DEPENDENCY" ]; then
+    echo "ES has the latest beats"
+  else
+    echo "Need to trigger a build, $BEATS_MANIFEST available but ES has $ES_BEATS_DEPENDENCY"
+    SHOULD_TRIGGER=true
+  fi
+
+  if [ "$ML_MANIFEST" = "$ES_ML_DEPENDENCY" ]; then
+    echo "ES has the latest ml-cpp"
+  else
+    echo "Need to trigger a build, $ML_MANIFEST available but ES has $ES_ML_DEPENDENCY"
+    SHOULD_TRIGGER=true
+  fi
+
+  if [[ "$SHOULD_TRIGGER" == "true" ]]; then
+    echo "Triggering DRA staging workflow for $BRANCH"
+    cat << EOF | buildkite-agent pipeline upload
+steps:
+  - trigger: elasticsearch-dra-workflow
+    label: Trigger DRA staging workflow for $BRANCH
+    async: true
+    build:
+      branch: "$BRANCH"
+      env:
+        DRA_WORKFLOW: staging
+EOF
+  fi
+done

--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail
+
+WORKFLOW="${DRA_WORKFLOW:-snapshot}"
+BRANCH="${BUILDKITE_BRANCH:-}"
+
+# Don't publish main branch to staging
+if [[ "$BRANCH" == "main" && "$WORKFLOW" == "staging" ]]; then
+  exit 0
+fi
+
+echo --- Preparing
+
+# TODO move this to image
+sudo apt-get update -y
+sudo apt-get install -y libxml2-utils python3.10-venv
+
+RM_BRANCH="$BRANCH"
+if [[ "$BRANCH" == "main" ]]; then
+  RM_BRANCH=master
+fi
+
+ES_VERSION=$(grep elasticsearch build-tools-internal/version.properties | sed "s/elasticsearch *= *//g")
+
+VERSION_SUFFIX=""
+if [[ "$WORKFLOW" == "snapshot" ]]; then
+  VERSION_SUFFIX="-SNAPSHOT"
+fi
+
+BEATS_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh beats "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
+ML_CPP_BUILD_ID="$(./.ci/scripts/resolve-dra-manifest.sh ml-cpp "$RM_BRANCH" "$ES_VERSION" "$WORKFLOW")"
+
+LICENSE_KEY_ARG=""
+BUILD_SNAPSHOT_ARG=""
+
+if [[ "$WORKFLOW" == "staging" ]]; then
+  LICENSE_KEY=$(mktemp -d)/license.key
+  # Notice that only the public key is being read here, which isn't really secret
+  vault read -field pubkey secret/ci/elastic-elasticsearch/migrated/license | base64 --decode > "$LICENSE_KEY"
+  LICENSE_KEY_ARG="-Dlicense.key=$LICENSE_KEY"
+
+  BUILD_SNAPSHOT_ARG="-Dbuild.snapshot=false"
+fi
+
+echo --- Building release artifacts
+
+.ci/scripts/run-gradle.sh -Ddra.artifacts=true \
+  -Ddra.artifacts.dependency.beats="${BEATS_BUILD_ID}" \
+  -Ddra.artifacts.dependency.ml-cpp="${ML_CPP_BUILD_ID}" \
+  -Ddra.workflow="$WORKFLOW" \
+  -Dcsv="$WORKSPACE/build/distributions/dependencies-${ES_VERSION}${VERSION_SUFFIX}.csv" \
+  $LICENSE_KEY_ARG \
+  $BUILD_SNAPSHOT_ARG \
+  buildReleaseArtifacts \
+  exportCompressedDockerImages \
+  :distribution:generateDependenciesReport
+
+PATH="$PATH:${JAVA_HOME}/bin" # Required by the following script
+x-pack/plugin/sql/connectors/tableau/package.sh asm qualifier="$VERSION_SUFFIX"
+
+# we regenerate this file as part of the release manager invocation
+rm "build/distributions/elasticsearch-jdbc-${ES_VERSION}${VERSION_SUFFIX}.taco.sha512"
+
+# Allow other users access to read the artifacts so they are readable in the
+# container
+find "$WORKSPACE" -type f -path "*/build/distributions/*" -exec chmod a+r {} \;
+
+# Allow other users write access to create checksum files
+find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
+
+echo --- Running release-manager
+
+# Artifacts should be generated
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR="$DRA_VAULT_ADDR" \
+  -e VAULT_ROLE_ID="$DRA_VAULT_ROLE_ID_SECRET" \
+  -e VAULT_SECRET_ID="$DRA_VAULT_SECRET_ID_SECRET" \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
+  docker.elastic.co/infra/release-manager:latest \
+  cli collect \
+  --project elasticsearch \
+  --branch "$RM_BRANCH" \
+  --commit "$BUILDKITE_COMMIT" \
+  --workflow "$WORKFLOW" \
+  --version "$ES_VERSION" \
+  --artifact-set main \
+  --dependency "beats:https://artifacts-${WORKFLOW}.elastic.co/beats/${BEATS_BUILD_ID}/manifest-${ES_VERSION}${VERSION_SUFFIX}.json" \
+  --dependency "ml-cpp:https://artifacts-${WORKFLOW}.elastic.co/ml-cpp/${ML_CPP_BUILD_ID}/manifest-${ES_VERSION}${VERSION_SUFFIX}.json"

--- a/.buildkite/scripts/dra-workflow.trigger.sh
+++ b/.buildkite/scripts/dra-workflow.trigger.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "steps:"
+
+source .buildkite/scripts/branches.sh
+
+for BRANCH in "${BRANCHES[@]}"; do
+  if [[ "$BRANCH" == "main" ]]; then
+    continue
+  fi
+
+  INTAKE_PIPELINE_SLUG="elasticsearch-intake"
+  BUILD_JSON=$(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "https://api.buildkite.com/v2/organizations/elastic/pipelines/${INTAKE_PIPELINE_SLUG}/builds?branch=${BRANCH}&state=passed&per_page=1" | jq '.[0] | {commit: .commit, url: .web_url}')
+  LAST_GOOD_COMMIT=$(echo "${BUILD_JSON}" | jq -r '.commit')
+
+  cat <<EOF
+  - trigger: elasticsearch-dra-workflow
+    label: Trigger DRA staging workflow for $BRANCH
+    async: true
+    build:
+      branch: "$BRANCH"
+      commit: "$LAST_GOOD_COMMIT"
+      env:
+        DRA_WORKFLOW: staging
+EOF
+done


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[buildkite] Migrate DRA workflows (#99132)](https://github.com/elastic/elasticsearch/pull/99132)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)