### PR TITLE
[8.10] Update ilm-shrink.asciidoc (#99366)

### DIFF
--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -17,7 +17,7 @@ stream. You cannot perform the `shrink` action on a write index.
 To use the `shrink` action in the `hot` phase, the `rollover` action *must* be
 present. If no rollover action is configured, {ilm-init} will reject the policy.
 
-The shrink action will unset the index's index.routing.allocation.total_shards_per_node
+The shrink action will unset the index's `index.routing.allocation.total_shards_per_node`
 setting, meaning that there will be no limit. This is to ensure that all shards of the
 index can be copied to a single node. This setting change will persist on the index
 even after the step completes.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Update ilm-shrink.asciidoc (#99366)](https://github.com/elastic/elasticsearch/pull/99366)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)