### PR TITLE
update by query should not enable _source in context, since it maybe cause lost fields

### DIFF
--- a/docs/changelog/99302.yaml
+++ b/docs/changelog/99302.yaml
@@ -1,0 +1,5 @@
+pr: 99302
+summary: update by query should not enable _source context, since it maybe cause other fields lost
+area: Data Management
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
@@ -8,17 +8,21 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
  * Request to update some documents. That means you can't change their type, id, index, or anything like that. This implements
@@ -183,5 +187,17 @@ public class UpdateByQueryRequest extends AbstractBulkIndexByScrollRequest<Updat
         getSearchRequest().source().innerToXContent(builder, params);
         builder.endObject();
         return builder;
+    }
+
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException e = super.validate();
+
+        FetchSourceContext fetchSourceContext = getSearchRequest().source().fetchSource();
+        if (fetchSourceContext != null) {
+            e = addValidationError("source is not supported in this context", e);
+        }
+        return e;
     }
 }


### PR DESCRIPTION
Hi, when I use `_update_by_query` with `script` and `_source` to update field value, I found `_update_by_query` will remove fields that not include in `_source`,  it's very confused. so I think maybe it's better to disable `_source` in `_ update_by_query` context to avoid this strange behavior.

**How to reproduce**:

```
PUT foo/_doc/1
{
  "f1": "hello",
  "f2": "world"
}

PUT foo/_doc/2
{
  "f1": "hello",
  "f2": "world"
}

POST foo/_search
{
  "query": {
    "bool": {
      "must": [
      ]
    }
  }
}

POST foo/_update_by_query
{
  "_source": ["f1"],  #only include f1 field
  "script" : {
    "source": "ctx._source.f1='h'",  #script update f1 field
    "lang": "painless",
    "params" : {
      "count" : 4
    }
  },
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "f1": "hello"
          }
        }
      ]
    }
  }
}
```
after `POST foo/_update_by_query` executed, the `f2` field will be removed(`ingest pipeline` or other way with `_source` also will meet this issue).

and I think the root cause of this issue is caused by when we use scroll query to fetch docs to reindex doc,  if search context include `_source`, the fetched doc will only include `_source` fields to reindex, it will lost other fields. 

```
org.elasticsearch.reindex.AbstractAsyncBulkByScrollAction#prepareSearchRequest
```

so maybe the best and simplest way to avoid this scenario we can just disable `_source` in `_update_by_query` context.



