### PR TITLE
Use DEBUG log level to report ESQL execution steps

### DIFF
--- a/docs/changelog/99303.yaml
+++ b/docs/changelog/99303.yaml
@@ -1,0 +1,5 @@
+pr: 99303
+summary: Use DEBUG log level to report ESQL execution steps
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -250,16 +250,16 @@ public class ComputeService {
                 new EsPhysicalOperationProviders(context.searchContexts)
             );
 
-            LOGGER.info("Received physical plan:\n{}", plan);
+            LOGGER.debug("Received physical plan:\n{}", plan);
             plan = PlannerUtils.localPlan(context.searchContexts, context.configuration, plan);
             LocalExecutionPlanner.LocalExecutionPlan localExecutionPlan = planner.plan(plan);
 
-            LOGGER.info("Local execution plan:\n{}", localExecutionPlan.describe());
+            LOGGER.debug("Local execution plan:\n{}", localExecutionPlan.describe());
             drivers = localExecutionPlan.createDrivers(context.sessionId);
             if (drivers.isEmpty()) {
                 throw new IllegalStateException("no drivers created");
             }
-            LOGGER.info("using {} drivers", drivers.size());
+            LOGGER.debug("using {} drivers", drivers.size());
         } catch (Exception e) {
             listener.onFailure(e);
             return;


### PR DESCRIPTION
Logging the physical and local execution plans is helpful for debugging, but may be too verbose for INFO level logs, which are generally user-facing.

Demote logging of physical plans, local execution plans as well as number of drivers to DEBUG.