### PR TITLE
Fix PIT when resolving with deleted indices

### DIFF
--- a/docs/changelog/99281.yaml
+++ b/docs/changelog/99281.yaml
@@ -1,0 +1,5 @@
+pr: 99281
+summary: Fix PIT when resolving with deleted indices
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1543,12 +1543,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             if (Strings.isEmpty(perNode.getClusterAlias())) {
                 final ShardId shardId = entry.getKey();
                 final List<String> targetNodes = new ArrayList<>(2);
-                // Prefer executing shard requests on nodes that are part of PIT first.
-                if (clusterState.nodes().nodeExists(perNode.getNode())) {
-                    targetNodes.add(perNode.getNode());
-                }
                 try {
                     final ShardIterator shards = OperationRouting.getShards(clusterState, shardId);
+                    // Prefer executing shard requests on nodes that are part of PIT first.
+                    if (clusterState.nodes().nodeExists(perNode.getNode())) {
+                        targetNodes.add(perNode.getNode());
+                    }
                     if (perNode.getSearchContextId().getSearcherId() != null) {
                         for (ShardRouting shard : shards) {
                             if (shard.currentNodeId().equals(perNode.getNode()) == false) {

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -1485,7 +1485,7 @@ public class TransportSearchActionTests extends ESTestCase {
             true
         ).stream().filter(si -> si.shardId().equals(anotherShardId)).findFirst();
         assertTrue(anotherShardIterator.isPresent());
-        assertThat(anotherShardIterator.get().getTargetNodeIds(), hasSize(1));
+        assertThat(anotherShardIterator.get().getTargetNodeIds(), hasSize(0));
     }
 
     public void testCCSCompatibilityCheck() throws Exception {


### PR DESCRIPTION
Today, when resolving a point-in-time, we always add a target node from the point-in-time if that node still exists, whether the index exists or not. However, this can lead to an authorization issue (I believe it's mostly related to logging noise) when the current query tries to access the the deleted indices.

To avoid this issue, we should create an empty search shard iterator for an index/shard that no longer exists in the cluster. This PR addresses this issue for the local cluster only. Fixing this for CCS requires more effort.