### PR TITLE
Replace executor(SAME) with DIRECT

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpHeaderThreadContextTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpHeaderThreadContextTests.java
@@ -19,6 +19,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.netty4.internal.HttpValidator;
 import org.elasticsearch.test.ESTestCase;
@@ -66,7 +67,7 @@ public class Netty4HttpHeaderThreadContextTests extends ESTestCase {
         channel.pipeline()
             .addLast(
                 new Netty4HttpHeaderValidator(
-                    getValidator(threadPool.executor(ThreadPool.Names.SAME), isValidationSuccessful, null),
+                    getValidator(EsExecutors.DIRECT_EXECUTOR_SERVICE, isValidationSuccessful, null),
                     threadPool.getThreadContext()
                 )
             );
@@ -86,7 +87,7 @@ public class Netty4HttpHeaderThreadContextTests extends ESTestCase {
         channel.pipeline()
             .addLast(
                 new Netty4HttpHeaderValidator(
-                    getValidator(threadPool.executor(ThreadPool.Names.SAME), isValidationSuccessful, null),
+                    getValidator(EsExecutors.DIRECT_EXECUTOR_SERVICE, isValidationSuccessful, null),
                     threadPool.getThreadContext()
                 )
             );

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -802,7 +802,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                         // If a processor went async and returned a response on a different thread then
                         // before we continue the bulk request we should fork back on a write thread:
                         if (originalThread == Thread.currentThread()) {
-                            threadPool.executor(Names.SAME).execute(runnable);
+                            runnable.run();
                         } else {
                             threadPool.executor(executorName).execute(runnable);
                         }

--- a/test/framework/src/test/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueueTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueueTests.java
@@ -398,9 +398,11 @@ public class DeterministicTaskQueueTests extends ESTestCase {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final AtomicBoolean executedNested = new AtomicBoolean(false);
         threadPool.generic().execute(() -> {
-            threadPool.executor(ThreadPool.Names.SAME).execute(() -> executedNested.set(true));
+            final var executor = threadPool.executor(ThreadPool.Names.SAME);
+            assertSame(EsExecutors.DIRECT_EXECUTOR_SERVICE, executor);
+            executor.execute(() -> assertTrue(executedNested.compareAndSet(false, true)));
             assertThat(executedNested.get(), is(true));
-            executed.set(true);
+            assertTrue(executed.compareAndSet(false, true));
         });
         taskQueue.runAllRunnableTasks();
         assertThat(executed.get(), is(true));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Releasable;
@@ -289,7 +290,7 @@ public class MlDailyMaintenanceService implements Releasable {
                 return;
             }
             TypedChainTaskExecutor<Tuple<DeleteJobAction.Request, AcknowledgedResponse>> chainTaskExecutor = new TypedChainTaskExecutor<>(
-                threadPool.executor(ThreadPool.Names.SAME),
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 unused -> true,
                 unused -> true
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
@@ -23,7 +24,6 @@ import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
@@ -171,7 +171,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
     ) {
         ActionListener<LocalModel> getModelListener = ActionListener.wrap(model -> {
             TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor = new TypedChainTaskExecutor<>(
-                client.threadPool().executor(ThreadPool.Names.SAME),
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 // run through all tasks
                 r -> true,
                 // Always fail immediately and return an error


### PR DESCRIPTION
Cleans up the places where we are unnecessarily looking up the SAME
executor on a threadpool.