### PR TITLE
[DOCS] Fix syntax errors in Docker docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -133,7 +133,7 @@ credentials using the following commands.
 --
 [source,sh,subs="attributes"]
 ----
-docker exec -it es01 /usr/share/elasticsearch/bin/elasticsearch-reset-password
+docker exec -it es01 /usr/share/elasticsearch/bin/elasticsearch-reset-password -u elastic
 docker exec -it es01 /usr/share/elasticsearch/bin/elasticsearch-create-enrollment-token -s kibana
 ----
 
@@ -202,28 +202,32 @@ curl --cacert http_ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200/_c
 
 . Pull the {kib} Docker image.
 +
+--
 ifeval::["{release-state}"=="unreleased"]
 WARNING: Version {version} of {kib} has not yet been released, so no
 Docker image is currently available for this version.
 endif::[]
-+
+
 [source,sh,subs="attributes"]
 ----
 docker pull {kib-docker-image}
 ----
+--
 
 . Optional: Verify the {kib} image's signature.
 +
+--
 ifeval::["{release-state}"=="unreleased"]
 WARNING: Version {version} of {kib} has not yet been released, so no
 Docker image signature is currently available for this version.
 endif::[]
-+
+
 [source,sh,subs="attributes"]
 ----
 wget https://artifacts.elastic.co/cosign.pub
 cosign verify --key cosign.pub {kib-docker-image}
 ----
+--
 
 . Start a {kib} container.
 +
@@ -251,7 +255,7 @@ To regenerate the password, run:
 +
 [source,sh]
 ----
-docker exec -it es01 /usr/share/elasticsearch/bin/elasticsearch-reset-password
+docker exec -it es01 /usr/share/elasticsearch/bin/elasticsearch-reset-password -u elastic
 ----
 
 [[remove-containers-docker]]


### PR DESCRIPTION
**Problem:**
- The `elasticsearch-reset-password` commands in the ES Docker install docs are missing the required `-u` flag
- The `ifeval` blocks in the Kibana section of the ES Docker install docs aren't rendering correctly in released docs.

<details>
<summary><strong>Before</strong></summary>

<img width="856" alt="Screenshot 2023-09-07 at 11 57 30 AM" src="https://github.com/elastic/elasticsearch/assets/40268737/db4e866e-92b2-45f3-be10-469599fc008c">

</details>


**Solution:**
- Add the `-u` flag to `elasticsearch-reset-password` examples
- Fix the Asciidoc syntax to correctly render the `ifeval` blocks. Example:

<details>
<summary><strong>After</strong></summary>

<img width="862" alt="Screenshot 2023-09-07 at 11 59 52 AM" src="https://github.com/elastic/elasticsearch/assets/40268737/c159f819-c847-4580-9dc9-e15e807ecff2">

</details>

Rel: https://github.com/elastic/elasticsearch/pull/99112

