### PR TITLE
Deduplicate org.apache.lucene.document.FieldType instances across mappers

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -76,15 +76,16 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "match_only_text";
 
     public static class Defaults {
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
 
         static {
-            FIELD_TYPE.setTokenized(true);
-            FIELD_TYPE.setStored(false);
-            FIELD_TYPE.setStoreTermVectors(false);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-            FIELD_TYPE.freeze();
+            final FieldType ft = new FieldType();
+            ft.setTokenized(true);
+            ft.setStored(false);
+            ft.setStoreTermVectors(false);
+            ft.setOmitNorms(true);
+            ft.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
 
     }
@@ -375,7 +376,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         super(simpleName, mappedFieldType, multiFields, copyTo, false, null);
         assert mappedFieldType.getTextSearchInfo().isTokenized();
         assert mappedFieldType.hasDocValues() == false;
-        this.fieldType = fieldType;
+        this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         this.indexCreatedVersion = builder.indexCreatedVersion;
         this.indexAnalyzers = builder.analyzers.indexAnalyzers;
         this.indexAnalyzer = builder.analyzers.getIndexAnalyzer();

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
@@ -43,13 +43,14 @@ public class RankFeatureFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "rank_feature";
 
     public static class Defaults {
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
 
         static {
-            FIELD_TYPE.setTokenized(false);
-            FIELD_TYPE.setIndexOptions(IndexOptions.NONE);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.freeze();
+            FieldType ft = new FieldType();
+            ft.setTokenized(false);
+            ft.setIndexOptions(IndexOptions.NONE);
+            ft.setOmitNorms(true);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
     }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -312,7 +312,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
                 new TextSearchInfo(fieldType, similarity, searchAnalyzer, searchQuoteAnalyzer),
                 meta
             );
-            this.fieldType = fieldType;
+            this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         }
 
         public void setPrefixField(PrefixFieldType prefixField) {
@@ -499,7 +499,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
 
         PrefixFieldMapper(FieldType fieldType, PrefixFieldType mappedFieldType) {
             super(mappedFieldType.name(), mappedFieldType, MultiFields.empty(), CopyTo.empty());
-            this.fieldType = fieldType;
+            this.fieldType = Mapper.freezeAndDeduplicateFieldType(fieldType);
         }
 
         @Override
@@ -538,7 +538,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
 
         ShingleFieldMapper(FieldType fieldType, ShingleFieldType mappedFieldtype) {
             super(mappedFieldtype.name(), mappedFieldtype, MultiFields.empty(), CopyTo.empty());
-            this.fieldType = fieldType;
+            this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         }
 
         FieldType getLuceneFieldType() {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -481,7 +481,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     ) {
         super(simpleName, mappedFieldType, multiFields, copyTo, false, null);
         assert collator.isFrozen();
-        this.fieldType = fieldType;
+        this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         this.params = builder.collatorParams();
         this.ignoreAbove = builder.ignoreAbove.getValue();
         this.collator = collator;

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -508,7 +508,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     ) {
         super(simpleName, mappedFieldType, multiFields, copyTo);
         assert fieldType.tokenized();
-        this.fieldType = fieldType;
+        this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         this.builder = builder;
         this.indexAnalyzer = wrapAnalyzer(builder.analyzers.getIndexAnalyzer());
     }

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -37,10 +37,11 @@ public class Murmur3FieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "murmur3";
 
     public static class Defaults {
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
         static {
-            FIELD_TYPE.setIndexOptions(IndexOptions.NONE);
-            FIELD_TYPE.freeze();
+            FieldType ft = new FieldType();
+            ft.setIndexOptions(IndexOptions.NONE);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -85,14 +85,15 @@ public class CompletionFieldMapper extends FieldMapper {
     }
 
     public static class Defaults {
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
         static {
-            FIELD_TYPE.setTokenized(true);
-            FIELD_TYPE.setStored(false);
-            FIELD_TYPE.setStoreTermVectors(false);
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.freeze();
+            final FieldType ft = new FieldType();
+            ft.setTokenized(true);
+            ft.setStored(false);
+            ft.setStoreTermVectors(false);
+            ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+            ft.setOmitNorms(true);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
         public static final boolean DEFAULT_PRESERVE_SEPARATORS = true;
         public static final boolean DEFAULT_POSITION_INCREMENTS = true;

--- a/server/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CustomDocValuesField.java
@@ -22,11 +22,12 @@ import java.io.Reader;
 // used for binary, geo and range fields
 public abstract class CustomDocValuesField implements IndexableField {
 
-    public static final FieldType TYPE = new FieldType();
+    public static final FieldType TYPE;
     static {
-        TYPE.setDocValuesType(DocValuesType.BINARY);
-        TYPE.setOmitNorms(true);
-        TYPE.freeze();
+        FieldType ft = new FieldType();
+        ft.setDocValuesType(DocValuesType.BINARY);
+        ft.setOmitNorms(true);
+        TYPE = Mapper.freezeAndDeduplicateFieldType(ft);
     }
 
     private final String name;

--- a/server/src/main/java/org/elasticsearch/index/mapper/CustomTermFreqField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CustomTermFreqField.java
@@ -21,11 +21,13 @@ import org.apache.lucene.index.IndexOptions;
  */
 public final class CustomTermFreqField extends Field {
 
-    private static final FieldType FIELD_TYPE = new FieldType();
+    private static final FieldType FIELD_TYPE;
     static {
-        FIELD_TYPE.setTokenized(false);
-        FIELD_TYPE.setOmitNorms(true);
-        FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+        final FieldType ft = new FieldType();
+        ft.setTokenized(false);
+        ft.setOmitNorms(true);
+        ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+        FIELD_TYPE = Mapper.freezeAndDeduplicateFieldType(ft);
     }
 
     private final int fieldValue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -87,14 +87,15 @@ public final class KeywordFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "keyword";
 
     public static class Defaults {
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
 
         static {
-            FIELD_TYPE.setTokenized(false);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-            FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_SET);
-            FIELD_TYPE.freeze();
+            FieldType ft = new FieldType();
+            ft.setTokenized(false);
+            ft.setOmitNorms(true);
+            ft.setIndexOptions(IndexOptions.DOCS);
+            ft.setDocValuesType(DocValuesType.SORTED_SET);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
 
         public static TextSearchInfo TEXT_SEARCH_INFO = new TextSearchInfo(
@@ -831,7 +832,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();
         this.indexOptions = builder.indexOptions.getValue();
-        this.fieldType = fieldType;
+        this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         this.similarity = builder.similarity.getValue();
         this.normalizerName = builder.normalizer.getValue();
         this.splitQueriesOnWhitespace = builder.splitQueriesOnWhitespace.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.document.FieldType;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.StringLiteralDeduplicator;
 import org.elasticsearch.index.IndexVersion;
@@ -15,8 +16,11 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
+
     public abstract static class Builder {
 
         protected final String name;
@@ -104,5 +108,24 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
      */
     public static String internFieldName(String fieldName) {
         return fieldNameStringDeduplicator.deduplicate(fieldName);
+    }
+
+    private static final Map<FieldType, FieldType> fieldTypeDeduplicator = new ConcurrentHashMap<>();
+
+    /**
+     * Freezes the given {@link FieldType} instances and tries to deduplicate it as long as the field does not return a non-empty value for
+     * {@link FieldType#getAttributes()}.
+     *
+     * @param fieldType field type to deduplicate
+     * @return deduplicated field type
+     */
+    public static FieldType freezeAndDeduplicateFieldType(FieldType fieldType) {
+        fieldType.freeze();
+        var attributes = fieldType.getAttributes();
+        if ((attributes != null && attributes.isEmpty() == false) || fieldType.getClass() != FieldType.class) {
+            // don't deduplicate subclasses or types with non-empty attribute maps to avoid memory leaks
+            return fieldType;
+        }
+        return fieldTypeDeduplicator.computeIfAbsent(fieldType, Function.identity());
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -126,6 +126,10 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             // don't deduplicate subclasses or types with non-empty attribute maps to avoid memory leaks
             return fieldType;
         }
+        if (fieldTypeDeduplicator.size() > 1000) {
+            // guard against the case where we run up too many combinations via (vector-)dimensions combinations
+            fieldTypeDeduplicator.clear();
+        }
         return fieldTypeDeduplicator.computeIfAbsent(fieldType, Function.identity());
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -50,10 +50,12 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
     // Like Lucene's LongField but single-valued (NUMERIC doc values instead of SORTED_NUMERIC doc values)
     private static class SingleValueLongField extends Field {
 
-        private static final FieldType FIELD_TYPE = new FieldType();
+        private static final FieldType FIELD_TYPE;
         static {
-            FIELD_TYPE.setDimensions(1, Long.BYTES);
-            FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+            FieldType ft = new FieldType();
+            ft.setDimensions(1, Long.BYTES);
+            ft.setDocValuesType(DocValuesType.NUMERIC);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
 
         private final BytesRef pointValue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -77,13 +77,14 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     public static class Defaults {
         public static final String NAME = SourceFieldMapper.NAME;
 
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
 
         static {
-            FIELD_TYPE.setIndexOptions(IndexOptions.NONE); // not indexed
-            FIELD_TYPE.setStored(true);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.freeze();
+            FieldType ft = new FieldType();
+            ft.setIndexOptions(IndexOptions.NONE); // not indexed
+            ft.setStored(true);
+            ft.setOmitNorms(true);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -99,15 +99,16 @@ public class TextFieldMapper extends FieldMapper {
         public static final int INDEX_PREFIX_MIN_CHARS = 2;
         public static final int INDEX_PREFIX_MAX_CHARS = 5;
 
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
 
         static {
-            FIELD_TYPE.setTokenized(true);
-            FIELD_TYPE.setStored(false);
-            FIELD_TYPE.setStoreTermVectors(false);
-            FIELD_TYPE.setOmitNorms(false);
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
-            FIELD_TYPE.freeze();
+            FieldType ft = new FieldType();
+            ft.setTokenized(true);
+            ft.setStored(false);
+            ft.setStoreTermVectors(false);
+            ft.setOmitNorms(false);
+            ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
 
         /**
@@ -664,7 +665,7 @@ public class TextFieldMapper extends FieldMapper {
         private final String field;
 
         SubFieldInfo(String field, FieldType fieldType, Analyzer analyzer) {
-            this.fieldType = fieldType;
+            this.fieldType = Mapper.freezeAndDeduplicateFieldType(fieldType);
             this.analyzer = analyzer;
             this.field = field;
         }
@@ -1170,7 +1171,7 @@ public class TextFieldMapper extends FieldMapper {
         if (fieldType.indexOptions() == IndexOptions.NONE && fieldType().fielddata()) {
             throw new IllegalArgumentException("Cannot enable fielddata on a [text] field that is not indexed: [" + name() + "]");
         }
-        this.fieldType = fieldType;
+        this.fieldType = freezeAndDeduplicateFieldType(fieldType);
         this.prefixFieldInfo = prefixFieldInfo;
         this.phraseFieldInfo = phraseFieldInfo;
         this.indexCreatedVersion = builder.indexCreatedVersion;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextSearchInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextSearchInfo.java
@@ -28,12 +28,13 @@ public record TextSearchInfo(
     NamedAnalyzer searchQuoteAnalyzer
 ) {
 
-    private static final FieldType SIMPLE_MATCH_ONLY_FIELD_TYPE = new FieldType();
+    private static final FieldType SIMPLE_MATCH_ONLY_FIELD_TYPE;
 
     static {
-        SIMPLE_MATCH_ONLY_FIELD_TYPE.setTokenized(false);
-        SIMPLE_MATCH_ONLY_FIELD_TYPE.setOmitNorms(true);
-        SIMPLE_MATCH_ONLY_FIELD_TYPE.freeze();
+        FieldType ft = new FieldType();
+        ft.setTokenized(false);
+        ft.setOmitNorms(true);
+        SIMPLE_MATCH_ONLY_FIELD_TYPE = Mapper.freezeAndDeduplicateFieldType(ft);
     }
 
     /**
@@ -100,7 +101,7 @@ public record TextSearchInfo(
         NamedAnalyzer searchAnalyzer,
         NamedAnalyzer searchQuoteAnalyzer
     ) {
-        this.luceneFieldType = luceneFieldType;
+        this.luceneFieldType = Mapper.freezeAndDeduplicateFieldType(luceneFieldType);
         this.similarity = similarity;
         this.searchAnalyzer = Objects.requireNonNull(searchAnalyzer);
         this.searchQuoteAnalyzer = Objects.requireNonNull(searchQuoteAnalyzer);

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -86,13 +86,14 @@ public class VersionStringFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "version";
 
     public static class Defaults {
-        public static final FieldType FIELD_TYPE = new FieldType();
+        public static final FieldType FIELD_TYPE;
 
         static {
-            FIELD_TYPE.setTokenized(false);
-            FIELD_TYPE.setOmitNorms(true);
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-            FIELD_TYPE.freeze();
+            FieldType ft = new FieldType();
+            ft.setTokenized(false);
+            ft.setOmitNorms(true);
+            ft.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
         }
     }
 
@@ -355,7 +356,7 @@ public class VersionStringFieldMapper extends FieldMapper {
         CopyTo copyTo
     ) {
         super(simpleName, mappedFieldType, multiFields, copyTo);
-        this.fieldType = fieldType;
+        this.fieldType = freezeAndDeduplicateFieldType(fieldType);
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -879,9 +879,17 @@ public class WildcardFieldMapper extends FieldMapper {
 
     }
 
+    private static final FieldType NGRAM_FIELD_TYPE;
+
+    static {
+        FieldType ft = new FieldType(Defaults.FIELD_TYPE);
+        ft.setTokenized(true);
+        NGRAM_FIELD_TYPE = freezeAndDeduplicateFieldType(ft);
+        assert NGRAM_FIELD_TYPE.indexOptions() == IndexOptions.DOCS;
+    }
+
     private final int ignoreAbove;
     private final String nullValue;
-    private final FieldType ngramFieldType;
     private final IndexVersion indexVersionCreated;
     private final boolean storeIgnored;
 
@@ -900,10 +908,6 @@ public class WildcardFieldMapper extends FieldMapper {
         this.ignoreAbove = ignoreAbove;
         this.storeIgnored = storeIgnored;
         this.indexVersionCreated = indexVersionCreated;
-        this.ngramFieldType = new FieldType(Defaults.FIELD_TYPE);
-        this.ngramFieldType.setTokenized(true);
-        this.ngramFieldType.freeze();
-        assert ngramFieldType.indexOptions() == IndexOptions.DOCS;
     }
 
     @Override
@@ -954,7 +958,7 @@ public class WildcardFieldMapper extends FieldMapper {
 
     void createFields(String value, LuceneDocument parseDoc, List<IndexableField> fields) {
         String ngramValue = addLineEndChars(value);
-        Field ngramField = new Field(fieldType().name(), ngramValue, ngramFieldType);
+        Field ngramField = new Field(fieldType().name(), ngramValue, NGRAM_FIELD_TYPE);
         fields.add(ngramField);
 
         CustomBinaryDocValuesField dvField = (CustomBinaryDocValuesField) parseDoc.getByKey(fieldType().name());


### PR DESCRIPTION
We mostly have a handful of `FieldType` values here across all mappers and none of them contain attributes. There's only so many combinations here, lets deduplicate these to save some heap and set up subsequent mapper heap savings.
The outright savings here aren't that big (a couple of MB per data-node in the many-shards benchmark) but I think there is some hidden performance benefit here from cache locality across mappers here as well on the indexing side.

Somewhat relates #31479