### PR TITLE
[7.17] [buildkite] Disable DRA release-manager temporarily (#99274)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -71,6 +71,8 @@ find "$WORKSPACE" -type d -path "*/build/distributions" -exec chmod a+w {} \;
 
 echo --- Running release-manager
 
+exit 0
+
 # Artifacts should be generated
 docker run --rm \
   --name release-manager \


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[buildkite] Disable DRA release-manager temporarily (#99274)](https://github.com/elastic/elasticsearch/pull/99274)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)