### PR TITLE
[Query Rules] Add INFER query rule

### DIFF
--- a/docs/changelog/99481.yaml
+++ b/docs/changelog/99481.yaml
@@ -1,5 +1,5 @@
 pr: 99481
-summary: "[Spacetime] Add INFER query rule"
+summary: "Add an infer query rule criteria definition, allowing for query rules matching inference results for text_expansion and text_classification inference configurations."
 area: Application
 type: enhancement
 issues: []

--- a/docs/changelog/99481.yaml
+++ b/docs/changelog/99481.yaml
@@ -1,0 +1,5 @@
+pr: 99481
+summary: "[Spacetime] Add INFER query rule"
+area: Application
+type: enhancement
+issues: []

--- a/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
@@ -76,11 +76,26 @@ Matches with a value greater than or equal to this value meet the criteria defin
 Only applicable for numerical values.
 - `always`
 Matches all queries, regardless of input.
+- `infer`
+Matches that return inferences matching this value meet the criteria defined by the rule.
+Only applicable for string values.
+The following properties are supported:
++
+*** `model_id` (string) Model ID to use for inference.
+     Defaults to `.elser_model_1`.
+*** `inference_config` (string) The inference configuration to use.
+    Supported inference configurations are `text_expansion` and `text_classification`.
+    Defaults to `text_expansion`.
+*** `threshold` (float) The minimum score required for the inference result to be considered a match.
+    Defaults to `1.0`.
+
 --
 - `metadata` (Optional, string)
   The metadata field to match against. Required for all criteria types except `global`.
 - `values` (Optional, array of strings)
   The values to match against the metadata field. Only one value must match for the criteria to be met. Required for all criteria types except `global`.
+- `properties` (Optional, map to strings to strings)
+     Additional properties for the criteria. Only applicable for `infer` criteria types.
 
 Actions depend on the rule type.
 For `pinned` rules, actions follow the format specified by the <<query-dsl-pinned-query,Pinned Query>>.

--- a/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
+++ b/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
@@ -84,6 +84,9 @@ Allowed criteria types are:
 
 |`always`
 |Always matches for all rule queries.
+
+|`infer`
+| Rule metadata matches a specified `text_expansion` or `text_classification` inference. Requires the specified trained model(s) to be loaded.
 |===
 
 [discrete]

--- a/x-pack/plugin/ent-search/qa/rest/build.gradle
+++ b/x-pack/plugin/ent-search/qa/rest/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 restResources {
   restApi {
-    include '_common', 'bulk', 'cluster', 'nodes', 'indices', 'index', 'query_ruleset', 'search_application', 'xpack', 'security', 'search'
+    include '_common', 'bulk', 'cluster', 'nodes', 'indices', 'index', 'query_ruleset', 'search_application', 'xpack', 'security', 'search', 'ml'
   }
 }
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/265_rule_query_infer.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/265_rule_query_infer.yml
@@ -1,0 +1,102 @@
+# This test uses the simple model defined in
+# TextExpansionQueryIT.java to create the token weights.
+setup:
+  - skip:
+      version: " - 8.10.99"
+      reason: Introduced in 8.11.0
+  - do:
+      indices.create:
+        index: index-with-rank-features
+        body:
+          mappings:
+            properties:
+              source_text:
+                type: keyword
+              ml.tokens:
+                type: rank_features
+
+  - do:
+      ml.put_trained_model:
+        model_id: "text_expansion_model"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "text_expansion": {
+                "tokenization": {
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                }
+              }
+            }
+          }
+  - do:
+      ml.put_trained_model_vocabulary:
+        model_id: "text_expansion_model"
+        body: >
+          { "vocabulary": ["[PAD]", "[UNK]", "these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"] }
+  - do:
+      ml.put_trained_model_definition_part:
+        model_id: "text_expansion_model"
+        part: 0
+        body: >
+          {
+            "total_definition_length":2078,
+            "definition": "UEsDBAAACAgAAAAAAAAAAAAAAAAAAAAAAAAUAA4Ac2ltcGxlbW9kZWwvZGF0YS5wa2xGQgoAWlpaWlpaWlpaWoACY19fdG9yY2hfXwpUaW55VGV4dEV4cGFuc2lvbgpxACmBfShYCAAAAHRyYWluaW5ncQGJWBYAAABfaXNfZnVsbF9iYWNrd2FyZF9ob29rcQJOdWJxAy5QSwcIITmbsFgAAABYAAAAUEsDBBQACAgIAAAAAAAAAAAAAAAAAAAAAAAdAB0Ac2ltcGxlbW9kZWwvY29kZS9fX3RvcmNoX18ucHlGQhkAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWoWRT4+cMAzF7/spfASJomF3e0Ga3nrrn8vcELIyxAzRhAQlpjvbT19DWDrdquqBA/bvPT87nVUxwsm41xPd+PNtUi4a77KvXs+W8voBAHFSQY3EFCIiHKFp1+p57vs/ShyUccZdoIaz93aBTMR+thbPqru+qKBx8P4q/e8TyxRlmwVctJp66H1YmCyS7WsZwD50A2L5V7pCBADGTTOj0bGGE7noQyqzv5JDfp0o9fZRCWqP37yjhE4+mqX5X3AdFZHGM/2TzOHDpy1IvQWR+OWo3KwsRiKdpcqg4pBFDtm+QJ7nqwIPckrlnGfFJG0uNhOl38Sjut3pCqg26QuZy8BR9In7ScHHrKkKMW0TIucFrGQXCMpdaDO05O6DpOiy8e4kr0Ed/2YKOIhplW8gPr4ntygrd9ixpx3j9UZZVRagl2c6+imWUzBjuf5m+Ch7afphuvvW+r/0dsfn+2N9MZGb9+/SFtCYdhd83CMYp+mGy0LiKNs8y/eUuEA8B/d2z4dfUEsHCFSE3IaCAQAAIAMAAFBLAwQUAAgICAAAAAAAAAAAAAAAAAAAAAAAJwApAHNpbXBsZW1vZGVsL2NvZGUvX190b3JjaF9fLnB5LmRlYnVnX3BrbEZCJQBaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpahZHLbtNAFIZtp03rSVIuLRKXjdk5ojitKJsiFq24lem0KKSqpRIZt55gE9/GM+lNLFgx4i1Ys2aHhIBXgAVICNggHgNm6rqJN2BZGv36/v/MOWeea/Z5RVHurLfRUsfZXOnccx522itrd53O0vLqbaKYtsAKUe1pcege7hm9JNtzM8+kOOzNApIX0A3xBXE6YE7g0UWjg2OaZAJXbKvALOnj2GEHKc496ykLktgNt3Jz17hprCUxFqExe7YIpQkNpO1/kfHhPUdtUAdH2/gfmeYiIFW7IkM6IBP2wrDNbMe3Mjf2ksiK3Hjghg7F2DN9l/omZZl5Mmez2QRk0q4WUUB0+1oh9nDwxGdUXJdXPMRZQs352eGaRPV9s2lcMeZFGWBfKJJiw0YgbCMLBaRmXyy4flx6a667Fch55q05QOq2Jg2ANOyZwplhNsjiohVApo7aa21QnNGW5+4GXv8gxK1beBeHSRrhmLXWVh+0aBhErZ7bx1ejxMOhlR6QU4ycNqGyk8/yNGCWkwY7/RCD7UEQek4QszCgDJAzZtfErA0VqHBy9ugQP9pUfUmgCjVYgWNwHFbhBJyEOgSwBuuwARWZmoI6J9PwLfzEocpRpPrT8DP8wqHG0b4UX+E3DiscvRglXIoi81KKPwioHI5x9EooNKWiy0KOc/T6WF4SssrRuzJ9L2VNRXUhJzj6UKYfS4W/q/5wuh/l4M9R9qsU+y2dpoo2hJzkaEET8r6KRONicnRdK9EbUi6raFVIwNGjsrlbpk6ZPi7TbS3fv3LyNjPiEKzG0aG0tvNb6xw90/whe6ONjnJcUxobHDUqQ8bIOW79BVBLBwhfSmPKdAIAAE4EAABQSwMEAAAICAAAAAAAAAAAAAAAAAAAAAAAABkABQBzaW1wbGVtb2RlbC9jb25zdGFudHMucGtsRkIBAFqAAikuUEsHCG0vCVcEAAAABAAAAFBLAwQAAAgIAAAAAAAAAAAAAAAAAAAAAAAAEwA7AHNpbXBsZW1vZGVsL3ZlcnNpb25GQjcAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWjMKUEsHCNGeZ1UCAAAAAgAAAFBLAQIAAAAACAgAAAAAAAAhOZuwWAAAAFgAAAAUAAAAAAAAAAAAAAAAAAAAAABzaW1wbGVtb2RlbC9kYXRhLnBrbFBLAQIAABQACAgIAAAAAABUhNyGggEAACADAAAdAAAAAAAAAAAAAAAAAKgAAABzaW1wbGVtb2RlbC9jb2RlL19fdG9yY2hfXy5weVBLAQIAABQACAgIAAAAAABfSmPKdAIAAE4EAAAnAAAAAAAAAAAAAAAAAJICAABzaW1wbGVtb2RlbC9jb2RlL19fdG9yY2hfXy5weS5kZWJ1Z19wa2xQSwECAAAAAAgIAAAAAAAAbS8JVwQAAAAEAAAAGQAAAAAAAAAAAAAAAACEBQAAc2ltcGxlbW9kZWwvY29uc3RhbnRzLnBrbFBLAQIAAAAACAgAAAAAAADRnmdVAgAAAAIAAAATAAAAAAAAAAAAAAAAANQFAABzaW1wbGVtb2RlbC92ZXJzaW9uUEsGBiwAAAAAAAAAHgMtAAAAAAAAAAAABQAAAAAAAAAFAAAAAAAAAGoBAAAAAAAAUgYAAAAAAABQSwYHAAAAALwHAAAAAAAAAQAAAFBLBQYAAAAABQAFAGoBAABSBgAAAAA=",
+            "total_parts": 1
+          }
+  - do:
+      bulk:
+        index: index-with-rank-features
+        refresh: true
+        body: |
+          {"index": {"_id": "id1" }}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
+          {"index": {"_id": "id2" }}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
+          {"index": {"_id": "id3" }}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
+          {"index": {"_id": "id4" }}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
+          {"index": {"_id": "id5" }}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
+          {"index": {"_id": "id6" }}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
+          {"index": {"_id": "id7" }}
+          {"source_text": "unrelated pinned content", "ml.tokens":{"unrelated":1.0,"pinned":1.0,"content":1.0}}
+
+  - do:
+      ml.start_trained_model_deployment:
+        model_id: text_expansion_model
+        wait_for: started
+
+  - do:
+      query_ruleset.put:
+        ruleset_id: ruleset
+        body:
+          rules:
+            - rule_id: id1
+              type: pinned
+              criteria:
+                - type: infer
+                  metadata: input
+                  values: [ octopus ]
+              actions:
+                ids:
+                  - 'id7'
+
+---
+"Test rule query with inference":
+  - do:
+      search:
+        index: index-with-rank-features
+        body:
+          query:
+            text_expansion:
+              ml.tokens:
+                model_id: text_expansion_model
+                model_text: "octopus comforter smells"
+  - match: { hits.total.value: 5 }
+  - match: { hits.hits.0._source.source_text: "unrelated pinned content" }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/265_rule_query_infer.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/265_rule_query_infer.yml
@@ -6,12 +6,14 @@ setup:
       reason: Introduced in 8.11.0
   - do:
       indices.create:
-        index: index-with-rank-features
+        index: test-infer
         body:
           mappings:
             properties:
               source_text:
                 type: keyword
+              theme:
+                type: text
               ml.tokens:
                 type: rank_features
 
@@ -49,23 +51,21 @@ setup:
           }
   - do:
       bulk:
-        index: index-with-rank-features
+        index: test-infer
         refresh: true
         body: |
-          {"index": {"_id": "id1" }}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
-          {"index": {"_id": "id2" }}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
-          {"index": {"_id": "id3" }}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
-          {"index": {"_id": "id4" }}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
-          {"index": {"_id": "id5" }}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
-          {"index": {"_id": "id6" }}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
-          {"index": {"_id": "id7" }}
-          {"source_text": "unrelated pinned content", "ml.tokens":{"unrelated":1.0,"pinned":1.0,"content":1.0}}
+          {"index": { "_id": "id1" }}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}, "theme": "bedding"}
+          {"index": { "_id": "id2" }}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}, "theme": "appliance"}
+          {"index": { "_id": "id3" }}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}, "theme": "sentence"}
+          {"index": { "_id": "id4" }}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}, "theme": "bedding"}
+          {"index": { "_id": "id5" }}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}, "theme": "bedding"}
+          {"index": { "_id": "id6" }}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}, "theme": "appliance"}
 
   - do:
       ml.start_trained_model_deployment:
@@ -77,26 +77,113 @@ setup:
         ruleset_id: ruleset
         body:
           rules:
-            - rule_id: id1
+            - rule_id: rule_id1
               type: pinned
               criteria:
                 - type: infer
                   metadata: input
-                  values: [ octopus ]
+                  values: [ comforter ]
+                  properties:
+                    model_id: text_expansion_model
               actions:
                 ids:
-                  - 'id7'
+                  - 'id1'
+                  - 'id5'
+                  - 'id4'
+
+  - do:
+      query_ruleset.put:
+        ruleset_id: bad-ruleset
+        body:
+          rules:
+            - rule_id: rule_id1
+              type: pinned
+              criteria:
+                - type: infer
+                  metadata: input
+                  values: [ washing machine ]
+                  properties:
+                    model_id: missing-model
+              actions:
+                ids:
+                  - 'id2'
 
 ---
-"Test rule query with inference":
+"Test rule query with inference match":
   - do:
       search:
-        index: index-with-rank-features
+        index:
+          test-infer
         body:
           query:
-            text_expansion:
-              ml.tokens:
-                model_id: text_expansion_model
-                model_text: "octopus comforter smells"
-  - match: { hits.total.value: 5 }
-  - match: { hits.hits.0._source.source_text: "unrelated pinned content" }
+            rule_query:
+              organic:
+                query_string:
+                  default_field: theme
+                  query: doesnt matter
+              match_criteria:
+                input: comforter
+              ruleset_id: ruleset
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: "id1" }
+  - match: { hits.hits.1._id: "id5" }
+  - match: { hits.hits.2._id: "id4" }
+
+---
+"Test rule query where inference is below the threshold and therefore the rule does not match":
+  - do:
+      query_ruleset.put:
+        ruleset_id: ruleset
+        body:
+          rules:
+            - rule_id: rule_id1
+              type: pinned
+              criteria:
+                - type: infer
+                  metadata: input
+                  values: [ comforter ]
+                  properties:
+                    model_id: text_expansion_model
+                    threshold: 100.0
+              actions:
+                ids:
+                  - 'id1'
+                  - 'id5'
+                  - 'id4'
+
+  - do:
+      search:
+        index:
+          test-infer
+        body:
+          query:
+            rule_query:
+              organic:
+                query_string:
+                  default_field: theme
+                  query: doesnt matter
+              match_criteria:
+                input: comforter
+              ruleset_id: ruleset
+
+  - match: { hits.total.value: 0 }
+
+
+---
+"Rule queries with inference return a 404 if there is no model found":
+  - do:
+      catch: "missing"
+      search:
+        index:
+          - test-no-infer
+        body:
+          query:
+            rule_query:
+              organic:
+                query_string:
+                  default_field: theme
+                  query: doesnt matter
+              match_criteria:
+                input: washing machine
+              ruleset_id: bad-ruleset

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.application.rules;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -281,7 +283,7 @@ public class QueryRule implements Writeable, ToXContentObject {
     }
 
     @SuppressWarnings("unchecked")
-    public AppliedQueryRules applyRule(AppliedQueryRules appliedRules, Map<String, Object> matchCriteria) {
+    public AppliedQueryRules applyRule(Client client, AppliedQueryRules appliedRules, Map<String, Object> matchCriteria) {
         if (type != QueryRule.QueryRuleType.PINNED) {
             throw new UnsupportedOperationException("Only pinned query rules are supported");
         }
@@ -298,7 +300,7 @@ public class QueryRule implements Writeable, ToXContentObject {
                 final String criteriaMetadata = criterion.criteriaMetadata();
 
                 if (criteriaType == ALWAYS || (criteriaMetadata != null && criteriaMetadata.equals(match))) {
-                    boolean singleCriterionMatches = criterion.isMatch(matchValue, criteriaType);
+                    boolean singleCriterionMatches = criterion.isMatch(client, matchValue, criteriaType);
                     isRuleMatch = (isRuleMatch == null) ? singleCriterionMatches : isRuleMatch && singleCriterionMatches;
                 }
             }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.application.rules;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -237,14 +237,15 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
                     return true;
                 }
             }
-        }
-        // Default case
-        final String matchString = matchValue.toString();
-        for (Object criteriaValue : criteriaValues) {
-            matchType.validateInput(matchValue);
-            boolean matchFound = matchType.isMatch(matchString, criteriaValue, criteriaProperties);
-            if (matchFound) {
-                return true;
+        } else {
+            // Default case
+            final String matchString = matchValue.toString();
+            for (Object criteriaValue : criteriaValues) {
+                matchType.validateInput(matchValue);
+                boolean matchFound = matchType.isMatch(matchString, criteriaValue, criteriaProperties);
+                if (matchFound) {
+                    return true;
+                }
             }
         }
         return false;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteria.java
@@ -81,6 +81,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         this.criteriaValues = criteriaValues;
         this.criteriaType = criteriaType;
         this.criteriaProperties = (criteriaProperties == null) ? Map.of() : criteriaProperties;
+        criteriaType.validateProperties(this.criteriaProperties);
 
     }
 
@@ -230,7 +231,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
         } else if (matchType == INFER) {
             final String matchString = matchValue.toString();
             for (Object criteriaValue : criteriaValues) {
-                matchType.validateInput(matchValue);
+                matchType.validate(matchValue, criteriaProperties);
                 QueryRulesInferenceService queryRulesInferenceService = new QueryRulesInferenceService(client);
                 boolean matchFound = matchType.isMatch(queryRulesInferenceService, matchString, criteriaValue, criteriaProperties);
                 if (matchFound) {
@@ -241,7 +242,7 @@ public class QueryRuleCriteria implements Writeable, ToXContentObject {
             // Default case
             final String matchString = matchValue.toString();
             for (Object criteriaValue : criteriaValues) {
-                matchType.validateInput(matchValue);
+                matchType.validate(matchValue, criteriaProperties);
                 boolean matchFound = matchType.isMatch(matchString, criteriaValue, criteriaProperties);
                 if (matchFound) {
                     return true;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfi
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Defines the different types of query rule criteria and their rules for matching input against the criteria.
@@ -125,6 +126,22 @@ public enum QueryRuleCriteriaType {
                     );
                 }
             }
+            if (criteriaProperties.containsKey(PROPERTY_INFERENCE_CONFIG)) {
+                String inferenceConfig = (String) criteriaProperties.get(PROPERTY_INFERENCE_CONFIG);
+                if (QueryRulesInferenceService.SUPPORTED_INFERENCE_CONFIGS.contains(inferenceConfig) == false) {
+                    throw new IllegalArgumentException(
+                        "Unsupported inference config ["
+                            + inferenceConfig
+                            + "]. Supported inference configs: "
+                            + QueryRulesInferenceService.SUPPORTED_INFERENCE_CONFIGS
+                    );
+                }
+            }
+        }
+
+        @Override
+        public Set<String> getAllowedPropertyNames() {
+            return DEFAULTS.keySet();
         }
 
         @Override
@@ -172,6 +189,10 @@ public enum QueryRuleCriteriaType {
             throw new IllegalArgumentException("Criteria type [" + this + "] does not define any allowed properties");
         }
         ;
+    }
+
+    public Set<String> getAllowedPropertyNames() {
+        return Set.of();
     }
 
     public static QueryRuleCriteriaType type(String criteriaType) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
@@ -17,6 +17,7 @@ import java.util.Map;
  * Defines the different types of query rule criteria and their rules for matching input against the criteria.
  */
 public enum QueryRuleCriteriaType {
+
     ALWAYS {
         @Override
         public boolean isMatch(Object input, Object criteriaValue, Map<String, Object> criteriaProperties) {
@@ -109,8 +110,9 @@ public enum QueryRuleCriteriaType {
         ) {
             validateInput(input);
             String modelId = criteriaProperties.getOrDefault("model_id", ".elser_model_1").toString();
+            String inferenceConfig = criteriaProperties.getOrDefault("inference_config", "text_expansion").toString();
             float threshold = ((Double) criteriaProperties.getOrDefault("threshold", 1.0)).floatValue();
-            return inferenceService.findInferenceRuleMatches(modelId, (String) input, (String) criteriaValue, threshold);
+            return inferenceService.findInferenceRuleMatches(modelId, inferenceConfig, (String) input, (String) criteriaValue, threshold);
         }
     };
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaType.java
@@ -109,7 +109,7 @@ public enum QueryRuleCriteriaType {
         ) {
             validateInput(input);
             String modelId = criteriaProperties.getOrDefault("model_id", ".elser_model_1").toString();
-            float threshold = (Float) criteriaProperties.getOrDefault("threshold", 1.0f);
+            float threshold = ((Double) criteriaProperties.getOrDefault("threshold", 1.0)).floatValue();
             return inferenceService.findInferenceRuleMatches(modelId, (String) input, (String) criteriaValue, threshold);
         }
     };

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -144,6 +144,11 @@ public class QueryRulesIndexService {
                             builder.field("type", "object");
                             builder.field("enabled", false);
                             builder.endObject();
+
+                            builder.startObject(QueryRuleCriteria.PROPERTIES_FIELD.getPreferredName());
+                            builder.field("type", "object");
+                            builder.field("enabled", false);
+                            builder.endObject();
                         }
                         builder.endObject();
                         builder.endObject();
@@ -219,7 +224,8 @@ public class QueryRulesIndexService {
                 new QueryRuleCriteria(
                     QueryRuleCriteriaType.type((String) entry.get(QueryRuleCriteria.TYPE_FIELD.getPreferredName())),
                     (String) entry.get(QueryRuleCriteria.METADATA_FIELD.getPreferredName()),
-                    (List<Object>) entry.get(QueryRuleCriteria.VALUES_FIELD.getPreferredName())
+                    (List<Object>) entry.get(QueryRuleCriteria.VALUES_FIELD.getPreferredName()),
+                    (Map<String, Object>) entry.get(QueryRuleCriteria.PROPERTIES_FIELD.getPreferredName())
                 )
             );
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
@@ -27,6 +27,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
 public class QueryRulesInferenceService {
 
+    public static final Set<String> SUPPORTED_INFERENCE_CONFIGS = Set.of(TextExpansionConfig.NAME, TextClassificationConfig.NAME);
+
     private static final int TIMEOUT_MS = 10000;
 
     private static final Logger logger = LogManager.getLogger(QueryRulesInferenceService.class);
@@ -48,9 +50,7 @@ public class QueryRulesInferenceService {
         } else if (inferenceConfig.equals(TextClassificationConfig.NAME)) {
             return findTextClassificationInferenceRuleMatches(modelId, queryString, matchValue, threshold);
         } else {
-            throw new UnsupportedOperationException(
-                "Only " + Set.of(TextExpansionConfig.NAME, TextClassificationConfig.NAME) + "inference configurations supported"
-            );
+            throw new UnsupportedOperationException("Only " + SUPPORTED_INFERENCE_CONFIGS + "inference configurations supported");
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.rules;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.core.ml.action.InferModelAction;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfigUpdate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
+
+public class QueryRulesInferenceService {
+
+    private static final Logger logger = LogManager.getLogger(QueryRulesInferenceService.class);
+    private final Client clientWithOrigin;
+
+    public QueryRulesInferenceService(Client client) {
+        this.clientWithOrigin = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
+    }
+
+    public boolean findInferenceRuleMatches(String modelId, String queryString, float threshold) {
+
+        SetOnce<Boolean> inferenceRuleMatches = new SetOnce<>();
+
+        InferModelAction.Request request = InferModelAction.Request.forTextInput(
+            modelId,
+            TextExpansionConfigUpdate.EMPTY_UPDATE,
+            List.of(queryString)
+        );
+        request.setHighPriority(true);
+
+        clientWithOrigin.execute(InferModelAction.INSTANCE, request, new ActionListener<>() {
+            @Override
+            public void onResponse(InferModelAction.Response response) {
+                List<InferenceResults> results = response.getInferenceResults();
+                for (InferenceResults result : results) {
+                    @SuppressWarnings("unchecked")
+                    Map<String,Float> predictedValues = (Map<String,Float>) result.asMap().get(result.getResultsField());
+                    if (predictedValues.containsKey(queryString)) {
+                        Float predictedValue = predictedValues.get(queryString);
+                        if (predictedValue >= threshold) {
+                            inferenceRuleMatches.set(true);
+                            break;
+                        }
+                    }
+                }
+                inferenceRuleMatches.trySet(false);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Boolean returnValue = inferenceRuleMatches.get();
+        while (returnValue == null) {
+            returnValue = inferenceRuleMatches.get();
+        }
+        return returnValue;
+    }
+
+
+
+
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
@@ -33,7 +33,13 @@ public class QueryRulesInferenceService {
         this.clientWithOrigin = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
     }
 
-    public boolean findInferenceRuleMatches(String modelId, String inferenceConfig, String queryString, String matchValue, float threshold) {
+    public boolean findInferenceRuleMatches(
+        String modelId,
+        String inferenceConfig,
+        String queryString,
+        String matchValue,
+        float threshold
+    ) {
 
         if (inferenceConfig.equals("text_expansion")) {
             return findTextExpansionInferenceRuleMatches(modelId, queryString, matchValue, threshold);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesInferenceService.java
@@ -60,7 +60,7 @@ public class QueryRulesInferenceService {
         for (InferenceResults result : results) {
             @SuppressWarnings("unchecked")
             Map<String, Float> predictedValues = (Map<String, Float>) result.asMap().get(result.getResultsField());
-            if (predictedValues.containsKey(queryString)) {
+            if (predictedValues.containsKey(matchValue)) {
                 Float predictedValue = predictedValues.get(matchValue);
                 if (predictedValue >= threshold) {
                     return true;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -219,7 +219,7 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
                 }
                 QueryRuleset queryRuleset = QueryRuleset.fromXContentBytes(rulesetId, getResponse.getSourceAsBytesRef(), XContentType.JSON);
                 for (QueryRule rule : queryRuleset.rules()) {
-                    rule.applyRule(appliedRules, matchCriteria);
+                    rule.applyRule(client, appliedRules, matchCriteria);
                 }
                 pinnedIdsSetOnce.set(appliedRules.pinnedIds().stream().distinct().toList());
                 pinnedDocsSetOnce.set(appliedRules.pinnedDocs().stream().distinct().toList());

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -25,6 +25,8 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -218,6 +220,20 @@ public class QueryRuleCriteriaTests extends ESTestCase {
             QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of(42), null);
             expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch(client, "puggles", type));
         }
+    }
+
+    public void testInvalidCriteriaProperties() {
+        Map<String, Object> invalidProperties = Map.of("foo", "bar");
+        for (QueryRuleCriteriaType type : QueryRuleCriteriaType.values()) {
+            expectThrows(IllegalArgumentException.class, () -> new QueryRuleCriteria(type, "foo", List.of("bar"), invalidProperties));
+        }
+
+        Map<String, Object> inferProperties = QueryRuleCriteriaType.INFER.getAllowedPropertyNames()
+            .stream()
+            .map(name -> Map.entry(name, "foo"))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        inferProperties.put("inference_config", "text_expansion");
+        new QueryRuleCriteria(QueryRuleCriteriaType.INFER, "foo", List.of("bar"), inferProperties);
     }
 
     private void assertXContent(QueryRuleCriteria queryRule, boolean humanReadable) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -208,35 +208,6 @@ public class QueryRuleCriteriaTests extends ESTestCase {
         assertTrue(queryRuleCriteria.isMatch(client, 42, type));
     }
 
-    // public void testDefaultInferMatch() {
-    // QueryRulesInferenceService queryRulesInferenceService = mockQueryRulesInferenceService();
-    // QueryRuleCriteriaType type = INFER;
-    // QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elk"), null);
-    // assertTrue(queryRuleCriteria.isMatch(client, "elk", type));
-    // assertFalse(queryRuleCriteria.isMatch(client, "puggles", type));
-    // }
-
-    // public void testInferMatchWithProperties() {
-    // QueryRulesInferenceService queryRulesInferenceService = mockQueryRulesInferenceService();
-    // QueryRuleCriteriaType type = INFER;
-    // QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(
-    // type,
-    // "query",
-    // List.of("elk"),
-    // Map.of("model_id", "my-model-id", "threshold", 2.5f)
-    // );
-    // assertTrue(queryRuleCriteria.isMatch(client, "elk", type));
-    // assertFalse(queryRuleCriteria.isMatch(client, "puggles", type));
-    // }
-
-    // private QueryRulesInferenceService mockQueryRulesInferenceService() {
-    // QueryRulesInferenceService queryRulesInferenceService = new QueryRulesInferenceService(client);
-    // when(queryRulesInferenceService.getInferences(any(InferModelAction.Request.class))).thenReturn(
-    // new InferModelAction.Response(emptyList(), null, false)
-    // );
-    // return queryRulesInferenceService;
-    // }
-
     public void testInvalidCriteriaInput() {
         for (QueryRuleCriteriaType type : List.of(FUZZY, PREFIX, SUFFIX, CONTAINS)) {
             QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of("bar"), null);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleCriteriaTests.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -32,6 +33,7 @@ import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EX
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.FUZZY;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GT;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.GTE;
+import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.INFER;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.LT;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.LTE;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.PREFIX;
@@ -59,7 +61,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public final void testAlwaysSerialization() throws IOException {
         for (int runs = 0; runs < 10; runs++) {
-            QueryRuleCriteria testInstance = new QueryRuleCriteria(ALWAYS, null, null);
+            QueryRuleCriteria testInstance = new QueryRuleCriteria(ALWAYS, null, null, null);
             assertTransportSerialization(testInstance);
             assertXContent(testInstance, randomBoolean());
         }
@@ -101,11 +103,11 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testExactMatch() {
         QueryRuleCriteriaType type = EXACT;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"), null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertFalse(queryRuleCriteria.isMatch("elasticc", type));
 
-        queryRuleCriteria = new QueryRuleCriteria(type, "zip_code", List.of("12345"));
+        queryRuleCriteria = new QueryRuleCriteria(type, "zip_code", List.of("12345"), null);
         assertTrue(queryRuleCriteria.isMatch(12345, type));
         assertTrue(queryRuleCriteria.isMatch("12345", type));
         assertFalse(queryRuleCriteria.isMatch("123456", type));
@@ -113,7 +115,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testFuzzyExactMatch() {
         QueryRuleCriteriaType type = FUZZY;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"), null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("elasticc", type));
         assertFalse(queryRuleCriteria.isMatch("elastic elastic elastic elastic", type));
@@ -121,7 +123,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testPrefixMatch() {
         QueryRuleCriteriaType type = PREFIX;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic", "kibana"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic", "kibana"), null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("kibana", type));
         assertTrue(queryRuleCriteria.isMatch("elastic is a great search engine", type));
@@ -131,7 +133,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testSuffixMatch() {
         QueryRuleCriteriaType type = SUFFIX;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("search", "lucene"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("search", "lucene"), null);
         assertTrue(queryRuleCriteria.isMatch("search", type));
         assertTrue(queryRuleCriteria.isMatch("lucene", type));
         assertTrue(queryRuleCriteria.isMatch("you know, for search", type));
@@ -142,7 +144,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testContainsMatch() {
         QueryRuleCriteriaType type = CONTAINS;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elastic"), null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch("I use elastic for search", type));
         assertFalse(queryRuleCriteria.isMatch("you know, for search", type));
@@ -150,7 +152,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testLtMatch() {
         QueryRuleCriteriaType type = LT;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"), null);
         assertTrue(queryRuleCriteria.isMatch(5, type));
         assertFalse(queryRuleCriteria.isMatch(10, type));
         assertFalse(queryRuleCriteria.isMatch(20, type));
@@ -158,7 +160,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testLteMatch() {
         QueryRuleCriteriaType type = LTE;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"), null);
         assertTrue(queryRuleCriteria.isMatch(5, type));
         assertTrue(queryRuleCriteria.isMatch(10, type));
         assertFalse(queryRuleCriteria.isMatch(20, type));
@@ -166,7 +168,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testGtMatch() {
         QueryRuleCriteriaType type = GT;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"), null);
         assertTrue(queryRuleCriteria.isMatch(20, type));
         assertFalse(queryRuleCriteria.isMatch(10, type));
         assertFalse(queryRuleCriteria.isMatch(5, type));
@@ -174,7 +176,7 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testGteMatch() {
         QueryRuleCriteriaType type = GTE;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"));
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "age", List.of("10"), null);
         assertTrue(queryRuleCriteria.isMatch(20, type));
         assertTrue(queryRuleCriteria.isMatch(10, type));
         assertFalse(queryRuleCriteria.isMatch(5, type));
@@ -182,19 +184,38 @@ public class QueryRuleCriteriaTests extends ESTestCase {
 
     public void testAlwaysMatch() {
         QueryRuleCriteriaType type = ALWAYS;
-        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, null, null);
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, null, null, null);
         assertTrue(queryRuleCriteria.isMatch("elastic", type));
         assertTrue(queryRuleCriteria.isMatch(42, type));
     }
 
+    public void testDefaultInferMatch() {
+        QueryRuleCriteriaType type = INFER;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "query", List.of("elk"), null);
+        assertTrue(queryRuleCriteria.isMatch("elk", type));
+        assertFalse(queryRuleCriteria.isMatch("puggles", type));
+    }
+
+    public void testInferMatchWithProperties() {
+        QueryRuleCriteriaType type = INFER;
+        QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(
+            type,
+            "query",
+            List.of("elk"),
+            Map.of("model_id", "my-model-id", "threshold", 2.5f)
+        );
+        assertTrue(queryRuleCriteria.isMatch("elk", type));
+        assertFalse(queryRuleCriteria.isMatch("puggles", type));
+    }
+
     public void testInvalidCriteriaInput() {
         for (QueryRuleCriteriaType type : List.of(FUZZY, PREFIX, SUFFIX, CONTAINS)) {
-            QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of("bar"));
+            QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of("bar"), null);
             expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch(42, type));
         }
 
         for (QueryRuleCriteriaType type : List.of(LT, LTE, GT, GTE)) {
-            QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of(42));
+            QueryRuleCriteria queryRuleCriteria = new QueryRuleCriteria(type, "foo", List.of(42), null);
             expectThrows(IllegalArgumentException.class, () -> queryRuleCriteria.isMatch("puggles", type));
         }
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
@@ -169,7 +169,7 @@ public class QueryRuleTests extends ESTestCase {
         QueryRule rule = new QueryRule(
             randomAlphaOfLength(10),
             QueryRule.QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(EXACT, "query", List.of("elastic"))),
+            List.of(new QueryRuleCriteria(EXACT, "query", List.of("elastic"), null)),
             Map.of("ids", List.of("id1", "id2"))
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
@@ -185,7 +185,10 @@ public class QueryRuleTests extends ESTestCase {
         QueryRule rule = new QueryRule(
             randomAlphaOfLength(10),
             QueryRule.QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(PREFIX, "query", List.of("elastic")), new QueryRuleCriteria(SUFFIX, "query", List.of("search"))),
+            List.of(
+                new QueryRuleCriteria(PREFIX, "query", List.of("elastic"), null),
+                new QueryRuleCriteria(SUFFIX, "query", List.of("search"), null)
+            ),
             Map.of("ids", List.of("id1", "id2"))
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
@@ -71,7 +71,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
             final QueryRule myQueryRule1 = new QueryRule(
                 "my_rule1",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"))),
+                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"), null)),
                 Map.of("ids", List.of("id1", "id2"))
             );
             final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", Collections.singletonList(myQueryRule1));
@@ -86,13 +86,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
         final QueryRule myQueryRule1 = new QueryRule(
             "my_rule1",
             QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"))),
+            List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"), null)),
             Map.of("docs", List.of(Map.of("_index", "my_index1", "_id", "id1"), Map.of("_index", "my_index2", "_id", "id2")))
         );
         final QueryRule myQueryRule2 = new QueryRule(
             "my_rule2",
             QueryRuleType.PINNED,
-            List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar"))),
+            List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar"), null)),
             Map.of("docs", List.of(Map.of("_index", "my_index1", "_id", "id3"), Map.of("_index", "my_index2", "_id", "id4")))
         );
         final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", List.of(myQueryRule1, myQueryRule2));
@@ -111,8 +111,8 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                     "my_rule_" + i,
                     QueryRuleType.PINNED,
                     List.of(
-                        new QueryRuleCriteria(EXACT, "query_string", List.of("foo" + i)),
-                        new QueryRuleCriteria(GTE, "query_string", List.of(i))
+                        new QueryRuleCriteria(EXACT, "query_string", List.of("foo" + i), null),
+                        new QueryRuleCriteria(GTE, "query_string", List.of(i), null)
                     ),
                     Map.of("ids", List.of("id1", "id2"))
                 ),
@@ -120,8 +120,8 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                     "my_rule_" + i + "_" + (i + 1),
                     QueryRuleType.PINNED,
                     List.of(
-                        new QueryRuleCriteria(FUZZY, "query_string", List.of("bar" + i)),
-                        new QueryRuleCriteria(GTE, "user.age", List.of(i))
+                        new QueryRuleCriteria(FUZZY, "query_string", List.of("bar" + i), null),
+                        new QueryRuleCriteria(GTE, "user.age", List.of(i), null)
                     ),
                     Map.of("ids", List.of("id3", "id4"))
                 )
@@ -172,13 +172,13 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
             final QueryRule myQueryRule1 = new QueryRule(
                 "my_rule1",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"))),
+                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("foo"), null)),
                 Map.of("ids", List.of("id1", "id2"))
             );
             final QueryRule myQueryRule2 = new QueryRule(
                 "my_rule2",
                 QueryRuleType.PINNED,
-                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar"))),
+                List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("bar"), null)),
                 Map.of("ids", List.of("id3", "id4"))
             );
             final QueryRuleset myQueryRuleset = new QueryRuleset("my_ruleset", List.of(myQueryRule1, myQueryRule2));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -141,7 +141,7 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
                 new QueryRule(
                     "my_rule1",
                     QueryRule.QueryRuleType.PINNED,
-                    List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("elastic"))),
+                    List.of(new QueryRuleCriteria(EXACT, "query_string", List.of("elastic"), null)),
                     Map.of("ids", List.of("id1", "id2"))
                 )
             );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetActionResponseBWCSerializingTests.java
@@ -54,7 +54,12 @@ public class GetQueryRulesetActionResponseBWCSerializingTests extends AbstractBW
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();
                 for (QueryRuleCriteria criteria : rule.criteria()) {
                     newCriteria.add(
-                        new QueryRuleCriteria(criteria.criteriaType(), criteria.criteriaMetadata(), criteria.criteriaValues().subList(0, 1))
+                        new QueryRuleCriteria(
+                            criteria.criteriaType(),
+                            criteria.criteriaMetadata(),
+                            criteria.criteriaValues().subList(0, 1),
+                            null
+                        )
                     );
                 }
                 rules.add(new QueryRule(rule.id(), rule.type(), newCriteria, rule.actions()));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestBWCSerializingTests.java
@@ -56,7 +56,12 @@ public class PutQueryRulesetActionRequestBWCSerializingTests extends AbstractBWC
                 List<QueryRuleCriteria> newCriteria = new ArrayList<>();
                 for (QueryRuleCriteria criteria : rule.criteria()) {
                     newCriteria.add(
-                        new QueryRuleCriteria(criteria.criteriaType(), criteria.criteriaMetadata(), criteria.criteriaValues().subList(0, 1))
+                        new QueryRuleCriteria(
+                            criteria.criteriaType(),
+                            criteria.criteriaMetadata(),
+                            criteria.criteriaValues().subList(0, 1),
+                            null
+                        )
                     );
                 }
                 rules.add(new QueryRule(rule.id(), rule.type(), newCriteria, rule.actions()));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTestUtils.java
@@ -85,7 +85,12 @@ public final class SearchApplicationTestUtils {
     public static QueryRuleCriteria randomQueryRuleCriteria() {
         // We intentionally don't allow ALWAYS criteria in this method, since we want to test parsing metadata and values
         QueryRuleCriteriaType type = randomFrom(Arrays.stream(QueryRuleCriteriaType.values()).filter(t -> t != ALWAYS).toList());
-        return new QueryRuleCriteria(type, randomAlphaOfLengthBetween(1, 10), randomList(1, 5, () -> randomAlphaOfLengthBetween(1, 10)));
+        return new QueryRuleCriteria(
+            type,
+            randomAlphaOfLengthBetween(1, 10),
+            randomList(1, 5, () -> randomAlphaOfLengthBetween(1, 10)),
+            Map.of()
+        );
     }
 
     public static QueryRule randomQueryRule() {


### PR DESCRIPTION
POC to add an `infer` query rule criteria type. Requires trained models to be deployed. 

Adds the concept of properties to query rules, so that individual rules can have their own properties configured. The `infer` query rule criteria type has three properties:

- `model_id` - Defaults to `.elser_model_1`
- `inference_config` - May be either `text_expansion` or `text_classification`, defaults to `text_expansion`
- `threshold` - The minimum threshold for this rule to match. Defaults to `1.0`.

Example script using `infer` query rules for text expansion, and text classification use cases: 
```
POST /test/_doc/1
{
  "text": "dog"
}
POST /test/_doc/2
{
  "text": "cat"
}

# Query ruleset using defaults: model_id .elser_model_1 and threshold of 1.0
PUT /_query_rules/ruleset
{
  "rules": [
    {
      "rule_id": "1",
      "type": "pinned",
      "criteria": [
        {
          "type": "infer",
          "metadata": "input",
          "values": ["dog"]
        }
      ], 
      "actions": {
        "ids": ["1"]
      }
    }
  ]
}

# For "puppy", "dog" is returned with a predicted value of 1.74.
POST _ml/trained_models/.elser_model_1/_infer
{"docs":[{"text_field":"puppy"}]}

POST test/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "puggles"
        }
      },
      "ruleset_id": "ruleset",
      "match_criteria": {
        "input": "puppy"
      }
    }
  }
}

# For "kitten", "dog" is returned with a predicted value of 0.26. 
POST _ml/trained_models/.elser_model_1/_infer
{"docs":[{"text_field":"kitten"}]}

# No results
POST test/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "puggles"
        }
      },
      "ruleset_id": "ruleset",
      "match_criteria": {
        "input": "kitten"
      }
    }
  }
}

# Query ruleset using a very aggressive strategy: model_id .elser_model_1 and threshold of 0.25
PUT /_query_rules/aggressive-ruleset
{
  "rules": [
    {
      "rule_id": "1",
      "type": "pinned",
      "criteria": [
        {
          "type": "infer",
          "metadata": "input",
          "values": ["dog"],
          "properties": {
            "model_id": ".elser_model_1",
            "threshold": 0.25
          }
        }
      ], 
      "actions": {
        "ids": ["1"]
      }
    }
  ]
}

# Matches due to aggressive score
POST test/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "puggles"
        }
      },
      "ruleset_id": "aggressive-ruleset",
      "match_criteria": {
        "input": "kitten"
      }
    }
  }
}

#Testing some inferences: 
# negative predicted value (0.77)
POST _ml/trained_models/cardiffnlp__twitter-roberta-base-sentiment-latest/_infer
{"docs":[{"text_field":"bad service"}]}

# positive predicted value (0.95)
POST _ml/trained_models/cardiffnlp__twitter-roberta-base-sentiment-latest/_infer
{"docs":[{"text_field":"awesome views"}]}

# neutral predicted value (0.49)
POST _ml/trained_models/cardiffnlp__twitter-roberta-base-sentiment-latest/_infer
{"docs":[{"text_field":"puggles"}]}

# New test dataset
POST customer-service/_doc/1
{
  "text": "Information about our product"
}

POST customer-service/_doc/2
{
  "text": "Happy about our product? Leave a Google review!"
}

POST customer-service/_doc/3
{
  "text": "Contact our customer service department"
}


PUT /_query_rules/sentiment-ruleset
{
  "rules": [
    {
      "rule_id": "1",
      "type": "pinned",
      "criteria": [
        {
          "type": "infer",
          "metadata": "input",
          "values": ["negative"],
          "properties": {
            "model_id": "cardiffnlp__twitter-roberta-base-sentiment-latest",
            "threshold": 0.50,
            "inference_config": "text_classification"
          }
        }
      ], 
      "actions": {
        "ids": ["3"]
      }
    },
    {
      "rule_id": "2",
      "type": "pinned",
      "criteria": [
        {
          "type": "infer",
          "metadata": "input",
          "values": ["positive"],
          "properties": {
            "model_id": "cardiffnlp__twitter-roberta-base-sentiment-latest",
            "threshold": 0.50,
            "inference_config": "text_classification"
          }
        }
      ], 
      "actions": {
        "ids": ["2"]
      }
    }
  ]
}

# Matches on negative sentiment 
POST customer-service/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "information"
        }
      },
      "ruleset_id": "sentiment-ruleset",
      "match_criteria": {
        "input": "horrible customer service"
      }
    }
  }
}

# Matches on positive sentiment 
POST customer-service/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "information"
        }
      },
      "ruleset_id": "sentiment-ruleset",
      "match_criteria": {
        "input": "amazing results"
      }
    }
  }
}

# No match, neutral sentiment
POST customer-service/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "information"
        }
      },
      "ruleset_id": "sentiment-ruleset",
      "match_criteria": {
        "input": "puggles are a mix of pugs and beagles"
      }
    }
  }
}
```