### PR TITLE
Use dot_product as default similarity for dense_vector fields

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/80_dense_vector_indexed_by_default.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/80_dense_vector_indexed_by_default.yml
@@ -29,7 +29,7 @@ setup:
               type: dense_vector
               dims: 5
               index: true
-              similarity: cosine
+              similarity: dot_product
 
 ---
 "Indexed by default with specified similarity and index options":
@@ -42,7 +42,7 @@ setup:
               vector:
                 type: dense_vector
                 dims: 5
-                similarity: dot_product
+                similarity: l2_norm
                 index_options:
                   type: hnsw
                   m: 32
@@ -62,7 +62,7 @@ setup:
               type: dense_vector
               dims: 5
               index: true
-              similarity: dot_product
+              similarity: l2_norm
               index_options:
                 type: hnsw
                 m: 32

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -123,6 +123,7 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
      */
     public static final IndexVersion V_8_500_000 = registerIndexVersion(8_500_000, Version.LUCENE_9_7_0, "bf656f5e-5808-4eee-bf8a-e2bf6736ff55");
     public static final IndexVersion V_8_500_001 = registerIndexVersion(8_500_001, Version.LUCENE_9_7_0, "45045a5a-fc57-4462-89f6-6bc04cda6015");
+    public static final IndexVersion V_8_500_002 = registerIndexVersion(8_500_002, Version.LUCENE_9_7_0, "5c49ca52-dd9e-4ca8-a201-94cb42c922d4");
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _
@@ -150,7 +151,7 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
      */
 
     private static class CurrentHolder {
-        private static final IndexVersion CURRENT = findCurrent(V_8_500_001);
+        private static final IndexVersion CURRENT = findCurrent(V_8_500_002);
 
         // finds the pluggable current version, or uses the given fallback
         private static IndexVersion findCurrent(IndexVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -75,6 +75,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
     public static final IndexVersion INDEXED_BY_DEFAULT_INDEX_VERSION = IndexVersion.V_8_11_0;
     public static final IndexVersion DOT_PRODUCT_AUTO_NORMALIZED = IndexVersion.V_8_11_0;
     public static final IndexVersion LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION = IndexVersion.V_8_9_0;
+    public static final IndexVersion DOT_PRODUCT_DEFAULT_SIMILARITY = IndexVersion.V_8_500_002;
 
     public static final String CONTENT_TYPE = "dense_vector";
     public static short MAX_DIMS_COUNT = 2048; // maximum allowed number of dimensions
@@ -145,7 +146,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 "similarity",
                 false,
                 m -> toType(m).similarity,
-                (Supplier<VectorSimilarity>) () -> indexedByDefault && indexed.getValue() ? VectorSimilarity.COSINE : null,
+                (Supplier<VectorSimilarity>) () -> indexedByDefault && indexed.getValue() ? defaultSimilarity(indexVersionCreated) : null,
                 VectorSimilarity.class
             ).acceptsNull().setSerializerCheck((id, ic, v) -> v != null);
             this.indexed.addValidator(v -> {
@@ -196,6 +197,10 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 copyTo.build()
             );
         }
+    }
+
+    private static VectorSimilarity defaultSimilarity(IndexVersion indexVersionCreated) {
+        return indexVersionCreated.onOrAfter(DOT_PRODUCT_DEFAULT_SIMILARITY) ? VectorSimilarity.DOT_PRODUCT : VectorSimilarity.COSINE;
     }
 
     private static FieldType getDenseVectorFieldType(

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
 
@@ -53,6 +54,7 @@ import java.util.Set;
 
 import static org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
 import static org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat.DEFAULT_MAX_CONN;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.INDEXED_BY_DEFAULT_INDEX_VERSION;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -79,7 +81,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void minimalMapping(XContentBuilder b, IndexVersion indexVersion) throws IOException {
-        indexMapping(b, indexVersion.onOrAfter(DenseVectorFieldMapper.INDEXED_BY_DEFAULT_INDEX_VERSION));
+        indexMapping(b, indexVersion.onOrAfter(INDEXED_BY_DEFAULT_INDEX_VERSION));
     }
 
     private void indexMapping(XContentBuilder b, boolean indexedByDefault) throws IOException {
@@ -92,7 +94,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
             b.field("index", indexed);
         }
         if (indexed) {
-            b.field("similarity", "dot_product");
+            if (indexedByDefault == false) {
+                // Add similarity when it's required
+                b.field("similarity", "dot_product");
+            }
             if (indexOptionsSet) {
                 b.startObject("index_options");
                 b.field("type", "hnsw");
@@ -242,7 +247,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "dense_vector").field("dims", 3)));
 
-        testIndexedVector(VectorSimilarity.COSINE, mapper);
+        testIndexedVector(VectorSimilarity.DOT_PRODUCT, mapper);
     }
 
     public void testIndexedVector() throws Exception {
@@ -517,8 +522,17 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         assertEquals(VectorSimilarity.DOT_PRODUCT, denseVectorFieldType.getSimilarity());
     }
 
-    public void testDefaultParamsIndexByDefault() throws Exception {
+    public void testDefaultParamsIndexedByDefault() throws Exception {
         DocumentMapper documentMapper = createDocumentMapper(fieldMapping(b -> { b.field("type", "dense_vector").field("dims", 3); }));
+        DenseVectorFieldMapper denseVectorFieldMapper = (DenseVectorFieldMapper) documentMapper.mappers().getMapper("field");
+        DenseVectorFieldType denseVectorFieldType = denseVectorFieldMapper.fieldType();
+
+        assertTrue(denseVectorFieldType.isIndexed());
+        assertEquals(VectorSimilarity.DOT_PRODUCT, denseVectorFieldType.getSimilarity());
+    }
+
+    public void testDefaultParamsBeforeDotProductNormalization() throws Exception {
+        DocumentMapper documentMapper = createDocumentMapper(INDEXED_BY_DEFAULT_INDEX_VERSION, fieldMapping(b -> { b.field("type", "dense_vector").field("dims", 3); }));
         DenseVectorFieldMapper denseVectorFieldMapper = (DenseVectorFieldMapper) documentMapper.mappers().getMapper("field");
         DenseVectorFieldType denseVectorFieldType = denseVectorFieldMapper.fieldType();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
 
@@ -532,7 +531,9 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     }
 
     public void testDefaultParamsBeforeDotProductNormalization() throws Exception {
-        DocumentMapper documentMapper = createDocumentMapper(INDEXED_BY_DEFAULT_INDEX_VERSION, fieldMapping(b -> { b.field("type", "dense_vector").field("dims", 3); }));
+        DocumentMapper documentMapper = createDocumentMapper(INDEXED_BY_DEFAULT_INDEX_VERSION, fieldMapping(b -> {
+            b.field("type", "dense_vector").field("dims", 3);
+        }));
         DenseVectorFieldMapper denseVectorFieldMapper = (DenseVectorFieldMapper) documentMapper.mappers().getMapper("field");
         DenseVectorFieldType denseVectorFieldType = denseVectorFieldMapper.fieldType();
 


### PR DESCRIPTION
Does what it says on the tin. Currently the default similarity for `dense_vector` if not specified is `cosine`, because this will work without normalized vectors. Dot_product offers better performance but requires normalization.

Since we will auto-normalize query and index vectors, we should update this default for new indices created in 8.11+. 