### PR TITLE
Remove string-based Scheduler#schedule override

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -96,12 +96,6 @@ public interface Scheduler {
     ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor);
 
     /**
-     * @deprecated Use {@link #schedule(Runnable, TimeValue, Executor)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    ScheduledCancellable schedule(Runnable command, TimeValue delay, String executorName);
-
-    /**
      * Schedules a periodic action that runs on scheduler thread. Do not run blocking calls on the scheduler thread. Subclasses may allow
      * to execute on a different executor, in which case blocking calls are allowed.
      *

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -454,16 +454,6 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     }
 
     /**
-     * @deprecated Use {@link #schedule(Runnable, TimeValue, Executor)} instead.
-     */
-    @Override
-    @SuppressWarnings("removal")
-    @Deprecated(forRemoval = true)
-    public final ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
-        return schedule(command, delay, executor(executor));
-    }
-
-    /**
      * Schedules a one-shot command to run after a given delay. The command is run in the context of the calling thread.
      *
      * @param command the command to run

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -554,11 +554,5 @@ public class BulkProcessorTests extends ESTestCase {
         public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
             throw new AssertionError("should not be called");
         }
-
-        @SuppressWarnings("removal")
-        @Override
-        public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executorName) {
-            throw new AssertionError("should not be called");
-        }
     }
 }


### PR DESCRIPTION
Completes the removal of the functionality deprecated by #99027.