### PR TITLE
Migrate ListenerTimeouts away from name-based executor

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/ListenerTimeouts.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ListenerTimeouts.java
@@ -14,6 +14,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -35,7 +36,7 @@ public class ListenerTimeouts {
         ThreadPool threadPool,
         ActionListener<Response> listener,
         TimeValue timeout,
-        String executor,
+        Executor executor,
         String listenerName
     ) {
         return wrapWithTimeout(threadPool, timeout, executor, listener, (ignore) -> {
@@ -58,7 +59,7 @@ public class ListenerTimeouts {
     public static <Response> ActionListener<Response> wrapWithTimeout(
         ThreadPool threadPool,
         TimeValue timeout,
-        String executor,
+        Executor executor,
         ActionListener<Response> listener,
         Consumer<ActionListener<Response>> onTimeout
     ) {

--- a/server/src/main/java/org/elasticsearch/action/support/ListenerTimeouts.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ListenerTimeouts.java
@@ -68,6 +68,22 @@ public class ListenerTimeouts {
         return wrappedListener;
     }
 
+    /**
+     * @deprecated Use {@link #wrapWithTimeout(ThreadPool, TimeValue, Executor, ActionListener, Consumer)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public static <Response> ActionListener<Response> wrapWithTimeout(
+        ThreadPool threadPool,
+        TimeValue timeout,
+        String executor,
+        ActionListener<Response> listener,
+        Consumer<ActionListener<Response>> onTimeout
+    ) {
+        TimeoutableListener<Response> wrappedListener = new TimeoutableListener<>(listener, onTimeout);
+        wrappedListener.cancellable = threadPool.schedule(wrappedListener, timeout, executor);
+        return wrappedListener;
+    }
+
     private static class TimeoutableListener<Response> implements ActionListener<Response>, Runnable {
 
         private final AtomicBoolean isDone = new AtomicBoolean(false);

--- a/server/src/test/java/org/elasticsearch/action/support/ListenerTimeoutsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ListenerTimeoutsTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -25,13 +26,16 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 public class ListenerTimeoutsTests extends ESTestCase {
 
     private final TimeValue timeout = TimeValue.timeValueMillis(10);
-    private final String generic = ThreadPool.Names.GENERIC;
     private DeterministicTaskQueue taskQueue;
+    private ThreadPool threadPool;
+    private Executor timeoutExecutor;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
         taskQueue = new DeterministicTaskQueue();
+        threadPool = taskQueue.getThreadPool();
+        timeoutExecutor = threadPool.generic();
     }
 
     public void testListenerTimeout() {
@@ -39,7 +43,7 @@ public class ListenerTimeoutsTests extends ESTestCase {
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<Void> listener = wrap(success, exception);
 
-        ActionListener<Void> wrapped = ListenerTimeouts.wrapWithTimeout(taskQueue.getThreadPool(), listener, timeout, generic, "test");
+        ActionListener<Void> wrapped = ListenerTimeouts.wrapWithTimeout(threadPool, listener, timeout, timeoutExecutor, "test");
         assertTrue(taskQueue.hasDeferredTasks());
         taskQueue.advanceTime();
         taskQueue.runAllRunnableTasks();
@@ -56,7 +60,7 @@ public class ListenerTimeoutsTests extends ESTestCase {
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<Void> listener = wrap(success, exception);
 
-        ActionListener<Void> wrapped = ListenerTimeouts.wrapWithTimeout(taskQueue.getThreadPool(), listener, timeout, generic, "test");
+        ActionListener<Void> wrapped = ListenerTimeouts.wrapWithTimeout(threadPool, listener, timeout, timeoutExecutor, "test");
         wrapped.onResponse(null);
         wrapped.onFailure(new IOException("boom"));
         wrapped.onResponse(null);
@@ -74,7 +78,7 @@ public class ListenerTimeoutsTests extends ESTestCase {
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<Void> listener = wrap(success, exception);
 
-        ActionListener<Void> wrapped = ListenerTimeouts.wrapWithTimeout(taskQueue.getThreadPool(), listener, timeout, generic, "test");
+        ActionListener<Void> wrapped = ListenerTimeouts.wrapWithTimeout(threadPool, listener, timeout, timeoutExecutor, "test");
         wrapped.onFailure(new IOException("boom"));
 
         assertTrue(taskQueue.hasDeferredTasks());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -583,6 +583,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                 response.getStoreFileMetadata(),
                 response.getMappingVersion(),
                 threadPool,
+                chunkResponseExecutor,
                 ccrSettings,
                 throttledTime::inc,
                 leaderShardId
@@ -595,7 +596,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                 threadPool,
                 responseListener,
                 ccrSettings.getRecoveryActionTimeout(),
-                ThreadPool.Names.GENERIC,
+                chunkResponseExecutor,
                 PutCcrRestoreSessionAction.INTERNAL_NAME
             )
         );
@@ -611,6 +612,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         private final CcrSettings ccrSettings;
         private final LongConsumer throttleListener;
         private final ThreadPool threadPool;
+        private final Executor timeoutExecutor;
         private final ShardId leaderShardId;
 
         RestoreSession(
@@ -623,6 +625,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             Store.MetadataSnapshot sourceMetadata,
             long mappingVersion,
             ThreadPool threadPool,
+            Executor timeoutExecutor,
             CcrSettings ccrSettings,
             LongConsumer throttleListener,
             ShardId leaderShardId
@@ -634,6 +637,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             this.sourceMetadata = sourceMetadata;
             this.mappingVersion = mappingVersion;
             this.threadPool = threadPool;
+            this.timeoutExecutor = timeoutExecutor;
             this.ccrSettings = ccrSettings;
             this.throttleListener = throttleListener;
             this.leaderShardId = leaderShardId;
@@ -685,7 +689,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                         ListenerTimeouts.wrapWithTimeout(threadPool, listener.map(getCcrRestoreFileChunkResponse -> {
                             writeFileChunk(request.md, getCcrRestoreFileChunkResponse);
                             return null;
-                        }), ccrSettings.getRecoveryActionTimeout(), ThreadPool.Names.GENERIC, GetCcrRestoreFileChunkAction.INTERNAL_NAME)
+                        }), ccrSettings.getRecoveryActionTimeout(), timeoutExecutor, GetCcrRestoreFileChunkAction.INTERNAL_NAME)
                     );
                 }
 
@@ -740,7 +744,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                 threadPool,
                 listener,
                 ccrSettings.getRecoveryActionTimeout(),
-                ThreadPool.Names.GENERIC,
+                timeoutExecutor,
                 ClearCcrRestoreSessionAction.INTERNAL_NAME
             );
             ClearCcrRestoreSessionRequest clearRequest = new ClearCcrRestoreSessionRequest(sessionUUID, node, leaderShardId);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -596,7 +596,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                 threadPool,
                 responseListener,
                 ccrSettings.getRecoveryActionTimeout(),
-                chunkResponseExecutor,
+                threadPool.generic(), // TODO should be the remote-client response executor to match the non-timeout case
                 PutCcrRestoreSessionAction.INTERNAL_NAME
             )
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetMlAutoscalingStats.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetMlAutoscalingStats.java
@@ -33,6 +33,8 @@ import org.elasticsearch.xpack.core.ml.action.GetMlAutoscalingStats.Response;
 import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingResourceTracker;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 
+import java.util.concurrent.Executor;
+
 /**
  * Internal (no-REST) transport to retrieve metrics for serverless autoscaling.
  */
@@ -41,6 +43,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
     private final Client client;
     private final MlMemoryTracker mlMemoryTracker;
     private final Settings settings;
+    private final Executor timeoutExecutor;
 
     @Inject
     public TransportGetMlAutoscalingStats(
@@ -67,6 +70,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
         this.client = client;
         this.mlMemoryTracker = mlMemoryTracker;
         this.settings = settings;
+        this.timeoutExecutor = threadPool.generic();
     }
 
     @Override
@@ -93,7 +97,7 @@ public class TransportGetMlAutoscalingStats extends TransportMasterNodeAction<Re
                 ListenerTimeouts.wrapWithTimeout(
                     threadPool,
                     request.timeout(),
-                    ThreadPool.Names.GENERIC,
+                    timeoutExecutor,
                     ActionListener.wrap(
                         ignored -> MlAutoscalingResourceTracker.getMlAutoscalingStats(
                             state,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -324,7 +324,7 @@ public class AsyncTaskManagementService<
                 ListenerTimeouts.wrapWithTimeout(
                     threadPool,
                     timeout,
-                    ThreadPool.Names.SEARCH,
+                    threadPool.executor(ThreadPool.Names.SEARCH),
                     ActionListener.wrap(
                         r -> listener.onResponse(new StoredAsyncResponse<>(r, task.getExpirationTimeMillis())),
                         e -> listener.onResponse(new StoredAsyncResponse<>(e, task.getExpirationTimeMillis()))


### PR DESCRIPTION
Replaces the executor name with a proper executor.

Relates #99027 and friends