### PR TITLE
[DOC+] ILM Searchable Snapshot migrations require repository "name" overlap

### DIFF
--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -17,6 +17,8 @@ PUT /_snapshot/my_repository
 }
 ----
 
+IMPORTANT: If you're migrating {ref}/searchable-snapshots.html[searchable snapshots], the repository's name must be identical in the source and destination clusters.
+
 [[put-snapshot-repo-api-request]]
 ==== {api-request-title}
 


### PR DESCRIPTION
👋 howdy, team! Expanding reference to [internal](https://github.com/elastic/cloud/pull/118105) update, we've just confirmed ILM requires the repository `name` to be the same among migrating clusters. This is a hard block for Searchable Snapshots which requires un-Searchable-Snapshotting or redoing migration to resolve.