### PR TITLE
[8.9] Update painless-walkthrough.asciidoc (#99263)

### DIFF
--- a/docs/painless/painless-guide/painless-walkthrough.asciidoc
+++ b/docs/painless/painless-guide/painless-walkthrough.asciidoc
@@ -116,7 +116,7 @@ GET hockey/_search
 `doc['myfield'].value` throws an exception if
 the field is missing in a document.
 
-For more dynamic index mappings, you may consider writting a catch equation
+For more dynamic index mappings, you may consider writing a catch equation
 
 ```
 if (!doc.containsKey('myfield') || doc['myfield'].empty) { return "unavailable" } else { return doc['myfield'].value }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Update painless-walkthrough.asciidoc (#99263)](https://github.com/elastic/elasticsearch/pull/99263)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)