### PR TITLE
Fix a typo in the data_stream _stats API documentation

### DIFF
--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -120,7 +120,7 @@ Total number of selected data streams.
 (integer)
 Total number of backing indices for the selected data streams.
 
-`total_store_sizes`::
+`total_store_size`::
 (<<byte-units,byte value>>)
 Total size of all shards for the selected data streams.
 This property is included only if the `human` query parameter is `true`.


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/current/data-stream-stats-api.html

There's no trailing 's', it's `total_store_size` not `total_store_sizes`.

Introduced in #59435, so it's just always been this way.