### PR TITLE
Remove driver runner without timeout

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
@@ -16,9 +18,11 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
+import org.elasticsearch.compute.operator.DriverRunner;
 import org.elasticsearch.compute.operator.exchange.ExchangeSinkHandler;
 import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -88,8 +92,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.elasticsearch.compute.operator.DriverRunner.runToCompletion;
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.ExpectedResults;
@@ -357,7 +361,6 @@ public class CsvTests extends ESTestCase {
 
         List<Driver> drivers = new ArrayList<>();
         List<Page> collectedPages = Collections.synchronizedList(new ArrayList<>());
-        Map<String, List<String>> responseHeaders;
 
         // replace fragment inside the coordinator plan
         try {
@@ -375,11 +378,50 @@ public class CsvTests extends ESTestCase {
                 drivers.addAll(dataNodeExecutionPlan.createDrivers(sessionId));
                 Randomness.shuffle(drivers);
             }
-            responseHeaders = runToCompletion(threadPool, between(1, 10_000), drivers);
+            // Execute the driver
+            DriverRunner runner = new DriverRunner() {
+                @Override
+                protected void start(Driver driver, ActionListener<Void> driverListener) {
+                    Driver.start(threadPool.executor(ESQL_THREAD_POOL_NAME), driver, between(1, 1000), driverListener);
+                }
+            };
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            runner.runToCompletion(drivers, future);
+            future.actionGet(TimeValue.timeValueSeconds(30));
+            var responseHeaders = threadPool.getThreadContext().getResponseHeaders();
+            return new ActualResults(columnNames, columnTypes, dataTypes, collectedPages, responseHeaders);
         } finally {
             Releasables.close(() -> Releasables.close(drivers), exchangeSource::decRef);
         }
-        return new ActualResults(columnNames, columnTypes, dataTypes, collectedPages, responseHeaders);
+    }
+
+    /**
+     * Run all the of the listed drivers in the supplier {@linkplain ThreadPool}.
+     * @return the headers added to the context while running the drivers
+     */
+    static Map<String, List<String>> runToCompletion(ThreadPool threadPool, int maxIterations, List<Driver> drivers) {
+        DriverRunner runner = new DriverRunner() {
+            @Override
+            protected void start(Driver driver, ActionListener<Void> driverListener) {
+                Driver.start(threadPool.executor("esql"), driver, maxIterations, driverListener);
+            }
+        };
+        AtomicReference<Map<String, List<String>>> responseHeaders = new AtomicReference<>();
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        runner.runToCompletion(drivers, new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {
+                responseHeaders.set(threadPool.getThreadContext().getResponseHeaders());
+                future.onResponse(null);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                future.onFailure(e);
+            }
+        });
+        future.actionGet(TimeValue.timeValueSeconds(30));
+        return responseHeaders.get();
     }
 
     private Throwable reworkException(Throwable th) {


### PR DESCRIPTION
Currently, we have the method `DriverRunner#runToCompletion`, which is exclusively used in tests. This method calls `Future.actionGet()` without a timeout, potentially causing tests to hang indefinitely if the future is never completed (see #99347).

This PR removes the `DriverRunner#runToCompletion` method entirely and replaces its usages with DriverRunners that include a timeout.

Relates #99347