### PR TITLE
Call TransportService#registerRequestHandler with Executor (#98998)

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorGetActionTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorGetActionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.grok.PatternBank;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -60,8 +61,9 @@ public class GrokProcessorGetActionTests extends ESTestCase {
     public void testResponseSorting() {
         List<String> sortedKeys = new ArrayList<>(LEGACY_TEST_PATTERNS.bank().keySet());
         Collections.sort(sortedKeys);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         GrokProcessorGetAction.TransportAction transportAction = new GrokProcessorGetAction.TransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             LEGACY_TEST_PATTERNS,
             ECS_TEST_PATTERNS
@@ -109,8 +111,9 @@ public class GrokProcessorGetActionTests extends ESTestCase {
     public void testEcsCompatibilityMode() {
         List<String> sortedKeys = new ArrayList<>(ECS_TEST_PATTERNS.bank().keySet());
         Collections.sort(sortedKeys);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         GrokProcessorGetAction.TransportAction transportAction = new GrokProcessorGetAction.TransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             LEGACY_TEST_PATTERNS,
             ECS_TEST_PATTERNS

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
@@ -74,10 +75,11 @@ public class TransportRankEvalActionTests extends ESTestCase {
             }
         };
 
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         TransportRankEvalAction action = new TransportRankEvalAction(
             mock(ActionFilters.class),
             client,
-            mock(TransportService.class),
+            transportService,
             mock(ScriptService.class),
             NamedXContentRegistry.EMPTY
         );

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActionScriptTestCase<
     UpdateByQueryRequest,
@@ -51,6 +52,10 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
     @Override
     protected TransportUpdateByQueryAction.AsyncIndexBySearchAction action(ScriptService scriptService, UpdateByQueryRequest request) {
         TransportService transportService = mock(TransportService.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         TransportUpdateByQueryAction transportAction = new TransportUpdateByQueryAction(
             threadPool,
             new ActionFilters(Collections.emptySet()),

--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -40,6 +40,7 @@ import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.internal.InternalSearchResponse;
@@ -103,37 +104,42 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
         try {
             newService.registerRequestHandler(
                 SearchShardsAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 SearchShardsRequest::new,
                 (request, channel, task) -> {
                     channel.sendResponse(new SearchShardsResponse(List.of(), List.of(), Collections.emptyMap()));
                 }
             );
-            newService.registerRequestHandler(SearchAction.NAME, ThreadPool.Names.SAME, SearchRequest::new, (request, channel, task) -> {
-                InternalSearchResponse response = new InternalSearchResponse(
-                    new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN),
-                    InternalAggregations.EMPTY,
-                    null,
-                    null,
-                    false,
-                    null,
-                    1
-                );
-                SearchResponse searchResponse = new SearchResponse(
-                    response,
-                    null,
-                    1,
-                    1,
-                    0,
-                    100,
-                    ShardSearchFailure.EMPTY_ARRAY,
-                    SearchResponse.Clusters.EMPTY
-                );
-                channel.sendResponse(searchResponse);
-            });
+            newService.registerRequestHandler(
+                SearchAction.NAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                SearchRequest::new,
+                (request, channel, task) -> {
+                    InternalSearchResponse response = new InternalSearchResponse(
+                        new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN),
+                        InternalAggregations.EMPTY,
+                        null,
+                        null,
+                        false,
+                        null,
+                        1
+                    );
+                    SearchResponse searchResponse = new SearchResponse(
+                        response,
+                        null,
+                        1,
+                        1,
+                        0,
+                        100,
+                        ShardSearchFailure.EMPTY_ARRAY,
+                        SearchResponse.Clusters.EMPTY
+                    );
+                    channel.sendResponse(searchResponse);
+                }
+            );
             newService.registerRequestHandler(
                 ClusterStateAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 ClusterStateRequest::new,
                 (request, channel, task) -> {
                     DiscoveryNodes.Builder builder = DiscoveryNodes.builder();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -62,7 +62,7 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
         );
         transportService.registerRequestHandler(
             PRE_SYNCED_FLUSH_ACTION_NAME,
-            ThreadPool.Names.FLUSH,
+            threadPool.executor(ThreadPool.Names.FLUSH),
             PreShardSyncedFlushRequest::new,
             new PreSyncedFlushTransportHandler(indicesService)
         );

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -92,7 +92,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         this.indicesService = indicesService;
         transportService.registerRequestHandler(
             ACTION_NODE_NAME,
-            ThreadPool.Names.SEARCH_COORDINATION,
+            this.searchCoordinationExecutor,
             FieldCapabilitiesNodeRequest::new,
             new NodeTransportHandler()
         );

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.CanMatchShardResponse;
 import org.elasticsearch.search.SearchPhaseResult;
@@ -450,7 +451,7 @@ public class SearchTransportService {
     public static void registerRequestHandler(TransportService transportService, SearchService searchService) {
         transportService.registerRequestHandler(
             FREE_CONTEXT_SCROLL_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ScrollFreeContextRequest::new,
             (request, channel, task) -> {
                 boolean freed = searchService.freeReaderContext(request.id());
@@ -460,7 +461,7 @@ public class SearchTransportService {
         TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_SCROLL_ACTION_NAME, false, SearchFreeContextResponse::new);
         transportService.registerRequestHandler(
             FREE_CONTEXT_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             SearchFreeContextRequest::new,
             (request, channel, task) -> {
                 boolean freed = searchService.freeReaderContext(request.id());
@@ -470,7 +471,7 @@ public class SearchTransportService {
         TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, false, SearchFreeContextResponse::new);
         transportService.registerRequestHandler(
             CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             TransportRequest.Empty::new,
             (request, channel, task) -> {
                 searchService.freeAllScrollContexts();
@@ -486,7 +487,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             DFS_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ShardSearchRequest::new,
             (request, channel, task) -> searchService.executeDfsPhase(request, (SearchShardTask) task, new ChannelActionListener<>(channel))
         );
@@ -495,7 +496,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             QUERY_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ShardSearchRequest::new,
             (request, channel, task) -> searchService.executeQueryPhase(
                 request,
@@ -512,7 +513,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             QUERY_ID_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             QuerySearchRequest::new,
             (request, channel, task) -> {
                 searchService.executeQueryPhase(request, (SearchShardTask) task, new ChannelActionListener<>(channel));
@@ -522,7 +523,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             QUERY_SCROLL_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             InternalScrollSearchRequest::new,
             (request, channel, task) -> {
                 searchService.executeQueryPhase(request, (SearchShardTask) task, new ChannelActionListener<>(channel));
@@ -532,7 +533,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             QUERY_FETCH_SCROLL_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             InternalScrollSearchRequest::new,
             (request, channel, task) -> {
                 searchService.executeFetchPhase(request, (SearchShardTask) task, new ChannelActionListener<>(channel));
@@ -542,7 +543,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             FETCH_ID_SCROLL_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ShardFetchRequest::new,
             (request, channel, task) -> {
                 searchService.executeFetchPhase(request, (SearchShardTask) task, new ChannelActionListener<>(channel));
@@ -552,7 +553,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             FETCH_ID_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             true,
             true,
             ShardFetchSearchRequest::new,
@@ -565,7 +566,7 @@ public class SearchTransportService {
         // this is cheap, it does not fetch during the rewrite phase, so we can let it quickly execute on a networking thread
         transportService.registerRequestHandler(
             QUERY_CAN_MATCH_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ShardSearchRequest::new,
             (request, channel, task) -> {
                 searchService.canMatch(request, new ChannelActionListener<>(channel));
@@ -575,7 +576,7 @@ public class SearchTransportService {
 
         transportService.registerRequestHandler(
             QUERY_CAN_MATCH_NODE_NAME,
-            ThreadPool.Names.SEARCH_COORDINATION,
+            transportService.getThreadPool().executor(ThreadPool.Names.SEARCH_COORDINATION),
             CanMatchNodeRequest::new,
             (request, channel, task) -> {
                 searchService.canMatch(request, new ChannelActionListener<>(channel));

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
@@ -68,7 +69,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
         this.searchTransportService = searchTransportService;
         transportService.registerRequestHandler(
             OPEN_SHARD_READER_CONTEXT_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ShardOpenReaderRequest::new,
             new ShardOpenReaderRequestHandler()
         );

--- a/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -61,7 +61,14 @@ public abstract class HandledTransportAction<Request extends ActionRequest, Resp
         String executor
     ) {
         super(actionName, actionFilters, transportService.getTaskManager());
-        transportService.registerRequestHandler(actionName, executor, false, canTripCircuitBreaker, requestReader, new TransportHandler());
+        transportService.registerRequestHandler(
+            actionName,
+            transportService.getThreadPool().executor(executor),
+            false,
+            canTripCircuitBreaker,
+            requestReader,
+            new TransportHandler()
+        );
     }
 
     class TransportHandler implements TransportRequestHandler<Request> {

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -75,7 +75,7 @@ public abstract class TransportBroadcastAction<
 
         transportService.registerRequestHandler(
             transportShardAction,
-            executor,
+            this.executor,
             shardRequestReader,
             (request, channel, task) -> ActionListener.completeWith(
                 new ChannelActionListener<>(channel),

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -119,7 +119,7 @@ public abstract class TransportBroadcastByNodeAction<
 
         transportService.registerRequestHandler(
             transportNodeBroadcastAction,
-            executor,
+            this.executor,
             false,
             canTripCircuitBreaker,
             NodeRequest::new,

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
@@ -60,7 +60,12 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
         this.transportUnpromotableAction = actionName + "[u]";
         this.executor = transportService.getThreadPool().executor(executor);
 
-        transportService.registerRequestHandler(transportUnpromotableAction, executor, requestReader, new UnpromotableTransportHandler());
+        transportService.registerRequestHandler(
+            transportUnpromotableAction,
+            this.executor,
+            requestReader,
+            new UnpromotableTransportHandler()
+        );
     }
 
     protected abstract void unpromotableShardOperation(Task task, Request request, ActionListener<Response> listener);

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -82,7 +82,7 @@ public abstract class TransportNodesAction<
         this.transportService = Objects.requireNonNull(transportService);
         this.finalExecutor = threadPool.executor(executor);
         this.transportNodeAction = actionName + "[n]";
-        transportService.registerRequestHandler(transportNodeAction, executor, nodeRequest, new NodeTransportHandler());
+        transportService.registerRequestHandler(transportNodeAction, finalExecutor, nodeRequest, new NodeTransportHandler());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -33,7 +34,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
@@ -72,7 +72,7 @@ public abstract class TransportInstanceSingleOperationAction<
         this.transportService = transportService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.shardActionName = actionName + "[s]";
-        transportService.registerRequestHandler(shardActionName, Names.SAME, request, new ShardTransportHandler());
+        transportService.registerRequestHandler(shardActionName, EsExecutors.DIRECT_EXECUTOR_SERVICE, request, new ShardTransportHandler());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
@@ -79,9 +80,14 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         this.executor = executor;
 
         if (isSubAction() == false) {
-            transportService.registerRequestHandler(actionName, ThreadPool.Names.SAME, request, new TransportHandler());
+            transportService.registerRequestHandler(actionName, EsExecutors.DIRECT_EXECUTOR_SERVICE, request, new TransportHandler());
         }
-        transportService.registerRequestHandler(transportShardAction, ThreadPool.Names.SAME, request, new ShardTransportHandler());
+        transportService.registerRequestHandler(
+            transportShardAction,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            request,
+            new ShardTransportHandler()
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -79,7 +79,12 @@ public abstract class TransportTasksAction<
         this.responsesReader = responsesReader;
         this.responseReader = responseReader;
 
-        transportService.registerRequestHandler(transportNodeAction, nodeExecutor, NodeTaskRequest::new, new NodeTransportHandler());
+        transportService.registerRequestHandler(
+            transportNodeAction,
+            transportService.getThreadPool().executor(nodeExecutor),
+            NodeTaskRequest::new,
+            new NodeTransportHandler()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -98,13 +99,13 @@ public class ShardStateAction {
 
         transportService.registerRequestHandler(
             SHARD_STARTED_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             StartedShardEntry::new,
             new ShardStartedTransportHandler(clusterService, new ShardStartedClusterStateTaskExecutor(allocationService, rerouteService))
         );
         transportService.registerRequestHandler(
             SHARD_FAILED_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             FailedShardEntry::new,
             new ShardFailedTransportHandler(clusterService, new ShardFailedClusterStateTaskExecutor(allocationService, rerouteService))
         );

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -271,7 +271,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         );
         transportService.registerRequestHandler(
             COMMIT_STATE_ACTION_NAME,
-            Names.CLUSTER_COORDINATION,
+            this.clusterCoordinationExecutor,
             false,
             false,
             ApplyCommitRequest::new,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -124,7 +124,7 @@ public class FollowersChecker {
         updateFastResponseState(0, Mode.CANDIDATE);
         transportService.registerRequestHandler(
             FOLLOWER_CHECK_ACTION_NAME,
-            Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             false,
             false,
             FollowerCheckRequest::new,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
@@ -114,7 +115,7 @@ public class JoinHelper {
 
         transportService.registerRequestHandler(
             JOIN_ACTION_NAME,
-            Names.CLUSTER_COORDINATION,
+            transportService.getThreadPool().executor(Names.CLUSTER_COORDINATION),
             false,
             false,
             JoinRequest::new,
@@ -126,7 +127,7 @@ public class JoinHelper {
 
         transportService.registerRequestHandler(
             START_JOIN_ACTION_NAME,
-            Names.CLUSTER_COORDINATION,
+            transportService.getThreadPool().executor(Names.CLUSTER_COORDINATION),
             false,
             false,
             StartJoinRequest::new,
@@ -139,7 +140,7 @@ public class JoinHelper {
 
         transportService.registerRequestHandler(
             JOIN_PING_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             false,
             false,
             TransportRequest.Empty::new,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
@@ -121,7 +121,7 @@ public class JoinValidationService {
         final var dataPaths = Environment.PATH_DATA_SETTING.get(settings);
         transportService.registerRequestHandler(
             JoinValidationService.JOIN_VALIDATE_ACTION_NAME,
-            ThreadPool.Names.CLUSTER_COORDINATION,
+            this.responseExecutor,
             ValidateJoinRequest::new,
             (request, channel, task) -> {
                 final var remoteState = request.getOrReadState();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -113,7 +113,7 @@ public class LeaderChecker {
 
         transportService.registerRequestHandler(
             LEADER_CHECK_ACTION_NAME,
-            Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             false,
             false,
             LeaderCheckRequest::new,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -106,7 +106,7 @@ public class PublicationTransportHandler {
 
         transportService.registerRequestHandler(
             PUBLISH_STATE_ACTION_NAME,
-            ThreadPool.Names.CLUSTER_COORDINATION,
+            this.clusterCoordinationExecutor,
             false,
             false,
             BytesTransportRequest::new,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StatefulPreVoteCollector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StatefulPreVoteCollector.java
@@ -64,7 +64,7 @@ public class StatefulPreVoteCollector extends PreVoteCollector {
 
         transportService.registerRequestHandler(
             REQUEST_PRE_VOTE_ACTION_NAME,
-            Names.CLUSTER_COORDINATION,
+            this.clusterCoordinationExecutor,
             false,
             false,
             PreVoteRequest::new,

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -110,7 +110,7 @@ public abstract class PeerFinder {
 
         transportService.registerRequestHandler(
             REQUEST_PEERS_ACTION_NAME,
-            Names.CLUSTER_COORDINATION,
+            this.clusterCoordinationExecutor,
             false,
             false,
             PeersRequest::new,

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -35,7 +35,6 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
@@ -73,7 +72,7 @@ public class LocalAllocateDangledIndices {
         this.indexMetadataVerifier = indexMetadataVerifier;
         transportService.registerRequestHandler(
             ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             AllocateDangledRequest::new,
             new AllocateDangledRequestHandler()
         );

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -79,7 +79,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         // node. Upon receiving START_RECOVERY, the source node will initiate the peer recovery.
         transportService.registerRequestHandler(
             Actions.START_RECOVERY,
-            ThreadPool.Names.GENERIC,
+            transportService.getThreadPool().executor(ThreadPool.Names.GENERIC),
             StartRecoveryRequest::new,
             (request, channel, task) -> recover(request, task, new ChannelActionListener<>(channel))
         );
@@ -89,7 +89,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         // action will fail and the target node will send a new START_RECOVERY request.
         transportService.registerRequestHandler(
             Actions.REESTABLISH_RECOVERY,
-            ThreadPool.Names.GENERIC,
+            transportService.getThreadPool().executor(ThreadPool.Names.GENERIC),
             ReestablishRecoveryRequest::new,
             (request, channel, task) -> reestablish(request, new ChannelActionListener<>(channel))
         );

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -122,7 +122,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
         transportService.registerRequestHandler(
             Actions.FILES_INFO,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryFilesInfoRequest::new,
             new RecoveryRequestHandler<>() {
                 @Override
@@ -140,7 +140,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         );
         transportService.registerRequestHandler(
             Actions.RESTORE_FILE_FROM_SNAPSHOT,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoverySnapshotFileRequest::new,
             new RecoveryRequestHandler<>() {
                 @Override
@@ -151,13 +151,13 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         );
         transportService.registerRequestHandler(
             Actions.FILE_CHUNK,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryFileChunkRequest::new,
             new FileChunkTransportRequestHandler()
         );
         transportService.registerRequestHandler(
             Actions.CLEAN_FILES,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryCleanFilesRequest::new,
             new RecoveryRequestHandler<>() {
                 @Override
@@ -179,7 +179,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         );
         transportService.registerRequestHandler(
             Actions.PREPARE_TRANSLOG,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryPrepareForTranslogOperationsRequest::new,
             new RecoveryRequestHandler<>() {
                 @Override
@@ -194,13 +194,13 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         );
         transportService.registerRequestHandler(
             Actions.TRANSLOG_OPS,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryTranslogOperationsRequest::new,
             new TranslogOperationsRequestHandler()
         );
         transportService.registerRequestHandler(
             Actions.FINALIZE,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryFinalizeRecoveryRequest::new,
             new RecoveryRequestHandler<>() {
                 @Override
@@ -215,7 +215,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         );
         transportService.registerRequestHandler(
             Actions.HANDOFF_PRIMARY_CONTEXT,
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             RecoveryHandoffPrimaryContextRequest::new,
             new HandoffPrimaryContextRequestHandler()
         );

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -102,7 +103,7 @@ public class IndicesStore implements ClusterStateListener, Closeable {
         this.threadPool = threadPool;
         transportService.registerRequestHandler(
             ACTION_SHARD_EXISTS,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             ShardActiveRequest::new,
             new ShardActiveRequestHandler()
         );

--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -56,7 +56,7 @@ public class VerifyNodeRepositoryAction {
         this.repositoriesService = repositoriesService;
         transportService.registerRequestHandler(
             ACTION_NAME,
-            ThreadPool.Names.SNAPSHOT,
+            transportService.getThreadPool().executor(ThreadPool.Names.SNAPSHOT),
             VerifyNodeRepositoryRequest::new,
             new VerifyNodeRepositoryRequestHandler()
         );

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.NodeDisconnectedException;
@@ -60,13 +61,13 @@ public class TaskCancellationService {
         this.deduplicator = new ResultDeduplicator<>(transportService.getThreadPool().getThreadContext());
         transportService.registerRequestHandler(
             BAN_PARENT_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             BanParentTaskRequest::new,
             new BanParentRequestHandler()
         );
         transportService.registerRequestHandler(
             CANCEL_CHILD_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             CancelChildRequest::new,
             new CancelChildRequestHandler()
         );

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.ReportingService;
@@ -539,7 +540,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
     static void registerRemoteClusterHandshakeRequestHandler(TransportService transportService) {
         transportService.registerRequestHandler(
             REMOTE_CLUSTER_HANDSHAKE_ACTION_NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             false,
             false,
             TransportService.HandshakeRequest::new,

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -188,7 +189,7 @@ public final class TransportActionProxy {
         RequestHandlerRegistry<? extends TransportRequest> requestHandler = service.getRequestHandler(action);
         service.registerRequestHandler(
             getProxyAction(action),
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             true,
             false,
             in -> cancellable

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1119,46 +1119,6 @@ public class TransportService extends AbstractLifecycleComponent
     }
 
     /**
-     * Temporary passthrough function that continues to take a String rather than Executor type.
-     *
-     * @param action
-     * @param executor
-     * @param requestReader
-     * @param handler
-     * @param <Request>
-     */
-    public <Request extends TransportRequest> void registerRequestHandler(
-        String action,
-        String executor,
-        Writeable.Reader<Request> requestReader,
-        TransportRequestHandler<Request> handler
-    ) {
-        registerRequestHandler(action, threadPool.executor(executor), requestReader, handler);
-    }
-
-    /**
-     * Temporary passthrough function that continues to take a String rather than Executor type.
-     *
-     * @param action
-     * @param executor
-     * @param forceExecution
-     * @param canTripCircuitBreaker
-     * @param requestReader
-     * @param handler
-     * @param <Request>
-     */
-    public <Request extends TransportRequest> void registerRequestHandler(
-        String action,
-        String executor,
-        boolean forceExecution,
-        boolean canTripCircuitBreaker,
-        Writeable.Reader<Request> requestReader,
-        TransportRequestHandler<Request> handler
-    ) {
-        registerRequestHandler(action, threadPool.executor(executor), forceExecution, canTripCircuitBreaker, requestReader, handler);
-    }
-
-    /**
      * Registers a new request handler
      *
      * @param action         The action the request handler is associated with

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportDeleteDesiredBalanceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportDeleteDesiredBalanceActionTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -56,17 +57,20 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportDeleteDesiredBalanceActionTests extends ESAllocationTestCase {
 
     public void testReturnsErrorIfAllocatorIsNotDesiredBalanced() throws Exception {
-
         var listener = new PlainActionFuture<ActionResponse.Empty>();
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+
         new TransportDeleteDesiredBalanceAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             mock(AllocationService.class),
@@ -131,8 +135,12 @@ public class TransportDeleteDesiredBalanceActionTests extends ESAllocationTestCa
 
         var listener = new PlainActionFuture<ActionResponse.Empty>();
 
+        // TODO: temporary, remove in #97879
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         var action = new TransportDeleteDesiredBalanceAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
             threadPool,
             mock(ActionFilters.class),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -162,6 +164,10 @@ public class ClusterFormationInfoActionTests extends ESTestCase {
         Coordinator coordinator = mock(Coordinator.class);
         ClusterFormationFailureHelper.ClusterFormationState clusterFormationState = getClusterFormationState();
         when(coordinator.getClusterFormationState()).thenReturn(clusterFormationState);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         ClusterFormationInfoAction.TransportAction action = new ClusterFormationInfoAction.TransportAction(
             transportService,
             actionFilters,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryActionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -24,6 +25,7 @@ import org.elasticsearch.transport.TransportService;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,6 +85,10 @@ public class MasterHistoryActionTests extends ESTestCase {
         when(threadPool.relativeTimeInMillis()).thenReturn(System.currentTimeMillis());
         MasterHistory masterHistory = new MasterHistory(threadPool, clusterService);
         when(masterHistoryService.getLocalMasterHistory()).thenReturn(masterHistory);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         MasterHistoryAction.TransportAction action = new MasterHistoryAction.TransportAction(
             transportService,
             actionFilters,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportUpdateDesiredNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportUpdateDesiredNodesActionTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -54,10 +55,12 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
     };
 
     public void testWriteBlocks() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportUpdateDesiredNodesAction action = new TransportUpdateDesiredNodesAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             NO_OP_SETTINGS_VALIDATOR,
@@ -79,10 +82,12 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
     }
 
     public void testNoBlocks() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportUpdateDesiredNodesAction action = new TransportUpdateDesiredNodesAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             NO_OP_SETTINGS_VALIDATOR,
@@ -103,10 +108,13 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
             }
         };
         ClusterService clusterService = mock(ClusterService.class);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportUpdateDesiredNodesAction action = new TransportUpdateDesiredNodesAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             validator,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/repositories/reservedstate/ReservedRepositoryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/repositories/reservedstate/ReservedRepositoryActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.reservedstate.TransformState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentParser;
@@ -132,14 +133,16 @@ public class ReservedRepositoryActionTests extends ESTestCase {
             }
         };
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         RepositoriesService repositoriesService = spy(
             new RepositoriesService(
                 Settings.EMPTY,
                 mock(ClusterService.class),
-                mock(TransportService.class),
+                transportService,
                 Map.of(),
                 Map.of("fs", fsFactory),
-                mock(ThreadPool.class),
+                threadPool,
                 null
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterGetSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterGetSettingsTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -47,10 +48,12 @@ public class ClusterGetSettingsTests extends ESTestCase {
     public void testTransportFilters() throws Exception {
         final SettingsFilter filter = new SettingsFilter(List.of("persistent.foo.filtered", "transient.foo.filtered"));
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportClusterGetSettingsAction action = new TransportClusterGetSettingsAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             filter,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.reservedstate.action.ReservedClusterSettingsAction;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -85,10 +86,12 @@ public class ClusterUpdateSettingsRequestTests extends ESTestCase {
     public void testOperatorHandler() throws IOException {
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportClusterUpdateSettingsAction action = new TransportClusterUpdateSettingsAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             clusterSettings

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
@@ -90,10 +91,13 @@ public class TransportCreateIndexActionTests extends ESTestCase {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(threadContext, SYSTEM_INDICES);
         this.metadataCreateIndexService = mock(MetadataCreateIndexService.class);
+
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         this.action = new TransportCreateIndexAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             metadataCreateIndexService,
             mock(ActionFilters.class),
             indexNameExpressionResolver,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
@@ -78,6 +79,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -354,6 +356,10 @@ public class TransportRolloverActionTests extends ESTestCase {
             EmptySystemIndices.INSTANCE,
             WriteLoadForecaster.DEFAULT
         );
+
+        // TODO: temporary, remove in #97879
+        when(mockTransportService.getThreadPool()).thenReturn(mockThreadPool);
+        when(mockThreadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         final TransportRolloverAction transportRolloverAction = new TransportRolloverAction(
             mockTransportService,
             mockClusterService,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
@@ -68,10 +69,13 @@ public class TransportUpdateSettingsActionTests extends ESTestCase {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(threadContext, SYSTEM_INDICES);
         MetadataUpdateSettingsService metadataUpdateSettingsService = mock(MetadataUpdateSettingsService.class);
+
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         this.action = new TransportUpdateSettingsAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             metadataUpdateSettingsService,
             mock(ActionFilters.class),
             indexNameExpressionResolver,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.reservedstate.ActionWithReservedState;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
 import org.elasticsearch.reservedstate.TransformState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -673,10 +674,12 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
     }
 
     public void testHandlerCorrectness() {
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var putIndexAction = new TransportPutComposableIndexTemplateAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             null,
             mock(ActionFilters.class),
             null
@@ -687,9 +690,9 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
             containsInAnyOrder(reservedComposableIndexName("aaa"))
         );
         var delIndexAction = new TransportDeleteComposableIndexTemplateAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             null,
             mock(ActionFilters.class),
             null
@@ -701,9 +704,9 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         );
 
         var putComponentAction = new TransportPutComponentTemplateAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             null,
             mock(ActionFilters.class),
             null,
@@ -716,9 +719,9 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
         );
 
         var delComponentAction = new TransportDeleteComponentTemplateAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             null,
             mock(ActionFilters.class),
             null
@@ -921,10 +924,12 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
 
         PutComposableIndexTemplateAction.Request pr = new PutComposableIndexTemplateAction.Request(conflictingTemplateName);
 
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var putTemplateAction = new TransportPutComposableIndexTemplateAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             null,
             mock(ActionFilters.class),
             null

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -32,6 +31,7 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -42,7 +42,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.util.Collections.emptySet;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,9 +106,6 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends ESTestCa
         when(clusterService.localNode()).thenReturn(localNode);
         when(localNode.isIngestNode()).thenReturn(randomBoolean());
 
-        final ThreadPool threadPool = mock(ThreadPool.class);
-        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
-
         final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(
             new ThreadContext(Settings.EMPTY),
             EmptySystemIndices.INSTANCE
@@ -120,9 +116,11 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends ESTestCa
             }
         };
 
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportBulkAction action = new TransportBulkAction(
             threadPool,
-            mock(TransportService.class),
+            transportService,
             clusterService,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -183,6 +183,11 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         MockitoAnnotations.openMocks(this);
         // setup services that will be called by action
         transportService = mock(TransportService.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+
         clusterService = mock(ClusterService.class);
         localIngest = true;
         // setup nodes for local and remote

--- a/server/src/test/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.reservedstate.action.ReservedClusterSettingsAction;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -47,7 +48,8 @@ public class ReservedStateAwareHandledTransportActionTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         doReturn(clusterState).when(clusterService).state();
 
-        Action handler = new Action("internal:testAction", clusterService, mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        Action handler = new Action("internal:testAction", clusterService, transportService, mock(ActionFilters.class));
 
         // nothing should happen here, since the request doesn't touch any of the immutable state keys
         var future = new PlainActionFuture<FakeResponse>();
@@ -61,7 +63,7 @@ public class ReservedStateAwareHandledTransportActionTests extends ESTestCase {
         FakeReservedStateAwareAction action = new FakeReservedStateAwareAction(
             "internal:testClusterSettings",
             clusterService,
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             null
         );

--- a/server/src/test/java/org/elasticsearch/action/support/replication/PostWriteRefreshTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/PostWriteRefreshTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.engine.DocIdSeqNoAndSource;
@@ -31,7 +32,6 @@ import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ReplicationGroup;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -67,7 +67,7 @@ public class PostWriteRefreshTests extends IndexShardTestCase {
         transportService.acceptIncomingRequests();
         transportService.registerRequestHandler(
             TransportUnpromotableShardRefreshAction.NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             UnpromotableShardRefreshRequest::new,
             (request, channel, task) -> {
                 unpromotableRefreshRequestReceived.set(true);

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -424,7 +424,7 @@ public class TransportWriteActionTests extends ESTestCase {
                 ),
                 TransportWriteActionTests.this.clusterService,
                 null,
-                null,
+                TransportWriteActionTests.threadPool,
                 null,
                 new ActionFilters(new HashSet<>()),
                 TestRequest::new,

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.transport.TransportService;
 
@@ -38,8 +39,9 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         final ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(NodeRoles.dataNode());
         when(indicesService.clusterService()).thenReturn(clusterService);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         PeerRecoverySourceService peerRecoverySourceService = new PeerRecoverySourceService(
-            mock(TransportService.class),
+            transportService,
             indicesService,
             new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             mock(RecoveryPlannerService.class)

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -132,7 +132,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
             childTransportService.getTaskManager().setTaskCancellationService(new TaskCancellationService(childTransportService));
             childTransportService.registerRequestHandler(
                 "internal:testAction[c]",
-                ThreadPool.Names.MANAGEMENT, // busy-wait for cancellation but not on a transport thread
+                threadPool.executor(ThreadPool.Names.MANAGEMENT), // busy-wait for cancellation but not on a transport thread
                 (StreamInput in) -> new TransportRequest.Empty(in) {
                     @Override
                     public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
@@ -125,7 +126,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
         try {
             newService.registerRequestHandler(
                 SearchShardsAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 SearchShardsRequest::new,
                 (request, channel, task) -> {
                     if ("index_not_found".equals(request.preference())) {
@@ -135,41 +136,50 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                     }
                 }
             );
-            newService.registerRequestHandler(SearchAction.NAME, ThreadPool.Names.SAME, SearchRequest::new, (request, channel, task) -> {
-                if ("index_not_found".equals(request.preference())) {
-                    channel.sendResponse(new IndexNotFoundException("index"));
-                    return;
+            newService.registerRequestHandler(
+                SearchAction.NAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                SearchRequest::new,
+                (request, channel, task) -> {
+                    if ("index_not_found".equals(request.preference())) {
+                        channel.sendResponse(new IndexNotFoundException("index"));
+                        return;
+                    }
+                    SearchHits searchHits;
+                    if ("null_target".equals(request.preference())) {
+                        searchHits = new SearchHits(
+                            new SearchHit[] { new SearchHit(0) },
+                            new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                            1F
+                        );
+                    } else {
+                        searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    }
+                    InternalSearchResponse response = new InternalSearchResponse(
+                        searchHits,
+                        InternalAggregations.EMPTY,
+                        null,
+                        null,
+                        false,
+                        null,
+                        1
+                    );
+                    SearchResponse searchResponse = new SearchResponse(
+                        response,
+                        null,
+                        1,
+                        1,
+                        0,
+                        100,
+                        ShardSearchFailure.EMPTY_ARRAY,
+                        SearchResponse.Clusters.EMPTY
+                    );
+                    channel.sendResponse(searchResponse);
                 }
-                SearchHits searchHits;
-                if ("null_target".equals(request.preference())) {
-                    searchHits = new SearchHits(new SearchHit[] { new SearchHit(0) }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1F);
-                } else {
-                    searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
-                }
-                InternalSearchResponse response = new InternalSearchResponse(
-                    searchHits,
-                    InternalAggregations.EMPTY,
-                    null,
-                    null,
-                    false,
-                    null,
-                    1
-                );
-                SearchResponse searchResponse = new SearchResponse(
-                    response,
-                    null,
-                    1,
-                    1,
-                    0,
-                    100,
-                    ShardSearchFailure.EMPTY_ARRAY,
-                    SearchResponse.Clusters.EMPTY
-                );
-                channel.sendResponse(searchResponse);
-            });
+            );
             newService.registerRequestHandler(
                 ClusterStateAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 ClusterStateRequest::new,
                 (request, channel, task) -> {
                     DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
@@ -183,7 +193,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             if (RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED.get(s)) {
                 newService.registerRequestHandler(
                     RemoteClusterNodesAction.NAME,
-                    ThreadPool.Names.SAME,
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
                     RemoteClusterNodesAction.Request::new,
                     (request, channel, task) -> channel.sendResponse(new RemoteClusterNodesAction.Response(knownNodes))
                 );

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
@@ -120,7 +121,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
         try {
             newService.registerRequestHandler(
                 ClusterStateAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 ClusterStateRequest::new,
                 (request, channel, task) -> {
                     DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
@@ -134,7 +135,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             if (hasClusterCredentials) {
                 newService.registerRequestHandler(
                     RemoteClusterNodesAction.NAME,
-                    ThreadPool.Names.SAME,
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
                     RemoteClusterNodesAction.Request::new,
                     (request, channel, task) -> channel.sendResponse(new RemoteClusterNodesAction.Response(knownNodes))
                 );

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -68,7 +69,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
 
         transportService.registerRequestHandler(
             testActionName,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             TransportRequest.Empty::new,
             (request, channel, task) -> channel.sendResponse(TransportResponse.Empty.INSTANCE)
         );

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
@@ -155,7 +155,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
             for (final var executor : EXECUTOR_NAMES) {
                 transportService.registerRequestHandler(
                     ACTION_NAME_PREFIX + executor,
-                    executor,
+                    threadPool.executor(executor),
                     TransportRequest.Empty::new,
                     (request, channel, task) -> {
                         if (randomBoolean()) {

--- a/test/framework/src/main/java/org/elasticsearch/test/MockUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.when;
+
+/**
+ * Utilities for setting up Mockito mocks.
+ */
+public class MockUtils {
+
+    /**
+     * Sets up a mock TransportService that can answer calls to TransportService.getThreadPool().executor(String).
+     *
+     * @return A mocked TransportService instance
+     */
+    public static TransportService setupTransportServiceWithThreadpoolExecutor() {
+        TransportService transportService = mock(TransportService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+
+        setMockReturns(transportService, threadPool);
+
+        return transportService;
+    }
+
+    /**
+     * Sets up a mock TransportService that can answer calls to TransportService.getThreadPool().executor(String), using the given
+     * threadPool in TransportService.
+     *
+     * @param threadPool A mock ThreadPool
+     * @return A mocked TransportService instance
+     */
+    public static TransportService setupTransportServiceWithThreadpoolExecutor(ThreadPool threadPool) {
+        assert mockingDetails(threadPool).isMock();
+        TransportService transportService = mock(TransportService.class);
+
+        setMockReturns(transportService, threadPool);
+
+        return transportService;
+    }
+
+    /**
+     * Sets up the given mock TransportService so that it can answer calls to TransportService.getThreadPool().executor(String).
+     *
+     * @param transportService A mock TransportService to be set up.
+     */
+    public static void setupTransportServiceWithThreadpoolExecutor(TransportService transportService) {
+        assert mockingDetails(transportService).isMock();
+        ThreadPool threadPool = mock(ThreadPool.class);
+
+        setMockReturns(transportService, threadPool);
+    }
+
+    private static void setMockReturns(TransportService transportService, ThreadPool threadPool) {
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -313,7 +313,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testHelloWorld() {
         serviceA.registerRequestHandler(
             "internal:sayHello",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 assertThat("moshe", equalTo(request.message));
@@ -397,7 +397,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
         serviceA.registerRequestHandler(
             "internal:ping_pong",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 assertEquals("ping_user", threadPool.getThreadContext().getHeader("test.ping.user"));
@@ -460,7 +460,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final AtomicReference<Exception> exception = new AtomicReference<>();
         serviceA.registerRequestHandler(
             "internal:localNode",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 try {
@@ -519,8 +519,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
         };
         final String ACTION = "internal:action";
-        serviceA.registerRequestHandler(ACTION, ThreadPool.Names.GENERIC, TransportRequest.Empty::new, requestHandler);
-        serviceB.registerRequestHandler(ACTION, ThreadPool.Names.GENERIC, TransportRequest.Empty::new, requestHandler);
+        serviceA.registerRequestHandler(ACTION, threadPool.executor(ThreadPool.Names.GENERIC), TransportRequest.Empty::new, requestHandler);
+        serviceB.registerRequestHandler(ACTION, threadPool.executor(ThreadPool.Names.GENERIC), TransportRequest.Empty::new, requestHandler);
 
         class CountingListener implements TransportMessageListener {
             AtomicInteger requestsReceived = new AtomicInteger();
@@ -639,7 +639,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         try (MockTransportService serviceC = buildService("TS_C", version0, transportVersion0, Settings.EMPTY)) {
             serviceA.registerRequestHandler(
                 "internal:sayHello",
-                ThreadPool.Names.GENERIC,
+                threadPool.executor(ThreadPool.Names.GENERIC),
                 TransportRequest.Empty::new,
                 (request, channel, task) -> {
                     try {
@@ -695,7 +695,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         try (MockTransportService serviceC = buildService("TS_C", version0, transportVersion0, Settings.EMPTY)) {
             serviceA.registerRequestHandler(
                 "internal:sayHello",
-                ThreadPool.Names.GENERIC,
+                threadPool.executor(ThreadPool.Names.GENERIC),
                 StringMessageRequest::new,
                 (request, channel, task) -> {
                     assertThat("moshe", equalTo(request.message));
@@ -765,8 +765,18 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                     fail(e.getMessage());
                 }
             };
-            serviceA.registerRequestHandler("internal:sayHello", ThreadPool.Names.GENERIC, StringMessageRequest::new, handler);
-            serviceC.registerRequestHandler("internal:sayHello", ThreadPool.Names.GENERIC, StringMessageRequest::new, handler);
+            serviceA.registerRequestHandler(
+                "internal:sayHello",
+                threadPool.executor(ThreadPool.Names.GENERIC),
+                StringMessageRequest::new,
+                handler
+            );
+            serviceC.registerRequestHandler(
+                "internal:sayHello",
+                threadPool.executor(ThreadPool.Names.GENERIC),
+                StringMessageRequest::new,
+                handler
+            );
 
             Settings settingsWithCompress = Settings.builder()
                 .put(TransportSettings.TRANSPORT_COMPRESS.getKey(), Compression.Enabled.INDEXING_DATA)
@@ -830,7 +840,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testErrorMessage() throws InterruptedException {
         serviceA.registerRequestHandler(
             "internal:sayHelloException",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 assertThat("moshe", equalTo(request.message));
@@ -893,7 +903,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         Set<Exception> responseErrors = ConcurrentCollections.newConcurrentSet();
         serviceA.registerRequestHandler(
             "internal:test",
-            randomBoolean() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC,
+            threadPool.executor(randomBoolean() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC),
             TestRequest::new,
             (request, channel, task) -> {
                 try {
@@ -912,7 +922,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 logger.trace("caught exception while responding from node B", e);
             }
         };
-        serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, TestRequest::new, ignoringRequestHandler);
+        serviceB.registerRequestHandler("internal:test", EsExecutors.DIRECT_EXECUTOR_SERVICE, TestRequest::new, ignoringRequestHandler);
 
         int halfSenders = scaledRandomIntBetween(3, 10);
         final CyclicBarrier go = new CyclicBarrier(halfSenders * 2 + 1);
@@ -1003,7 +1013,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 // simulate restart of nodeB
                 serviceB.close();
                 MockTransportService newService = buildService("TS_B_" + i, version1, transportVersion1, Settings.EMPTY);
-                newService.registerRequestHandler("internal:test", ThreadPool.Names.SAME, TestRequest::new, ignoringRequestHandler);
+                newService.registerRequestHandler(
+                    "internal:test",
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                    TestRequest::new,
+                    ignoringRequestHandler
+                );
                 serviceB = newService;
                 nodeB = newService.getLocalDiscoNode();
                 connectToNode(serviceB, nodeA);
@@ -1027,7 +1042,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         try {
             serviceA.registerRequestHandler(
                 "internal:foobar",
-                ThreadPool.Names.GENERIC,
+                threadPool.executor(ThreadPool.Names.GENERIC),
                 StringMessageRequest::new,
                 (request, channel, task) -> {
                     try {
@@ -1060,7 +1075,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testTimeoutSendExceptionWithNeverSendingBackResponse() throws Exception {
         serviceA.registerRequestHandler(
             "internal:sayHelloTimeoutNoResponse",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> assertThat("moshe", equalTo(request.message))
         ); // don't send back a response
@@ -1105,7 +1120,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         Semaphore inFlight = new Semaphore(Integer.MAX_VALUE);
         serviceA.registerRequestHandler(
             "internal:sayHelloTimeoutDelayedResponse",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 String message = request.message;
@@ -1250,12 +1265,22 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             public void handleException(TransportException exp) {}
         };
 
-        serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, StringMessageRequest::new, handler);
-        serviceA.registerRequestHandler("internal:testNotSeen", ThreadPool.Names.SAME, StringMessageRequest::new, handler);
-        serviceA.registerRequestHandler("internal:testError", ThreadPool.Names.SAME, StringMessageRequest::new, handlerWithError);
-        serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, StringMessageRequest::new, handler);
-        serviceB.registerRequestHandler("internal:testNotSeen", ThreadPool.Names.SAME, StringMessageRequest::new, handler);
-        serviceB.registerRequestHandler("internal:testError", ThreadPool.Names.SAME, StringMessageRequest::new, handlerWithError);
+        serviceA.registerRequestHandler("internal:test", EsExecutors.DIRECT_EXECUTOR_SERVICE, StringMessageRequest::new, handler);
+        serviceA.registerRequestHandler("internal:testNotSeen", EsExecutors.DIRECT_EXECUTOR_SERVICE, StringMessageRequest::new, handler);
+        serviceA.registerRequestHandler(
+            "internal:testError",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            StringMessageRequest::new,
+            handlerWithError
+        );
+        serviceB.registerRequestHandler("internal:test", EsExecutors.DIRECT_EXECUTOR_SERVICE, StringMessageRequest::new, handler);
+        serviceB.registerRequestHandler("internal:testNotSeen", EsExecutors.DIRECT_EXECUTOR_SERVICE, StringMessageRequest::new, handler);
+        serviceB.registerRequestHandler(
+            "internal:testError",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            StringMessageRequest::new,
+            handlerWithError
+        );
 
         String includeSettings;
         String excludeSettings;
@@ -1570,13 +1595,18 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
     public void testVersionFrom0to1() throws Exception {
-        serviceB.registerRequestHandler("internal:version", ThreadPool.Names.SAME, Version1Request::new, (request, channel, task) -> {
-            assertThat(request.value1, equalTo(1));
-            assertThat(request.value2, equalTo(0)); // not set, coming from service A
-            Version1Response response = new Version1Response(1, 2);
-            channel.sendResponse(response);
-            assertEquals(transportVersion0, channel.getVersion());
-        });
+        serviceB.registerRequestHandler(
+            "internal:version",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            Version1Request::new,
+            (request, channel, task) -> {
+                assertThat(request.value1, equalTo(1));
+                assertThat(request.value2, equalTo(0)); // not set, coming from service A
+                Version1Response response = new Version1Response(1, 2);
+                channel.sendResponse(response);
+                assertEquals(transportVersion0, channel.getVersion());
+            }
+        );
 
         Version0Request version0Request = new Version0Request();
         version0Request.value1 = 1;
@@ -1613,12 +1643,17 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
     public void testVersionFrom1to0() throws Exception {
-        serviceA.registerRequestHandler("internal:version", ThreadPool.Names.SAME, Version0Request::new, (request, channel, task) -> {
-            assertThat(request.value1, equalTo(1));
-            Version0Response response = new Version0Response(1);
-            channel.sendResponse(response);
-            assertEquals(transportVersion0, channel.getVersion());
-        });
+        serviceA.registerRequestHandler(
+            "internal:version",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            Version0Request::new,
+            (request, channel, task) -> {
+                assertThat(request.value1, equalTo(1));
+                Version0Response response = new Version0Response(1);
+                channel.sendResponse(response);
+                assertEquals(transportVersion0, channel.getVersion());
+            }
+        );
 
         Version1Request version1Request = new Version1Request();
         version1Request.value1 = 1;
@@ -1658,15 +1693,20 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
     public void testVersionFrom1to1() throws Exception {
-        serviceB.registerRequestHandler("internal:version", ThreadPool.Names.SAME, Version1Request::new, (request, channel, task) -> {
-            assertThat(request.value1, equalTo(1));
-            assertThat(request.value2, equalTo(2));
-            Version1Response response = new Version1Response(1, 2);
-            channel.sendResponse(response);
-            // channel versions don't make sense on DirectResponseChannel
-            assertThat(channel, instanceOf(TaskTransportChannel.class));
-            assertThat(((TaskTransportChannel) channel).getChannel(), instanceOf(TransportService.DirectResponseChannel.class));
-        });
+        serviceB.registerRequestHandler(
+            "internal:version",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            Version1Request::new,
+            (request, channel, task) -> {
+                assertThat(request.value1, equalTo(1));
+                assertThat(request.value2, equalTo(2));
+                Version1Response response = new Version1Response(1, 2);
+                channel.sendResponse(response);
+                // channel versions don't make sense on DirectResponseChannel
+                assertThat(channel, instanceOf(TaskTransportChannel.class));
+                assertThat(((TaskTransportChannel) channel).getChannel(), instanceOf(TransportService.DirectResponseChannel.class));
+            }
+        );
 
         Version1Request version1Request = new Version1Request();
         version1Request.value1 = 1;
@@ -1706,14 +1746,19 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
     public void testVersionFrom0to0() throws Exception {
-        serviceA.registerRequestHandler("internal:version", ThreadPool.Names.SAME, Version0Request::new, (request, channel, task) -> {
-            assertThat(request.value1, equalTo(1));
-            Version0Response response = new Version0Response(1);
-            channel.sendResponse(response);
-            // channel versions don't make sense on DirectResponseChannel
-            assertThat(channel, instanceOf(TaskTransportChannel.class));
-            assertThat(((TaskTransportChannel) channel).getChannel(), instanceOf(TransportService.DirectResponseChannel.class));
-        });
+        serviceA.registerRequestHandler(
+            "internal:version",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            Version0Request::new,
+            (request, channel, task) -> {
+                assertThat(request.value1, equalTo(1));
+                Version0Response response = new Version0Response(1);
+                channel.sendResponse(response);
+                // channel versions don't make sense on DirectResponseChannel
+                assertThat(channel, instanceOf(TaskTransportChannel.class));
+                assertThat(((TaskTransportChannel) channel).getChannel(), instanceOf(TransportService.DirectResponseChannel.class));
+            }
+        );
 
         Version0Request version0Request = new Version0Request();
         version0Request.value1 = 1;
@@ -1752,7 +1797,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testMockFailToSendNoConnectRule() throws Exception {
         serviceA.registerRequestHandler(
             "internal:sayHello",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 assertThat("moshe", equalTo(request.message));
@@ -1808,7 +1853,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testMockUnresponsiveRule() throws InterruptedException {
         serviceA.registerRequestHandler(
             "internal:sayHello",
-            ThreadPool.Names.GENERIC,
+            threadPool.executor(ThreadPool.Names.GENERIC),
             StringMessageRequest::new,
             (request, channel, task) -> {
                 assertThat("moshe", equalTo(request.message));
@@ -1860,11 +1905,16 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(2);
         final AtomicReference<InetSocketAddress> addressA = new AtomicReference<>();
         final AtomicReference<InetSocketAddress> addressB = new AtomicReference<>();
-        serviceB.registerRequestHandler("internal:action1", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
-            addressA.set(request.remoteAddress());
-            channel.sendResponse(new TestResponse((String) null));
-            latch.countDown();
-        });
+        serviceB.registerRequestHandler(
+            "internal:action1",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TestRequest::new,
+            (request, channel, task) -> {
+                addressA.set(request.remoteAddress());
+                channel.sendResponse(new TestResponse((String) null));
+                latch.countDown();
+            }
+        );
         serviceA.sendRequest(nodeB, "internal:action1", new TestRequest(), new TransportResponseHandler<TestResponse>() {
             @Override
             public TestResponse read(StreamInput in) throws IOException {
@@ -1902,10 +1952,15 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testRejectEarlyIncomingRequests() throws Exception {
         try (TransportService service = buildService("TS_TEST", version0, transportVersion0, null, Settings.EMPTY, false, false)) {
             AtomicBoolean requestProcessed = new AtomicBoolean(false);
-            service.registerRequestHandler("internal:action", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
-                requestProcessed.set(true);
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
-            });
+            service.registerRequestHandler(
+                "internal:action",
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                TestRequest::new,
+                (request, channel, task) -> {
+                    requestProcessed.set(true);
+                    channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                }
+            );
 
             DiscoveryNode node = service.getLocalNode();
             serviceA.close();
@@ -2145,19 +2200,19 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
         serviceB.registerRequestHandler(
             "internal:action1",
-            randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+            threadPool.executor(randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC)),
             TestRequest::new,
             new TestRequestHandler(serviceB)
         );
         serviceC.registerRequestHandler(
             "internal:action1",
-            randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+            threadPool.executor(randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC)),
             TestRequest::new,
             new TestRequestHandler(serviceC)
         );
         serviceA.registerRequestHandler(
             "internal:action1",
-            randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+            threadPool.executor(randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC)),
             TestRequest::new,
             new TestRequestHandler(serviceA)
         );
@@ -2231,7 +2286,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testRegisterHandlerTwice() {
         serviceB.registerRequestHandler(
             "internal:action1",
-            randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+            threadPool.executor(randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC)),
             TestRequest::new,
             (request, message, task) -> {
                 throw new AssertionError("boom");
@@ -2241,7 +2296,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             IllegalArgumentException.class,
             () -> serviceB.registerRequestHandler(
                 "internal:action1",
-                randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+                threadPool.executor(randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC)),
                 TestRequest::new,
                 (request, message, task) -> {
                     throw new AssertionError("boom");
@@ -2251,7 +2306,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
         serviceA.registerRequestHandler(
             "internal:action1",
-            randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+            threadPool.executor(randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC)),
             TestRequest::new,
             (request, message, task) -> {
                 throw new AssertionError("boom");
@@ -2449,16 +2504,21 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     public void testResponseHeadersArePreserved() throws InterruptedException {
         List<String> executors = new ArrayList<>(ThreadPool.THREAD_POOL_TYPES.keySet());
         CollectionUtil.timSort(executors); // makes sure it's reproducible
-        serviceA.registerRequestHandler("internal:action", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
+        serviceA.registerRequestHandler(
+            "internal:action",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TestRequest::new,
+            (request, channel, task) -> {
 
-            threadPool.getThreadContext().putTransient("boom", new Object());
-            threadPool.getThreadContext().addResponseHeader("foo.bar", "baz");
-            if ("fail".equals(request.info)) {
-                throw new RuntimeException("boom");
-            } else {
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                threadPool.getThreadContext().putTransient("boom", new Object());
+                threadPool.getThreadContext().addResponseHeader("foo.bar", "baz");
+                if ("fail".equals(request.info)) {
+                    throw new RuntimeException("boom");
+                } else {
+                    channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                }
             }
-        });
+        );
 
         CountDownLatch latch = new CountDownLatch(2);
 
@@ -2512,9 +2572,14 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         List<String> executors = new ArrayList<>(ThreadPool.THREAD_POOL_TYPES.keySet());
         CollectionUtil.timSort(executors); // makes sure it's reproducible
         TransportService serviceC = buildService("TS_C", version0, transportVersion0, Settings.EMPTY);
-        serviceC.registerRequestHandler("internal:action", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
-            // do nothing
-        });
+        serviceC.registerRequestHandler(
+            "internal:action",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TestRequest::new,
+            (request, channel, task) -> {
+                // do nothing
+            }
+        );
         CountDownLatch latch = new CountDownLatch(1);
         TransportResponseHandler<TransportResponse> transportResponseHandler = new TransportResponseHandler<TransportResponse>() {
             @Override
@@ -2576,26 +2641,31 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         MockTransportService serviceC = buildService("TS_C", version0, transportVersion0, Settings.EMPTY);
         CountDownLatch receivedLatch = new CountDownLatch(1);
         CountDownLatch sendResponseLatch = new CountDownLatch(1);
-        serviceC.registerRequestHandler("internal:action", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
-            // don't block on a network thread here
-            threadPool.generic().execute(new AbstractRunnable() {
-                @Override
-                public void onFailure(Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException e1) {
-                        throw new UncheckedIOException(e1);
+        serviceC.registerRequestHandler(
+            "internal:action",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TestRequest::new,
+            (request, channel, task) -> {
+                // don't block on a network thread here
+                threadPool.generic().execute(new AbstractRunnable() {
+                    @Override
+                    public void onFailure(Exception e) {
+                        try {
+                            channel.sendResponse(e);
+                        } catch (IOException e1) {
+                            throw new UncheckedIOException(e1);
+                        }
                     }
-                }
 
-                @Override
-                protected void doRun() throws Exception {
-                    receivedLatch.countDown();
-                    sendResponseLatch.await();
-                    channel.sendResponse(TransportResponse.Empty.INSTANCE);
-                }
-            });
-        });
+                    @Override
+                    protected void doRun() throws Exception {
+                        receivedLatch.countDown();
+                        sendResponseLatch.await();
+                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                    }
+                });
+            }
+        );
         CountDownLatch responseLatch = new CountDownLatch(1);
         TransportResponseHandler<TransportResponse.Empty> transportResponseHandler = new TransportResponseHandler.Empty() {
             @Override
@@ -2643,26 +2713,31 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         MockTransportService serviceC = buildService("TS_C", version0, transportVersion0, Settings.EMPTY);
         CountDownLatch receivedLatch = new CountDownLatch(1);
         CountDownLatch sendResponseLatch = new CountDownLatch(1);
-        serviceB.registerRequestHandler("internal:action", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
-            // don't block on a network thread here
-            threadPool.generic().execute(new AbstractRunnable() {
-                @Override
-                public void onFailure(Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException e1) {
-                        throw new UncheckedIOException(e1);
+        serviceB.registerRequestHandler(
+            "internal:action",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TestRequest::new,
+            (request, channel, task) -> {
+                // don't block on a network thread here
+                threadPool.generic().execute(new AbstractRunnable() {
+                    @Override
+                    public void onFailure(Exception e) {
+                        try {
+                            channel.sendResponse(e);
+                        } catch (IOException e1) {
+                            throw new UncheckedIOException(e1);
+                        }
                     }
-                }
 
-                @Override
-                protected void doRun() throws Exception {
-                    receivedLatch.countDown();
-                    sendResponseLatch.await();
-                    channel.sendResponse(TransportResponse.Empty.INSTANCE);
-                }
-            });
-        });
+                    @Override
+                    protected void doRun() throws Exception {
+                        receivedLatch.countDown();
+                        sendResponseLatch.await();
+                        channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                    }
+                });
+            }
+        );
         CountDownLatch responseLatch = new CountDownLatch(1);
         TransportResponseHandler<TransportResponse.Empty> transportResponseHandler = new TransportResponseHandler.Empty() {
             @Override
@@ -2755,26 +2830,31 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         CountDownLatch sendResponseLatch = new CountDownLatch(1);
         Exception ex = new RuntimeException("boom");
         ex.setStackTrace(new StackTraceElement[0]);
-        serviceB.registerRequestHandler("internal:action", ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
-            // don't block on a network thread here
-            threadPool.generic().execute(new AbstractRunnable() {
-                @Override
-                public void onFailure(Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException e1) {
-                        throw new UncheckedIOException(e1);
+        serviceB.registerRequestHandler(
+            "internal:action",
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TestRequest::new,
+            (request, channel, task) -> {
+                // don't block on a network thread here
+                threadPool.generic().execute(new AbstractRunnable() {
+                    @Override
+                    public void onFailure(Exception e) {
+                        try {
+                            channel.sendResponse(e);
+                        } catch (IOException e1) {
+                            throw new UncheckedIOException(e1);
+                        }
                     }
-                }
 
-                @Override
-                protected void doRun() throws Exception {
-                    receivedLatch.countDown();
-                    sendResponseLatch.await();
-                    onFailure(ex);
-                }
-            });
-        });
+                    @Override
+                    protected void doRun() throws Exception {
+                        receivedLatch.countDown();
+                        sendResponseLatch.await();
+                        onFailure(ex);
+                    }
+                });
+            }
+        );
         CountDownLatch responseLatch = new CountDownLatch(1);
         AtomicReference<TransportException> receivedException = new AtomicReference<>(null);
         TransportResponseHandler<TransportResponse.Empty> transportResponseHandler = new TransportResponseHandler.Empty() {
@@ -3120,31 +3200,41 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     public void testChannelToString() {
         final String ACTION = "internal:action";
-        serviceA.registerRequestHandler(ACTION, ThreadPool.Names.SAME, TransportRequest.Empty::new, (request, channel, task) -> {
-            assertThat(
-                channel.toString(),
-                allOf(
-                    containsString("DirectResponseChannel"),
-                    containsString('{' + ACTION + '}'),
-                    containsString("TaskTransportChannel{task=" + task.getId() + '}')
-                )
-            );
-            assertThat(new ChannelActionListener<>(channel).toString(), containsString(channel.toString()));
-            channel.sendResponse(TransportResponse.Empty.INSTANCE);
-        });
-        serviceB.registerRequestHandler(ACTION, ThreadPool.Names.SAME, TransportRequest.Empty::new, (request, channel, task) -> {
-            assertThat(
-                channel.toString(),
-                allOf(
-                    containsString("TcpTransportChannel"),
-                    containsString('{' + ACTION + '}'),
-                    containsString("TaskTransportChannel{task=" + task.getId() + '}'),
-                    containsString("localAddress="),
-                    containsString(serviceB.getLocalNode().getAddress().toString())
-                )
-            );
-            channel.sendResponse(TransportResponse.Empty.INSTANCE);
-        });
+        serviceA.registerRequestHandler(
+            ACTION,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TransportRequest.Empty::new,
+            (request, channel, task) -> {
+                assertThat(
+                    channel.toString(),
+                    allOf(
+                        containsString("DirectResponseChannel"),
+                        containsString('{' + ACTION + '}'),
+                        containsString("TaskTransportChannel{task=" + task.getId() + '}')
+                    )
+                );
+                assertThat(new ChannelActionListener<>(channel).toString(), containsString(channel.toString()));
+                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+            }
+        );
+        serviceB.registerRequestHandler(
+            ACTION,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            TransportRequest.Empty::new,
+            (request, channel, task) -> {
+                assertThat(
+                    channel.toString(),
+                    allOf(
+                        containsString("TcpTransportChannel"),
+                        containsString('{' + ACTION + '}'),
+                        containsString("TaskTransportChannel{task=" + task.getId() + '}'),
+                        containsString("localAddress="),
+                        containsString(serviceB.getLocalNode().getAddress().toString())
+                    )
+                );
+                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+            }
+        );
 
         PlainActionFuture.get(
             f -> submitRequest(
@@ -3233,7 +3323,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final var requestSize = between(0, ByteSizeUnit.MB.toIntBytes(1));
         final var responseSize = between(0, ByteSizeUnit.MB.toIntBytes(1));
 
-        serviceB.registerRequestHandler(ACTION, ThreadPool.Names.SAME, Request::new, (request, channel, task) -> {
+        serviceB.registerRequestHandler(ACTION, EsExecutors.DIRECT_EXECUTOR_SERVICE, Request::new, (request, channel, task) -> {
             assertEquals(requestSize, request.refSize);
             channel.sendResponse(new Response(responseSize));
         });

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -322,7 +322,12 @@ public class DisruptableMockTransportTests extends ESTestCase {
     }
 
     private void registerRequestHandler(TransportService transportService, TransportRequestHandler<TestRequest> handler) {
-        transportService.registerRequestHandler(TEST_ACTION, ThreadPool.Names.GENERIC, TestRequest::new, handler);
+        transportService.registerRequestHandler(
+            TEST_ACTION,
+            transportService.getThreadPool().executor(ThreadPool.Names.GENERIC),
+            TestRequest::new,
+            handler
+        );
     }
 
     private void send(

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -59,13 +60,15 @@ public class AnalyticsInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() throws Exception {
-        AnalyticsInfoTransportAction featureSet = new AnalyticsInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+        AnalyticsInfoTransportAction featureSet = new AnalyticsInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
         Client client = mockClient();
         AnalyticsUsageTransportAction usageAction = new AnalyticsUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             client
@@ -84,14 +87,16 @@ public class AnalyticsInfoTransportActionTests extends ESTestCase {
     }
 
     public void testEnabled() throws Exception {
-        AnalyticsInfoTransportAction featureSet = new AnalyticsInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+        AnalyticsInfoTransportAction featureSet = new AnalyticsInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
         assertTrue(featureSet.enabled());
         Client client = mockClient();
         AnalyticsUsageTransportAction usageAction = new AnalyticsUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             client

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -36,6 +37,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +45,10 @@ public class TransportAnalyticsStatsActionTests extends ESTestCase {
     public TransportAnalyticsStatsAction action(AnalyticsUsage usage) {
         TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         ClusterService clusterService = mock(ClusterService.class);
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.create("nodeId");

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
@@ -39,10 +40,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class TransportDeleteAutoscalingPolicyActionTests extends AutoscalingTestCase {
 
     public void testWriteBlock() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportDeleteAutoscalingPolicyAction action = new TransportDeleteAutoscalingPolicyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );
@@ -61,10 +64,12 @@ public class TransportDeleteAutoscalingPolicyActionTests extends AutoscalingTest
     }
 
     public void testNoWriteBlock() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportDeleteAutoscalingPolicyAction action = new TransportDeleteAutoscalingPolicyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.AutoscalingLicenseChecker;
@@ -37,10 +38,12 @@ import static org.mockito.Mockito.mock;
 public class TransportGetAutoscalingPolicyActionTests extends AutoscalingTestCase {
 
     public void testReadBlock() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportGetAutoscalingPolicyAction action = new TransportGetAutoscalingPolicyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             new AutoscalingLicenseChecker(() -> true)
@@ -64,10 +67,12 @@ public class TransportGetAutoscalingPolicyActionTests extends AutoscalingTestCas
     }
 
     public void testNoReadBlock() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportGetAutoscalingPolicyAction action = new TransportGetAutoscalingPolicyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             new AutoscalingLicenseChecker(() -> true)

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.AutoscalingLicenseChecker;
@@ -41,10 +42,12 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
     private static final PolicyValidator NO_VALIDATION = policy -> {};
 
     public void testWriteBlock() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportPutAutoscalingPolicyAction action = new TransportPutAutoscalingPolicyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             NO_VALIDATION,
@@ -65,10 +68,12 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
     }
 
     public void testNoWriteBlock() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         final TransportPutAutoscalingPolicyAction action = new TransportPutAutoscalingPolicyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             NO_VALIDATION,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRInfoTransportActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRInfoTransportActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
@@ -48,8 +49,9 @@ public class CCRInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() {
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         CCRInfoTransportAction featureSet = new CCRInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             Settings.EMPTY,
             licenseState
@@ -64,8 +66,9 @@ public class CCRInfoTransportActionTests extends ESTestCase {
 
     public void testEnabled() {
         Settings.Builder settings = Settings.builder().put("xpack.ccr.enabled", false);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         CCRInfoTransportAction featureSet = new CCRInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             settings.build(),
             licenseState
@@ -73,13 +76,14 @@ public class CCRInfoTransportActionTests extends ESTestCase {
         assertThat(featureSet.enabled(), equalTo(false));
 
         settings = Settings.builder().put("xpack.ccr.enabled", true);
-        featureSet = new CCRInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class), settings.build(), licenseState);
+        featureSet = new CCRInfoTransportAction(transportService, mock(ActionFilters.class), settings.build(), licenseState);
         assertThat(featureSet.enabled(), equalTo(true));
     }
 
     public void testName() {
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         CCRInfoTransportAction featureSet = new CCRInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             Settings.EMPTY,
             licenseState
@@ -137,10 +141,12 @@ public class CCRInfoTransportActionTests extends ESTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).metadata(metadata).build();
         Mockito.when(clusterService.state()).thenReturn(clusterState);
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var usageAction = new CCRUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             Settings.EMPTY,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/repositories/ClearCcrRestoreSessionActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/repositories/ClearCcrRestoreSessionActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.ccr.repository.CcrRestoreSourceService;
@@ -57,6 +58,7 @@ public class ClearCcrRestoreSessionActionTests extends ESTestCase {
         final TransportService transportService = mock(TransportService.class);
         final CcrRestoreSourceService ccrRestoreSourceService = mock(CcrRestoreSourceService.class);
 
+        MockUtils.setupTransportServiceWithThreadpoolExecutor(transportService);
         final var action = new ClearCcrRestoreSessionAction.TransportAction(actionFilters, transportService, ccrRestoreSourceService);
         assertThat(action.actionName, equalTo(ClearCcrRestoreSessionAction.NAME));
 
@@ -87,6 +89,7 @@ public class ClearCcrRestoreSessionActionTests extends ESTestCase {
             }
         }).when(ccrRestoreSourceService).ensureSessionShardIdConsistency(anyString(), any());
 
+        MockUtils.setupTransportServiceWithThreadpoolExecutor(transportService);
         final var action = new ClearCcrRestoreSessionAction.TransportAction(actionFilters, transportService, ccrRestoreSourceService);
 
         final String sessionUUID = UUIDs.randomBase64UUID();

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.ccr.repository.CcrRestoreSourceService;
@@ -62,6 +63,7 @@ public class GetCcrRestoreFileChunkActionTests extends ESTestCase {
         final TransportService transportService = mock(TransportService.class);
         final CcrRestoreSourceService ccrRestoreSourceService = mock(CcrRestoreSourceService.class);
 
+        MockUtils.setupTransportServiceWithThreadpoolExecutor(transportService);
         final var action = new GetCcrRestoreFileChunkAction.TransportAction(
             bigArrays,
             transportService,
@@ -103,6 +105,7 @@ public class GetCcrRestoreFileChunkActionTests extends ESTestCase {
             }
         }).when(ccrRestoreSourceService).ensureSessionShardIdConsistency(anyString(), any());
 
+        MockUtils.setupTransportServiceWithThreadpoolExecutor(transportService);
         final var action = new GetCcrRestoreFileChunkAction.TransportAction(
             bigArrays,
             transportService,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
@@ -135,7 +135,7 @@ public class TransportTermsEnumAction extends HandledTransportAction<TermsEnumRe
 
         transportService.registerRequestHandler(
             transportShardAction,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             NodeTermsEnumRequest::new,
             new NodeTransportHandler()
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.FeatureSetsInfo.FeatureSet;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
@@ -59,8 +60,9 @@ public class TransportXPackInfoActionTests extends ESTestCase {
             });
         }
 
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         TransportXPackInfoAction action = new TransportXPackInfoAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             licenseService,
             client

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.test.ESTestCase;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
@@ -62,6 +64,11 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
         when(node.getId()).thenReturn("mock-node");
         TransportService transportService = Mockito.mock(TransportService.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+
         when(transportService.getLocalNode()).thenReturn(node);
         PluginsService pluginsService = Mockito.mock(PluginsService.class);
         ActionFilters actionFilters = Mockito.mock(ActionFilters.class);

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 
@@ -28,7 +29,8 @@ public class InternalExecutePolicyActionTests extends ESTestCase {
 
     @Before
     public void instantiateTransportAction() {
-        transportAction = new InternalExecutePolicyAction.Transport(mock(TransportService.class), mock(ActionFilters.class), null, null);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        transportAction = new InternalExecutePolicyAction.Transport(transportService, mock(ActionFilters.class), null, null);
     }
 
     public void testSelectNodeForPolicyExecution() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlInfoTransportActionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlInfoTransportActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
@@ -54,12 +55,14 @@ public class EqlInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        EqlInfoTransportAction featureSet = new EqlInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        EqlInfoTransportAction featureSet = new EqlInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
     }
 
     public void testEnabled() {
-        EqlInfoTransportAction featureSet = new EqlInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        EqlInfoTransportAction featureSet = new EqlInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
     }
 
@@ -93,10 +96,12 @@ public class EqlInfoTransportActionTests extends ESTestCase {
         when(mockNode.getId()).thenReturn("mocknode");
         when(clusterService.localNode()).thenReturn(mockNode);
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var usageAction = new EqlUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             client

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
@@ -36,9 +36,9 @@ public class DriverTaskRunner {
     public static final String ACTION_NAME = "internal:data/read/esql/compute";
     private final TransportService transportService;
 
-    public DriverTaskRunner(TransportService transportService, String executorName) {
+    public DriverTaskRunner(TransportService transportService, Executor executor) {
         this.transportService = transportService;
-        transportService.registerRequestHandler(ACTION_NAME, executorName, DriverRequest::new, new DriverRequestHandler());
+        transportService.registerRequestHandler(ACTION_NAME, executor, DriverRequest::new, new DriverRequestHandler());
     }
 
     public void executeDrivers(Task parentTask, List<Driver> drivers, Executor executor, ActionListener<Void> listener) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
@@ -79,13 +79,13 @@ public final class ExchangeService extends AbstractLifecycleComponent {
     public void registerTransportHandler(TransportService transportService) {
         transportService.registerRequestHandler(
             EXCHANGE_ACTION_NAME,
-            requestExecutorName,
+            threadPool.executor(requestExecutorName),
             ExchangeRequest::new,
             new ExchangeTransportAction()
         );
         transportService.registerRequestHandler(
             OPEN_EXCHANGE_ACTION_NAME,
-            requestExecutorName,
+            threadPool.executor(requestExecutorName),
             OpenExchangeRequest::new,
             new OpenExchangeRequestHandler()
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -102,12 +102,7 @@ public class EnrichLookupService {
         this.searchService = searchService;
         this.transportService = transportService;
         this.executor = transportService.getThreadPool().executor(EsqlPlugin.ESQL_THREAD_POOL_NAME);
-        transportService.registerRequestHandler(
-            LOOKUP_ACTION_NAME,
-            EsqlPlugin.ESQL_THREAD_POOL_NAME,
-            LookupRequest::new,
-            new TransportHandler()
-        );
+        transportService.registerRequestHandler(LOOKUP_ACTION_NAME, this.executor, LookupRequest::new, new TransportHandler());
     }
 
     public void lookupAsync(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -103,14 +103,9 @@ public class ComputeService {
         this.searchService = searchService;
         this.transportService = transportService;
         this.bigArrays = bigArrays.withCircuitBreaking();
-        transportService.registerRequestHandler(
-            DATA_ACTION_NAME,
-            ESQL_THREAD_POOL_NAME,
-            DataNodeRequest::new,
-            new DataNodeRequestHandler()
-        );
         this.esqlExecutor = threadPool.executor(ESQL_THREAD_POOL_NAME);
-        this.driverRunner = new DriverTaskRunner(transportService, ESQL_THREAD_POOL_NAME);
+        transportService.registerRequestHandler(DATA_ACTION_NAME, this.esqlExecutor, DataNodeRequest::new, new DataNodeRequestHandler());
+        this.driverRunner = new DriverTaskRunner(transportService, this.esqlExecutor);
         this.exchangeService = exchangeService;
         this.enrichLookupService = enrichLookupService;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/EsqlInfoTransportActionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/EsqlInfoTransportActionTests.java
@@ -43,11 +43,17 @@ import static org.mockito.Mockito.when;
 public class EsqlInfoTransportActionTests extends ESTestCase {
 
     private ThreadPool threadPool;
+    private TransportService transportService;
     private Client client;
 
     @Before
     public void init() {
         threadPool = new TestThreadPool(getTestName());
+
+        // TODO: temporary, remove in #97879
+        transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
     }
@@ -58,12 +64,12 @@ public class EsqlInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        EsqlInfoTransportAction featureSet = new EsqlInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        EsqlInfoTransportAction featureSet = new EsqlInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
     }
 
     public void testEnabled() {
-        EsqlInfoTransportAction featureSet = new EsqlInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        EsqlInfoTransportAction featureSet = new EsqlInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
     }
 
@@ -98,7 +104,7 @@ public class EsqlInfoTransportActionTests extends ESTestCase {
         when(clusterService.localNode()).thenReturn(mockNode);
 
         var usageAction = new EsqlUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
             threadPool,
             mock(ActionFilters.class),

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphInfoTransportActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphInfoTransportActionTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -33,8 +34,9 @@ public class GraphInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() throws Exception {
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         GraphInfoTransportAction featureSet = new GraphInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             Settings.EMPTY,
             licenseState
@@ -44,7 +46,7 @@ public class GraphInfoTransportActionTests extends ESTestCase {
         assertThat(featureSet.available(), is(available));
 
         var usageAction = new GraphUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             null,
             mock(ThreadPool.class),
             mock(ActionFilters.class),
@@ -73,8 +75,10 @@ public class GraphInfoTransportActionTests extends ESTestCase {
         } else {
             settings.put("xpack.graph.enabled", enabled);
         }
+
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         GraphInfoTransportAction featureSet = new GraphInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             settings.build(),
             licenseState
@@ -82,7 +86,7 @@ public class GraphInfoTransportActionTests extends ESTestCase {
         assertThat(featureSet.enabled(), is(enabled));
 
         GraphUsageTransportAction usageAction = new GraphUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             null,
             mock(ThreadPool.class),
             mock(ActionFilters.class),

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderActionTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.idp.saml.idp.SamlIdentityProvider;
 import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderDocument;
@@ -57,10 +58,10 @@ public class TransportPutSamlServiceProviderActionTests extends ESTestCase {
         index = mock(SamlServiceProviderIndex.class);
         idp = mock(SamlIdentityProvider.class);
         when(idp.getAllowedNameIdFormats()).thenReturn(Set.of(TRANSIENT));
-
         now = Instant.ofEpochMilli(System.currentTimeMillis() + randomLongBetween(-500_000, 500_000));
         final Clock clock = Clock.fixed(now, randomZone());
-        action = new TransportPutSamlServiceProviderAction(mock(TransportService.class), mock(ActionFilters.class), index, idp, clock);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        action = new TransportPutSamlServiceProviderAction(transportService, mock(ActionFilters.class), index, idp, clock);
     }
 
     public void testRegisterNewServiceProvider() throws Exception {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInfoTransportActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInfoTransportActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
@@ -52,18 +53,14 @@ public class IndexLifecycleInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        IndexLifecycleInfoTransportAction featureSet = new IndexLifecycleInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class)
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        IndexLifecycleInfoTransportAction featureSet = new IndexLifecycleInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), equalTo(true));
     }
 
     public void testName() {
-        IndexLifecycleInfoTransportAction featureSet = new IndexLifecycleInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class)
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        IndexLifecycleInfoTransportAction featureSet = new IndexLifecycleInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.name(), equalTo("ilm"));
     }
 
@@ -94,13 +91,9 @@ public class IndexLifecycleInfoTransportActionTests extends ESTestCase {
         ClusterState clusterState = buildClusterState(policies, indexPolicies);
         Mockito.when(clusterService.state()).thenReturn(clusterState);
 
-        var usageAction = new IndexLifecycleUsageTransportAction(
-            mock(TransportService.class),
-            null,
-            mock(ThreadPool.class),
-            mock(ActionFilters.class),
-            null
-        );
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+        var usageAction = new IndexLifecycleUsageTransportAction(transportService, null, threadPool, mock(ActionFilters.class), null);
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, clusterState, future);
         IndexLifecycleFeatureSetUsage ilmUsage = (IndexLifecycleFeatureSetUsage) future.get().getUsage();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportDeleteLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportDeleteLifecycleActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction;
@@ -20,10 +21,12 @@ import static org.mockito.Mockito.mock;
 
 public class TransportDeleteLifecycleActionTests extends ESTestCase {
     public void testReservedStateHandler() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportDeleteLifecycleAction putAction = new TransportDeleteLifecycleAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -46,10 +47,12 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
     }
 
     public void testReservedStateHandler() throws Exception {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportPutLifecycleAction putAction = new TransportPutLifecycleAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             mock(NamedXContentRegistry.class),

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportStopILMActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportStopILMActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ilm.StopILMRequest;
@@ -34,10 +35,12 @@ public class TransportStopILMActionTests extends ESTestCase {
     public void testStopILMClusterStatePriorityIsImmediate() {
         ClusterService clusterService = mock(ClusterService.class);
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportStopILMAction transportStopILMAction = new TransportStopILMAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportDeletePipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportDeletePipelineActionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportService;
@@ -27,8 +28,9 @@ public class TransportDeletePipelineActionTests extends ESTestCase {
 
     public void testDeletePipelineWithMissingIndex() throws Exception {
         try (Client client = getFailureClient(new IndexNotFoundException("missing .logstash"))) {
+            TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
             final TransportDeletePipelineAction action = new TransportDeletePipelineAction(
-                mock(TransportService.class),
+                transportService,
                 mock(ActionFilters.class),
                 client
             );

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportService;
@@ -100,11 +101,8 @@ public class TransportGetPipelineActionTests extends ESTestCase {
 
         try (Client client = getMockClient(multiGetResponse)) {
             Loggers.addAppender(logger, mockLogAppender);
-            TransportGetPipelineAction action = new TransportGetPipelineAction(
-                mock(TransportService.class),
-                mock(ActionFilters.class),
-                client
-            );
+            TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+            TransportGetPipelineAction action = new TransportGetPipelineAction(transportService, mock(ActionFilters.class), client);
             action.doExecute(null, request, testActionListener);
         } finally {
             Loggers.removeAppender(logger, mockLogAppender);
@@ -152,8 +150,9 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             }
         };
 
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         try (Client client = getMockClient(searchResponse)) {
-            new TransportGetPipelineAction(mock(TransportService.class), mock(ActionFilters.class), client).doExecute(
+            new TransportGetPipelineAction(transportService, mock(ActionFilters.class), client).doExecute(
                 null,
                 request,
                 testActionListener
@@ -165,8 +164,9 @@ public class TransportGetPipelineActionTests extends ESTestCase {
 
     public void testMissingIndexHandling() throws Exception {
         try (Client failureClient = getFailureClient(new IndexNotFoundException("foo"))) {
+            TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
             final TransportGetPipelineAction action = new TransportGetPipelineAction(
-                mock(TransportService.class),
+                transportService,
                 mock(ActionFilters.class),
                 failureClient
             );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -145,10 +146,12 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
         boolean isDataFrameAnalyticsEnabled,
         boolean isNlpEnabled
     ) {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         return new MachineLearningUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class),
             TestEnvironment.newEnvironment(settings),
@@ -162,8 +165,9 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() throws Exception {
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         MachineLearningInfoTransportAction featureSet = new MachineLearningInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             commonSettings,
             licenseState
@@ -191,9 +195,11 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             enabled = randomBoolean();
             settings.put("xpack.ml.enabled", enabled);
         }
+
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         boolean expected = enabled;
         MachineLearningInfoTransportAction featureSet = new MachineLearningInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             settings.build(),
             licenseState

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.MlTasks;
@@ -337,10 +338,12 @@ public class TransportCloseJobActionTests extends ESTestCase {
     }
 
     private TransportCloseJobAction createAction() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         return new TransportCloseJobAction(
-            mock(TransportService.class),
+            transportService,
             client,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             clusterService,
             mock(AnomalyDetectionAuditor.class),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class TransportDeleteExpiredDataActionTests extends ESTestCase {
 
@@ -59,6 +60,10 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
     public void setup() {
         threadPool = new TestThreadPool("TransportDeleteExpiredDataActionTests thread pool");
         TransportService transportService = mock(TransportService.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         Client client = mock(Client.class);
         ClusterService clusterService = mock(ClusterService.class);
         auditor = mock(AnomalyDetectionAuditor.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
@@ -81,8 +81,12 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
     }
 
     private TransportFinalizeJobExecutionAction createAction(ClusterService clusterService) {
+        // TODO: temporary, remove in #97879
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         return new TransportFinalizeJobExecutionAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
             threadPool,
             mock(ActionFilters.class),

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringInfoTransportActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringInfoTransportActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -44,18 +45,14 @@ public class MonitoringInfoTransportActionTests extends ESTestCase {
     private final Exporters exporters = mock(Exporters.class);
 
     public void testAvailable() {
-        MonitoringInfoTransportAction featureSet = new MonitoringInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class)
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        MonitoringInfoTransportAction featureSet = new MonitoringInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
     }
 
     public void testMonitoringEnabledByDefault() {
-        MonitoringInfoTransportAction featureSet = new MonitoringInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class)
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        MonitoringInfoTransportAction featureSet = new MonitoringInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
     }
 
@@ -94,10 +91,12 @@ public class MonitoringInfoTransportActionTests extends ESTestCase {
         when(exporters.getEnabledExporters()).thenReturn(exporterList);
         when(monitoring.isMonitoringActive()).thenReturn(collectionEnabled);
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var usageAction = new MonitoringUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             new MonitoringUsageServices(monitoring, exporters)

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -97,6 +98,10 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
         clusterService = mock(ClusterService.class);
         transportService = mock(TransportService.class);
         filters = mock(ActionFilters.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.executor(anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
         when(transportService.getTaskManager()).thenReturn(taskManager);
         when(taskManager.register(anyString(), eq(MonitoringBulkAction.NAME), any(TaskAwareRequest.class))).thenReturn(mock(Task.class));

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
@@ -49,7 +50,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilde
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportService;
@@ -105,7 +105,7 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
 
         transportService.registerRequestHandler(
             actionName,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             false,
             true,
             SearchRequest::new,

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupInfoTransportActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupInfoTransportActionTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -25,23 +26,21 @@ import static org.mockito.Mockito.mock;
 public class RollupInfoTransportActionTests extends ESTestCase {
 
     public void testAvailable() {
-        RollupInfoTransportAction featureSet = new RollupInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        RollupInfoTransportAction featureSet = new RollupInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
     }
 
     public void testEnabledDefault() {
-        RollupInfoTransportAction featureSet = new RollupInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        RollupInfoTransportAction featureSet = new RollupInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
     }
 
     public void testUsage() throws ExecutionException, InterruptedException, IOException {
-        var usageAction = new RollupUsageTransportAction(
-            mock(TransportService.class),
-            null,
-            mock(ThreadPool.class),
-            mock(ActionFilters.class),
-            null
-        );
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+        var usageAction = new RollupUsageTransportAction(transportService, null, threadPool, mock(ActionFilters.class), null);
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, null, future);
         XPackFeatureSet.Usage rollupUsage = future.get().getUsage();

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -1108,7 +1109,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
         try {
             service.registerRequestHandler(
                 ClusterStateAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 ClusterStateRequest::new,
                 (request, channel, task) -> {
                     capturedHeaders.add(
@@ -1121,7 +1122,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
             );
             service.registerRequestHandler(
                 RemoteClusterNodesAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 RemoteClusterNodesAction.Request::new,
                 (request, channel, task) -> {
                     capturedHeaders.add(
@@ -1132,7 +1133,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
             );
             service.registerRequestHandler(
                 SearchShardsAction.NAME,
-                ThreadPool.Names.SAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 SearchShardsRequest::new,
                 (request, channel, task) -> {
                     capturedHeaders.add(
@@ -1141,31 +1142,36 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                     channel.sendResponse(new SearchShardsResponse(List.of(), List.of(), Collections.emptyMap()));
                 }
             );
-            service.registerRequestHandler(SearchAction.NAME, ThreadPool.Names.SAME, SearchRequest::new, (request, channel, task) -> {
-                capturedHeaders.add(
-                    new CapturedActionWithHeaders(task.getAction(), Map.copyOf(threadPool.getThreadContext().getHeaders()))
-                );
-                channel.sendResponse(
-                    new SearchResponse(
-                        new InternalSearchResponse(
-                            new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN),
-                            InternalAggregations.EMPTY,
+            service.registerRequestHandler(
+                SearchAction.NAME,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                SearchRequest::new,
+                (request, channel, task) -> {
+                    capturedHeaders.add(
+                        new CapturedActionWithHeaders(task.getAction(), Map.copyOf(threadPool.getThreadContext().getHeaders()))
+                    );
+                    channel.sendResponse(
+                        new SearchResponse(
+                            new InternalSearchResponse(
+                                new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN),
+                                InternalAggregations.EMPTY,
+                                null,
+                                null,
+                                false,
+                                null,
+                                1
+                            ),
                             null,
-                            null,
-                            false,
-                            null,
-                            1
-                        ),
-                        null,
-                        1,
-                        1,
-                        0,
-                        100,
-                        ShardSearchFailure.EMPTY_ARRAY,
-                        SearchResponse.Clusters.EMPTY
-                    )
-                );
-            });
+                            1,
+                            1,
+                            0,
+                            100,
+                            ShardSearchFailure.EMPTY_ARRAY,
+                            SearchResponse.Clusters.EMPTY
+                        )
+                    );
+                }
+            );
             service.start();
             service.acceptIncomingRequests();
             success = true;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
@@ -78,24 +79,18 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        SecurityInfoTransportAction featureSet = new SecurityInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class),
-            settings
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        SecurityInfoTransportAction featureSet = new SecurityInfoTransportAction(transportService, mock(ActionFilters.class), settings);
         assertThat(featureSet.available(), is(true));
     }
 
     public void testEnabled() {
-        SecurityInfoTransportAction featureSet = new SecurityInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class),
-            settings
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        SecurityInfoTransportAction featureSet = new SecurityInfoTransportAction(transportService, mock(ActionFilters.class), settings);
         assertThat(featureSet.enabled(), is(true));
 
         Settings disabled = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), false).build();
-        featureSet = new SecurityInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class), disabled);
+        featureSet = new SecurityInfoTransportAction(transportService, mock(ActionFilters.class), disabled);
         assertThat(featureSet.enabled(), is(false));
     }
 
@@ -371,10 +366,12 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
     }
 
     private SecurityUsageTransportAction newUsageAction(Settings settings) {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         return new SecurityUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             null,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             settings,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateCrossClusterApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateCrossClusterApiKeyActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyResponse;
@@ -42,12 +43,8 @@ public class TransportCreateCrossClusterApiKeyActionTests extends ESTestCase {
         super.setUp();
         apiKeyService = mock(ApiKeyService.class);
         securityContext = mock(SecurityContext.class);
-        action = new TransportCreateCrossClusterApiKeyAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class),
-            apiKeyService,
-            securityContext
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        action = new TransportCreateCrossClusterApiKeyAction(transportService, mock(ActionFilters.class), apiKeyService, securityContext);
     }
 
     public void testApiKeyWillBeCreatedWithEmptyUserRoleDescriptors() throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyActionTests.java
@@ -61,6 +61,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class TransportGrantApiKeyActionTests extends ESTestCase {
 
@@ -69,6 +70,7 @@ public class TransportGrantApiKeyActionTests extends ESTestCase {
     private ApiKeyUserRoleDescriptorResolver resolver;
     private AuthenticationService authenticationService;
     private ThreadPool threadPool;
+    private TransportService transportService;
     private AuthorizationService authorizationService;
 
     @Before
@@ -81,8 +83,12 @@ public class TransportGrantApiKeyActionTests extends ESTestCase {
         threadPool = new TestThreadPool("TP-" + getTestName());
         final ThreadContext threadContext = threadPool.getThreadContext();
 
+        // TODO: temporary, remove in #97879
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         action = new TransportGrantApiKeyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             threadContext,
             authenticationService,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateCrossClusterApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateCrossClusterApiKeyActionTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.apikey.ApiKey;
@@ -55,8 +56,9 @@ public class TransportUpdateCrossClusterApiKeyActionTests extends ESTestCase {
             () -> AuthenticationTestHelper.builder().build()
         );
         when(securityContext.getAuthentication()).thenReturn(authentication);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final var action = new TransportUpdateCrossClusterApiKeyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             apiKeyService,
             securityContext
@@ -120,8 +122,9 @@ public class TransportUpdateCrossClusterApiKeyActionTests extends ESTestCase {
 
     public void testAuthenticationCheck() {
         final SecurityContext securityContext = mock(SecurityContext.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final var action = new TransportUpdateCrossClusterApiKeyAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             mock(ApiKeyService.class),
             securityContext

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/profile/TransportProfileHasPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/profile/TransportProfileHasPrivilegesActionTests.java
@@ -64,6 +64,7 @@ import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportProfileHasPrivilegesActionTests extends ESTestCase {
 
@@ -80,6 +81,10 @@ public class TransportProfileHasPrivilegesActionTests extends ESTestCase {
     public void setup() {
         threadPool = new TestThreadPool(TransportProfileHasPrivilegesActionTests.class.getSimpleName());
         transportService = mock(TransportService.class);
+
+        // TODO: temporary, remove in #97879
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         actionFilters = mock(ActionFilters.class);
         authorizationService = mock(AuthorizationService.class);
         nativePrivilegeStore = mock(NativePrivilegeStore.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/realm/TransportClearRealmCacheActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/realm/TransportClearRealmCacheActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheRequest;
@@ -50,10 +51,13 @@ public class TransportClearRealmCacheActionTests extends ESTestCase {
         fileRealm = mockRealm("file");
         final Realms realms = mockRealms(List.of(nativeRealm, fileRealm));
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+
         action = new TransportClearRealmCacheAction(
-            mock(ThreadPool.class),
+            threadPool,
             mockClusterService(),
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             realms,
             authenticationService

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportCreateServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportCreateServiceAccountTokenActionTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
@@ -40,8 +41,10 @@ public class TransportCreateServiceAccountTokenActionTests extends ESTestCase {
     public void init() throws IOException {
         serviceAccountService = mock(ServiceAccountService.class);
         securityContext = mock(SecurityContext.class);
+
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportCreateServiceAccountTokenAction = new TransportCreateServiceAccountTokenAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             serviceAccountService,
             securityContext

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenResponse;
@@ -32,8 +33,9 @@ public class TransportDeleteServiceAccountTokenActionTests extends ESTestCase {
     @Before
     public void init() {
         serviceAccountService = mock(ServiceAccountService.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportDeleteServiceAccountTokenAction = new TransportDeleteServiceAccountTokenAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             serviceAccountService
         );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountResponse;
@@ -31,8 +32,9 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
 
     @Before
     public void init() {
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportGetServiceAccountAction = new TransportGetServiceAccountAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet())
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountCredentialsActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountCredentialsActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountCredentialsRequest;
@@ -58,8 +59,10 @@ public class TransportGetServiceAccountCredentialsActionTests extends ESTestCase
         when(transport.boundAddress()).thenReturn(new BoundTransportAddress(new TransportAddress[] { transportAddress }, transportAddress));
         final Settings settings = builder.build();
         serviceAccountService = mock(ServiceAccountService.class);
+
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportGetServiceAccountCredentialsAction = new TransportGetServiceAccountCredentialsAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             serviceAccountService
         );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -88,6 +88,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         .build();
 
     private ThreadPool threadPool;
+    private TransportService transportService;
     private Client client;
     private SecurityIndexManager securityIndex;
     private ClusterService clusterService;
@@ -99,6 +100,11 @@ public class TransportCreateTokenActionTests extends ESTestCase {
     @Before
     public void setupClient() {
         threadPool = new TestThreadPool(getTestName());
+
+        // TODO: temporary, remove in #97879
+        transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         client = mock(Client.class);
         idxReqReference = new AtomicReference<>();
         authenticationService = mock(AuthenticationService.class);
@@ -221,7 +227,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService,
             authenticationService,
@@ -262,7 +268,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService,
             authenticationService,
@@ -305,7 +311,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService,
             authenticationService,
@@ -358,7 +364,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService,
             authenticationService,
@@ -397,7 +403,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService,
             authenticationService,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenActionTests.java
@@ -56,6 +56,7 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
         .build();
 
     private ThreadPool threadPool;
+    private TransportService transportService;
     private Client client;
     private SecurityIndexManager securityIndex;
     private ClusterService clusterService;
@@ -65,6 +66,11 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
     @Before
     public void setup() {
         threadPool = new TestThreadPool(getTestName());
+
+        // TODO: temporary, remove in #97879
+        transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
         securityContext = new SecurityContext(Settings.EMPTY, threadPool.getThreadContext());
         client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
@@ -91,7 +97,7 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
             clusterService
         );
         final TransportInvalidateTokenAction action = new TransportInvalidateTokenAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService
         );
@@ -137,7 +143,7 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
             clusterService
         );
         final TransportInvalidateTokenAction action = new TransportInvalidateTokenAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Collections.emptySet()),
             tokenService
         );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
@@ -57,8 +58,10 @@ public class TransportHasPrivilegesActionTests extends ESTestCase {
             .build(false);
         when(context.getAuthentication()).thenReturn(authentication);
         threadContext.putTransient(AuthenticationField.AUTHENTICATION_KEY, authentication);
+
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final TransportHasPrivilegesAction transportHasPrivilegesAction = new TransportHasPrivilegesAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Set.of()),
             mock(AuthorizationService.class),
             mock(NativePrivilegeStore.class),
@@ -110,8 +113,10 @@ public class TransportHasPrivilegesActionTests extends ESTestCase {
             );
             return null;
         }).when(authorizationService).checkPrivileges(any(), any(), anyCollection(), anyActionListener());
+
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final var action = new TransportHasPrivilegesAction(
-            mock(TransportService.class),
+            transportService,
             new ActionFilters(Set.of()),
             authorizationService,
             privilegeStore,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.mocksocket.MockSocket;
@@ -159,7 +160,7 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
         DiscoveryNode remoteNode = remoteTransportService.getLocalDiscoNode();
         remoteTransportService.registerRequestHandler(
             RemoteClusterNodesAction.NAME,
-            ThreadPool.Names.SAME,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             RemoteClusterNodesAction.Request::new,
             (request, channel, task) -> channel.sendResponse(new RemoteClusterNodesAction.Response(List.of(remoteNode)))
         );

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeActionTests.java
@@ -19,8 +19,8 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.shutdown.TransportDeleteShutdownNodeAction.DeleteShutdownNodeExecutor;
 import org.elasticsearch.xpack.shutdown.TransportDeleteShutdownNodeAction.DeleteShutdownNodeTask;
 import org.junit.Before;
@@ -55,7 +55,7 @@ public class TransportDeleteShutdownNodeActionTests extends ESTestCase {
         MockitoAnnotations.openMocks(this);
         // TODO: it takes almost 2 seconds to create these mocks....WHY?!?
         var threadPool = mock(ThreadPool.class);
-        var transportService = mock(TransportService.class);
+        var transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         clusterService = mock(ClusterService.class);
         var actionFilters = mock(ActionFilters.class);
         var indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeActionTests.java
@@ -19,8 +19,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.shutdown.TransportPutShutdownNodeAction.PutShutdownNodeExecutor;
 import org.elasticsearch.xpack.shutdown.TransportPutShutdownNodeAction.PutShutdownNodeTask;
 import org.junit.Before;
@@ -61,7 +61,7 @@ public class TransportPutShutdownNodeActionTests extends ESTestCase {
         MockitoAnnotations.openMocks(this);
         // TODO: it takes almost 2 seconds to create these mocks....WHY?!?
         var threadPool = mock(ThreadPool.class);
-        var transportService = mock(TransportService.class);
+        var transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         clusterService = mock(ClusterService.class);
         var actionFilters = mock(ActionFilters.class);
         var indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/action/ReservedSnapshotLifecycleStateServiceTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/action/ReservedSnapshotLifecycleStateServiceTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.reservedstate.service.ReservedClusterStateService;
 import org.elasticsearch.reservedstate.service.ReservedStateUpdateTask;
 import org.elasticsearch.reservedstate.service.ReservedStateUpdateTaskExecutor;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentParser;
@@ -363,10 +364,12 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
     }
 
     public void testDeleteSLMReservedStateHandler() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var deleteAction = new TransportDeleteSnapshotLifecycleAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );
@@ -377,10 +380,12 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
     }
 
     public void testPutSLMReservedStateHandler() throws Exception {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var putAction = new TransportPutSnapshotLifecycleAction(
-            mock(TransportService.class),
+            transportService,
             mock(ClusterService.class),
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/action/TransportStopSLMActionTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/action/TransportStopSLMActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ilm.action.StopILMAction;
@@ -33,11 +34,12 @@ public class TransportStopSLMActionTests extends ESTestCase {
 
     public void testStopILMClusterStatePriorityIsImmediate() {
         ClusterService clusterService = mock(ClusterService.class);
-
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         TransportStopSLMAction transportStopSLMAction = new TransportStopSLMAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             mock(IndexNameExpressionResolver.class)
         );

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialInfoTransportActionTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialInfoTransportActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -56,13 +57,15 @@ public class SpatialInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() throws Exception {
-        SpatialInfoTransportAction featureSet = new SpatialInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+        SpatialInfoTransportAction featureSet = new SpatialInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
 
         var usageAction = new SpatialUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             mockClient()
@@ -80,14 +83,16 @@ public class SpatialInfoTransportActionTests extends ESTestCase {
     }
 
     public void testEnabled() throws Exception {
-        SpatialInfoTransportAction featureSet = new SpatialInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
+        SpatialInfoTransportAction featureSet = new SpatialInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
         assertTrue(featureSet.enabled());
 
         SpatialUsageTransportAction usageAction = new SpatialUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             mockClient()

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportActionTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -47,8 +48,8 @@ public class SpatialStatsTransportActionTests extends ESTestCase {
 
     @Before
     public void mockServices() {
-        transportService = mock(TransportService.class);
         threadPool = mock(ThreadPool.class);
+        transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         clusterService = mock(ClusterService.class);
 
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.create("nodeId");

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlInfoTransportActionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlInfoTransportActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
@@ -57,11 +58,8 @@ public class SqlInfoTransportActionTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        SqlInfoTransportAction featureSet = new SqlInfoTransportAction(
-            mock(TransportService.class),
-            mock(ActionFilters.class),
-            licenseState
-        );
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        SqlInfoTransportAction featureSet = new SqlInfoTransportAction(transportService, mock(ActionFilters.class), licenseState);
         assertThat(featureSet.available(), is(true));
     }
 
@@ -95,10 +93,12 @@ public class SqlInfoTransportActionTests extends ESTestCase {
         when(mockNode.getId()).thenReturn("mocknode");
         when(clusterService.localNode()).thenReturn(mockNode);
 
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         var usageAction = new SqlUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             licenseState,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformInfoTransportActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformInfoTransportActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 
@@ -29,12 +30,14 @@ import static org.mockito.Mockito.when;
 public class TransformInfoTransportActionTests extends ESTestCase {
 
     public void testAvailable() {
-        TransformInfoTransportAction featureSet = new TransformInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        TransformInfoTransportAction featureSet = new TransformInfoTransportAction(transportService, mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
     }
 
     public void testEnabledDefault() {
-        TransformInfoTransportAction featureSet = new TransformInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+        TransformInfoTransportAction featureSet = new TransformInfoTransportAction(transportService, mock(ActionFilters.class));
         assertTrue(featureSet.enabled());
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
@@ -55,20 +56,23 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
 
     private MockLicenseState licenseState;
     private Client client;
+    private ThreadPool threadPool;
+    private TransportService transportService;
 
     @Before
     public void init() throws Exception {
         licenseState = mock(MockLicenseState.class);
         client = mock(Client.class);
-        ThreadPool threadPool = mock(ThreadPool.class);
+        threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(client.threadPool()).thenReturn(threadPool);
+        transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
     }
 
     public void testAvailable() {
         WatcherInfoTransportAction featureSet = new WatcherInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             Settings.EMPTY,
             licenseState
@@ -89,7 +93,7 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
             settings.put("xpack.watcher.enabled", enabled);
         }
         WatcherInfoTransportAction featureSet = new WatcherInfoTransportAction(
-            mock(TransportService.class),
+            transportService,
             mock(ActionFilters.class),
             settings.build(),
             licenseState
@@ -130,9 +134,9 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
         when(clusterService.localNode()).thenReturn(mockNode);
 
         var usageAction = new WatcherUsageTransportAction(
-            mock(TransportService.class),
+            transportService,
             clusterService,
-            mock(ThreadPool.class),
+            threadPool,
             mock(ActionFilters.class),
             null,
             Settings.EMPTY,

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
@@ -56,8 +57,8 @@ public class TransportAckWatchActionTests extends ESTestCase {
 
     @Before
     public void setupAction() {
-        TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         WatchParser watchParser = mock(WatchParser.class);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -63,7 +64,7 @@ public class TransportPutWatchActionTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
-        TransportService transportService = mock(TransportService.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
 
         WatchParser parser = mock(WatchParser.class);
         when(parser.parseWithSecrets(eq("_id"), eq(false), any(), any(), any(), anyBoolean(), anyLong(), anyLong())).thenReturn(watch);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -44,8 +45,8 @@ public class TransportWatcherStatsActionTests extends ESTestCase {
 
     @Before
     public void setupTransportAction() {
-        TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
 
         ClusterService clusterService = mock(ClusterService.class);
         DiscoveryNode discoveryNode = DiscoveryNodeUtils.create("nodeId");


### PR DESCRIPTION
Remove temporary TransportService#registerRequestHandler functions
that take String instead of Executor and update the callers. This
is part of a larger change to pass Executor into request handlers,
rather than creating and stashing Strings that are only used to
eventually fetch appropriate Executors anyway.

Extensive testing changes were required to make TransportService and
ThreadPool mocks capable of looking up Executors from Strings for
TransportAction constructors. Added a new MockUtils class to
modularize the additional test setup.

Part of the changes for #97879