### PR TITLE
Document the origin of the DateProcessor format literals

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -126,6 +126,10 @@ enum DateFormat {
     abstract Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale);
 
     static DateFormat fromString(String format) {
+        // note: the ALL_CAPS format names here (UNIX_MS, etc) are present for historical reasons:
+        // they are the format literals that are supported by the logstash date filter plugin
+        // (see https://www.elastic.co/guide/en/logstash/current/plugins-filters-date.html#plugins-filters-date-match).
+        // don't extend this list with new special keywords (unless logstash has grown the same keyword).
         return switch (format) {
             case "ISO8601" -> Iso8601;
             case "UNIX" -> Unix;

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
@@ -162,7 +162,15 @@ teardown:
         index: test
         id: "1"
         pipeline: "my_pipeline"
-        body: { date_source_1: "2018-02-05T13:44:56.657+0100", date_source_2: "2017-04-04 13:43:09 +0200", date_source_3: "10/Aug/2018:09:45:56 +0200", date_source_4: "1", date_source_5: "1", date_source_6: "4000000050d506482dbdf024", date_source_7: "2018-02-05T13:44:56.657+0100" }
+        body: {
+          date_source_1: "2018-02-05T13:44:56.657+0100",
+          date_source_2: "2017-04-04 13:43:09 +0200",
+          date_source_3: "10/Aug/2018:09:45:56 +0200",
+          date_source_4: "1",
+          date_source_5: "1",
+          date_source_6: "4000000050d506482dbdf024",
+          date_source_7: "2018-02-05T13:44:56.657+0100"
+      }
 
   - do:
       get:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
@@ -152,6 +152,13 @@ teardown:
                   "target_field" : "date_target_7",
                   "formats" : [ "ISO8601" ]
                 }
+              },
+              {
+                "date" : {
+                  "field" : "date_source_8",
+                  "target_field" : "date_target_8",
+                  "formats" : [ "epoch_second" ]
+                }
               }
             ]
           }
@@ -169,7 +176,8 @@ teardown:
           date_source_4: "1",
           date_source_5: "1",
           date_source_6: "4000000050d506482dbdf024",
-          date_source_7: "2018-02-05T13:44:56.657+0100"
+          date_source_7: "2018-02-05T13:44:56.657+0100",
+          date_source_8: "1688548995.987654321"
       }
 
   - do:
@@ -190,6 +198,7 @@ teardown:
   - match: { _source.date_target_6: "2012-12-22T01:00:46.767Z" }
   - match: { _source.date_source_7: "2018-02-05T13:44:56.657+0100" }
   - match: { _source.date_target_7: "2018-02-05T12:44:56.657Z" }
+  - match: { _source.date_target_8: "2023-07-05T09:23:15.987Z" }
 
 
 ---


### PR DESCRIPTION
Supersedes https://github.com/elastic/elasticsearch/pull/97492, and I'll also be closing https://github.com/elastic/elasticsearch/issues/86106 as part of this, too. (Closes https://github.com/elastic/elasticsearch/issues/86106 <-- magic keywords for Github.)

The date processor came in way back when via #14184, and the motivation for some of the date processor's behavior can be seen on #14049. In particular, the special keyworded `ALL_CAPS` formats (`UNIX_MS`, etc) are there because that's what logstash supports, see https://www.elastic.co/guide/en/logstash/current/plugins-filters-date.html#plugins-filters-date-match.

This PR adds a comment about the history of why those literals are there (and that we shouldn't add new ones). It also adds a test to show that `epoch_second` actually already supports the desired format that was added as `UNIX_NS` on #97492.