### PR TITLE
[buildkite] Add buildkite pr-bot config for triggering builds with opt-in label

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -11,7 +11,7 @@
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "run\\W+elasticsearch-ci.+",
+      "trigger_comment_regex": "buildkite\\W+elasticsearch-ci.+",
       "labels": "buildkite-opt-in"
     }
   ]

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,18 @@
+{
+  "jobs": [
+    {
+      "enabled": true,
+      "pipeline_slug": "elasticsearch-pull-request",
+      "allow_org_users": true,
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "set_commit_status": false,
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "run\\W+elasticsearch-ci.+",
+      "labels": "buildkite-opt-in"
+    }
+  ]
+}


### PR DESCRIPTION
I'm currently developing the Buildkite PR pipeline, and need to be able to trigger PRs on an opt-in basis.

This should, for now, only trigger builds for PRs that have the `buildkite-opt-in` label, or have a comment with `buildkite elasticsearch-ci ...`.