### PR TITLE
Close index reader in tests

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/SimilarityScriptTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/SimilarityScriptTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.similarity.ScriptedSimilarity;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.script.ScriptContext;
@@ -55,39 +56,39 @@ public class SimilarityScriptTests extends ScriptTestCase {
             Collections.emptyMap()
         );
         ScriptedSimilarity sim = new ScriptedSimilarity("foobar", null, "foobaz", factory::newInstance, true);
-        Directory dir = new ByteBuffersDirectory();
-        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
+        try (Directory dir = new ByteBuffersDirectory()) {
+            IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
 
-        Document doc = new Document();
-        doc.add(new TextField("f", "foo bar", Store.NO));
-        doc.add(new StringField("match", "no", Store.NO));
-        w.addDocument(doc);
+            Document doc = new Document();
+            doc.add(new TextField("f", "foo bar", Store.NO));
+            doc.add(new StringField("match", "no", Store.NO));
+            w.addDocument(doc);
 
-        doc = new Document();
-        doc.add(new TextField("f", "foo foo bar", Store.NO));
-        doc.add(new StringField("match", "yes", Store.NO));
-        w.addDocument(doc);
+            doc = new Document();
+            doc.add(new TextField("f", "foo foo bar", Store.NO));
+            doc.add(new StringField("match", "yes", Store.NO));
+            w.addDocument(doc);
 
-        doc = new Document();
-        doc.add(new TextField("f", "bar", Store.NO));
-        doc.add(new StringField("match", "no", Store.NO));
-        w.addDocument(doc);
+            doc = new Document();
+            doc.add(new TextField("f", "bar", Store.NO));
+            doc.add(new StringField("match", "no", Store.NO));
+            w.addDocument(doc);
 
-        IndexReader r = DirectoryReader.open(w);
-        w.close();
-        IndexSearcher searcher = newSearcher(r);
-        searcher.setSimilarity(sim);
-        Query query = new BoostQuery(
-            new BooleanQuery.Builder().add(new TermQuery(new Term("f", "foo")), Occur.SHOULD)
-                .add(new TermQuery(new Term("match", "yes")), Occur.FILTER)
-                .build(),
-            3.2f
-        );
-        TopDocs topDocs = searcher.search(query, 1);
-        assertEquals(1, topDocs.totalHits.value);
-        assertEquals((float) (3.2 * 2 / 3), topDocs.scoreDocs[0].score, 0);
-        w.close();
-        dir.close();
+            try (IndexReader r = DirectoryReader.open(w)) {
+                w.close();
+                IndexSearcher searcher = newSearcher(r);
+                searcher.setSimilarity(sim);
+                Query query = new BoostQuery(
+                    new BooleanQuery.Builder().add(new TermQuery(new Term("f", "foo")), Occur.SHOULD)
+                        .add(new TermQuery(new Term("match", "yes")), Occur.FILTER)
+                        .build(),
+                    3.2f
+                );
+                TopDocs topDocs = searcher.search(query, 1);
+                assertEquals(1, topDocs.totalHits.value);
+                assertEquals((float) (3.2 * 2 / 3), topDocs.scoreDocs[0].score, 0);
+            }
+        }
     }
 
     public void testWeightScript() throws IOException {
@@ -104,38 +105,38 @@ public class SimilarityScriptTests extends ScriptTestCase {
             Collections.emptyMap()
         );
         ScriptedSimilarity sim = new ScriptedSimilarity("foobar", weightFactory::newInstance, "foobaz", factory::newInstance, true);
-        Directory dir = new ByteBuffersDirectory();
-        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
+        try (Directory dir = new ByteBuffersDirectory()) {
+            IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
 
-        Document doc = new Document();
-        doc.add(new TextField("f", "foo bar", Store.NO));
-        doc.add(new StringField("match", "no", Store.NO));
-        w.addDocument(doc);
+            Document doc = new Document();
+            doc.add(new TextField("f", "foo bar", Store.NO));
+            doc.add(new StringField("match", "no", Store.NO));
+            w.addDocument(doc);
 
-        doc = new Document();
-        doc.add(new TextField("f", "foo foo bar", Store.NO));
-        doc.add(new StringField("match", "yes", Store.NO));
-        w.addDocument(doc);
+            doc = new Document();
+            doc.add(new TextField("f", "foo foo bar", Store.NO));
+            doc.add(new StringField("match", "yes", Store.NO));
+            w.addDocument(doc);
 
-        doc = new Document();
-        doc.add(new TextField("f", "bar", Store.NO));
-        doc.add(new StringField("match", "no", Store.NO));
-        w.addDocument(doc);
+            doc = new Document();
+            doc.add(new TextField("f", "bar", Store.NO));
+            doc.add(new StringField("match", "no", Store.NO));
+            w.addDocument(doc);
 
-        IndexReader r = DirectoryReader.open(w);
-        w.close();
-        IndexSearcher searcher = newSearcher(r);
-        searcher.setSimilarity(sim);
-        Query query = new BoostQuery(
-            new BooleanQuery.Builder().add(new TermQuery(new Term("f", "foo")), Occur.SHOULD)
-                .add(new TermQuery(new Term("match", "yes")), Occur.FILTER)
-                .build(),
-            3.2f
-        );
-        TopDocs topDocs = searcher.search(query, 1);
-        assertEquals(1, topDocs.totalHits.value);
-        assertEquals((float) (3.2 * 2 / 3), topDocs.scoreDocs[0].score, 0);
-        w.close();
-        dir.close();
+            try (IndexReader r = DirectoryReader.open(w)) {
+                w.close();
+                IndexSearcher searcher = newSearcher(r);
+                searcher.setSimilarity(sim);
+                Query query = new BoostQuery(
+                    new BooleanQuery.Builder().add(new TermQuery(new Term("f", "foo")), Occur.SHOULD)
+                        .add(new TermQuery(new Term("match", "yes")), Occur.FILTER)
+                        .build(),
+                    3.2f
+                );
+                TopDocs topDocs = searcher.search(query, 1);
+                assertEquals(1, topDocs.totalHits.value);
+                assertEquals((float) (3.2 * 2 / 3), topDocs.scoreDocs[0].score, 0);
+            }
+        }
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/SimilarityScriptTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/SimilarityScriptTests.java
@@ -25,7 +25,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
-import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.similarity.ScriptedSimilarity;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.script.ScriptContext;

--- a/server/src/test/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQueryTests.java
@@ -19,7 +19,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;

--- a/server/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
+++ b/server/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
@@ -44,47 +44,48 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SimpleLuceneTests extends ESTestCase {
     public void testSortValues() throws Exception {
-        Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
-        for (int i = 0; i < 10; i++) {
-            Document document = new Document();
-            String text = new String(new char[] { (char) (97 + i), (char) (97 + i) });
-            document.add(new TextField("str", text, Field.Store.YES));
-            document.add(new SortedDocValuesField("str", new BytesRef(text)));
-            indexWriter.addDocument(document);
-        }
-        IndexReader reader = DirectoryReader.open(indexWriter);
-        IndexSearcher searcher = newSearcher(reader);
-        TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("str", SortField.Type.STRING)));
-        for (int i = 0; i < 10; i++) {
-            FieldDoc fieldDoc = (FieldDoc) docs.scoreDocs[i];
-            assertThat((BytesRef) fieldDoc.fields[0], equalTo(new BytesRef(new String(new char[] { (char) (97 + i), (char) (97 + i) }))));
+        try (Directory dir = new ByteBuffersDirectory();
+        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+            for (int i = 0; i < 10; i++) {
+                Document document = new Document();
+                String text = new String(new char[] { (char) (97 + i), (char) (97 + i) });
+                document.add(new TextField("str", text, Field.Store.YES));
+                document.add(new SortedDocValuesField("str", new BytesRef(text)));
+                indexWriter.addDocument(document);
+            }
+            try (IndexReader reader = DirectoryReader.open(indexWriter)) {
+                IndexSearcher searcher = newSearcher(reader);
+                TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("str", SortField.Type.STRING)));
+                for (int i = 0; i < 10; i++) {
+                    FieldDoc fieldDoc = (FieldDoc) docs.scoreDocs[i];
+                    assertThat((BytesRef) fieldDoc.fields[0], equalTo(new BytesRef(new String(new char[] { (char) (97 + i), (char) (97 + i) }))));
+                }
+            }
         }
     }
 
     public void testSimpleNumericOps() throws Exception {
-        Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
+        try (Directory dir = new ByteBuffersDirectory();
+        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+            Document document = new Document();
+            document.add(new TextField("_id", "1", Field.Store.YES));
+            document.add(new IntPoint("test", 2));
+            document.add(new StoredField("test", 2));
+            indexWriter.addDocument(document);
 
-        Document document = new Document();
-        document.add(new TextField("_id", "1", Field.Store.YES));
-        document.add(new IntPoint("test", 2));
-        document.add(new StoredField("test", 2));
-        indexWriter.addDocument(document);
+            try (IndexReader reader = DirectoryReader.open(indexWriter)) {
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs topDocs = searcher.search(new TermQuery(new Term("_id", "1")), 1);
+                Document doc = searcher.doc(topDocs.scoreDocs[0].doc);
+                IndexableField f = doc.getField("test");
+                assertThat(f.numericValue(), equalTo(2));
 
-        IndexReader reader = DirectoryReader.open(indexWriter);
-        IndexSearcher searcher = newSearcher(reader);
-        TopDocs topDocs = searcher.search(new TermQuery(new Term("_id", "1")), 1);
-        Document doc = searcher.doc(topDocs.scoreDocs[0].doc);
-        IndexableField f = doc.getField("test");
-        assertThat(f.numericValue(), equalTo(2));
-
-        topDocs = searcher.search(IntPoint.newExactQuery("test", 2), 1);
-        doc = searcher.doc(topDocs.scoreDocs[0].doc);
-        f = doc.getField("test");
-        assertThat(f.stringValue(), equalTo("2"));
-
-        indexWriter.close();
+                topDocs = searcher.search(IntPoint.newExactQuery("test", 2), 1);
+                doc = searcher.doc(topDocs.scoreDocs[0].doc);
+                f = doc.getField("test");
+                assertThat(f.stringValue(), equalTo("2"));
+            }
+        }
     }
 
     /**
@@ -93,54 +94,51 @@ public class SimpleLuceneTests extends ESTestCase {
      * first (with load and break).
      */
     public void testOrdering() throws Exception {
-        Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
+        try (Directory dir = new ByteBuffersDirectory();
+        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+            Document document = new Document();
+            document.add(new TextField("_id", "1", Field.Store.YES));
+            document.add(new TextField("#id", "1", Field.Store.YES));
+            indexWriter.addDocument(document);
 
-        Document document = new Document();
-        document.add(new TextField("_id", "1", Field.Store.YES));
-        document.add(new TextField("#id", "1", Field.Store.YES));
-        indexWriter.addDocument(document);
+            try (IndexReader reader = DirectoryReader.open(indexWriter)) {
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs topDocs = searcher.search(new TermQuery(new Term("_id", "1")), 1);
+                final ArrayList<String> fieldsOrder = new ArrayList<>();
+                searcher.doc(topDocs.scoreDocs[0].doc, new StoredFieldVisitor() {
+                    @Override
+                    public Status needsField(FieldInfo fieldInfo) throws IOException {
+                        fieldsOrder.add(fieldInfo.name);
+                        return Status.YES;
+                    }
+                });
 
-        IndexReader reader = DirectoryReader.open(indexWriter);
-        IndexSearcher searcher = newSearcher(reader);
-        TopDocs topDocs = searcher.search(new TermQuery(new Term("_id", "1")), 1);
-        final ArrayList<String> fieldsOrder = new ArrayList<>();
-        searcher.doc(topDocs.scoreDocs[0].doc, new StoredFieldVisitor() {
-            @Override
-            public Status needsField(FieldInfo fieldInfo) throws IOException {
-                fieldsOrder.add(fieldInfo.name);
-                return Status.YES;
+                assertThat(fieldsOrder.size(), equalTo(2));
+                assertThat(fieldsOrder.get(0), equalTo("_id"));
+                assertThat(fieldsOrder.get(1), equalTo("#id"));
             }
-        });
-
-        assertThat(fieldsOrder.size(), equalTo(2));
-        assertThat(fieldsOrder.get(0), equalTo("_id"));
-        assertThat(fieldsOrder.get(1), equalTo("#id"));
-
-        indexWriter.close();
+        }
     }
 
     public void testNRTSearchOnClosedWriter() throws Exception {
-        Directory dir = new ByteBuffersDirectory();
+        try (Directory dir = new ByteBuffersDirectory();
         IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
-        DirectoryReader reader = DirectoryReader.open(indexWriter);
-
-        for (int i = 0; i < 100; i++) {
-            Document document = new Document();
-            TextField field = new TextField("_id", Integer.toString(i), Field.Store.YES);
-            document.add(field);
-            indexWriter.addDocument(document);
-        }
-        reader = refreshReader(reader);
-
-        indexWriter.close();
-
-        for (LeafReaderContext leaf : reader.leaves()) {
-            leaf.reader().terms("_id").iterator().next();
+             DirectoryReader reader = DirectoryReader.open(indexWriter)) {
+            for (int i = 0; i < 100; i++) {
+                Document document = new Document();
+                TextField field = new TextField("_id", Integer.toString(i), Field.Store.YES);
+                document.add(field);
+                indexWriter.addDocument(document);
+            }
+            try (DirectoryReader refreshedReader = refreshReader(reader)) {
+                for (LeafReaderContext leaf : refreshedReader.leaves()) {
+                    leaf.reader().terms("_id").iterator().next();
+                }
+            }
         }
     }
 
-    private DirectoryReader refreshReader(DirectoryReader reader) throws IOException {
+    private static DirectoryReader refreshReader(DirectoryReader reader) throws IOException {
         DirectoryReader oldReader = reader;
         reader = DirectoryReader.openIfChanged(reader);
         if (reader != oldReader) {

--- a/server/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
+++ b/server/src/test/java/org/elasticsearch/deps/lucene/SimpleLuceneTests.java
@@ -44,8 +44,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SimpleLuceneTests extends ESTestCase {
     public void testSortValues() throws Exception {
-        try (Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+        try (
+            Directory dir = new ByteBuffersDirectory();
+            IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))
+        ) {
             for (int i = 0; i < 10; i++) {
                 Document document = new Document();
                 String text = new String(new char[] { (char) (97 + i), (char) (97 + i) });
@@ -58,15 +60,20 @@ public class SimpleLuceneTests extends ESTestCase {
                 TopFieldDocs docs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField("str", SortField.Type.STRING)));
                 for (int i = 0; i < 10; i++) {
                     FieldDoc fieldDoc = (FieldDoc) docs.scoreDocs[i];
-                    assertThat((BytesRef) fieldDoc.fields[0], equalTo(new BytesRef(new String(new char[] { (char) (97 + i), (char) (97 + i) }))));
+                    assertThat(
+                        (BytesRef) fieldDoc.fields[0],
+                        equalTo(new BytesRef(new String(new char[] { (char) (97 + i), (char) (97 + i) })))
+                    );
                 }
             }
         }
     }
 
     public void testSimpleNumericOps() throws Exception {
-        try (Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+        try (
+            Directory dir = new ByteBuffersDirectory();
+            IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))
+        ) {
             Document document = new Document();
             document.add(new TextField("_id", "1", Field.Store.YES));
             document.add(new IntPoint("test", 2));
@@ -94,8 +101,10 @@ public class SimpleLuceneTests extends ESTestCase {
      * first (with load and break).
      */
     public void testOrdering() throws Exception {
-        try (Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))) {
+        try (
+            Directory dir = new ByteBuffersDirectory();
+            IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER))
+        ) {
             Document document = new Document();
             document.add(new TextField("_id", "1", Field.Store.YES));
             document.add(new TextField("#id", "1", Field.Store.YES));
@@ -121,9 +130,11 @@ public class SimpleLuceneTests extends ESTestCase {
     }
 
     public void testNRTSearchOnClosedWriter() throws Exception {
-        try (Directory dir = new ByteBuffersDirectory();
-        IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
-             DirectoryReader reader = DirectoryReader.open(indexWriter)) {
+        try (
+            Directory dir = new ByteBuffersDirectory();
+            IndexWriter indexWriter = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
+            DirectoryReader reader = DirectoryReader.open(indexWriter)
+        ) {
             for (int i = 0; i < 100; i++) {
                 Document document = new Document();
                 TextField field = new TextField("_id", Integer.toString(i), Field.Store.YES);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2017,17 +2017,21 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     public static IndexSearcher newSearcher(IndexReader reader) {
         IndexSearcher searcher = LuceneTestCase.newSearcher(reader);
-        ExecutorService executorService = Executors.newFixedThreadPool(1);
-        executorService.execute(() -> {});
-        reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
+        if (reader.getReaderCacheHelper() != null) {
+            ExecutorService executorService = Executors.newFixedThreadPool(1);
+            executorService.execute(() -> {});
+            reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
+        }
         return searcher;
     }
 
     public static IndexSearcher newSearcher(IndexReader reader, boolean maybeWrap) {
         IndexSearcher searcher = LuceneTestCase.newSearcher(reader, maybeWrap);
-        ExecutorService executorService = Executors.newFixedThreadPool(1);
-        executorService.execute(() -> {});
-        reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
+        if (reader.getReaderCacheHelper() != null) {
+            ExecutorService executorService = Executors.newFixedThreadPool(1);
+            executorService.execute(() -> {});
+            reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
+        }
         return searcher;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2014,24 +2014,4 @@ public abstract class ESTestCase extends LuceneTestCase {
         return Locale.getDefault().getLanguage().equals(new Locale("tr").getLanguage())
             || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());
     }
-
-    public static IndexSearcher newSearcher(IndexReader reader) {
-        IndexSearcher searcher = LuceneTestCase.newSearcher(reader);
-        if (reader.getReaderCacheHelper() != null) {
-            ExecutorService executorService = Executors.newFixedThreadPool(1);
-            executorService.execute(() -> {});
-            reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
-        }
-        return searcher;
-    }
-
-    public static IndexSearcher newSearcher(IndexReader reader, boolean maybeWrap) {
-        IndexSearcher searcher = LuceneTestCase.newSearcher(reader, maybeWrap);
-        if (reader.getReaderCacheHelper() != null) {
-            ExecutorService executorService = Executors.newFixedThreadPool(1);
-            executorService.execute(() -> {});
-            reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
-        }
-        return searcher;
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -32,8 +32,6 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.tests.util.TestRuleMarkFailure;

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2015,7 +2015,6 @@ public abstract class ESTestCase extends LuceneTestCase {
             || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());
     }
 
-
     public static IndexSearcher newSearcher(IndexReader reader) {
         IndexSearcher searcher = LuceneTestCase.newSearcher(reader);
         ExecutorService executorService = Executors.newFixedThreadPool(1);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -156,7 +156,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -32,6 +32,8 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.tests.util.TestRuleMarkFailure;
@@ -156,6 +158,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
@@ -2010,5 +2013,22 @@ public abstract class ESTestCase extends LuceneTestCase {
     protected static boolean isTurkishLocale() {
         return Locale.getDefault().getLanguage().equals(new Locale("tr").getLanguage())
             || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());
+    }
+
+
+    public static IndexSearcher newSearcher(IndexReader reader) {
+        IndexSearcher searcher = LuceneTestCase.newSearcher(reader);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        executorService.execute(() -> {});
+        reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
+        return searcher;
+    }
+
+    public static IndexSearcher newSearcher(IndexReader reader, boolean maybeWrap) {
+        IndexSearcher searcher = LuceneTestCase.newSearcher(reader, maybeWrap);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        executorService.execute(() -> {});
+        reader.getReaderCacheHelper().addClosedListener(key -> terminate(executorService));
+        return searcher;
     }
 }


### PR DESCRIPTION
Not closing the index reader in unit tests did not cause issues so far, but it becomes a problem since we use newSearcher more often which randomly sets an executor to the searcher. This is because the executor is shutdown as part of the index reader closing listener, and if the reader is not closed, the test leaks threads which causes test failures.

This is more evident in the lucene_snapshot branch as lucene 9.8 will introduce unconditional offloading of tasks to the executor when provided (including sequential execution). In main, there's many cases where even if we have an executor, it is never used because execution is sequential (single slice) hence it won't leak threads in that case.

This commit fixes the unit tests that use `LuceneTestCase#newSearcher` to create the searcher, which may randomize the executor and need the reader to be closed as that triggers the shutdown of the executor too.