### PR TITLE
[8.10]  Fix a typo in the data_stream _stats API documentation (#99438)

### DIFF
--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -120,7 +120,7 @@ Total number of selected data streams.
 (integer)
 Total number of backing indices for the selected data streams.
 
-`total_store_sizes`::
+`total_store_size`::
 (<<byte-units,byte value>>)
 Total size of all shards for the selected data streams.
 This property is included only if the `human` query parameter is `true`.


### PR DESCRIPTION
Backports the following commits to 8.10:
 -  Fix a typo in the data_stream _stats API documentation (#99438)