### PR TITLE
[8.10] [DOC+] ILM Searchable Snapshot migrations require repository "name" to be the same (#99308)

### DIFF
--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -17,6 +17,8 @@ PUT /_snapshot/my_repository
 }
 ----
 
+IMPORTANT: If you're migrating {ref}/searchable-snapshots.html[searchable snapshots], the repository's name must be identical in the source and destination clusters.
+
 [[put-snapshot-repo-api-request]]
 ==== {api-request-title}
 


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOC+] ILM Searchable Snapshot migrations require repository "name" to be the same (#99308)