### PR TITLE
ESQL: "params" correctly parses the values including an optional "type"

### DIFF
--- a/docs/changelog/99310.yaml
+++ b/docs/changelog/99310.yaml
@@ -1,0 +1,6 @@
+pr: 99310
+summary: "ESQL: \"params\" correctly parses the values including an optional \"type\""
+area: ES|QL
+type: bug
+issues:
+ - 99294

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -297,3 +297,29 @@ setup:
   - match: {columns.2.type: "keyword"}
   - length: {values: 1}
   - match: {values.0: [1, 44, "green"]}
+
+---
+"Test Mixed Input Params":
+  - do:
+      esql.query:
+        body:
+          query: 'from test | eval x = ?, y = ?, z = ?, t = ?, u = ?, v = ? | keep x, y, z, t, u, v | limit 3'
+          params: [{"value": 1, "type": "keyword"}, {"value": 2, "type": "double"}, null, true, 123, {"value": 123, "type": "long"}]
+
+  - length: {columns: 6}
+  - match: {columns.0.name: "x"}
+  - match: {columns.0.type: "keyword"}
+  - match: {columns.1.name: "y"}
+  - match: {columns.1.type: "double"}
+  - match: {columns.2.name: "z"}
+  - match: {columns.2.type: "null"}
+  - match: {columns.3.name: "t"}
+  - match: {columns.3.type: "boolean"}
+  - match: {columns.4.name: "u"}
+  - match: {columns.4.type: "integer"}
+  - match: {columns.5.name: "v"}
+  - match: {columns.5.type: "long"}
+  - length: {values: 3}
+  - match: {values.0: ["1",2.0,null,true,123,123]}
+  - match: {values.1: ["1",2.0,null,true,123,123]}
+  - match: {values.2: ["1",2.0,null,true,123,123]}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
@@ -135,7 +135,7 @@ public class EsqlParser {
             Token token = delegate.nextToken();
             if (token.getType() == EsqlBaseLexer.PARAM) {
                 if (param >= params.size()) {
-                    throw new ParsingException("Not enough actual parameters {} ", params.size());
+                    throw new ParsingException("Not enough actual parameters {}", params.size());
                 }
                 paramTokens.put(token, params.get(param));
                 param++;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
@@ -23,13 +23,16 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.esql.parser.TypedParamValue;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -42,33 +45,18 @@ public class EsqlQueryRequestTests extends ESTestCase {
         ZoneId zoneId = randomZone();
         Locale locale = randomLocale(random());
         QueryBuilder filter = randomQueryBuilder();
-        List<Object> params = randomList(5, () -> randomBoolean() ? randomInt(100) : randomAlphaOfLength(10));
-        StringBuilder paramsString = new StringBuilder();
-        paramsString.append("[");
-        boolean first = true;
-        for (Object param : params) {
-            if (first == false) {
-                paramsString.append(", ");
-            }
-            first = false;
-            if (param instanceof String) {
-                paramsString.append("\"");
-                paramsString.append(param);
-                paramsString.append("\"");
-            } else {
-                paramsString.append(param);
-            }
-        }
-        paramsString.append("]");
+
+        List<TypedParamValue> params = randomParameters();
+        boolean hasParams = params.isEmpty() == false;
+        StringBuilder paramsString = paramsString(params, hasParams);
         String json = String.format(Locale.ROOT, """
             {
                 "query": "%s",
                 "columnar": %s,
                 "time_zone": "%s",
                 "locale": "%s",
-                "filter": %s,
-                "params": %s
-            }""", query, columnar, zoneId, locale.toLanguageTag(), filter, paramsString);
+                "filter": %s
+                %s""", query, columnar, zoneId, locale.toLanguageTag(), filter, paramsString);
 
         EsqlQueryRequest request = parseEsqlQueryRequest(json);
 
@@ -81,7 +69,7 @@ public class EsqlQueryRequestTests extends ESTestCase {
 
         assertEquals(params.size(), request.params().size());
         for (int i = 0; i < params.size(); i++) {
-            assertEquals(params.get(i), request.params().get(i).value);
+            assertEquals(params.get(i), request.params().get(i));
         }
     }
 
@@ -134,6 +122,65 @@ public class EsqlQueryRequestTests extends ESTestCase {
             .replaceAll("41770830", Long.toString(taskInfo.runningTimeNanos()))
             .trim();
         assertThat(json, equalTo(expected));
+    }
+
+    private List<TypedParamValue> randomParameters() {
+        if (randomBoolean()) {
+            return Collections.emptyList();
+        } else {
+            int len = randomIntBetween(1, 10);
+            List<TypedParamValue> arr = new ArrayList<>(len);
+            for (int i = 0; i < len; i++) {
+                boolean hasExplicitType = randomBoolean();
+                @SuppressWarnings("unchecked")
+                Supplier<TypedParamValue> supplier = randomFrom(
+                    () -> new TypedParamValue("boolean", randomBoolean(), hasExplicitType),
+                    () -> new TypedParamValue("integer", randomInt(), hasExplicitType),
+                    () -> new TypedParamValue("long", randomLong(), hasExplicitType),
+                    () -> new TypedParamValue("double", randomDouble(), hasExplicitType),
+                    () -> new TypedParamValue("null", null, hasExplicitType),
+                    () -> new TypedParamValue("keyword", randomAlphaOfLength(10), hasExplicitType)
+                );
+                arr.add(supplier.get());
+            }
+            return Collections.unmodifiableList(arr);
+        }
+    }
+
+    private StringBuilder paramsString(List<TypedParamValue> params, boolean hasParams) {
+        StringBuilder paramsString = new StringBuilder();
+        if (hasParams) {
+            paramsString.append(",\"params\":[");
+            boolean first = true;
+            for (TypedParamValue param : params) {
+                if (first == false) {
+                    paramsString.append(", ");
+                }
+                first = false;
+                if (param.hasExplicitType()) {
+                    paramsString.append("{\"type\":\"");
+                    paramsString.append(param.type);
+                    paramsString.append("\",\"value\":");
+                }
+                switch (param.type) {
+                    case "keyword" -> {
+                        paramsString.append("\"");
+                        paramsString.append(param.value);
+                        paramsString.append("\"");
+                    }
+                    case "integer", "long", "boolean", "null", "double" -> {
+                        paramsString.append(param.value);
+                    }
+                }
+                if (param.hasExplicitType()) {
+                    paramsString.append("}");
+                }
+            }
+            paramsString.append("]}");
+        } else {
+            paramsString.append("}");
+        }
+        return paramsString;
     }
 
     private static void assertParserErrorMessage(String json, String message) {


### PR DESCRIPTION
Fixes #99294.
It's also supporting an optional `type` & `value` combination:

```
{
  "query": "from test | eval x = ?, y = ?",
  "params": [{"type": "double", "value": 12345}, "abc"]
}
```