### PR TITLE
[DOCS] Remove 'coming in 8.10' from remote cluster API key auth docs

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -1,7 +1,6 @@
 [[remote-clusters-api-key]]
 === Add remote clusters using API key authentication
 
-coming::[8.10]
 beta::[]
 
 API key authentication enables a local cluster to authenticate itself with a


### PR DESCRIPTION
Removes the 'coming in 8.10' notice from the remote cluster API key authentication docs. Merge on release day.