### PR TITLE
Compute cluster state chunk count in tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigE
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -26,6 +27,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
@@ -36,10 +38,13 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.alias.RandomAliasActionsGenerator;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.index.IndexVersionUtils;
+import org.elasticsearch.upgrades.FeatureMigrationResults;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -61,6 +66,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -68,6 +74,8 @@ import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBack
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createFirstBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.newInstance;
 import static org.elasticsearch.cluster.metadata.Metadata.Builder.assertDataStreams;
+import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_API;
+import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_PARAM;
 import static org.elasticsearch.test.LambdaMatchers.transformedItemsMatch;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
@@ -2150,41 +2158,65 @@ public class MetadataTests extends ESTestCase {
         assertSame(instance, deserializedDiff.apply(instance));
     }
 
-    public void testChunkedToXContent() throws IOException {
-        final int datastreams = randomInt(10);
-        // 2 chunks at the beginning
-        // 1 chunk for each index + 2 to wrap the indices field
-        // 2 chunks for wrapping reserved state + 1 chunk for each item
-        // 2 chunks wrapping templates and one chunk per template
-        // 2 chunks to wrap each custom
-        // 1 chunk per datastream, 4 chunks to wrap ds and ds-aliases, or 0 if there are no datastreams
-        // 2 chunks to wrap index graveyard and one per tombstone
-        // 2 chunks to wrap component templates and one per component template
-        // 2 chunks to wrap v2 templates and one per v2 template
-        // 1 chunk to close metadata
-        AbstractChunkedSerializingTestCase.assertChunkCount(randomMetadata(datastreams), instance -> {
-            // 2 chunks at the beginning
-            // 1 chunk for each index + 2 to wrap the indices field
-            final int indicesChunks = instance.indices().size() + 2;
-            // 2 chunks for wrapping reserved state + 1 chunk for each item
-            final int reservedStateChunks = instance.reservedStateMetadata().size() + 2;
-            // 2 chunks wrapping templates and one chunk per template
-            final int templatesChunks = instance.templates().size() + 2;
-            // 2 chunks to wrap each custom
-            final int customChunks = 2 * instance.customs().size();
-            // 1 chunk per datastream, 4 chunks to wrap ds and ds-aliases, or 0 if there are no datastreams
-            final int dsChunks = datastreams == 0 ? 0 : (datastreams + 4);
-            // 2 chunks to wrap index graveyard and one per tombstone
-            final int graveYardChunks = instance.indexGraveyard().getTombstones().size() + 2;
-            // 2 chunks to wrap component templates and one per component template
-            final int componentTemplateChunks = instance.componentTemplates().size() + 2;
-            // 2 chunks to wrap v2 templates and one per v2 template
-            final int v2TemplateChunks = instance.templatesV2().size() + 2;
-            // 1 chunk to close metadata
+    public void testChunkedToXContent() {
+        AbstractChunkedSerializingTestCase.assertChunkCount(randomMetadata(randomInt(10)), MetadataTests::expectedChunkCount);
+    }
 
-            return 2 + indicesChunks + reservedStateChunks + templatesChunks + customChunks + dsChunks + graveYardChunks
-                + componentTemplateChunks + v2TemplateChunks + 1;
-        });
+    private static int expectedChunkCount(Metadata metadata) {
+        return expectedChunkCount(ToXContent.EMPTY_PARAMS, metadata);
+    }
+
+    public static int expectedChunkCount(ToXContent.Params params, Metadata metadata) {
+        final var context = Metadata.XContentContext.valueOf(params.param(CONTEXT_MODE_PARAM, CONTEXT_MODE_API));
+
+        // 2 chunks at the beginning
+        int chunkCount = 2;
+        // 1 optional chunk for persistent settings
+        if (context != Metadata.XContentContext.API && metadata.persistentSettings().isEmpty() == false) {
+            chunkCount += 1;
+        }
+        // 2 chunks wrapping templates and one chunk per template
+        chunkCount += 2 + metadata.templates().size();
+        // 1 chunk for each index + 2 to wrap the indices field
+        chunkCount += 2 + metadata.indices().size();
+
+        for (Metadata.Custom custom : metadata.customs().values()) {
+            chunkCount += 2;
+
+            if (custom instanceof ComponentTemplateMetadata componentTemplateMetadata) {
+                chunkCount += 2 + componentTemplateMetadata.componentTemplates().size();
+            } else if (custom instanceof ComposableIndexTemplateMetadata composableIndexTemplateMetadata) {
+                chunkCount += 2 + composableIndexTemplateMetadata.indexTemplates().size();
+            } else if (custom instanceof DataStreamMetadata dataStreamMetadata) {
+                chunkCount += 4 + dataStreamMetadata.dataStreams().size() + dataStreamMetadata.getDataStreamAliases().size();
+            } else if (custom instanceof DesiredNodesMetadata) {
+                chunkCount += 1;
+            } else if (custom instanceof FeatureMigrationResults featureMigrationResults) {
+                chunkCount += 2 + featureMigrationResults.getFeatureStatuses().size();
+            } else if (custom instanceof IndexGraveyard indexGraveyard) {
+                chunkCount += 2 + indexGraveyard.getTombstones().size();
+            } else if (custom instanceof IngestMetadata ingestMetadata) {
+                chunkCount += 2 + ingestMetadata.getPipelines().size();
+            } else if (custom instanceof NodesShutdownMetadata nodesShutdownMetadata) {
+                chunkCount += 2 + nodesShutdownMetadata.getAll().size();
+            } else if (custom instanceof PersistentTasksCustomMetadata persistentTasksCustomMetadata) {
+                chunkCount += 3 + persistentTasksCustomMetadata.tasks().size();
+            } else if (custom instanceof RepositoriesMetadata repositoriesMetadata) {
+                chunkCount += repositoriesMetadata.repositories().size();
+            } else {
+                // could be anything, we have to just try it
+                chunkCount += Iterables.size(
+                    (Iterable<ToXContent>) (() -> Iterators.map(custom.toXContentChunked(params), Function.identity()))
+                );
+            }
+        }
+
+        // 2 chunks for wrapping reserved state + 1 chunk for each item
+        chunkCount += 2 + metadata.reservedStateMetadata().size();
+        // 1 chunk to close metadata
+        chunkCount += 1;
+
+        return chunkCount;
     }
 
     /**


### PR DESCRIPTION
Today in tests we hard-code the expected chunk count for cluster state
responses, which means we have to change several magic numbers whenever
anything about the serialization changes. This commit adjusts these
tests to compute the expected chunk count based on the contents of the
cluster state instead, which removes the need for those magic numbers.