### PR TITLE
ESQL: Improve log messages

### DIFF
--- a/docs/changelog/99470.yaml
+++ b/docs/changelog/99470.yaml
@@ -1,0 +1,5 @@
+pr: 99470
+summary: "ESQL: Improve log messages"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -143,12 +143,12 @@ public class EsqlResponseListener extends RestResponseListener<EsqlQueryResponse
         return ActionListener.wrap(r -> {
             onResponse(r);
             // At this point, the StopWatch should already have been stopped, so we log a consistent time.
-            LOGGER.info("Successfully executed ESQL query in {}ms:\n{}", stopWatch.stop().getMillis(), esqlQuery);
+            LOGGER.info("Successfully executed ESQL query in [{}]ms: [{}]", stopWatch.stop().getMillis(), esqlQuery);
         }, ex -> {
             // In case of failure, stop the time manually before sending out the response.
             long timeMillis = stopWatch.stop().getMillis();
             onFailure(ex);
-            LOGGER.info("Failed executing ESQL query in {}ms:\n{}", timeMillis, esqlQuery);
+            LOGGER.info("Failed executing ESQL query in [{}]ms: [{}]", timeMillis, esqlQuery);
         });
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -136,7 +136,7 @@ public class ComputeService {
         }
         QueryBuilder requestFilter = PlannerUtils.requestFilter(dataNodePlan);
 
-        LOGGER.info("Sending data node plan\n{}\n with filter [{}]", dataNodePlan, requestFilter);
+        LOGGER.debug("Sending data node plan\n{}\n with filter [{}]", dataNodePlan, requestFilter);
 
         String[] originalIndices = PlannerUtils.planOriginalIndices(physicalPlan);
         computeTargetNodes(


### PR DESCRIPTION
- Demote another compute service log message to DEBUG to avoid clutter in production logs.
- Format ESQL query logs more consistently with other production log messages.
