### PR TITLE
[Backport] Consider node shutdown in DataTierAllocationDecider

### DIFF
--- a/docs/changelog/98824.yaml
+++ b/docs/changelog/98824.yaml
@@ -1,0 +1,6 @@
+pr: 98824
+summary: Consider node shutdown in `DataTierAllocationDecider`
+area: "Allocation"
+type: bug
+issues:
+ - 97207

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
@@ -467,6 +467,16 @@ public class SingleNodeShutdownMetadata implements SimpleDiffable<SingleNodeShut
                 default -> throw new IllegalArgumentException("unknown shutdown type: " + type);
             };
         }
+
+        /**
+         * @return True if this shutdown type indicates that the node will be permanently removed from the cluster, false otherwise.
+         */
+        public boolean isRemovalType() {
+            return switch (this) {
+                case REMOVE, SIGTERM, REPLACE -> true;
+                case RESTART -> false;
+            };
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.elasticsearch.cluster.routing.allocation.DataTier.ALL_DATA_TIERS;
 
 /**
  * This class holds all {@link DiscoveryNode} in the cluster and provides convenience methods to
@@ -63,7 +66,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
     private final Version maxNodeVersion;
     private final Version minNodeVersion;
 
-    private final Set<String> availableRoles;
+    private final Map<String, Set<String>> tiersToNodeIds;
 
     private DiscoveryNodes(
         long nodeLeftGeneration,
@@ -76,7 +79,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
         Version minNonClientNodeVersion,
         Version maxNodeVersion,
         Version minNodeVersion,
-        Set<String> availableRoles
+        Map<String, Set<String>> tiersToNodeIds
     ) {
         this.nodeLeftGeneration = nodeLeftGeneration;
         this.nodes = nodes;
@@ -92,7 +95,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
         this.minNodeVersion = minNodeVersion;
         this.maxNodeVersion = maxNodeVersion;
         assert (localNodeId == null) == (localNode == null);
-        this.availableRoles = availableRoles;
+        this.tiersToNodeIds = tiersToNodeIds;
     }
 
     public DiscoveryNodes withMasterNodeId(@Nullable String masterNodeId) {
@@ -108,7 +111,7 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
             minNonClientNodeVersion,
             maxNodeVersion,
             minNodeVersion,
-            availableRoles
+            tiersToNodeIds
         );
     }
 
@@ -141,13 +144,12 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
     }
 
     /**
-     * Checks if any node has the role with the given {@code roleName}.
+     * Gets a {@link Map} of node roles to node IDs which have those roles.
      *
-     * @param roleName name to check
-     * @return true if any node has the role of the given name
+     * @return {@link Map} of node roles to node IDs which have those roles.
      */
-    public boolean isRoleAvailable(String roleName) {
-        return availableRoles.contains(roleName);
+    public Map<String, Set<String>> getTiersToNodeIds() {
+        return tiersToNodeIds;
     }
 
     /**
@@ -834,12 +836,26 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
                 minNonClientNodeVersion == null ? Version.CURRENT : minNonClientNodeVersion,
                 maxNodeVersion == null ? Version.CURRENT : maxNodeVersion,
                 minNodeVersion == null ? Version.CURRENT.minimumCompatibilityVersion() : minNodeVersion,
-                dataNodes.values()
-                    .stream()
-                    .flatMap(n -> n.getRoles().stream())
-                    .map(DiscoveryNodeRole::roleName)
-                    .collect(Collectors.toUnmodifiableSet())
+                computeTiersToNodesMap(dataNodes)
             );
+        }
+
+        private static Map<String, Set<String>> computeTiersToNodesMap(final Map<String, DiscoveryNode> dataNodes) {
+            Map<String, Set<String>> tiersToNodes = new HashMap<>(ALL_DATA_TIERS.size() + 1);
+            for (var node : dataNodes.values()) {
+                if (node.hasRole(DiscoveryNodeRole.DATA_ROLE.roleName())) {
+                    tiersToNodes.computeIfAbsent(DiscoveryNodeRole.DATA_ROLE.roleName(), (key) -> new HashSet<>()).add(node.getId());
+                }
+                for (var role : ALL_DATA_TIERS) {
+                    if (node.hasRole(role)) {
+                        tiersToNodes.computeIfAbsent(role, (key) -> new HashSet<>()).add(node.getId());
+                    }
+                }
+            }
+            for (var entry : tiersToNodes.entrySet()) {
+                entry.setValue(Collections.unmodifiableSet(entry.getValue()));
+            }
+            return Collections.unmodifiableMap(tiersToNodes);
         }
 
         public boolean isLocalNodeElectedMaster() {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.DataStreamMetadata;
 import org.elasticsearch.cluster.metadata.DesiredNodes;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -579,7 +580,12 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return allocation.metadata().getIndexSafe(shard.index());
         }
 
-        private Optional<String> highestPreferenceTier(List<String> preferredTiers, DiscoveryNodes unused, DesiredNodes desiredNodes) {
+        private Optional<String> highestPreferenceTier(
+            List<String> preferredTiers,
+            DiscoveryNodes unused,
+            DesiredNodes desiredNodes,
+            NodesShutdownMetadata shutdownMetadata
+        ) {
             return Optional.of(highestPreferenceTier(preferredTiers));
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.cluster.routing.allocation;
 import org.elasticsearch.cluster.metadata.DesiredNode;
 import org.elasticsearch.cluster.metadata.DesiredNodes;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -22,6 +23,8 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Strings;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -64,7 +67,12 @@ public final class DataTierAllocationDecider extends AllocationDecider {
     }
 
     public interface PreferredTierFunction {
-        Optional<String> apply(List<String> tierPreference, DiscoveryNodes nodes, DesiredNodes desiredNodes);
+        Optional<String> apply(
+            List<String> tierPreference,
+            DiscoveryNodes nodes,
+            DesiredNodes desiredNodes,
+            NodesShutdownMetadata shutdownMetadata
+        );
     }
 
     private static final Decision YES_PASSES = Decision.single(Decision.YES.type(), NAME, "node passes tier preference filters");
@@ -79,7 +87,12 @@ public final class DataTierAllocationDecider extends AllocationDecider {
         if (tierPreference.isEmpty()) {
             return YES_PASSES;
         }
-        Optional<String> tier = preferredTierFunction.apply(tierPreference, allocation.nodes(), allocation.desiredNodes());
+        Optional<String> tier = preferredTierFunction.apply(
+            tierPreference,
+            allocation.nodes(),
+            allocation.desiredNodes(),
+            allocation.getClusterState().metadata().nodeShutdowns()
+        );
         if (tier.isPresent()) {
             String tierName = tier.get();
             if (allocationAllowed(tierName, node)) {
@@ -136,14 +149,20 @@ public final class DataTierAllocationDecider extends AllocationDecider {
      * in order to know if there are planned topology changes in the cluster
      * that can remove a tier that's part of the cluster now.
      */
-    public static Optional<String> preferredAvailableTier(List<String> prioritizedTiers, DiscoveryNodes nodes, DesiredNodes desiredNodes) {
+    public static Optional<String> preferredAvailableTier(
+        List<String> prioritizedTiers,
+        DiscoveryNodes nodes,
+        DesiredNodes desiredNodes,
+        NodesShutdownMetadata shutdownMetadata
+    ) {
+
         final var desiredNodesPreferredTier = getPreferredTierFromDesiredNodes(prioritizedTiers, nodes, desiredNodes);
 
         if (desiredNodesPreferredTier.isPresent()) {
             return desiredNodesPreferredTier;
         }
 
-        return getPreferredAvailableTierFromClusterMembers(prioritizedTiers, nodes);
+        return getPreferredAvailableTierFromClusterMembers(prioritizedTiers, nodes, removingNodeIds(shutdownMetadata));
     }
 
     /**
@@ -199,9 +218,13 @@ public final class DataTierAllocationDecider extends AllocationDecider {
         return tierNodesPresent(tier, desiredNodes.pending()) && tierNodesPresent(tier, discoveryNodes);
     }
 
-    private static Optional<String> getPreferredAvailableTierFromClusterMembers(List<String> prioritizedTiers, DiscoveryNodes nodes) {
+    private static Optional<String> getPreferredAvailableTierFromClusterMembers(
+        List<String> prioritizedTiers,
+        DiscoveryNodes nodes,
+        Set<String> removingNodeIds
+    ) {
         for (String tier : prioritizedTiers) {
-            if (tierNodesPresent(tier, nodes)) {
+            if (tierNodesPresentConsideringRemovals(tier, nodes, removingNodeIds)) {
                 return Optional.of(tier);
             }
         }
@@ -219,10 +242,40 @@ public final class DataTierAllocationDecider extends AllocationDecider {
         return false;
     }
 
+    // This overload for Desired Nodes codepaths, which do not consider Node Shutdown, as Desired Nodes takes precedence
     static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {
+        return tierNodesPresentConsideringRemovals(singleTier, nodes, Collections.emptySet());
+    }
+
+    static boolean tierNodesPresentConsideringRemovals(String singleTier, DiscoveryNodes nodes, Set<String> removingNodeIds) {
         assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier)
             : "tier " + singleTier + " is an invalid tier name";
-        return nodes.isRoleAvailable(DiscoveryNodeRole.DATA_ROLE.roleName()) || nodes.isRoleAvailable(singleTier);
+        var rolesToNodes = nodes.getTiersToNodeIds();
+        Set<String> nodesWithTier = rolesToNodes.getOrDefault(singleTier, Collections.emptySet());
+        Set<String> dataNodes = rolesToNodes.getOrDefault(DiscoveryNodeRole.DATA_ROLE.roleName(), Collections.emptySet());
+
+        if (removingNodeIds.isEmpty()) {
+            return nodesWithTier.isEmpty() == false || dataNodes.isEmpty() == false;
+        } else if (removingNodeIds.size() < nodesWithTier.size() || removingNodeIds.size() < dataNodes.size()) {
+            // There are more nodes in the tier (or more generic data nodes) than there are nodes that are being removed, so
+            // there's at least one node that can hold data for the preferred tier that isn't being removed
+            return true;
+        }
+
+        // A tier might be unavailable because all remaining nodes in the tier are being removed, so now we have to check if there are any
+        // nodes with appropriate roles that aren't being removed.
+        for (String nodeId : dataNodes) {
+            if (removingNodeIds.contains(nodeId) == false) {
+                return true;
+            }
+        }
+        for (String nodeId : nodesWithTier) {
+            if (removingNodeIds.contains(nodeId) == false) {
+                return true;
+            }
+        }
+        // All the nodes with roles appropriate for this tier are being removed, so this tier is not available.
+        return false;
     }
 
     public static boolean allocationAllowed(String tierName, DiscoveryNode node) {
@@ -243,5 +296,19 @@ public final class DataTierAllocationDecider extends AllocationDecider {
             }
         }
         return false;
+    }
+
+    private static Set<String> removingNodeIds(NodesShutdownMetadata shutdownMetadata) {
+        if (shutdownMetadata.getAll().isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        Set<String> removingNodes = new HashSet<>();
+        for (var shutdownEntry : shutdownMetadata.getAll().values()) {
+            if (shutdownEntry.getType().isRemovalType()) {
+                removingNodes.add(shutdownEntry.getNodeId());
+            }
+        }
+        return Collections.unmodifiableSet(removingNodes);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -56,7 +56,8 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
         Optional<String> availableDestinationTier = DataTierAllocationDecider.preferredAvailableTier(
             preferredTierConfiguration,
             clusterState.getNodes(),
-            DesiredNodes.latestFromClusterState(clusterState)
+            DesiredNodes.latestFromClusterState(clusterState),
+            clusterState.metadata().nodeShutdowns()
         );
 
         if (ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName()) == false) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForDataTierStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForDataTierStep.java
@@ -37,7 +37,8 @@ public class WaitForDataTierStep extends ClusterStateWaitStep {
         boolean present = DataTierAllocationDecider.preferredAvailableTier(
             DataTier.parseTierList(tierPreference),
             clusterState.nodes(),
-            DesiredNodes.latestFromClusterState(clusterState)
+            DesiredNodes.latestFromClusterState(clusterState),
+            clusterState.metadata().nodeShutdowns()
         ).isPresent();
         SingleMessageFieldInfo info = present ? null : new SingleMessageFieldInfo("no nodes for tiers [" + tierPreference + "] available");
         return new Result(present, info);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -19,6 +19,8 @@ import org.elasticsearch.cluster.metadata.DesiredNodes;
 import org.elasticsearch.cluster.metadata.DesiredNodesMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
+import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -37,6 +39,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
@@ -44,10 +47,13 @@ import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.routing.allocation.DataTier.DATA_COLD;
 import static org.elasticsearch.cluster.routing.allocation.DataTier.DATA_FROZEN;
@@ -61,12 +67,14 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
 
     private static final DiscoveryNode HOT_NODE = newNode("node-hot", Collections.singleton(DiscoveryNodeRole.DATA_HOT_NODE_ROLE));
     private static final DiscoveryNode WARM_NODE = newNode("node-warm", Collections.singleton(DiscoveryNodeRole.DATA_WARM_NODE_ROLE));
+    private static final DiscoveryNode WARM_NODE_TWO = newNode("node-warm-2", Collections.singleton(DiscoveryNodeRole.DATA_WARM_NODE_ROLE));
     private static final DiscoveryNode COLD_NODE = newNode("node-cold", Collections.singleton(DiscoveryNodeRole.DATA_COLD_NODE_ROLE));
     private static final DiscoveryNode CONTENT_NODE = newNode(
         "node-content",
         Collections.singleton(DiscoveryNodeRole.DATA_CONTENT_NODE_ROLE)
     );
     private static final DiscoveryNode DATA_NODE = newNode("node-data", Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
+    private static final DiscoveryNode DATA_NODE_TWO = newNode("node-data-2", Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
 
     private static final DesiredNode HOT_DESIRED_NODE = newDesiredNode("node-hot", DiscoveryNodeRole.DATA_HOT_NODE_ROLE);
     private static final DesiredNode WARM_DESIRED_NODE = newDesiredNode("node-warm", DiscoveryNodeRole.DATA_WARM_NODE_ROLE);
@@ -201,27 +209,110 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
     public void testTierNodesPresent() {
         DiscoveryNodes nodes = DiscoveryNodes.builder().build();
 
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data", nodes));
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data_hot", nodes));
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data_warm", nodes));
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data_cold", nodes));
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data_content", nodes));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data", nodes, irrelevantNodeIds(nodes)));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_hot", nodes, irrelevantNodeIds(nodes)));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_warm", nodes, irrelevantNodeIds(nodes)));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_cold", nodes, irrelevantNodeIds(nodes)));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_content", nodes, irrelevantNodeIds(nodes)));
 
         nodes = DiscoveryNodes.builder().add(WARM_NODE).add(CONTENT_NODE).build();
 
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data", nodes));
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data_hot", nodes));
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data_warm", nodes));
-        assertFalse(DataTierAllocationDecider.tierNodesPresent("data_cold", nodes));
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data_content", nodes));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data", nodes, irrelevantNodeIds(nodes)));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_hot", nodes, irrelevantNodeIds(nodes)));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_warm", nodes, irrelevantNodeIds(nodes)));
+        assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_cold", nodes, irrelevantNodeIds(nodes)));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_content", nodes, irrelevantNodeIds(nodes)));
 
         nodes = DiscoveryNodes.builder().add(DATA_NODE).build();
 
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data", nodes));
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data_hot", nodes));
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data_warm", nodes));
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data_cold", nodes));
-        assertTrue(DataTierAllocationDecider.tierNodesPresent("data_content", nodes));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data", nodes, irrelevantNodeIds(nodes)));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_hot", nodes, irrelevantNodeIds(nodes)));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_warm", nodes, irrelevantNodeIds(nodes)));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_cold", nodes, irrelevantNodeIds(nodes)));
+        assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_content", nodes, irrelevantNodeIds(nodes)));
+    }
+
+    public void testTierNodesPresentWithRelevantNodeShutdowns() {
+        {
+            DiscoveryNodes nodes = DiscoveryNodes.builder().add(HOT_NODE).add(WARM_NODE).add(DATA_NODE).build();
+
+            assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_hot", nodes, Set.of(HOT_NODE.getId())));
+            assertFalse(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_hot",
+                    nodes,
+                    Set.of(HOT_NODE.getId(), DATA_NODE.getId())
+                )
+            );
+
+            assertTrue(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_warm",
+                    nodes,
+                    Set.of(HOT_NODE.getId(), DATA_NODE.getId())
+                )
+            );
+            assertFalse(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_warm",
+                    nodes,
+                    Set.of(HOT_NODE.getId(), WARM_NODE.getId(), DATA_NODE.getId())
+                )
+            );
+
+            assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_cold", nodes, Set.of(HOT_NODE.getId())));
+            assertFalse(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_cold",
+                    nodes,
+                    Set.of(HOT_NODE.getId(), DATA_NODE.getId())
+                )
+            );
+        }
+
+        {
+            DiscoveryNodes onlyTierNodes = DiscoveryNodes.builder().add(HOT_NODE).add(WARM_NODE).add(WARM_NODE_TWO).build();
+            assertFalse(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_hot", onlyTierNodes, Set.of(HOT_NODE.getId())));
+            assertTrue(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_warm", onlyTierNodes, Set.of(WARM_NODE.getId()))
+            );
+            assertFalse(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_warm",
+                    onlyTierNodes,
+                    Set.of(WARM_NODE.getId(), WARM_NODE_TWO.getId())
+                )
+            );
+        }
+
+        {
+            DiscoveryNodes nodes = DiscoveryNodes.builder().add(HOT_NODE).add(DATA_NODE).add(DATA_NODE_TWO).build();
+            assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_hot", nodes, Set.of(HOT_NODE.getId())));
+            assertTrue(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_hot",
+                    nodes,
+                    Set.of(HOT_NODE.getId(), DATA_NODE.getId())
+                )
+            );
+            assertTrue(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_hot",
+                    nodes,
+                    Set.of(HOT_NODE.getId(), DATA_NODE_TWO.getId())
+                )
+            );
+            assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_warm", nodes, Set.of(DATA_NODE.getId())));
+            assertTrue(DataTierAllocationDecider.tierNodesPresentConsideringRemovals("data_warm", nodes, Set.of(DATA_NODE_TWO.getId())));
+            assertFalse(
+                DataTierAllocationDecider.tierNodesPresentConsideringRemovals(
+                    "data_warm",
+                    nodes,
+                    Set.of(DATA_NODE.getId(), DATA_NODE_TWO.getId())
+                )
+            );
+
+        }
     }
 
     public void testTierNodesPresentDesiredNodes() {
@@ -258,19 +349,47 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 : createDesiredNodesWithPendingNodes(HOT_DESIRED_NODE, WARM_DESIRED_NODE, COLD_DESIRED_NODE);
 
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.empty())
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_hot,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_hot,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.empty())
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_warm,data_content"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_warm,data_content"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.empty())
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_cold"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_cold"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.empty())
             );
         }
@@ -282,26 +401,57 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 : createDesiredNodesWithActualizedNodes(WARM_DESIRED_NODE, CONTENT_DESIRED_NODE);
 
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.empty())
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_hot,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_hot,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.of("data_warm"))
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_warm,data_content"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_warm,data_content"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.of("data_warm"))
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_content,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_content,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
+                ),
                 equalTo(Optional.of("data_content"))
             );
             assertThat(
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_hot,data_content,data_warm"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
                 ),
                 equalTo(Optional.of("data_content"))
             );
@@ -309,7 +459,10 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_hot,data_cold,data_warm"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    desiredNodes == null
+                        ? irrelevantNodesShutdownMetadata(nodes)
+                        : nodesShutdownMetadataForDesiredNodesTests(desiredNodes, nodes)
                 ),
                 equalTo(Optional.of("data_warm"))
             );
@@ -318,28 +471,45 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
         {
             final var nodes = DiscoveryNodes.builder().add(WARM_NODE).add(CONTENT_NODE).build();
             final var desiredNodes = createDesiredNodesWithActualizedNodes(HOT_DESIRED_NODE, WARM_DESIRED_NODE, CONTENT_DESIRED_NODE);
+            final var shutdownMetadata = irrelevantNodesShutdownMetadata(nodes);
 
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data"), nodes, desiredNodes, shutdownMetadata),
                 equalTo(Optional.empty())
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_hot,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_hot,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_hot"))
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_warm,data_content"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_warm,data_content"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_warm"))
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_content,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_content,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_content"))
             );
             assertThat(
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_hot,data_content,data_warm"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    shutdownMetadata
                 ),
                 equalTo(Optional.of("data_hot"))
             );
@@ -347,7 +517,8 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_hot,data_cold,data_warm"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    shutdownMetadata
                 ),
                 equalTo(Optional.of("data_hot"))
             );
@@ -366,28 +537,45 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                     actualizedDesiredNode(CONTENT_DESIRED_NODE)
                 )
             );
+            final var shutdownMetadata = irrelevantNodesShutdownMetadata(nodes);
 
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data"), nodes, desiredNodes, shutdownMetadata),
                 equalTo(Optional.empty())
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_hot,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_hot,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_warm"))
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_warm,data_content"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_warm,data_content"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_warm"))
             );
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_content,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_content,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_content"))
             );
             assertThat(
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_hot,data_content,data_warm"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    shutdownMetadata
                 ),
                 equalTo(Optional.of("data_content"))
             );
@@ -395,7 +583,8 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_hot,data_cold,data_warm"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    shutdownMetadata
                 ),
                 equalTo(Optional.of("data_warm"))
             );
@@ -405,9 +594,15 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
             // Cold tier is planned to be removed
             final var nodes = DiscoveryNodes.builder().add(HOT_NODE).add(WARM_NODE).add(COLD_NODE).build();
             final var desiredNodes = createDesiredNodesWithActualizedNodes(HOT_DESIRED_NODE, WARM_DESIRED_NODE);
+            final var shutdownMetadata = irrelevantNodesShutdownMetadata(nodes);
 
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_cold,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_cold,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_warm"))
             );
         }
@@ -425,9 +620,15 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                     pendingDesiredNode(COLD_DESIRED_NODE)
                 )
             );
+            final var shutdownMetadata = irrelevantNodesShutdownMetadata(nodes);
 
             assertThat(
-                DataTierAllocationDecider.preferredAvailableTier(DataTier.parseTierList("data_cold,data_warm"), nodes, desiredNodes),
+                DataTierAllocationDecider.preferredAvailableTier(
+                    DataTier.parseTierList("data_cold,data_warm"),
+                    nodes,
+                    desiredNodes,
+                    shutdownMetadata
+                ),
                 equalTo(Optional.of("data_cold"))
             );
         }
@@ -436,6 +637,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
             // Ensure that when we are removing a tier and growing the next preferred tier we wait until all the new
             // nodes have joined the cluster avoiding filling the new nodes with shards from the removed tier
             final var nodes = DiscoveryNodes.builder().add(HOT_NODE).add(WARM_NODE).add(COLD_NODE).build();
+            final var shutdownMetadata = irrelevantNodesShutdownMetadata(nodes);
             final DesiredNodes desiredNodes;
             // Grow any of the next preferred tiers
             if (randomBoolean()) {
@@ -466,7 +668,8 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_cold,data_warm,data_hot"),
                     nodes,
-                    desiredNodes
+                    desiredNodes,
+                    shutdownMetadata
                 ),
                 equalTo(Optional.of("data_cold"))
             );
@@ -482,11 +685,95 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
                 DataTierAllocationDecider.preferredAvailableTier(
                     DataTier.parseTierList("data_cold,data_warm,data_hot"),
                     nodes,
-                    updatedDesiredNodes
+                    updatedDesiredNodes,
+                    shutdownMetadata
                 ),
                 equalTo(Optional.of("data_warm"))
             );
         }
+    }
+
+    public void testDataTierDeciderConsidersNodeShutdown() {
+        final var nodes = DiscoveryNodes.builder().add(HOT_NODE).add(WARM_NODE).add(COLD_NODE).build();
+        final DesiredNodes desiredNodes = null; // Desired nodes will take precedence over node shutdown if it is present
+
+        assertThat(
+            DataTierAllocationDecider.preferredAvailableTier(
+                DataTier.parseTierList("data_warm,data_cold,data_hot"),
+                nodes,
+                desiredNodes,
+                new NodesShutdownMetadata(Map.of(WARM_NODE.getId(), randomShutdownMetadataRemovingNode(WARM_NODE.getId())))
+            ),
+            equalTo(Optional.of("data_cold"))
+        );
+
+        assertThat(
+            DataTierAllocationDecider.preferredAvailableTier(
+                DataTier.parseTierList("data_warm,data_cold,data_hot"),
+                nodes,
+                desiredNodes,
+                new NodesShutdownMetadata(
+                    Map.of(
+                        WARM_NODE.getId(),
+                        randomShutdownMetadataRemovingNode(WARM_NODE.getId()),
+                        COLD_NODE.getId(),
+                        randomShutdownMetadataRemovingNode(COLD_NODE.getId())
+                    )
+                )
+            ),
+            equalTo(Optional.of("data_hot"))
+        );
+
+        assertThat(
+            DataTierAllocationDecider.preferredAvailableTier(
+                DataTier.parseTierList("data_warm,data_cold,data_hot"),
+                nodes,
+                desiredNodes,
+                new NodesShutdownMetadata(
+                    Map.of(
+                        WARM_NODE.getId(),
+                        randomShutdownMetadataRemovingNode(WARM_NODE.getId()),
+                        COLD_NODE.getId(),
+                        randomShutdownMetadataRemovingNode(COLD_NODE.getId()),
+                        HOT_NODE.getId(),
+                        randomShutdownMetadataRemovingNode(HOT_NODE.getId())
+                    )
+                )
+            ),
+            equalTo(Optional.empty())
+        );
+
+    }
+
+    private SingleNodeShutdownMetadata randomShutdownMetadataRemovingNode(String nodeId) {
+        SingleNodeShutdownMetadata.Type type = randomFrom(
+            SingleNodeShutdownMetadata.Type.SIGTERM,
+            SingleNodeShutdownMetadata.Type.REPLACE,
+            SingleNodeShutdownMetadata.Type.REMOVE
+        );
+        return switch (type) {
+            case REMOVE -> SingleNodeShutdownMetadata.builder()
+                .setNodeId(nodeId)
+                .setType(type)
+                .setReason(this.getTestName())
+                .setStartedAtMillis(randomNonNegativeLong())
+                .build();
+            case REPLACE -> SingleNodeShutdownMetadata.builder()
+                .setNodeId(nodeId)
+                .setType(type)
+                .setTargetNodeName(randomAlphaOfLength(10))
+                .setReason(this.getTestName())
+                .setStartedAtMillis(randomNonNegativeLong())
+                .build();
+            case SIGTERM -> SingleNodeShutdownMetadata.builder()
+                .setNodeId(nodeId)
+                .setType(type)
+                .setGracePeriod(TimeValue.parseTimeValue(randomTimeValue(), this.getTestName()))
+                .setReason(this.getTestName())
+                .setStartedAtMillis(randomNonNegativeLong())
+                .build();
+            case RESTART -> throw new AssertionError("bad randomization, this method only generates removal type shutdowns");
+        };
     }
 
     public void testFrozenIllegalForRegularIndices() {
@@ -659,4 +946,78 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
     private DesiredNodeWithStatus pendingDesiredNode(DesiredNode desiredNode) {
         return new DesiredNodeWithStatus(desiredNode, DesiredNodeWithStatus.Status.PENDING);
     }
+
+    /**
+     * Creates node shutdown metadata that should not impact the decider, either because it is empty or because it is irrelevant to the
+     * decider logic.
+     */
+    private NodesShutdownMetadata irrelevantNodesShutdownMetadata(DiscoveryNodes currentNodes) {
+        final Set<String> currentNodeIds = currentNodes.stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
+        int kind = currentNodes.size() == 0 ? randomFrom(1, 2) : randomFrom(1, 2, 3);
+        return switch (kind) {
+            case 1 -> new NodesShutdownMetadata(Collections.emptyMap());
+            case 2 -> randomRemovalNotInCluster(currentNodeIds);
+            case 3 -> randomRestartInCluster(currentNodeIds);
+            default -> throw new AssertionError("not all randomization branches covered in test");
+        };
+    }
+
+    /**
+     * Desired Nodes should take precedence over node shutdown if it's in use, so this method generates node shutdown metadata that
+     * intersects with current or desired nodes. The output of this function shouldn't matter, whatever node shutdowns it generates; if it
+     * does there's a bug.
+     */
+    private NodesShutdownMetadata nodesShutdownMetadataForDesiredNodesTests(DesiredNodes desiredNodes, DiscoveryNodes currentNodes) {
+        // Note that the desired node's External ID is not the same as the final node ID, but mix them in anyway
+        Set<String> nodeIds = Stream.concat(
+            desiredNodes != null ? desiredNodes.nodes().stream().map(DesiredNodeWithStatus::externalId) : Stream.empty(),
+            currentNodes.stream().map(DiscoveryNode::getId)
+        ).collect(Collectors.toSet());
+        if (nodeIds.isEmpty()) {
+            return new NodesShutdownMetadata(Collections.emptyMap());
+        }
+        int kind = randomFrom(1, 2);
+        return switch (kind) {
+            case 1 -> new NodesShutdownMetadata(Collections.emptyMap());
+            case 2 -> randomRemovalInCluster(nodeIds);
+            default -> throw new AssertionError("not all randomization branches covered in test");
+        };
+    }
+
+    private Set<String> irrelevantNodeIds(DiscoveryNodes currentNodes) {
+        Set<String> nodeIds = new HashSet<>();
+        int numIds = randomIntBetween(0, 10);
+        for (int i = 0; i < numIds; i++) {
+            nodeIds.add(
+                randomValueOtherThanMany((val) -> currentNodes.nodeExists(val) || nodeIds.contains(val), () -> randomAlphaOfLength(10))
+            );
+        }
+        return nodeIds;
+    }
+
+    private NodesShutdownMetadata randomRemovalNotInCluster(Set<String> currentNodes) {
+        String nodeId = randomValueOtherThanMany(currentNodes::contains, () -> randomAlphaOfLength(10));
+        return new NodesShutdownMetadata(Map.of(nodeId, randomShutdownMetadataRemovingNode(nodeId)));
+    }
+
+    private NodesShutdownMetadata randomRemovalInCluster(Set<String> currentNodes) {
+        String nodeId = randomFrom(currentNodes);
+        return new NodesShutdownMetadata(Map.of(nodeId, randomShutdownMetadataRemovingNode(nodeId)));
+    }
+
+    private NodesShutdownMetadata randomRestartInCluster(Set<String> currentNodes) {
+        String nodeId = randomFrom(currentNodes);
+        return new NodesShutdownMetadata(
+            Map.of(
+                nodeId,
+                SingleNodeShutdownMetadata.builder()
+                    .setNodeId(nodeId)
+                    .setType(SingleNodeShutdownMetadata.Type.RESTART)
+                    .setReason(this.getTestName())
+                    .setStartedAtMillis(randomNonNegativeLong())
+                    .build()
+            )
+        );
+    }
+
 }


### PR DESCRIPTION
Prior to this commit, while DataTierAllocationDecider accounted for
Desired Nodes (if available), it did not account for Node Shutdown
information.

As of this commit, nodes that are marked as shutting down for
removal from the cluster are ignored for the purposes of computing
the available data tiers. Desired Nodes configuration, if present,
takes precedence over node shutdown, as desired nodes should be
preferred if possible.

Backport of #98824