### PR TITLE
Make ESQL RepetitiveEval test deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -110,9 +110,8 @@ true               | false                | false              | true           
 ;
 
 
-// AwaitsFix https://github.com/elastic/elasticsearch/issues/99394
-repetitiveEval-Ignore
-from employees | keep emp_no | eval sum = emp_no + 1 
+repetitiveEval
+from employees | sort emp_no | keep emp_no | eval sum = emp_no + 1 
 | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no  
 | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no 
 | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no 
@@ -160,7 +159,6 @@ from employees | keep emp_no | eval sum = emp_no + 1
 | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no 
 | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no | eval sum = sum + emp_no
 | limit 3 
-| sort emp_no
 ;
 
 emp_no:i | sum:i


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/99394

The test was not-deterministic (especially in multi-node execution) because the SORT happened after the LIMIT. 
Moving the SORT at the beginning of the query fixes the problem.