### PR TITLE
[DOCS] Set up redirect for old anchor

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1922,7 +1922,13 @@ See <<put-synonyms-set>>
 
 Refer to <<remote-clusters>>
 
+[float]
+[[configure-remote-clusters-dynamic]]
+==== Dynamically configure remote clusters
+
+Refer to <<remote-clusters>>.
+
 [role="exclude",id="remote-clusters-privileges"]
 === Configure roles and users for remote clusters
 
-Refer to <<remote-clusters>>
+Refer to <<remote-clusters>>.


### PR DESCRIPTION
Sets up a redirect for `remote-clusters-connect.html#configure-remote-clusters-dynamic`, linked to from the ECE docs.

Fixes a docs build error on the 8.10 version bump (https://github.com/elastic/docs/pull/2756).