### PR TITLE
[8.10] Exclude x-pack docs from CI jobs (#99207)

### DIFF
--- a/.ci/templates.t/pull-request-gradle-unix.yml
+++ b/.ci/templates.t/pull-request-gradle-unix.yml
@@ -20,6 +20,7 @@
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
     builders:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Exclude x-pack docs from CI jobs (#99207)](https://github.com/elastic/elasticsearch/pull/99207)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)