### PR TITLE
[DOCS] Add `docker-verify-signature` anchor to Docker docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -52,6 +52,7 @@ docker pull {docker-image}
 https://docs.sigstore.dev/system_config/installation/[Cosign] for your
 environment. Then use Cosign to verify the {es} image's signature.
 +
+[[docker-verify-signature]]
 [source,sh,subs="attributes"]
 ----
 wget https://artifacts.elastic.co/cosign.pub


### PR DESCRIPTION
**Problem:**

Other Elastic doc sets ([Beats](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-docker.html), [APM](https://www.elastic.co/guide/en/apm/guide/current/running-on-docker.html)) link to the [Verify the Elasticsearch Docker image signature](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/docker.html#docker-verify-signature) section of the Docker docs. This section was removed as part of https://github.com/elastic/elasticsearch/pull/99371. When we bump to the next version, this will create broken links and break the docs build.

**Solution:**
Re-add the anchor so we don't create broken links or break the docs build.

This commit was added to the backports of https://github.com/elastic/elasticsearch/pull/99371:

- https://github.com/elastic/elasticsearch/pull/99429
- https://github.com/elastic/elasticsearch/pull/99430