### PR TITLE
Fix sparse vector tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -125,7 +125,7 @@
       version: " - 7.99.99, 8.11.0 - "
       reason: "sparse_vector field type not supported in 8.x until 8.11.0"
   - do:
-      catch: /The \[sparse_vector\] field type is no longer supported/
+      catch: /The \[sparse_vector\] field type .* supported/
       indices.create:
         index: test
         body:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -122,10 +122,8 @@
 ---
 "Sparse vector in 8.x":
   - skip:
-      # version: " - 7.99.99, 8.11.0 - "
-      # reason: "sparse_vector field type not supported in 8.x until 8.11.0"
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/99318"
+      version: " - 7.99.99, 8.11.0 - "
+      reason: "sparse_vector field type not supported in 8.x until 8.11.0"
   - do:
       catch: /The \[sparse_vector\] field type .* supported/
       indices.create:


### PR DESCRIPTION
Fix sparse vector test so it can catch errors thrown before 8.11, which can happen on a mixed cluster.

Closes https://github.com/elastic/elasticsearch/issues/99318