### PR TITLE
ESQL: Make the stats test more deterministic (for multi-node testing)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -360,7 +360,7 @@ byUnmentionedLongAndLong
 FROM employees
 | EVAL trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000
 | STATS c = count(gender) by languages.long, trunk_worked_seconds
-| SORT c desc, trunk_worked_seconds;
+| SORT c desc, trunk_worked_seconds, languages.long nulls first;
 
 c:long | languages.long:long | trunk_worked_seconds:long
 13     |5                    |300000000

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -360,21 +360,21 @@ byUnmentionedLongAndLong
 FROM employees
 | EVAL trunk_worked_seconds = avg_worked_seconds / 100000000 * 100000000
 | STATS c = count(gender) by languages.long, trunk_worked_seconds
-| SORT c desc, trunk_worked_seconds, languages.long nulls first;
+| SORT c desc, trunk_worked_seconds, languages.long;
 
 c:long | languages.long:long | trunk_worked_seconds:long
-13     |5                    |300000000
-10     |2                    |300000000
- 9     |3                    |200000000
- 9     |4                    |300000000
- 8     |4                    |200000000
- 8     |3                    |300000000
- 7     |1                    |200000000
- 6     |2                    |200000000
- 6     |null                 |300000000
- 6     |1                    |300000000
- 4     |null                 |200000000
- 4     |5                    |200000000
+13     |5                    |300000000           
+10     |2                    |300000000           
+9      |3                    |200000000           
+9      |4                    |300000000           
+8      |4                    |200000000           
+8      |3                    |300000000           
+7      |1                    |200000000           
+6      |2                    |200000000           
+6      |1                    |300000000           
+6      |null                 |300000000           
+4      |5                    |200000000           
+4      |null                 |200000000
 ;
 
 byUnmentionedIntAndLong


### PR DESCRIPTION
Added an additional sorting clause for `ByUnmentionedLongAndLong` test in `stats.csv-spec`.
I caught this one test failing in multi-node test with the following outcome:

```
  1> [2023-09-11T22:30:59,998][INFO ][o.e.x.e.q.m.EsqlSpecIT   ] [test] [stats.ByUnmentionedLongAndLong] before test
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] c(LONG)              | languages.long(LONG) | trunk_worked_second~
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] ------------------------------------------------------------------
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [13, 5, 300000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [10, 2, 300000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [9, 3, 200000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [9, 4, 300000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [8, 4, 200000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [8, 3, 300000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [7, 1, 200000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [6, 2, 200000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [6, 1, 300000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] ^^^ Assertion failure ^^^
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.r.EsqlSpecTestCase] [test] [6, null, 300000000]
  1> [2023-09-11T22:31:00,019][INFO ][o.e.x.e.q.m.EsqlSpecIT   ] [test] [stats.ByUnmentionedLongAndLong] after test
  2> REPRODUCE WITH: gradlew ':x-pack:plugin:esql:qa:server:multi-node:javaRestTest' --tests "org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT" -Dtests.method="test {stats.ByUnmentionedLongAndLong}" -Dtests.seed=BFE48ED6A25BBD62 -Dtests.locale=fr-CA -Dtests.timezone=Europe/Rome -Druntime.java=20
  2> org.junit.ComparisonFailure: expected:<[null]> but was:<[1]>
        at __randomizedtesting.SeedInfo.seed([BFE48ED6A25BBD62:37B0B10C0CA7D09A]:0)
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.elasticsearch.xpack.esql.CsvAssert.assertData(CsvAssert.java:208)
        at org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase.doTest(EsqlSpecTestCase.java:103)
```