### PR TITLE
[DOCS] Docker: Add tabbed widget for `vm.max_map_count`

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -331,8 +331,45 @@ The `vm.max_map_count` kernel setting must be set to at least `262144` for produ
 
 How you set `vm.max_map_count` depends on your platform.
 
-====== Linux
+// Start tabbed widget
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Operating system">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="linux-tab"
+            id="linux">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-mac-tab"
+            id="docker-mac"
+            tabindex="-1">
+      Docker for Mac
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-desktop-tab"
+            id="docker-desktop"
+            tabindex="-1">
+      Docker Desktop for Windows or Mac
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-desktop-wsl2-tab"
+            id="docker-desktop-wsl2"
+            tabindex="-1">
+      Docker Desktop WSL 2
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab"
+       aria-labelledby="linux">
+++++
 
+// Linux
 To view the current value for the `vm.max_map_count` setting, run:
 
 [source,sh]
@@ -351,8 +388,16 @@ sysctl -w vm.max_map_count=262144
 To permanently change the value for the `vm.max_map_count` setting, update the
 value in `/etc/sysctl.conf`.
 
-====== macOS with https://docs.docker.com/docker-for-mac[Docker for Mac]
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-mac-tab"
+       aria-labelledby="docker-mac"
+       hidden="">
+++++
 
+// macOS with Docker for Mac
 The `vm.max_map_count` setting must be set within the xhyve virtual machine:
 
 . From the command line, run:
@@ -371,8 +416,16 @@ sysctl -w vm.max_map_count=262144
 
 . To exit the `screen` session, type `Ctrl a d`.
 
-====== Windows and macOS with https://www.docker.com/products/docker-desktop[Docker Desktop]
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-desktop-tab"
+       aria-labelledby="docker-desktop"
+       hidden="">
+++++
 
+// Windows and macOS with Docker Desktop
 The `vm.max_map_count` setting must be set via docker-machine:
 
 [source,sh]
@@ -381,8 +434,16 @@ docker-machine ssh
 sudo sysctl -w vm.max_map_count=262144
 --------------------------------------------
 
-====== Windows with https://docs.docker.com/docker-for-windows/wsl[Docker Desktop WSL 2 backend]
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-desktop-wsl2-tab"
+       aria-labelledby="docker-desktop-wsl2"
+       hidden="">
+++++
 
+// Windows with Docker Desktop WSL 2 backend
 The `vm.max_map_count` setting must be set in the "docker-desktop" WSL instance before the
 {es} container will properly start. There are several ways to do this, depending
 on your version of Windows and your version of WSL.
@@ -429,6 +490,12 @@ and appending a line which reads:
 --------------------------------------------
 vm.max_map_count = 262144
 --------------------------------------------
+
+++++
+  </div>
+</div>
+++++
+// End tabbed widget
 
 ===== Configuration files must be readable by the `elasticsearch` user
 


### PR DESCRIPTION
**Problem:** The [vm.max_map_count](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_set_vm_max_map_count_to_at_least_262144) section of the Docker install docs is overly long.

**Solution:** Create a tabbed widget that shows the instructions for one environment at a time.

This PR does NOT make substantive changes to [vm.max_map_count](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_set_vm_max_map_count_to_at_least_262144) section or test its content.

Closes https://github.com/elastic/platform-docs-team/issues/185
Closes https://github.com/elastic/platform-docs-team/issues/183