### PR TITLE
[Test] More robust order of assertions

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -204,9 +204,12 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
                         fail("No connection should be available if authn fails");
                     }, e -> {
                         logger.info("Expected: no connection could not be established");
-                        assertThat(e, instanceOf(RemoteTransportException.class));
-                        assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
-                        connectionTestDone.countDown();
+                        try {
+                            assertThat(e, instanceOf(RemoteTransportException.class));
+                            assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
+                        } finally {
+                            connectionTestDone.countDown();
+                        }
                     }));
                 assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
             }
@@ -261,9 +264,12 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
                         fail("No connection should be available if authn fails");
                     }, e -> {
                         logger.info("Expected: no connection could be established");
-                        assertThat(e, instanceOf(RemoteTransportException.class));
-                        assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
-                        connectionTestDone.countDown();
+                        try {
+                            assertThat(e, instanceOf(RemoteTransportException.class));
+                            assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
+                        } finally {
+                            connectionTestDone.countDown();
+                        }
                     }));
                 assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -204,9 +204,9 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
                         fail("No connection should be available if authn fails");
                     }, e -> {
                         logger.info("Expected: no connection could not be established");
-                        connectionTestDone.countDown();
                         assertThat(e, instanceOf(RemoteTransportException.class));
                         assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
+                        connectionTestDone.countDown();
                     }));
                 assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
             }
@@ -261,9 +261,9 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
                         fail("No connection should be available if authn fails");
                     }, e -> {
                         logger.info("Expected: no connection could be established");
-                        connectionTestDone.countDown();
                         assertThat(e, instanceOf(RemoteTransportException.class));
                         assertThat(e.getCause(), instanceOf(authenticationException.get().getClass()));
+                        connectionTestDone.countDown();
                     }));
                 assertTrue(connectionTestDone.await(10L, TimeUnit.SECONDS));
             }


### PR DESCRIPTION
This PR adjusts the order of assertions to ensure we are done with the atomic reference variable in the previous assertions before changing it to null.

Resolves: #99406
