### PR TITLE
Avoiding using getDefaultBackingIndexName in DataStreamLifecycleServiceIT (#99062)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingIndexName;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.backingIndexEqualTo;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.READ_ONLY;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DEFAULT_TIMESTAMP_FIELD;
@@ -306,7 +305,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         int finalGeneration = randomIntBetween(3, 4);
         for (int currentGeneration = 1; currentGeneration < finalGeneration; currentGeneration++) {
             // This is currently the write index, but it will be rolled over as soon as data stream lifecycle runs:
-            final String toBeRolledOverIndex = DataStream.getDefaultBackingIndexName(dataStreamName, currentGeneration);
+            final String toBeRolledOverIndex = getBackingIndices(dataStreamName).get(currentGeneration - 1);
             for (int i = 0; i < randomIntBetween(10, 50); i++) {
                 indexDocs(dataStreamName, randomIntBetween(1, 300));
                 // Make sure the segments get written:
@@ -318,7 +317,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
             if (currentGeneration == 1) {
                 toBeForceMergedIndex = null; // Not going to be used
             } else {
-                toBeForceMergedIndex = DataStream.getDefaultBackingIndexName(dataStreamName, currentGeneration - 1);
+                toBeForceMergedIndex = getBackingIndices(dataStreamName).get(currentGeneration - 2);
             }
             int currentBackingIndexCount = currentGeneration;
             DataStreamLifecycleService dataStreamLifecycleService = internalCluster().getInstance(
@@ -410,7 +409,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         indexDocs(dataStreamName, 1);
 
         assertBusy(() -> {
-            String writeIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 2);
+            String writeIndexName = getBackingIndices(dataStreamName).get(1);
             String writeIndexRolloverError = null;
             Iterable<DataStreamLifecycleService> lifecycleServices = internalCluster().getInstances(DataStreamLifecycleService.class);
 
@@ -429,20 +428,15 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         updateClusterSettings(Settings.builder().putNull("*"));
 
         assertBusy(() -> {
-            GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
-            GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
-                .actionGet();
-            assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
-            assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName));
-            List<Index> backingIndices = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices();
+            List<String> backingIndices = getBackingIndices(dataStreamName);
             assertThat(backingIndices.size(), equalTo(3));
-            String writeIndex = backingIndices.get(2).getName();
+            String writeIndex = backingIndices.get(2);
             // rollover was successful and we got to generation 3
             assertThat(writeIndex, backingIndexEqualTo(dataStreamName, 3));
 
             // we recorded the error against the previous write index (generation 2)
             // let's check there's no error recorded against it anymore
-            String previousWriteInddex = DataStream.getDefaultBackingIndexName(dataStreamName, 2);
+            String previousWriteInddex = backingIndices.get(1);
             Iterable<DataStreamLifecycleService> lifecycleServices = internalCluster().getInstances(DataStreamLifecycleService.class);
 
             for (DataStreamLifecycleService lifecycleService : lifecycleServices) {
@@ -491,7 +485,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
             assertThat(writeIndex, backingIndexEqualTo(dataStreamName, 2));
         });
 
-        String firstGenerationIndex = DataStream.getDefaultBackingIndexName(dataStreamName, 1L);
+        String firstGenerationIndex = getBackingIndices(dataStreamName).get(0);
 
         // mark the first generation index as read-only so deletion fails when we enable the retention configuration
         updateIndexSettings(Settings.builder().put(READ_ONLY.settingName(), true), firstGenerationIndex);
@@ -585,7 +579,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
             assertThat(writeIndex, backingIndexEqualTo(dataStreamName, 2));
         });
 
-        String firstGenerationIndex = DataStream.getDefaultBackingIndexName(dataStreamName, 1L);
+        String firstGenerationIndex = getBackingIndices(dataStreamName).get(0);
         ClusterGetSettingsAction.Response response = client().execute(
             ClusterGetSettingsAction.INSTANCE,
             new ClusterGetSettingsAction.Request()
@@ -623,16 +617,11 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
 
         // let's allow one rollover to go through
         assertBusy(() -> {
-            GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
-            GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
-                .actionGet();
-            assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
-            assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName));
-            List<Index> backingIndices = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices();
+            List<String> backingIndices = getBackingIndices(dataStreamName);
             assertThat(backingIndices.size(), equalTo(3));
         });
 
-        String secondGenerationIndex = DataStream.getDefaultBackingIndexName(dataStreamName, 1L);
+        String secondGenerationIndex = getBackingIndices(dataStreamName).get(1);
         // check the 2nd generation index picked up the new setting values
         assertBusy(() -> {
             GetSettingsRequest getSettingsRequest = new GetSettingsRequest().indices(secondGenerationIndex).includeDefaults(true);
@@ -646,6 +635,15 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
                 is(ByteSizeValue.ofMb(5).getStringRep())
             );
         });
+    }
+
+    private static List<String> getBackingIndices(String dataStreamName) {
+        GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
+        GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
+            .actionGet();
+        assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
+        assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName));
+        return getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().stream().map(Index::getName).toList();
     }
 
     static void indexDocs(String dataStream, int numDocs) {
@@ -678,10 +676,10 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).get();
 
         indexDocs(dataStreamName, 10);
-
+        List<String> backingIndices = getBackingIndices(dataStreamName);
         {
             // backing index should not be managed
-            String writeIndex = getDefaultBackingIndexName(dataStreamName, 1);
+            String writeIndex = backingIndices.get(0);
 
             ExplainDataStreamLifecycleAction.Response dataStreamLifecycleExplainResponse = client().execute(
                 ExplainDataStreamLifecycleAction.INSTANCE,
@@ -695,14 +693,8 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
 
         {
             // data stream has only one backing index
-            GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
-            GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
-                .actionGet();
-            assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
-            assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName));
-            List<Index> backingIndices = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices();
             assertThat(backingIndices.size(), equalTo(1));
-            String writeIndex = getDefaultBackingIndexName(dataStreamName, 1);
+            String writeIndex = backingIndices.get(0);
             assertThat(writeIndex, backingIndexEqualTo(dataStreamName, 1));
         }
 
@@ -714,16 +706,11 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         );
 
         assertBusy(() -> {
-            GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
-            GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
-                .actionGet();
-            assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
-            assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName));
-            List<Index> backingIndices = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices();
-            assertThat(backingIndices.size(), equalTo(2));
-            String backingIndex = backingIndices.get(0).getName();
+            List<String> currentBackingIndices = getBackingIndices(dataStreamName);
+            assertThat(currentBackingIndices.size(), equalTo(2));
+            String backingIndex = currentBackingIndices.get(0);
             assertThat(backingIndex, backingIndexEqualTo(dataStreamName, 1));
-            String writeIndex = backingIndices.get(1).getName();
+            String writeIndex = currentBackingIndices.get(1);
             assertThat(writeIndex, backingIndexEqualTo(dataStreamName, 2));
         });
     }


### PR DESCRIPTION
DataStreamLifecycleServiceIT uses DataStream.getDefaultBackingIndexName() in a lot of places to get the expected backing index name. This fails when the test runs across midnight though (because the index name is computed using the current date, which has changed).
Also this fixes testDataLifecycleServiceConfiguresTheMergePolicy() to make assertions about the backing index that it had intended to.
Closes https://github.com/elastic/elasticsearch/issues/99017