### PR TITLE
More ESQL CSV deterministic tests (part 4)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -150,7 +150,7 @@ y:date                        | count(emp_no):long
 ;
 
 in
-from employees | eval x = date_trunc(1 year, hire_date) | where birth_date not in (x, hire_date) | keep x, hire_date | sort x desc | limit 4;
+from employees | eval x = date_trunc(1 year, hire_date) | where birth_date not in (x, hire_date) | keep x, hire_date | sort x desc, hire_date | limit 4;
 
 x:date                  |hire_date:date
 1999-01-01T00:00:00.000Z|1999-04-30T00:00:00.000Z

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -356,21 +356,21 @@ c:long | languages.long:long | trunk_worked_seconds:long
 ;
 
 byUnmentionedIntAndLong
-from employees | eval trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000 | stats c = count(gender) by languages, trunk_worked_seconds | sort c desc, trunk_worked_seconds;
+from employees | eval trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000 | stats c = count(gender) by languages, trunk_worked_seconds | sort c desc, languages, trunk_worked_seconds;
 
 c:long | languages:integer | trunk_worked_seconds:long
 13             |5              |300000000           
 10             |2              |300000000           
 9              |3              |200000000           
 9              |4              |300000000           
-8              |4              |200000000           
 8              |3              |300000000           
+8              |4              |200000000           
 7              |1              |200000000           
+6              |1              |300000000           
 6              |2              |200000000           
 6              |null           |300000000           
-6              |1              |300000000           
-4              |null           |200000000           
 4              |5              |200000000       
+4              |null           |200000000           
 ;
 
 byUnmentionedIntAndBoolean


### PR DESCRIPTION
As for https://github.com/elastic/elasticsearch/pull/99152 and https://github.com/elastic/elasticsearch/pull/99086

Adding more deterministic SORT to CSV tests to avoid failures in multi-node