### PR TITLE
[TEST] Address ExplainableScriptIT failure

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.DocReader;
@@ -43,7 +42,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -76,7 +74,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
                         }
 
                         @Override
-                        public ScoreScript newInstance(DocReader docReader) throws IOException {
+                        public ScoreScript newInstance(DocReader docReader) {
                             return new MyScript(params1, lookup, ((DocValuesDocReader) docReader).getLeafReaderContext());
                         }
                     };
@@ -99,13 +97,13 @@ public class ExplainableScriptIT extends ESIntegTestCase {
 
         @Override
         public Explanation explain(Explanation subQueryScore) throws IOException {
-            Explanation scoreExp = Explanation.match(subQueryScore.getValue(), "_score: ", subQueryScore);
-            return Explanation.match((float) (execute(null)), "This script returned " + execute(null), scoreExp);
+            double score = execute(null);
+            return Explanation.match((float) score, "This script returned " + score);
         }
 
         @Override
         public double execute(ExplanationHolder explanation) {
-            return ((Number) ((ScriptDocValues) getDoc().get("number_field")).get(0)).doubleValue();
+            return ((Number) (getDoc().get("number_field")).get(0)).doubleValue();
         }
     }
 
@@ -114,7 +112,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
         return Arrays.asList(ExplainableScriptPlugin.class);
     }
 
-    public void testExplainScript() throws InterruptedException, IOException, ExecutionException {
+    public void testExplainScript() throws InterruptedException, IOException {
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             indexRequests.add(
@@ -146,8 +144,6 @@ public class ExplainableScriptIT extends ESIntegTestCase {
         for (SearchHit hit : hits.getHits()) {
             assertThat(hit.getId(), equalTo(Integer.toString(idCounter)));
             assertThat(hit.getExplanation().toString(), containsString(Double.toString(idCounter)));
-            assertThat(hit.getExplanation().toString(), containsString("1 = n"));
-            assertThat(hit.getExplanation().toString(), containsString("1 = N"));
             assertThat(hit.getExplanation().getDetails().length, equalTo(2));
             idCounter--;
         }


### PR DESCRIPTION
ExplainableScriptIT tests the output of an explainable score script. The script declares that it does not need the score, in fact it returns the score as the value of a field from each document. The explain output though includes the explanation of the sub query, whose score is completely replaced by function score. The test assertson the sub query explanation which is thought inaccurate as the script declares that it needs no score.

This test issue was made more evident by
https://github.com/apache/lucene/pull/12383  as the sub query score became 0 . The solution is to not include the sub query explanation in the script explain output and remove the assertions that depend on that part of the output.
