### PR TITLE
[ESQL] Plumb through ranges and warnings for the casting to double tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -138,36 +138,45 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         String name,
         String lhsName,
         String rhsName,
-        DoubleBinaryOperator expected
+        DoubleBinaryOperator expected,
+        Double lhsMin,
+        Double lhsMax,
+        Double rhsMin,
+        Double rhsMax
     ) {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
-        for (DataType lhsType : EsqlDataTypes.types()) {
-            if (lhsType.isNumeric() == false || EsqlDataTypes.isRepresentable(lhsType) == false) {
-                continue;
-            }
-            for (Map.Entry<String, Supplier<Object>> lhsSupplier : RANDOM_VALUE_SUPPLIERS.get(lhsType)) {
-                for (DataType rhsType : EsqlDataTypes.types()) {
-                    if (rhsType.isNumeric() == false || EsqlDataTypes.isRepresentable(rhsType) == false) {
-                        continue;
-                    }
-                    for (Map.Entry<String, Supplier<Object>> rhsSupplier : RANDOM_VALUE_SUPPLIERS.get(rhsType)) {
-                        String caseName = lhsSupplier.getKey() + ", " + rhsSupplier.getKey();
-                        suppliers.add(new TestCaseSupplier(caseName, List.of(lhsType, rhsType), () -> {
-                            Number lhs = (Number) lhsSupplier.getValue().get();
-                            Number rhs = (Number) rhsSupplier.getValue().get();
+        List<TypedDataSupplier> lhsSuppliers = new ArrayList<>();
+        List<TypedDataSupplier> rhsSuppliers = new ArrayList<>();
+
+        lhsSuppliers.addAll(intCases(lhsMin.intValue(), lhsMax.intValue()));
+        lhsSuppliers.addAll(longCases(lhsMin.longValue(), lhsMax.longValue()));
+        lhsSuppliers.addAll(ulongCases(BigInteger.valueOf((long) Math.ceil(lhsMin)), BigInteger.valueOf((long) Math.floor(lhsMax))));
+        lhsSuppliers.addAll(doubleCases(lhsMin, lhsMax));
+
+        rhsSuppliers.addAll(intCases(rhsMin.intValue(), rhsMax.intValue()));
+        rhsSuppliers.addAll(longCases(rhsMin.longValue(), rhsMax.longValue()));
+        rhsSuppliers.addAll(ulongCases(BigInteger.valueOf((long) Math.ceil(rhsMin)), BigInteger.valueOf((long) Math.floor(rhsMax))));
+        rhsSuppliers.addAll(doubleCases(rhsMin, rhsMax));
+
+            for (TypedDataSupplier lhsSupplier : lhsSuppliers) {
+                    for (TypedDataSupplier rhsSupplier : rhsSuppliers) {
+                        String caseName = lhsSupplier.name() + ", " + rhsSupplier.name();
+                        suppliers.add(new TestCaseSupplier(caseName, List.of(lhsSupplier.type(), rhsSupplier.type()), () -> {
+                            Number lhs = (Number) lhsSupplier.supplier().get();
+                            Number rhs = (Number) rhsSupplier.supplier().get();
                             TypedData lhsTyped = new TypedData(
                                 // TODO there has to be a better way to handle unsigned long
                                 lhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : lhs,
-                                lhsType,
+                                lhsSupplier.type(),
                                 "lhs"
                             );
                             TypedData rhsTyped = new TypedData(
                                 rhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : rhs,
-                                rhsType,
+                                rhsSupplier.type(),
                                 "rhs"
                             );
-                            String lhsEvalName = castToDoubleEvaluator("Attribute[channel=0]", lhsType);
-                            String rhsEvalName = castToDoubleEvaluator("Attribute[channel=1]", rhsType);
+                            String lhsEvalName = castToDoubleEvaluator("Attribute[channel=0]", lhsSupplier.type());
+                            String rhsEvalName = castToDoubleEvaluator("Attribute[channel=1]", rhsSupplier.type());
                             return new TestCase(
                                 List.of(lhsTyped, rhsTyped),
                                 name + "[" + lhsName + "=" + lhsEvalName + ", " + rhsName + "=" + rhsEvalName + "]",
@@ -176,9 +185,8 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
                             );
                         }));
                     }
-                }
-            }
         }
+
         return suppliers;
     }
 
@@ -352,7 +360,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
                 suppliers,
                 expectedEvaluatorToString,
                 type,
-                stringCases(type.typeName()),
+                stringCases(type),
                 expectedType,
                 v -> expectedValue.apply((BytesRef) v),
                 warnings
@@ -385,7 +393,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         List<TestCaseSupplier> suppliers,
         String expectedEvaluatorToString,
         DataType inputType,
-        List<Map.Entry<String, Supplier<Object>>> valueSuppliers,
+        List<TypedDataSupplier> valueSuppliers,
         DataType expectedOutputType,
         Function<Number, Object> expected,
         List<String> warnings
@@ -405,18 +413,18 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         List<TestCaseSupplier> suppliers,
         String expectedEvaluatorToString,
         DataType inputType,
-        List<Map.Entry<String, Supplier<Object>>> valueSuppliers,
+        List<TypedDataSupplier> valueSuppliers,
         DataType expectedOutputType,
         Function<Object, Object> expected,
         List<String> warnings
     ) {
-        for (Map.Entry<String, Supplier<Object>> supplier : valueSuppliers) {
-            suppliers.add(new TestCaseSupplier(supplier.getKey(), List.of(inputType), () -> {
-                Object value = supplier.getValue().get();
+        for (TypedDataSupplier supplier : valueSuppliers) {
+            suppliers.add(new TestCaseSupplier(supplier.name(), List.of(supplier.type()), () -> {
+                Object value = supplier.supplier().get();
                 TypedData typed = new TypedData(
                     // TODO there has to be a better way to handle unsigned long
                     value instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : value,
-                    inputType,
+                    supplier.type(),
                     "value"
                 );
                 TestCase testCase = new TestCase(
@@ -433,61 +441,61 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         }
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> intCases(int min, int max) {
-        List<Map.Entry<String, Supplier<Object>>> cases = new ArrayList<>();
+    private static List<TypedDataSupplier> intCases(int min, int max) {
+        List<TypedDataSupplier> cases = new ArrayList<>();
         if (0 <= max && 0 >= min) {
-            cases.add(Map.entry("<0 int>", () -> 0));
+            cases.add(new TypedDataSupplier("<0 int>", () -> 0, DataTypes.INTEGER));
         }
 
         int lower = Math.max(min, 1);
         int upper = Math.min(max, Integer.MAX_VALUE);
         if (lower < upper) {
-            cases.add(Map.entry("<positive int>", () -> ESTestCase.randomIntBetween(lower, upper)));
+            cases.add(new TypedDataSupplier("<positive int>", () -> ESTestCase.randomIntBetween(lower, upper), DataTypes.INTEGER));
         } else if (lower == upper) {
-            cases.add(Map.entry("<" + lower + " int>", () -> lower));
+            cases.add(new TypedDataSupplier("<" + lower + " int>", () -> lower, DataTypes.INTEGER));
         }
 
         int lower1 = Math.max(min, Integer.MIN_VALUE);
         int upper1 = Math.min(max, -1);
         if (lower1 < upper1) {
-            cases.add(Map.entry("<negative int>", () -> ESTestCase.randomIntBetween(lower1, upper1)));
+            cases.add(new TypedDataSupplier("<negative int>", () -> ESTestCase.randomIntBetween(lower1, upper1), DataTypes.INTEGER));
         } else if (lower1 == upper1) {
-            cases.add(Map.entry("<" + lower1 + " int>", () -> lower1));
+            cases.add(new TypedDataSupplier("<" + lower1 + " int>", () -> lower1, DataTypes.INTEGER));
         }
         return cases;
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> longCases(long min, long max) {
-        List<Map.Entry<String, Supplier<Object>>> cases = new ArrayList<>();
+    private static List<TypedDataSupplier> longCases(long min, long max) {
+        List<TypedDataSupplier> cases = new ArrayList<>();
         if (0L <= max && 0L >= min) {
-            cases.add(Map.entry("<0 long>", () -> 0L));
+            cases.add(new TypedDataSupplier("<0 long>", () -> 0L, DataTypes.LONG));
         }
 
         long lower = Math.max(min, 1);
         long upper = Math.min(max, Long.MAX_VALUE);
         if (lower < upper) {
-            cases.add(Map.entry("<positive long>", () -> ESTestCase.randomLongBetween(lower, upper)));
+            cases.add(new TypedDataSupplier("<positive long>", () -> ESTestCase.randomLongBetween(lower, upper), DataTypes.LONG));
         } else if (lower == upper) {
-            cases.add(Map.entry("<" + lower + " long>", () -> lower));
+            cases.add(new TypedDataSupplier("<" + lower + " long>", () -> lower, DataTypes.LONG));
         }
 
         long lower1 = Math.max(min, Long.MIN_VALUE);
         long upper1 = Math.min(max, -1);
         if (lower1 < upper1) {
-            cases.add(Map.entry("<negative long>", () -> ESTestCase.randomLongBetween(lower1, upper1)));
+            cases.add(new TypedDataSupplier("<negative long>", () -> ESTestCase.randomLongBetween(lower1, upper1), DataTypes.LONG));
         } else if (lower1 == upper1) {
-            cases.add(Map.entry("<" + lower1 + " long>", () -> lower1));
+            cases.add(new TypedDataSupplier("<" + lower1 + " long>", () -> lower1, DataTypes.LONG));
         }
 
         return cases;
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> ulongCases(BigInteger min, BigInteger max) {
-        List<Map.Entry<String, Supplier<Object>>> cases = new ArrayList<>();
+    private static List<TypedDataSupplier> ulongCases(BigInteger min, BigInteger max) {
+        List<TypedDataSupplier> cases = new ArrayList<>();
 
         // Zero
         if (BigInteger.ZERO.compareTo(max) <= 0 && BigInteger.ZERO.compareTo(min) >= 0) {
-            cases.add(Map.entry("<0 unsigned long>", () -> BigInteger.ZERO));
+            cases.add(new TypedDataSupplier("<0 unsigned long>", () -> BigInteger.ZERO, DataTypes.UNSIGNED_LONG));
         }
 
         // small values, less than Long.MAX_VALUE
@@ -495,13 +503,14 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         BigInteger upper1 = max.min(BigInteger.valueOf(Long.MAX_VALUE));
         if (lower1.compareTo(upper1) < 0) {
             cases.add(
-                Map.entry(
+                new TypedDataSupplier(
                     "<small unsigned long>",
-                    () -> BigInteger.valueOf(ESTestCase.randomLongBetween(lower1.longValue(), upper1.longValue()))
+                    () -> BigInteger.valueOf(ESTestCase.randomLongBetween(lower1.longValue(), upper1.longValue())),
+                    DataTypes.UNSIGNED_LONG
                 )
             );
         } else if (lower1.compareTo(upper1) == 0) {
-            cases.add(Map.entry("<small unsigned long>", () -> lower1));
+            cases.add(new TypedDataSupplier("<small unsigned long>", () -> lower1, DataTypes.UNSIGNED_LONG));
         }
 
         // Big values, greater than Long.MAX_VALUE
@@ -509,51 +518,66 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         BigInteger upper2 = max.min(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.valueOf(Integer.MAX_VALUE)));
         if (lower2.compareTo(upper2) < 0) {
             cases.add(
-                Map.entry(
+                new TypedDataSupplier(
                     "<big unsigned long>",
-                    () -> BigInteger.valueOf(ESTestCase.randomLongBetween(lower2.longValue(), upper2.longValue()))
+                    () -> BigInteger.valueOf(ESTestCase.randomLongBetween(lower2.longValue(), upper2.longValue())),
+                    DataTypes.UNSIGNED_LONG
                 )
             );
         } else if (lower2.compareTo(upper2) == 0) {
-            cases.add(Map.entry("<big unsigned long>", () -> lower2));
+            cases.add(new TypedDataSupplier("<big unsigned long>", () -> lower2, DataTypes.UNSIGNED_LONG));
         }
         return cases;
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> doubleCases(double min, double max) {
-        List<Map.Entry<String, Supplier<Object>>> cases = new ArrayList<>();
+    private static List<TypedDataSupplier> doubleCases(double min, double max) {
+        List<TypedDataSupplier> cases = new ArrayList<>();
 
         // Zeros
         if (0d <= max && 0d >= min) {
-            cases.add(Map.entry("<0 double>", () -> 0.0d));
-            cases.add(Map.entry("<-0 double>", () -> -0.0d));
+            cases.add(new TypedDataSupplier("<0 double>", () -> 0.0d, DataTypes.DOUBLE));
+            cases.add(new TypedDataSupplier("<-0 double>", () -> -0.0d, DataTypes.DOUBLE));
         }
 
         // Positive small double
         double lower1 = Math.max(0d, min);
         double upper1 = Math.min(1d, max);
         if (lower1 < upper1) {
-            cases.add(Map.entry("<small positive double>", () -> ESTestCase.randomDoubleBetween(lower1, upper1, true)));
+            cases.add(
+                new TypedDataSupplier(
+                    "<small positive double>",
+                    () -> ESTestCase.randomDoubleBetween(lower1, upper1, true),
+                    DataTypes.DOUBLE
+                )
+            );
         } else if (lower1 == upper1) {
-            cases.add(Map.entry("<small positive double>", () -> lower1));
+            cases.add(new TypedDataSupplier("<small positive double>", () -> lower1, DataTypes.DOUBLE));
         }
 
         // Negative small double
         double lower2 = Math.max(-1d, min);
         double upper2 = Math.min(0d, max);
         if (lower2 < upper2) {
-            cases.add(Map.entry("<small negative double>", () -> ESTestCase.randomDoubleBetween(lower2, upper2, true)));
+            cases.add(
+                new TypedDataSupplier(
+                    "<small negative double>",
+                    () -> ESTestCase.randomDoubleBetween(lower2, upper2, true),
+                    DataTypes.DOUBLE
+                )
+            );
         } else if (lower2 == upper2) {
-            cases.add(Map.entry("<small negative double>", () -> lower2));
+            cases.add(new TypedDataSupplier("<small negative double>", () -> lower2, DataTypes.DOUBLE));
         }
 
         // Positive big double
         double lower3 = Math.max(1d, min); // start at 1 (inclusive) because the density of values between 0 and 1 is very high
         double upper3 = Math.min(Double.MAX_VALUE, max);
         if (lower3 < upper3) {
-            cases.add(Map.entry("<big positive double>", () -> ESTestCase.randomDoubleBetween(lower3, upper3, true)));
+            cases.add(
+                new TypedDataSupplier("<big positive double>", () -> ESTestCase.randomDoubleBetween(lower3, upper3, true), DataTypes.DOUBLE)
+            );
         } else if (lower3 == upper3) {
-            cases.add(Map.entry("<big positive double>", () -> lower3));
+            cases.add(new TypedDataSupplier("<big positive double>", () -> lower3, DataTypes.DOUBLE));
         }
 
         // Negative big double
@@ -561,48 +585,73 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         double lower4 = Math.max(-Double.MAX_VALUE, min);
         double upper4 = Math.min(-1, max); // because again, the interval from -1 to 0 is very high density
         if (lower4 < upper4) {
-            cases.add(Map.entry("<big negative double>", () -> ESTestCase.randomDoubleBetween(lower4, upper4, true)));
+            cases.add(
+                new TypedDataSupplier("<big negative double>", () -> ESTestCase.randomDoubleBetween(lower4, upper4, true), DataTypes.DOUBLE)
+            );
         } else if (lower4 == upper4) {
-            cases.add(Map.entry("<big negative double>", () -> lower4));
+            cases.add(new TypedDataSupplier("<big negative double>", () -> lower4, DataTypes.DOUBLE));
         }
         return cases;
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> booleanCases() {
-        return List.of(Map.entry("<true>", () -> true), Map.entry("<false>", () -> false));
+    private static List<TypedDataSupplier> booleanCases() {
+        return List.of(
+            new TypedDataSupplier("<true>", () -> true, DataTypes.BOOLEAN),
+            new TypedDataSupplier("<false>", () -> false, DataTypes.BOOLEAN)
+        );
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> dateCases() {
+    private static List<TypedDataSupplier> dateCases() {
         return List.of(
-            Map.entry("<1970-01-01T00:00:00Z>", () -> 0L),
-            Map.entry(
+            new TypedDataSupplier("<1970-01-01T00:00:00Z>", () -> 0L, DataTypes.DATETIME),
+            new TypedDataSupplier(
                 "<date>",
-                () -> ESTestCase.randomLongBetween(0, 10 * (long) 10e11) // 1970-01-01T00:00:00Z - 2286-11-20T17:46:40Z
+                () -> ESTestCase.randomLongBetween(0, 10 * (long) 10e11), // 1970-01-01T00:00:00Z - 2286-11-20T17:46:40Z
+                DataTypes.DATETIME
             ),
-            Map.entry(
+            new TypedDataSupplier(
                 "<far future date>",
                 // 2286-11-20T17:46:40Z - +292278994-08-17T07:12:55.807Z
-                () -> ESTestCase.randomLongBetween(10 * (long) 10e11, Long.MAX_VALUE)
+                () -> ESTestCase.randomLongBetween(10 * (long) 10e11, Long.MAX_VALUE),
+                DataTypes.DATETIME
             )
         );
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> ipCases() {
+    private static List<TypedDataSupplier> ipCases() {
         return List.of(
-            Map.entry("<127.0.0.1 ip>", () -> new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1")))),
-            Map.entry("<ipv4>", () -> new BytesRef(InetAddressPoint.encode(ESTestCase.randomIp(true)))),
-            Map.entry("<ipv6>", () -> new BytesRef(InetAddressPoint.encode(ESTestCase.randomIp(false))))
+            new TypedDataSupplier(
+                "<127.0.0.1 ip>",
+                () -> new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1"))),
+                DataTypes.IP
+            ),
+            new TypedDataSupplier("<ipv4>", () -> new BytesRef(InetAddressPoint.encode(ESTestCase.randomIp(true))), DataTypes.IP),
+            new TypedDataSupplier("<ipv6>", () -> new BytesRef(InetAddressPoint.encode(ESTestCase.randomIp(false))), DataTypes.IP)
         );
     }
 
-    private static List<Map.Entry<String, Supplier<Object>>> stringCases(String type) {
-        List<Map.Entry<String, Supplier<Object>>> result = new ArrayList<>();
-        result.add(Map.entry("<empty " + type + ">", () -> new BytesRef("")));
-        result.add(Map.entry("<short alpha " + type + ">", () -> new BytesRef(ESTestCase.randomAlphaOfLengthBetween(1, 30))));
-        result.add(Map.entry("<long alpha " + type + ">", () -> new BytesRef(ESTestCase.randomAlphaOfLengthBetween(300, 3000))));
-        result.add(Map.entry("<short unicode " + type + ">", () -> new BytesRef(ESTestCase.randomRealisticUnicodeOfLengthBetween(1, 30))));
+    private static List<TypedDataSupplier> stringCases(DataType type) {
+        List<TypedDataSupplier> result = new ArrayList<>();
+        result.add(new TypedDataSupplier("<empty " + type + ">", () -> new BytesRef(""), type));
         result.add(
-            Map.entry("<long unicode " + type + ">", () -> new BytesRef(ESTestCase.randomRealisticUnicodeOfLengthBetween(300, 3000)))
+            new TypedDataSupplier("<short alpha " + type + ">", () -> new BytesRef(ESTestCase.randomAlphaOfLengthBetween(1, 30)), type)
+        );
+        result.add(
+            new TypedDataSupplier("<long alpha " + type + ">", () -> new BytesRef(ESTestCase.randomAlphaOfLengthBetween(300, 3000)), type)
+        );
+        result.add(
+            new TypedDataSupplier(
+                "<short unicode " + type + ">",
+                () -> new BytesRef(ESTestCase.randomRealisticUnicodeOfLengthBetween(1, 30)),
+                type
+            )
+        );
+        result.add(
+            new TypedDataSupplier(
+                "<long unicode " + type + ">",
+                () -> new BytesRef(ESTestCase.randomRealisticUnicodeOfLengthBetween(300, 3000)),
+                type
+            )
         );
         return result;
     }
@@ -610,17 +659,23 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
     /**
      * Supplier test case data for {@link Version} fields.
      */
-    public static List<Map.Entry<String, Supplier<Object>>> versionCases(String prefix) {
+    public static List<TypedDataSupplier> versionCases(String prefix) {
         return List.of(
-            Map.entry("<" + prefix + "version major>", () -> new Version(Integer.toString(ESTestCase.between(0, 100))).toBytesRef()),
-            Map.entry(
-                "<" + prefix + "version major.minor>",
-                () -> new Version(ESTestCase.between(0, 100) + "." + ESTestCase.between(0, 100)).toBytesRef()
+            new TypedDataSupplier(
+                "<" + prefix + "version major>",
+                () -> new Version(Integer.toString(ESTestCase.between(0, 100))).toBytesRef(),
+                DataTypes.VERSION
             ),
-            Map.entry(
+            new TypedDataSupplier(
+                "<" + prefix + "version major.minor>",
+                () -> new Version(ESTestCase.between(0, 100) + "." + ESTestCase.between(0, 100)).toBytesRef(),
+                DataTypes.VERSION
+            ),
+            new TypedDataSupplier(
                 "<" + prefix + "version major.minor.patch>",
                 () -> new Version(ESTestCase.between(0, 100) + "." + ESTestCase.between(0, 100) + "." + ESTestCase.between(0, 100))
-                    .toBytesRef()
+                    .toBytesRef(),
+                DataTypes.VERSION
             )
         );
     }
@@ -785,6 +840,13 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
             return new TestCase(data, evaluatorToString, expectedType, matcher, newWarnings, expectedTypeError);
         }
     }
+
+    /**
+     * Holds a supplier for a data value, along with the type of that value and a name for generating test case names. This mostly
+     * exists because we can't generate random values from the test parameter generation functions, and instead need to return
+     * suppliers which generate the random values at test execution time.
+     */
+    public record TypedDataSupplier(String name, Supplier<Object> supplier, DataType type) {}
 
     /**
      * Holds a data value and the intended parse type of that value

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -680,46 +680,6 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         );
     }
 
-    private static final Map<DataType, List<Map.Entry<String, Supplier<Object>>>> RANDOM_VALUE_SUPPLIERS = Map.ofEntries(
-        Map.entry(
-            DataTypes.DOUBLE,
-            List.of(
-                Map.entry("<0 double>", () -> 0.0d),
-                Map.entry("<small positive double>", () -> ESTestCase.randomDouble()),
-                Map.entry("<small negative double>", () -> -ESTestCase.randomDouble()),
-                Map.entry("<big positive double>", () -> ESTestCase.randomDoubleBetween(0, Double.MAX_VALUE, false)),
-                Map.entry("<negative positive double>", () -> ESTestCase.randomDoubleBetween(Double.MIN_VALUE, 0 - Double.MIN_NORMAL, true))
-            )
-        ),
-        Map.entry(
-            DataTypes.LONG,
-            List.of(
-                Map.entry("<0 long>", () -> 0L),
-                Map.entry("<positive long>", () -> ESTestCase.randomLongBetween(1, Long.MAX_VALUE)),
-                Map.entry("<negative long>", () -> ESTestCase.randomLongBetween(Long.MIN_VALUE, -1))
-            )
-        ),
-        Map.entry(
-            DataTypes.INTEGER,
-            List.of(
-                Map.entry("<0 int>", () -> 0),
-                Map.entry("<positive long>", () -> ESTestCase.between(1, Integer.MAX_VALUE)),
-                Map.entry("<negative long>", () -> ESTestCase.between(Integer.MIN_VALUE, -1))
-            )
-        ),
-        Map.entry(
-            DataTypes.UNSIGNED_LONG,
-            List.of(
-                Map.entry("<0 unsigned long>", () -> BigInteger.ZERO),
-                Map.entry("<small unsigned long>", () -> BigInteger.valueOf(ESTestCase.randomLongBetween(1, Integer.MAX_VALUE))),
-                Map.entry(
-                    "<big unsigned long>",
-                    () -> BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.valueOf(ESTestCase.randomLongBetween(1, Integer.MAX_VALUE)))
-                )
-            )
-        )
-    );
-
     private static String castToDoubleEvaluator(String original, DataType current) {
         if (current == DataTypes.DOUBLE) {
             return original;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -94,7 +94,8 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         DoubleUnaryOperator expected,
         Double min,
         Double max,
-        List<String> warnings) {
+        List<String> warnings
+    ) {
         String read = "Attribute[channel=0]";
         String eval = name + "[" + argName + "=";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
@@ -142,7 +143,8 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         Double lhsMax,
         Double rhsMin,
         Double rhsMax,
-        List<String> warnings) {
+        List<String> warnings
+    ) {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
         List<TypedDataSupplier> lhsSuppliers = new ArrayList<>();
         List<TypedDataSupplier> rhsSuppliers = new ArrayList<>();
@@ -157,37 +159,37 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         rhsSuppliers.addAll(ulongCases(BigInteger.valueOf((long) Math.ceil(rhsMin)), BigInteger.valueOf((long) Math.floor(rhsMax))));
         rhsSuppliers.addAll(doubleCases(rhsMin, rhsMax));
 
-            for (TypedDataSupplier lhsSupplier : lhsSuppliers) {
-                    for (TypedDataSupplier rhsSupplier : rhsSuppliers) {
-                        String caseName = lhsSupplier.name() + ", " + rhsSupplier.name();
-                        suppliers.add(new TestCaseSupplier(caseName, List.of(lhsSupplier.type(), rhsSupplier.type()), () -> {
-                            Number lhs = (Number) lhsSupplier.supplier().get();
-                            Number rhs = (Number) rhsSupplier.supplier().get();
-                            TypedData lhsTyped = new TypedData(
-                                // TODO there has to be a better way to handle unsigned long
-                                lhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : lhs,
-                                lhsSupplier.type(),
-                                "lhs"
-                            );
-                            TypedData rhsTyped = new TypedData(
-                                rhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : rhs,
-                                rhsSupplier.type(),
-                                "rhs"
-                            );
-                            String lhsEvalName = castToDoubleEvaluator("Attribute[channel=0]", lhsSupplier.type());
-                            String rhsEvalName = castToDoubleEvaluator("Attribute[channel=1]", rhsSupplier.type());
-                            TestCase testCase = new TestCase(
-                                List.of(lhsTyped, rhsTyped),
-                                name + "[" + lhsName + "=" + lhsEvalName + ", " + rhsName + "=" + rhsEvalName + "]",
-                                DataTypes.DOUBLE,
-                                equalTo(expected.applyAsDouble(lhs.doubleValue(), rhs.doubleValue()))
-                            );
-                            for (String warning : warnings) {
-                                testCase = testCase.withWarning(warning);
-                            }
-                            return testCase;
-                        }));
+        for (TypedDataSupplier lhsSupplier : lhsSuppliers) {
+            for (TypedDataSupplier rhsSupplier : rhsSuppliers) {
+                String caseName = lhsSupplier.name() + ", " + rhsSupplier.name();
+                suppliers.add(new TestCaseSupplier(caseName, List.of(lhsSupplier.type(), rhsSupplier.type()), () -> {
+                    Number lhs = (Number) lhsSupplier.supplier().get();
+                    Number rhs = (Number) rhsSupplier.supplier().get();
+                    TypedData lhsTyped = new TypedData(
+                        // TODO there has to be a better way to handle unsigned long
+                        lhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : lhs,
+                        lhsSupplier.type(),
+                        "lhs"
+                    );
+                    TypedData rhsTyped = new TypedData(
+                        rhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : rhs,
+                        rhsSupplier.type(),
+                        "rhs"
+                    );
+                    String lhsEvalName = castToDoubleEvaluator("Attribute[channel=0]", lhsSupplier.type());
+                    String rhsEvalName = castToDoubleEvaluator("Attribute[channel=1]", rhsSupplier.type());
+                    TestCase testCase = new TestCase(
+                        List.of(lhsTyped, rhsTyped),
+                        name + "[" + lhsName + "=" + lhsEvalName + ", " + rhsName + "=" + rhsEvalName + "]",
+                        DataTypes.DOUBLE,
+                        equalTo(expected.applyAsDouble(lhs.doubleValue(), rhs.doubleValue()))
+                    );
+                    for (String warning : warnings) {
+                        testCase = testCase.withWarning(warning);
                     }
+                    return testCase;
+                }));
+            }
         }
 
         return suppliers;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.versionfield.Version;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
@@ -51,9 +51,9 @@ public class ToVersionTests extends AbstractFunctionTestCase {
         );
         // But strings that are shaped like versions do parse to valid versions
         for (DataType inputType : EsqlDataTypes.types().stream().filter(EsqlDataTypes::isString).toList()) {
-            for (Map.Entry<String, Supplier<Object>> versionGen : TestCaseSupplier.versionCases(inputType.typeName() + " ")) {
-                suppliers.add(new TestCaseSupplier(versionGen.getKey(), List.of(inputType), () -> {
-                    BytesRef encodedVersion = (BytesRef) versionGen.getValue().get();
+            for (TestCaseSupplier.TypedDataSupplier versionGen : TestCaseSupplier.versionCases(inputType.typeName() + " ")) {
+                suppliers.add(new TestCaseSupplier(versionGen.name(), List.of(inputType), () -> {
+                    BytesRef encodedVersion = (BytesRef) versionGen.supplier().get();
                     TestCaseSupplier.TypedData typed = new TestCaseSupplier.TypedData(
                         new BytesRef(new Version(encodedVersion).toString()),
                         inputType,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
@@ -30,8 +30,8 @@ public class AcosTests extends AbstractFunctionTestCase {
             "val",
             Math::acos,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
@@ -31,7 +31,8 @@ public class AcosTests extends AbstractFunctionTestCase {
             Math::acos,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
@@ -30,8 +30,8 @@ public class AsinTests extends AbstractFunctionTestCase {
             "val",
             Math::asin,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
@@ -31,7 +31,8 @@ public class AsinTests extends AbstractFunctionTestCase {
             Math::asin,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2Tests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2Tests.java
@@ -25,7 +25,7 @@ public class Atan2Tests extends AbstractFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        List<TestCaseSupplier> suppliers = TestCaseSupplier.forBinaryCastingToDouble("Atan2Evaluator", "y", "x", Math::atan2, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        List<TestCaseSupplier> suppliers = TestCaseSupplier.forBinaryCastingToDouble("Atan2Evaluator", "y", "x", Math::atan2, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2Tests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2Tests.java
@@ -25,7 +25,17 @@ public class Atan2Tests extends AbstractFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        List<TestCaseSupplier> suppliers = TestCaseSupplier.forBinaryCastingToDouble("Atan2Evaluator", "y", "x", Math::atan2, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, List.of());
+        List<TestCaseSupplier> suppliers = TestCaseSupplier.forBinaryCastingToDouble(
+            "Atan2Evaluator",
+            "y",
+            "x",
+            Math::atan2,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2Tests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2Tests.java
@@ -25,7 +25,7 @@ public class Atan2Tests extends AbstractFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        List<TestCaseSupplier> suppliers = TestCaseSupplier.forBinaryCastingToDouble("Atan2Evaluator", "y", "x", Math::atan2);
+        List<TestCaseSupplier> suppliers = TestCaseSupplier.forBinaryCastingToDouble("Atan2Evaluator", "y", "x", Math::atan2, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AtanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AtanTests.java
@@ -31,7 +31,8 @@ public class AtanTests extends AbstractFunctionTestCase {
             Math::atan,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AtanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AtanTests.java
@@ -30,8 +30,8 @@ public class AtanTests extends AbstractFunctionTestCase {
             "val",
             Math::atan,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CosTests.java
@@ -31,7 +31,8 @@ public class CosTests extends AbstractFunctionTestCase {
             Math::cos,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CosTests.java
@@ -30,8 +30,8 @@ public class CosTests extends AbstractFunctionTestCase {
             "val",
             Math::cos,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
@@ -31,7 +31,8 @@ public class CoshTests extends AbstractFunctionTestCase {
             Math::cosh,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
@@ -30,8 +30,8 @@ public class CoshTests extends AbstractFunctionTestCase {
             "val",
             Math::cosh,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinTests.java
@@ -30,8 +30,8 @@ public class SinTests extends AbstractFunctionTestCase {
             "val",
             Math::sin,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinTests.java
@@ -31,7 +31,8 @@ public class SinTests extends AbstractFunctionTestCase {
             Math::sin,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
@@ -30,8 +30,8 @@ public class SinhTests extends AbstractFunctionTestCase {
             "val",
             Math::sinh,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
@@ -31,7 +31,8 @@ public class SinhTests extends AbstractFunctionTestCase {
             Math::sinh,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanTests.java
@@ -30,8 +30,8 @@ public class TanTests extends AbstractFunctionTestCase {
             "val",
             Math::tan,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanTests.java
@@ -31,7 +31,8 @@ public class TanTests extends AbstractFunctionTestCase {
             Math::tan,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanhTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanhTests.java
@@ -30,8 +30,8 @@ public class TanhTests extends AbstractFunctionTestCase {
             "val",
             Math::tanh,
             Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY
-        );
+            Double.POSITIVE_INFINITY,
+                List.of());
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanhTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TanhTests.java
@@ -31,7 +31,8 @@ public class TanhTests extends AbstractFunctionTestCase {
             Math::tanh,
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-                List.of());
+            List.of()
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
     }
 


### PR DESCRIPTION
Add the warnings and range checking parameters to unary and binary casting to double test generators.  I also moved the data type to the value supplier, which the binary case needed. That feels more right - that's what I was intending with `TypedData` to begin with, but our abstractions are still messy here.   