### PR TITLE
[DOCS] Use different index names in ESQL example

### DIFF
--- a/docs/reference/esql/source-commands/from.asciidoc
+++ b/docs/reference/esql/source-commands/from.asciidoc
@@ -25,7 +25,7 @@ or aliases:
 
 [source,esql]
 ----
-FROM employees-00001,employees-*
+FROM employees-00001,other-employees-*
 ----
 
 Use the `METADATA` directive to enable <<esql-metadata-fields,metadata fields>>:


### PR DESCRIPTION
To make it more clear let's use different index names for comma-separated index list. Now it clearly shows that we can refer very different index patterns
