### PR TITLE
Support serialization of GeoShapeValue and CartesianShapeValue

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -166,6 +166,7 @@ public class TransportVersions {
     public static final TransportVersion ML_TRAINED_MODEL_PREFIX_STRINGS_ADDED = def(8_535_00_0);
     public static final TransportVersion COUNTED_KEYWORD_ADDED = def(8_536_00_0);
 
+    public static final TransportVersion SHAPE_VALUE_SERIALIZATION_ADDED = def(8_537_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  */
 public final class ByteArrayStreamInput extends StreamInput {
 
-    protected byte[] bytes;
+    private byte[] bytes;
     private int pos;
     private int limit;
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  */
 public final class ByteArrayStreamInput extends StreamInput {
 
-    private byte[] bytes;
+    protected byte[] bytes;
     private int pos;
     private int limit;
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -46,6 +46,8 @@ import org.elasticsearch.xpack.spatial.action.SpatialInfoTransportAction;
 import org.elasticsearch.xpack.spatial.action.SpatialStatsTransportAction;
 import org.elasticsearch.xpack.spatial.action.SpatialUsageTransportAction;
 import org.elasticsearch.xpack.spatial.common.CartesianBoundingBox;
+import org.elasticsearch.xpack.spatial.index.fielddata.CartesianShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeScriptFieldType;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
@@ -201,7 +203,11 @@ public class SpatialPlugin extends Plugin implements ActionPlugin, MapperPlugin,
 
     @Override
     public List<GenericNamedWriteableSpec> getGenericNamedWriteables() {
-        return List.of(new GenericNamedWriteableSpec("CartesianBoundingBox", CartesianBoundingBox::new));
+        return List.of(
+            new GenericNamedWriteableSpec("CartesianBoundingBox", CartesianBoundingBox::new),
+            new GenericNamedWriteableSpec("GeoShapeValue", GeoShapeValues.GeoShapeValue::new),
+            new GenericNamedWriteableSpec("CartesianShapeValue", CartesianShapeValues.CartesianShapeValue::new)
+        );
     }
 
     private static void registerGeoShapeBoundsAggregator(ValuesSourceRegistry.Builder builder) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValues.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.geo.XYGeometry;
 import org.apache.lucene.geo.XYPoint;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -66,6 +67,11 @@ public abstract class CartesianShapeValues extends ShapeValues<CartesianShapeVal
             super(CoordinateEncoder.CARTESIAN, CartesianPoint::new);
         }
 
+        public CartesianShapeValue(StreamInput in) throws IOException {
+            this();
+            this.reset(in);
+        }
+
         @Override
         protected Component2D centroidAsComponent2D() throws IOException {
             return XYGeometry.create(new XYPoint((float) getX(), (float) getY()));
@@ -79,6 +85,11 @@ public abstract class CartesianShapeValues extends ShapeValues<CartesianShapeVal
          */
         public GeoRelation relate(XYGeometry geometry) throws IOException {
             return relate(XYGeometry.create(geometry));
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "CartesianShapeValue";
         }
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -12,6 +12,7 @@ import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.geo.Point;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
@@ -69,6 +70,11 @@ public abstract class GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShape
             this.tile2DVisitor = new Tile2DVisitor();
         }
 
+        public GeoShapeValue(StreamInput in) throws IOException {
+            this();
+            reset(in);
+        }
+
         @Override
         protected Component2D centroidAsComponent2D() throws IOException {
             return LatLonGeometry.create(new Point(getY(), getX()));
@@ -92,6 +98,11 @@ public abstract class GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShape
          */
         public GeoRelation relate(LatLonGeometry geometry) throws IOException {
             return relate(LatLonGeometry.create(geometry));
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "GeoShapeValue";
         }
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
@@ -8,10 +8,7 @@
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 
@@ -38,21 +35,23 @@ import java.io.IOException;
  * -----------------------------------------
  * -----------------------------------------
  */
-public class GeometryDocValueReader implements Writeable {
-    private final GeometryByteArrayReader input;
+public class GeometryDocValueReader {
+    private final ByteArrayStreamInput input;
     private final Extent extent;
     private int treeOffset;
     private int docValueOffset;
+    private BytesRef bytesRef;
 
     public GeometryDocValueReader() {
         this.extent = new Extent();
-        this.input = new GeometryByteArrayReader();
+        this.input = new ByteArrayStreamInput();
     }
 
     /**
      * reset the geometry.
      */
     public void reset(BytesRef bytesRef) throws IOException {
+        this.bytesRef = bytesRef; // Needed only for supporting Writable, maintaining original offset, not adjusted on from input
         this.input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         docValueOffset = bytesRef.offset;
         treeOffset = 0;
@@ -112,17 +111,7 @@ public class GeometryDocValueReader implements Writeable {
         }
     }
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        input.writeTo(out);
+    public BytesRef getBytesRef() {
+        return bytesRef;
     }
-
-    private static class GeometryByteArrayReader extends ByteArrayStreamInput implements Writeable {
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeBytesReference(new BytesArray(bytes));
-        }
-    }
-
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
@@ -8,7 +8,10 @@
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 
@@ -35,15 +38,15 @@ import java.io.IOException;
  * -----------------------------------------
  * -----------------------------------------
  */
-public class GeometryDocValueReader {
-    private final ByteArrayStreamInput input;
+public class GeometryDocValueReader implements Writeable {
+    private final GeometryByteArrayReader input;
     private final Extent extent;
     private int treeOffset;
     private int docValueOffset;
 
     public GeometryDocValueReader() {
         this.extent = new Extent();
-        this.input = new ByteArrayStreamInput();
+        this.input = new GeometryByteArrayReader();
     }
 
     /**
@@ -109,10 +112,17 @@ public class GeometryDocValueReader {
         }
     }
 
-    byte[] copyBytes() {
-        input.setPosition(0);
-        byte[] copy = new byte[input.length()];
-        input.readBytes(copy, 0, copy.length);
-        return copy;
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        input.writeTo(out);
     }
+
+    private static class GeometryByteArrayReader extends ByteArrayStreamInput implements Writeable {
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBytesReference(new BytesArray(bytes));
+        }
+    }
+
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
@@ -109,4 +109,10 @@ public class GeometryDocValueReader {
         }
     }
 
+    byte[] copyBytes() {
+        input.setPosition(0);
+        byte[] copy = new byte[input.length()];
+        input.readBytes(copy, 0, copy.length);
+        return copy;
+    }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -119,10 +119,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         }
 
         protected void reset(StreamInput in) throws IOException {
-            int length = in.readInt();
-            byte[] bytes = new byte[length];
-            int read = in.read(bytes, 0, bytes.length);
-            assert read == length : "Failed to read all bytes";
+            byte[] bytes = in.readByteArray();
             reset(new BytesRef(bytes, 0, bytes.length));
         }
 
@@ -209,7 +206,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             byte[] bytes = this.reader.copyBytes();
-            out.writeInt(bytes.length);
+            out.writeVInt(bytes.length);
             out.write(bytes, 0, bytes.length);
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -209,6 +209,19 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBytesReference(new BytesArray(reader.getBytesRef()));
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof ShapeValue other) {
+                return reader.getBytesRef().equals(other.reader.getBytesRef());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return reader.getBytesRef().hashCode();
+        }
     }
 
     public static class BoundingBox {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -12,7 +12,6 @@ import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.GenericNamedWriteable;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -207,8 +207,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            byte[] bytes = this.reader.copyBytes();
-            out.writeBytesReference(new BytesArray(bytes));
+            this.reader.writeTo(out);
         }
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -12,6 +12,7 @@ import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.GenericNamedWriteable;
@@ -206,7 +207,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            this.reader.writeTo(out);
+            out.writeBytesReference(new BytesArray(reader.getBytesRef()));
         }
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -12,6 +12,8 @@ import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -119,8 +121,8 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         }
 
         protected void reset(StreamInput in) throws IOException {
-            byte[] bytes = in.readByteArray();
-            reset(new BytesRef(bytes, 0, bytes.length));
+            BytesReference bytes = in.readBytesReference();
+            reset(bytes.toBytesRef());
         }
 
         public BoundingBox boundingBox() {
@@ -206,8 +208,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             byte[] bytes = this.reader.copyBytes();
-            out.writeVInt(bytes.length);
-            out.write(bytes, 0, bytes.length);
+            out.writeBytesReference(new BytesArray(bytes));
         }
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
@@ -141,7 +141,11 @@ public class SpatialPluginTests extends ESTestCase {
             .filter(e -> e.categoryClass.equals(GenericNamedWriteable.class))
             .map(e -> e.name)
             .collect(Collectors.toSet());
-        assertThat("Expect both Geo and Cartesian BoundingBox", names, equalTo(Set.of("GeoBoundingBox", "CartesianBoundingBox")));
+        assertThat(
+            "Expect both Geo and Cartesian BoundingBox",
+            names,
+            equalTo(Set.of("GeoBoundingBox", "CartesianBoundingBox", "GeoShapeValue", "CartesianShapeValue"))
+        );
     }
 
     private SpatialPlugin getPluginWithOperationMode(License.OperationMode operationMode) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
@@ -142,7 +142,7 @@ public class SpatialPluginTests extends ESTestCase {
             .map(e -> e.name)
             .collect(Collectors.toSet());
         assertThat(
-            "Expect both Geo and Cartesian BoundingBox",
+            "Expect both Geo and Cartesian BoundingBox and ShapeValue",
             names,
             equalTo(Set.of("GeoBoundingBox", "CartesianBoundingBox", "GeoShapeValue", "CartesianShapeValue"))
         );

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValuesGenericWriteableTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValuesGenericWriteableTests.java
@@ -1,68 +1,32 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
-import org.elasticsearch.common.geo.GeoBoundingBox;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.GenericNamedWriteable;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.test.AbstractWireTestCase;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import java.io.IOException;
-import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
-
-public class CartesianShapeValuesGenericWriteableTests extends AbstractWireTestCase<
-    CartesianShapeValuesGenericWriteableTests.GenericWriteableWrapper> {
-
-    /**
-     * Wrapper around a CartesianShapeValue to verify that it round-trips via {@code writeGenericValue} and {@code readGenericValue}
-     */
-    public record GenericWriteableWrapper(CartesianShapeValues.CartesianShapeValue shapeValue) implements Writeable {
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeGenericValue(shapeValue);
-        }
-
-        public static GenericWriteableWrapper readFrom(StreamInput in) throws IOException {
-            return new GenericWriteableWrapper((CartesianShapeValues.CartesianShapeValue) in.readGenericValue());
-        }
-    }
-
-    private static final NamedWriteableRegistry NAMED_WRITEABLE_REGISTRY = new NamedWriteableRegistry(
-        List.of(
-            new NamedWriteableRegistry.Entry(
-                GenericNamedWriteable.class,
-                CartesianShapeValues.CartesianShapeValue.class.getSimpleName(),
-                CartesianShapeValues.CartesianShapeValue::new
-            )
-        )
-    );
+public class CartesianShapeValuesGenericWriteableTests extends ShapeValuesGenericWriteableTests<CartesianShapeValues.CartesianShapeValue> {
 
     @Override
-    protected NamedWriteableRegistry writableRegistry() {
-        return NAMED_WRITEABLE_REGISTRY;
+    protected String shapeValueName() {
+        return "CartesianShapeValue";
     }
 
     @Override
     protected GenericWriteableWrapper createTestInstance() {
         try {
-            GeoBoundingBox bbox = GeoTestUtils.randomBBox();
-            Rectangle rectangle = new Rectangle(bbox.left(), bbox.right(), bbox.top(), bbox.bottom());
+            double minX = randomDoubleBetween(-Float.MAX_VALUE, 0, false);
+            double minY = randomDoubleBetween(-Float.MAX_VALUE, 0, false);
+            double maxX = randomDoubleBetween(minX + 10, Float.MAX_VALUE, false);
+            double maxY = randomDoubleBetween(minY + 10, Float.MAX_VALUE, false);
+            Rectangle rectangle = new Rectangle(minX, maxX, maxY, minY);
             CartesianShapeValues.CartesianShapeValue shapeValue = GeoTestUtils.cartesianShapeValue(rectangle);
             return new GenericWriteableWrapper(shapeValue);
         } catch (IOException e) {
@@ -72,7 +36,7 @@ public class CartesianShapeValuesGenericWriteableTests extends AbstractWireTestC
 
     @Override
     protected GenericWriteableWrapper mutateInstance(GenericWriteableWrapper instance) throws IOException {
-        CartesianShapeValues.CartesianShapeValue shapeValue = instance.shapeValue;
+        ShapeValues.ShapeValue shapeValue = instance.shapeValue();
         ShapeValues.BoundingBox bbox = shapeValue.boundingBox();
         double height = bbox.maxY() - bbox.minY();
         double width = bbox.maxX() - bbox.minX();
@@ -80,23 +44,5 @@ public class CartesianShapeValuesGenericWriteableTests extends AbstractWireTestC
         double ys = height * 0.001;
         Rectangle rectangle = new Rectangle(bbox.minX() + xs, bbox.maxX() - xs, bbox.maxY() - ys, bbox.minY() + ys);
         return new GenericWriteableWrapper(GeoTestUtils.cartesianShapeValue(rectangle));
-    }
-
-    @Override
-    protected GenericWriteableWrapper copyInstance(GenericWriteableWrapper instance, TransportVersion version) throws IOException {
-        return copyInstance(instance, writableRegistry(), StreamOutput::writeWriteable, GenericWriteableWrapper::readFrom, version);
-    }
-
-    public void testSerializationFailsWithOlderVersion() {
-        TransportVersion older = TransportVersions.KNN_AS_QUERY_ADDED;
-        assert older.before(TransportVersions.SHAPE_VALUE_SERIALIZATION_ADDED);
-        final var testInstance = createTestInstance().shapeValue();
-        try (var output = new BytesStreamOutput()) {
-            output.setTransportVersion(older);
-            assertThat(
-                expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
-                containsString("[CartesianShapeValue] requires minimal transport version")
-            );
-        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValuesGenericWriteableTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValuesGenericWriteableTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.geo.GeoBoundingBox;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.test.AbstractWireTestCase;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class CartesianShapeValuesGenericWriteableTests extends AbstractWireTestCase<
+    CartesianShapeValuesGenericWriteableTests.GenericWriteableWrapper> {
+
+    /**
+     * Wrapper around a CartesianShapeValue to verify that it round-trips via {@code writeGenericValue} and {@code readGenericValue}
+     */
+    public record GenericWriteableWrapper(CartesianShapeValues.CartesianShapeValue shapeValue) implements Writeable {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeGenericValue(shapeValue);
+        }
+
+        public static GenericWriteableWrapper readFrom(StreamInput in) throws IOException {
+            return new GenericWriteableWrapper((CartesianShapeValues.CartesianShapeValue) in.readGenericValue());
+        }
+    }
+
+    private static final NamedWriteableRegistry NAMED_WRITEABLE_REGISTRY = new NamedWriteableRegistry(
+        List.of(
+            new NamedWriteableRegistry.Entry(
+                GenericNamedWriteable.class,
+                CartesianShapeValues.CartesianShapeValue.class.getSimpleName(),
+                CartesianShapeValues.CartesianShapeValue::new
+            )
+        )
+    );
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return NAMED_WRITEABLE_REGISTRY;
+    }
+
+    @Override
+    protected GenericWriteableWrapper createTestInstance() {
+        try {
+            GeoBoundingBox bbox = GeoTestUtils.randomBBox();
+            Rectangle rectangle = new Rectangle(bbox.left(), bbox.right(), bbox.top(), bbox.bottom());
+            CartesianShapeValues.CartesianShapeValue shapeValue = GeoTestUtils.cartesianShapeValue(rectangle);
+            return new GenericWriteableWrapper(shapeValue);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected GenericWriteableWrapper mutateInstance(GenericWriteableWrapper instance) throws IOException {
+        CartesianShapeValues.CartesianShapeValue shapeValue = instance.shapeValue;
+        ShapeValues.BoundingBox bbox = shapeValue.boundingBox();
+        double height = bbox.maxY() - bbox.minY();
+        double width = bbox.maxX() - bbox.minX();
+        double xs = width * 0.001;
+        double ys = height * 0.001;
+        Rectangle rectangle = new Rectangle(bbox.minX() + xs, bbox.maxX() - xs, bbox.maxY() - ys, bbox.minY() + ys);
+        return new GenericWriteableWrapper(GeoTestUtils.cartesianShapeValue(rectangle));
+    }
+
+    @Override
+    protected GenericWriteableWrapper copyInstance(GenericWriteableWrapper instance, TransportVersion version) throws IOException {
+        return copyInstance(instance, writableRegistry(), StreamOutput::writeWriteable, GenericWriteableWrapper::readFrom, version);
+    }
+
+    public void testSerializationFailsWithOlderVersion() {
+        TransportVersion older = TransportVersions.KNN_AS_QUERY_ADDED;
+        assert older.before(TransportVersions.SHAPE_VALUE_SERIALIZATION_ADDED);
+        final var testInstance = createTestInstance().shapeValue();
+        try (var output = new BytesStreamOutput()) {
+            output.setTransportVersion(older);
+            assertThat(
+                expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
+                containsString("[CartesianShapeValue] requires minimal transport version")
+            );
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValuesGenericWriteableTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValuesGenericWriteableTests.java
@@ -1,60 +1,23 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.geo.GeoBoundingBox;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.GenericNamedWriteable;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.test.AbstractWireTestCase;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import java.io.IOException;
-import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
-
-public class GeoShapeValuesGenericWriteableTests extends AbstractWireTestCase<GeoShapeValuesGenericWriteableTests.GenericWriteableWrapper> {
-
-    /**
-     * Wrapper around a GeoShapeValue to verify that it round-trips via {@code writeGenericValue} and {@code readGenericValue}
-     */
-    public record GenericWriteableWrapper(GeoShapeValues.GeoShapeValue shapeValue) implements Writeable {
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeGenericValue(shapeValue);
-        }
-
-        public static GenericWriteableWrapper readFrom(StreamInput in) throws IOException {
-            return new GenericWriteableWrapper((GeoShapeValues.GeoShapeValue) in.readGenericValue());
-        }
-    }
-
-    private static final NamedWriteableRegistry NAMED_WRITEABLE_REGISTRY = new NamedWriteableRegistry(
-        List.of(
-            new NamedWriteableRegistry.Entry(
-                GenericNamedWriteable.class,
-                GeoShapeValues.GeoShapeValue.class.getSimpleName(),
-                GeoShapeValues.GeoShapeValue::new
-            )
-        )
-    );
+public class GeoShapeValuesGenericWriteableTests extends ShapeValuesGenericWriteableTests<GeoShapeValues.GeoShapeValue> {
 
     @Override
-    protected NamedWriteableRegistry writableRegistry() {
-        return NAMED_WRITEABLE_REGISTRY;
+    protected String shapeValueName() {
+        return "GeoShapeValue";
     }
 
     @Override
@@ -71,7 +34,7 @@ public class GeoShapeValuesGenericWriteableTests extends AbstractWireTestCase<Ge
 
     @Override
     protected GenericWriteableWrapper mutateInstance(GenericWriteableWrapper instance) throws IOException {
-        GeoShapeValues.GeoShapeValue shapeValue = instance.shapeValue;
+        ShapeValues.ShapeValue shapeValue = instance.shapeValue();
         ShapeValues.BoundingBox bbox = shapeValue.boundingBox();
         double height = bbox.maxY() - bbox.minY();
         double width = bbox.maxX() - bbox.minX();
@@ -79,23 +42,5 @@ public class GeoShapeValuesGenericWriteableTests extends AbstractWireTestCase<Ge
         double ys = height * 0.001;
         Rectangle rectangle = new Rectangle(bbox.minX() + xs, bbox.maxX() - xs, bbox.maxY() - ys, bbox.minY() + ys);
         return new GenericWriteableWrapper(GeoTestUtils.geoShapeValue(rectangle));
-    }
-
-    @Override
-    protected GenericWriteableWrapper copyInstance(GenericWriteableWrapper instance, TransportVersion version) throws IOException {
-        return copyInstance(instance, writableRegistry(), StreamOutput::writeWriteable, GenericWriteableWrapper::readFrom, version);
-    }
-
-    public void testSerializationFailsWithOlderVersion() {
-        TransportVersion older = TransportVersions.KNN_AS_QUERY_ADDED;
-        assert older.before(TransportVersions.SHAPE_VALUE_SERIALIZATION_ADDED);
-        final var testInstance = createTestInstance().shapeValue();
-        try (var output = new BytesStreamOutput()) {
-            output.setTransportVersion(older);
-            assertThat(
-                expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
-                containsString("[GeoShapeValue] requires minimal transport version")
-            );
-        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValuesGenericWriteableTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValuesGenericWriteableTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.geo.GeoBoundingBox;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.test.AbstractWireTestCase;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class GeoShapeValuesGenericWriteableTests extends AbstractWireTestCase<GeoShapeValuesGenericWriteableTests.GenericWriteableWrapper> {
+
+    /**
+     * Wrapper around a GeoShapeValue to verify that it round-trips via {@code writeGenericValue} and {@code readGenericValue}
+     */
+    public record GenericWriteableWrapper(GeoShapeValues.GeoShapeValue shapeValue) implements Writeable {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeGenericValue(shapeValue);
+        }
+
+        public static GenericWriteableWrapper readFrom(StreamInput in) throws IOException {
+            return new GenericWriteableWrapper((GeoShapeValues.GeoShapeValue) in.readGenericValue());
+        }
+    }
+
+    private static final NamedWriteableRegistry NAMED_WRITEABLE_REGISTRY = new NamedWriteableRegistry(
+        List.of(
+            new NamedWriteableRegistry.Entry(
+                GenericNamedWriteable.class,
+                GeoShapeValues.GeoShapeValue.class.getSimpleName(),
+                GeoShapeValues.GeoShapeValue::new
+            )
+        )
+    );
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return NAMED_WRITEABLE_REGISTRY;
+    }
+
+    @Override
+    protected GenericWriteableWrapper createTestInstance() {
+        try {
+            GeoBoundingBox bbox = GeoTestUtils.randomBBox();
+            Rectangle rectangle = new Rectangle(bbox.left(), bbox.right(), bbox.top(), bbox.bottom());
+            GeoShapeValues.GeoShapeValue shapeValue = GeoTestUtils.geoShapeValue(rectangle);
+            return new GenericWriteableWrapper(shapeValue);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected GenericWriteableWrapper mutateInstance(GenericWriteableWrapper instance) throws IOException {
+        GeoShapeValues.GeoShapeValue shapeValue = instance.shapeValue;
+        ShapeValues.BoundingBox bbox = shapeValue.boundingBox();
+        double height = bbox.maxY() - bbox.minY();
+        double width = bbox.maxX() - bbox.minX();
+        double xs = width * 0.001;
+        double ys = height * 0.001;
+        Rectangle rectangle = new Rectangle(bbox.minX() + xs, bbox.maxX() - xs, bbox.maxY() - ys, bbox.minY() + ys);
+        return new GenericWriteableWrapper(GeoTestUtils.geoShapeValue(rectangle));
+    }
+
+    @Override
+    protected GenericWriteableWrapper copyInstance(GenericWriteableWrapper instance, TransportVersion version) throws IOException {
+        return copyInstance(instance, writableRegistry(), StreamOutput::writeWriteable, GenericWriteableWrapper::readFrom, version);
+    }
+
+    public void testSerializationFailsWithOlderVersion() {
+        TransportVersion older = TransportVersions.KNN_AS_QUERY_ADDED;
+        assert older.before(TransportVersions.SHAPE_VALUE_SERIALIZATION_ADDED);
+        final var testInstance = createTestInstance().shapeValue();
+        try (var output = new BytesStreamOutput()) {
+            output.setTransportVersion(older);
+            assertThat(
+                expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
+                containsString("[GeoShapeValue] requires minimal transport version")
+            );
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValuesGenericWriteableTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValuesGenericWriteableTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+
+public abstract class ShapeValuesGenericWriteableTests<T extends ShapeValues.ShapeValue> extends AbstractWireTestCase<
+    ShapeValuesGenericWriteableTests.GenericWriteableWrapper> {
+
+    /**
+     * Wrapper around a GeoShapeValue to verify that it round-trips via {@code writeGenericValue} and {@code readGenericValue}
+     */
+    public record GenericWriteableWrapper(ShapeValues.ShapeValue shapeValue) implements Writeable {
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeGenericValue(shapeValue);
+        }
+
+        public static GenericWriteableWrapper readFrom(StreamInput in) throws IOException {
+            return new GenericWriteableWrapper((ShapeValues.ShapeValue) in.readGenericValue());
+        }
+    }
+
+    private static final NamedWriteableRegistry NAMED_WRITEABLE_REGISTRY = new NamedWriteableRegistry(
+        List.of(
+            new NamedWriteableRegistry.Entry(
+                GenericNamedWriteable.class,
+                GeoShapeValues.GeoShapeValue.class.getSimpleName(),
+                GeoShapeValues.GeoShapeValue::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                GenericNamedWriteable.class,
+                CartesianShapeValues.CartesianShapeValue.class.getSimpleName(),
+                CartesianShapeValues.CartesianShapeValue::new
+            )
+        )
+    );
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return NAMED_WRITEABLE_REGISTRY;
+    }
+
+    @Override
+    protected GenericWriteableWrapper copyInstance(GenericWriteableWrapper instance, TransportVersion version) throws IOException {
+        return copyInstance(instance, writableRegistry(), StreamOutput::writeWriteable, GenericWriteableWrapper::readFrom, version);
+    }
+
+    protected abstract String shapeValueName();
+
+    public void testSerializationFailsWithOlderVersion() {
+        TransportVersion older = TransportVersions.KNN_AS_QUERY_ADDED;
+        assert older.before(TransportVersions.SHAPE_VALUE_SERIALIZATION_ADDED);
+        final var testInstance = createTestInstance().shapeValue();
+        try (var output = new BytesStreamOutput()) {
+            output.setTransportVersion(older);
+            assertThat(
+                expectThrows(Throwable.class, () -> output.writeGenericValue(testInstance)).getMessage(),
+                containsString("[" + shapeValueName() + "] requires minimal transport version")
+            );
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.spatial.index.fielddata.CartesianShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.CentroidCalculator;
 import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
@@ -67,6 +68,12 @@ public class GeoTestUtils {
     public static GeoShapeValues.GeoShapeValue geoShapeValue(Geometry geometry) throws IOException {
         GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue();
         value.reset(binaryGeoShapeDocValuesField("test", geometry).binaryValue());
+        return value;
+    }
+
+    public static CartesianShapeValues.CartesianShapeValue cartesianShapeValue(Geometry geometry) throws IOException {
+        CartesianShapeValues.CartesianShapeValue value = new CartesianShapeValues.CartesianShapeValue();
+        value.reset(binaryCartesianShapeDocValuesField("test", geometry).binaryValue());
         return value;
     }
 


### PR DESCRIPTION
In serverless testing the suite of YAML tests in xpack is run, and in the case of xpack.spatial all tests involving GeoBoundingBox and GeoShape were failing. The former was an actual bug in production, reported as such at https://github.com/elastic/elasticsearch/issues/99089, and fixed in https://github.com/elastic/elasticsearch/pull/99163. But the later is a more subtle case, and could be seen as a test failure.

The issue is that serialization of `GeoShapeValues.GeoShapeValue` using `XContentBuilder` is explicitly not supported for scripts, and the test asserts that using a script to pull out such a field will result in the string `<unserializable>` being returned. This works in the YAML tests as long as they are run in a single-node cluster. But in a multi-node cluster (which serverless always is), we also need to deal with `StreamOutput` and `StreamInput`. These do not support this type and throw an IllegalArgumentException, which in YAML tests cases the server instance to terminate, killing all subsequent tests.

This PR extends the solution used in https://github.com/elastic/elasticsearch/pull/99163, which means to support serialization in StreamOuput/StreamInput, even though final rendering will still not be supported.

Tasks:

- [x] Implement GenericNamedWriteable (similar to https://github.com/elastic/elasticsearch/pull/99163)
- [x] Manual testing with a multi-node cluster to verify this fixes #99266
- [x] Unit tests for version checking
- [x] Unit tests for serialization of GeoShapeValue and CartesianShapeValue

Fixes #99266