### PR TITLE
[8.10] [DOCS] Set up redirect for old anchor (#99401)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1946,7 +1946,13 @@ See <<put-synonyms-set>>
 
 Refer to <<remote-clusters>>
 
+[float]
+[[configure-remote-clusters-dynamic]]
+==== Dynamically configure remote clusters
+
+Refer to <<remote-clusters>>.
+
 [role="exclude",id="remote-clusters-privileges"]
 === Configure roles and users for remote clusters
 
-Refer to <<remote-clusters>>
+Refer to <<remote-clusters>>.


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOCS] Set up redirect for old anchor (#99401)