### PR TITLE
[8.9] Exclude x-pack docs from CI jobs (#99207)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
@@ -31,6 +31,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'build-benchmark'
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
@@ -31,6 +31,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'build-benchmark'
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
@@ -24,6 +24,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'test-windows'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
@@ -22,6 +22,7 @@
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
             - 'test-full-bwc'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
@@ -23,6 +23,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'cloud-deploy'
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
@@ -20,6 +20,7 @@
           cancel-builds-on-update: true
           included-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
@@ -22,6 +22,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
@@ -22,6 +22,7 @@
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'test-full-bwc'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
@@ -23,6 +23,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
             - ':Delivery/Packaging'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
@@ -23,6 +23,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - ':Delivery/Packaging'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
@@ -27,6 +27,7 @@
             - 7.16
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - ':Delivery/Packaging'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
@@ -27,6 +27,7 @@
             - 7.16
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
             - ':Delivery/Packaging'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
@@ -26,6 +26,7 @@
             - 7.16
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
             - ':Delivery/Packaging'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
@@ -27,6 +27,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - ':Delivery/Packaging'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
@@ -24,6 +24,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - ':Delivery/Packaging'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
@@ -22,6 +22,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'Team:Security'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
@@ -23,6 +23,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'test-windows'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
@@ -22,6 +22,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'Team:Security'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
@@ -23,6 +23,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'test-windows'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
@@ -23,6 +23,7 @@
             - 7.17
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'Team:Security'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
@@ -24,6 +24,7 @@
             - 7.17
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'test-windows'
           black-list-labels:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
@@ -20,6 +20,7 @@
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
           black-list-target-branches:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
@@ -22,6 +22,7 @@
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           white-list-labels:
             - 'test-release'
           black-list-target-branches:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
@@ -25,6 +25,7 @@
             - 6.8
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
     builders:

--- a/.ci/templates.t/pull-request-gradle-unix.yml
+++ b/.ci/templates.t/pull-request-gradle-unix.yml
@@ -20,6 +20,7 @@
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
+            - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
     builders:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Exclude x-pack docs from CI jobs (#99207)](https://github.com/elastic/elasticsearch/pull/99207)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)