### PR TITLE
[ESQL] Test that we don't return NaNs or Infinites

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -269,13 +269,15 @@ a:double | acos:double
 // end::acos-result[]
 ;
 
-acosNan
+acosNull
 ROW a=12.0
 | EVAL acos=ACOS(a)
 ;
+warning:Line 2:13: evaluation of [ACOS(a)] failed, treating result as null. Only first 20 failures recorded.
+warning:java.lang.ArithmeticException: Acos input out of range
 
 a:double | acos:double
-      12 | NaN
+      12 | null
 ;
 
 sin
@@ -317,13 +319,15 @@ a:double | asin:double
 // end::asin-result[]
 ;
 
-asinNan
+asinNull
 ROW a=12.0
 | EVAL asin=ASIN(a)
 ;
+warning:Line 2:13: evaluation of [ASIN(a)] failed, treating result as null. Only first 20 failures recorded.
+warning:java.lang.ArithmeticException: Asin input out of range
 
 a:double | asin:double
-      12 | NaN
+      12 | null
 ;
 
 tan

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -1019,10 +1019,12 @@ l:ul                  | s:double
 ;
 
 sqrtOfNegative
-row d = -1.0 | eval s = is_nan(sqrt(d));
+row d = -1.0 | eval s = sqrt(d);
+warning:Line 1:25: evaluation of [sqrt(d)] failed, treating result as null. Only first 20 failures recorded.
+warning:java.lang.ArithmeticException: Square root of negative
 
-d:double | s:boolean
--1.0     | true
+d:double | s:double
+-1.0     | null
 ;
 
 sqrtOfNan

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.Override;
 import java.lang.String;
 import org.elasticsearch.compute.data.Block;
@@ -11,15 +12,20 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Acos}.
  * This class is generated. Do not edit it.
  */
 public final class AcosEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
   private final EvalOperator.ExpressionEvaluator val;
 
-  public AcosEvaluator(EvalOperator.ExpressionEvaluator val) {
+  public AcosEvaluator(Source source, EvalOperator.ExpressionEvaluator val) {
+    this.warnings = new Warnings(source);
     this.val = val;
   }
 
@@ -34,7 +40,7 @@ public final class AcosEvaluator implements EvalOperator.ExpressionEvaluator {
     if (valVector == null) {
       return eval(page.getPositionCount(), valBlock);
     }
-    return eval(page.getPositionCount(), valVector).asBlock();
+    return eval(page.getPositionCount(), valVector);
   }
 
   public DoubleBlock eval(int positionCount, DoubleBlock valBlock) {
@@ -44,15 +50,25 @@ public final class AcosEvaluator implements EvalOperator.ExpressionEvaluator {
         result.appendNull();
         continue position;
       }
-      result.appendDouble(Acos.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      try {
+        result.appendDouble(Acos.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector valVector) {
-    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+  public DoubleBlock eval(int positionCount, DoubleVector valVector) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
     position: for (int p = 0; p < positionCount; p++) {
-      result.appendDouble(Acos.process(valVector.getDouble(p)));
+      try {
+        result.appendDouble(Acos.process(valVector.getDouble(p)));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.Override;
 import java.lang.String;
 import org.elasticsearch.compute.data.Block;
@@ -11,15 +12,20 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Cosh}.
  * This class is generated. Do not edit it.
  */
 public final class CoshEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
   private final EvalOperator.ExpressionEvaluator val;
 
-  public CoshEvaluator(EvalOperator.ExpressionEvaluator val) {
+  public CoshEvaluator(Source source, EvalOperator.ExpressionEvaluator val) {
+    this.warnings = new Warnings(source);
     this.val = val;
   }
 
@@ -34,7 +40,7 @@ public final class CoshEvaluator implements EvalOperator.ExpressionEvaluator {
     if (valVector == null) {
       return eval(page.getPositionCount(), valBlock);
     }
-    return eval(page.getPositionCount(), valVector).asBlock();
+    return eval(page.getPositionCount(), valVector);
   }
 
   public DoubleBlock eval(int positionCount, DoubleBlock valBlock) {
@@ -44,15 +50,25 @@ public final class CoshEvaluator implements EvalOperator.ExpressionEvaluator {
         result.appendNull();
         continue position;
       }
-      result.appendDouble(Cosh.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      try {
+        result.appendDouble(Cosh.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector valVector) {
-    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+  public DoubleBlock eval(int positionCount, DoubleVector valVector) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
     position: for (int p = 0; p < positionCount; p++) {
-      result.appendDouble(Cosh.process(valVector.getDouble(p)));
+      try {
+        result.appendDouble(Cosh.process(valVector.getDouble(p)));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.Override;
 import java.lang.String;
 import org.elasticsearch.compute.data.Block;
@@ -11,15 +12,20 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Sinh}.
  * This class is generated. Do not edit it.
  */
 public final class SinhEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
   private final EvalOperator.ExpressionEvaluator val;
 
-  public SinhEvaluator(EvalOperator.ExpressionEvaluator val) {
+  public SinhEvaluator(Source source, EvalOperator.ExpressionEvaluator val) {
+    this.warnings = new Warnings(source);
     this.val = val;
   }
 
@@ -34,7 +40,7 @@ public final class SinhEvaluator implements EvalOperator.ExpressionEvaluator {
     if (valVector == null) {
       return eval(page.getPositionCount(), valBlock);
     }
-    return eval(page.getPositionCount(), valVector).asBlock();
+    return eval(page.getPositionCount(), valVector);
   }
 
   public DoubleBlock eval(int positionCount, DoubleBlock valBlock) {
@@ -44,15 +50,25 @@ public final class SinhEvaluator implements EvalOperator.ExpressionEvaluator {
         result.appendNull();
         continue position;
       }
-      result.appendDouble(Sinh.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      try {
+        result.appendDouble(Sinh.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector valVector) {
-    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+  public DoubleBlock eval(int positionCount, DoubleVector valVector) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
     position: for (int p = 0; p < positionCount; p++) {
-      result.appendDouble(Sinh.process(valVector.getDouble(p)));
+      try {
+        result.appendDouble(Sinh.process(valVector.getDouble(p)));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtDoubleEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.Override;
 import java.lang.String;
 import org.elasticsearch.compute.data.Block;
@@ -11,15 +12,20 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Sqrt}.
  * This class is generated. Do not edit it.
  */
 public final class SqrtDoubleEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
   private final EvalOperator.ExpressionEvaluator val;
 
-  public SqrtDoubleEvaluator(EvalOperator.ExpressionEvaluator val) {
+  public SqrtDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator val) {
+    this.warnings = new Warnings(source);
     this.val = val;
   }
 
@@ -34,7 +40,7 @@ public final class SqrtDoubleEvaluator implements EvalOperator.ExpressionEvaluat
     if (valVector == null) {
       return eval(page.getPositionCount(), valBlock);
     }
-    return eval(page.getPositionCount(), valVector).asBlock();
+    return eval(page.getPositionCount(), valVector);
   }
 
   public DoubleBlock eval(int positionCount, DoubleBlock valBlock) {
@@ -44,15 +50,25 @@ public final class SqrtDoubleEvaluator implements EvalOperator.ExpressionEvaluat
         result.appendNull();
         continue position;
       }
-      result.appendDouble(Sqrt.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      try {
+        result.appendDouble(Sqrt.process(valBlock.getDouble(valBlock.getFirstValueIndex(p))));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }
 
-  public DoubleVector eval(int positionCount, DoubleVector valVector) {
-    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+  public DoubleBlock eval(int positionCount, DoubleVector valVector) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
     position: for (int p = 0; p < positionCount; p++) {
-      result.appendDouble(Sqrt.process(valVector.getDouble(p)));
+      try {
+        result.appendDouble(Sqrt.process(valVector.getDouble(p)));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtLongEvaluator.java
@@ -4,24 +4,29 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.Override;
 import java.lang.String;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Sqrt}.
  * This class is generated. Do not edit it.
  */
 public final class SqrtLongEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
   private final EvalOperator.ExpressionEvaluator val;
 
-  public SqrtLongEvaluator(EvalOperator.ExpressionEvaluator val) {
+  public SqrtLongEvaluator(Source source, EvalOperator.ExpressionEvaluator val) {
+    this.warnings = new Warnings(source);
     this.val = val;
   }
 
@@ -36,7 +41,7 @@ public final class SqrtLongEvaluator implements EvalOperator.ExpressionEvaluator
     if (valVector == null) {
       return eval(page.getPositionCount(), valBlock);
     }
-    return eval(page.getPositionCount(), valVector).asBlock();
+    return eval(page.getPositionCount(), valVector);
   }
 
   public DoubleBlock eval(int positionCount, LongBlock valBlock) {
@@ -46,15 +51,25 @@ public final class SqrtLongEvaluator implements EvalOperator.ExpressionEvaluator
         result.appendNull();
         continue position;
       }
-      result.appendDouble(Sqrt.process(valBlock.getLong(valBlock.getFirstValueIndex(p))));
+      try {
+        result.appendDouble(Sqrt.process(valBlock.getLong(valBlock.getFirstValueIndex(p))));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }
 
-  public DoubleVector eval(int positionCount, LongVector valVector) {
-    DoubleVector.Builder result = DoubleVector.newVectorBuilder(positionCount);
+  public DoubleBlock eval(int positionCount, LongVector valVector) {
+    DoubleBlock.Builder result = DoubleBlock.newBlockBuilder(positionCount);
     position: for (int p = 0; p < positionCount; p++) {
-      result.appendDouble(Sqrt.process(valVector.getLong(p)));
+      try {
+        result.appendDouble(Sqrt.process(valVector.getLong(p)));
+      } catch (ArithmeticException e) {
+        warnings.registerException(e);
+        result.appendNull();
+      }
     }
     return result.build();
   }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Acos.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Acos.java
@@ -26,7 +26,7 @@ public class Acos extends AbstractTrigonometricFunction {
 
     @Override
     protected EvalOperator.ExpressionEvaluator doubleEvaluator(EvalOperator.ExpressionEvaluator field) {
-        return new AcosEvaluator(field);
+        return new AcosEvaluator(source(), field);
     }
 
     @Override
@@ -39,8 +39,11 @@ public class Acos extends AbstractTrigonometricFunction {
         return NodeInfo.create(this, Acos::new, field());
     }
 
-    @Evaluator
+    @Evaluator(warnExceptions = ArithmeticException.class)
     static double process(double val) {
+        if (Math.abs(val) > 1) {
+            throw new ArithmeticException("Acos input out of range");
+        }
         return Math.acos(val);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Asin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Asin.java
@@ -26,7 +26,7 @@ public class Asin extends AbstractTrigonometricFunction {
 
     @Override
     protected EvalOperator.ExpressionEvaluator doubleEvaluator(EvalOperator.ExpressionEvaluator field) {
-        return new AsinEvaluator(field);
+        return new AsinEvaluator(source(), field);
     }
 
     @Override
@@ -39,8 +39,11 @@ public class Asin extends AbstractTrigonometricFunction {
         return NodeInfo.create(this, Asin::new, field());
     }
 
-    @Evaluator
+    @Evaluator(warnExceptions = ArithmeticException.class)
     static double process(double val) {
+        if (Math.abs(val) > 1) {
+            throw new ArithmeticException("Asin input out of range");
+        }
         return Math.asin(val);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cosh.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cosh.java
@@ -41,7 +41,7 @@ public class Cosh extends AbstractTrigonometricFunction {
 
     @Evaluator(warnExceptions = ArithmeticException.class)
     static double process(double val) {
-        double res =  Math.cosh(val);
+        double res = Math.cosh(val);
         if (Double.isNaN(res) || Double.isInfinite(res)) {
             throw new ArithmeticException("cosh overflow");
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cosh.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cosh.java
@@ -26,7 +26,7 @@ public class Cosh extends AbstractTrigonometricFunction {
 
     @Override
     protected EvalOperator.ExpressionEvaluator doubleEvaluator(EvalOperator.ExpressionEvaluator field) {
-        return new CoshEvaluator(field);
+        return new CoshEvaluator(source(), field);
     }
 
     @Override
@@ -39,8 +39,12 @@ public class Cosh extends AbstractTrigonometricFunction {
         return NodeInfo.create(this, Cosh::new, field());
     }
 
-    @Evaluator
+    @Evaluator(warnExceptions = ArithmeticException.class)
     static double process(double val) {
-        return Math.cosh(val);
+        double res =  Math.cosh(val);
+        if (Double.isNaN(res) || Double.isInfinite(res)) {
+            throw new ArithmeticException("cosh overflow");
+        }
+        return res;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sinh.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sinh.java
@@ -26,7 +26,7 @@ public class Sinh extends AbstractTrigonometricFunction {
 
     @Override
     protected EvalOperator.ExpressionEvaluator doubleEvaluator(EvalOperator.ExpressionEvaluator field) {
-        return new SinhEvaluator(field);
+        return new SinhEvaluator(source(), field);
     }
 
     @Override
@@ -39,8 +39,12 @@ public class Sinh extends AbstractTrigonometricFunction {
         return NodeInfo.create(this, Sinh::new, field());
     }
 
-    @Evaluator
+    @Evaluator(warnExceptions = ArithmeticException.class)
     static double process(double val) {
-        return Math.sinh(val);
+        double res =  Math.sinh(val);
+        if (Double.isNaN(res) || Double.isInfinite(res)) {
+            throw new ArithmeticException("sinh overflow");
+        }
+        return res;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sinh.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sinh.java
@@ -41,7 +41,7 @@ public class Sinh extends AbstractTrigonometricFunction {
 
     @Evaluator(warnExceptions = ArithmeticException.class)
     static double process(double val) {
-        double res =  Math.sinh(val);
+        double res = Math.sinh(val);
         if (Double.isNaN(res) || Double.isInfinite(res)) {
             throw new ArithmeticException("sinh overflow");
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sqrt.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Sqrt.java
@@ -41,13 +41,13 @@ public class Sqrt extends UnaryScalarFunction implements EvaluatorMapper {
         var eval = field.get();
 
         if (fieldType == DataTypes.DOUBLE) {
-            return () -> new SqrtDoubleEvaluator(eval);
+            return () -> new SqrtDoubleEvaluator(source(), eval);
         }
         if (fieldType == DataTypes.INTEGER) {
-            return () -> new SqrtIntEvaluator(eval);
+            return () -> new SqrtIntEvaluator(source(), eval);
         }
         if (fieldType == DataTypes.LONG) {
-            return () -> new SqrtLongEvaluator(eval);
+            return () -> new SqrtLongEvaluator(source(), eval);
         }
         if (fieldType == DataTypes.UNSIGNED_LONG) {
             return () -> new SqrtUnsignedLongEvaluator(eval);
@@ -56,13 +56,19 @@ public class Sqrt extends UnaryScalarFunction implements EvaluatorMapper {
         throw EsqlIllegalArgumentException.illegalDataType(fieldType);
     }
 
-    @Evaluator(extraName = "Double")
+    @Evaluator(extraName = "Double", warnExceptions = ArithmeticException.class)
     static double process(double val) {
+        if (val < 0) {
+            throw new ArithmeticException("Square root of negative");
+        }
         return Math.sqrt(val);
     }
 
-    @Evaluator(extraName = "Long")
+    @Evaluator(extraName = "Long", warnExceptions = ArithmeticException.class)
     static double process(long val) {
+        if (val < 0) {
+            throw new ArithmeticException("Square root of negative");
+        }
         return Math.sqrt(val);
     }
 
@@ -71,8 +77,11 @@ public class Sqrt extends UnaryScalarFunction implements EvaluatorMapper {
         return Math.sqrt(NumericUtils.unsignedLongToDouble(val));
     }
 
-    @Evaluator(extraName = "Int")
+    @Evaluator(extraName = "Int", warnExceptions = ArithmeticException.class)
     static double process(int val) {
+        if (val < 0) {
+            throw new ArithmeticException("Square root of negative");
+        }
         return Math.sqrt(val);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -64,6 +64,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.elasticsearch.xpack.esql.SerializationTestUtils.assertSerialization;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
@@ -179,6 +180,9 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
         assertThat(expression.dataType(), equalTo(testCase.expectedType));
         // TODO should we convert unsigned_long into BigDecimal so it's easier to assert?
         Object result = toJavaObject(evaluator(expression).get().eval(row(testCase.getDataValues())), 0);
+        assertThat(result, not(equalTo(Double.NaN)));
+        assertThat(result, not(equalTo(Double.POSITIVE_INFINITY)));
+        assertThat(result, not(equalTo(Double.NEGATIVE_INFINITY)));
         assertThat(result, testCase.getMatcher());
         if (testCase.getExpectedWarnings() != null) {
             assertWarnings(testCase.getExpectedWarnings());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -28,11 +28,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.DoubleBinaryOperator;
 import java.util.function.DoubleFunction;
-import java.util.function.DoubleUnaryOperator;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -91,7 +91,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
     public static List<TestCaseSupplier> forUnaryCastingToDouble(
         String name,
         String argName,
-        DoubleUnaryOperator expected,
+        UnaryOperator<Double> expected,
         Double min,
         Double max,
         List<String> warnings
@@ -103,7 +103,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
             suppliers,
             eval + castToDoubleEvaluator(read, DataTypes.INTEGER) + "]",
             DataTypes.DOUBLE,
-            i -> expected.applyAsDouble(i),
+            i -> expected.apply(Double.valueOf(i)),
             min.intValue(),
             max.intValue(),
             warnings
@@ -112,7 +112,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
             suppliers,
             eval + castToDoubleEvaluator(read, DataTypes.LONG) + "]",
             DataTypes.DOUBLE,
-            l -> expected.applyAsDouble(l),
+            i -> expected.apply(Double.valueOf(i)),
             min.longValue(),
             max.longValue(),
             warnings
@@ -121,12 +121,12 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
             suppliers,
             eval + castToDoubleEvaluator(read, DataTypes.UNSIGNED_LONG) + "]",
             DataTypes.DOUBLE,
-            ul -> expected.applyAsDouble(ul.doubleValue()),
+            ul -> expected.apply(ul.doubleValue()),
             BigInteger.valueOf((int) Math.ceil(min)),
             BigInteger.valueOf((int) Math.floor(max)),
             warnings
         );
-        forUnaryDouble(suppliers, eval + read + "]", DataTypes.DOUBLE, i -> expected.applyAsDouble(i), min, max, warnings);
+        forUnaryDouble(suppliers, eval + read + "]", DataTypes.DOUBLE, expected::apply, min, max, warnings);
         return suppliers;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
@@ -25,15 +25,41 @@ public class AcosTests extends AbstractFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
+        // values in range
         List<TestCaseSupplier> suppliers = TestCaseSupplier.forUnaryCastingToDouble(
             "AcosEvaluator",
             "val",
             Math::acos,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
+            -1d,
+            1d,
             List.of()
         );
-        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
+        suppliers = anyNullIsNull(true, suppliers);
+
+        // Values out of range
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "AcosEvaluator",
+            "val",
+            k -> null,
+            Double.NEGATIVE_INFINITY,
+            Math.nextDown(-1d),
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Acos input out of range"
+            )
+        ));
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "AcosEvaluator",
+            "val",
+            k -> null,
+            Math.nextUp(1d),
+            Double.POSITIVE_INFINITY,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Acos input out of range"
+            )
+        ));
+        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AcosTests.java
@@ -26,39 +26,36 @@ public class AcosTests extends AbstractFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         // values in range
-        List<TestCaseSupplier> suppliers = TestCaseSupplier.forUnaryCastingToDouble(
-            "AcosEvaluator",
-            "val",
-            Math::acos,
-            -1d,
-            1d,
-            List.of()
-        );
+        List<TestCaseSupplier> suppliers = TestCaseSupplier.forUnaryCastingToDouble("AcosEvaluator", "val", Math::acos, -1d, 1d, List.of());
         suppliers = anyNullIsNull(true, suppliers);
 
         // Values out of range
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "AcosEvaluator",
-            "val",
-            k -> null,
-            Double.NEGATIVE_INFINITY,
-            Math.nextDown(-1d),
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: Acos input out of range"
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "AcosEvaluator",
+                "val",
+                k -> null,
+                Double.NEGATIVE_INFINITY,
+                Math.nextDown(-1d),
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: Acos input out of range"
+                )
             )
-        ));
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "AcosEvaluator",
-            "val",
-            k -> null,
-            Math.nextUp(1d),
-            Double.POSITIVE_INFINITY,
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: Acos input out of range"
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "AcosEvaluator",
+                "val",
+                k -> null,
+                Math.nextUp(1d),
+                Double.POSITIVE_INFINITY,
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: Acos input out of range"
+                )
             )
-        ));
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
@@ -26,39 +26,36 @@ public class AsinTests extends AbstractFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         // values in range
-        List<TestCaseSupplier> suppliers = TestCaseSupplier.forUnaryCastingToDouble(
-            "AsinEvaluator",
-            "val",
-            Math::asin,
-            -1d,
-            1d,
-            List.of()
-        );
+        List<TestCaseSupplier> suppliers = TestCaseSupplier.forUnaryCastingToDouble("AsinEvaluator", "val", Math::asin, -1d, 1d, List.of());
         suppliers = anyNullIsNull(true, suppliers);
 
         // Values out of range
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "AsinEvaluator",
-            "val",
-            k -> null,
-            Double.NEGATIVE_INFINITY,
-            Math.nextDown(-1d),
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: Asin input out of range"
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "AsinEvaluator",
+                "val",
+                k -> null,
+                Double.NEGATIVE_INFINITY,
+                Math.nextDown(-1d),
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: Asin input out of range"
+                )
             )
-        ));
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "AsinEvaluator",
-            "val",
-            k -> null,
-            Math.nextUp(1d),
-            Double.POSITIVE_INFINITY,
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: Asin input out of range"
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "AsinEvaluator",
+                "val",
+                k -> null,
+                Math.nextUp(1d),
+                Double.POSITIVE_INFINITY,
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: Asin input out of range"
+                )
             )
-        ));
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AsinTests.java
@@ -25,15 +25,41 @@ public class AsinTests extends AbstractFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
+        // values in range
         List<TestCaseSupplier> suppliers = TestCaseSupplier.forUnaryCastingToDouble(
             "AsinEvaluator",
             "val",
             Math::asin,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
+            -1d,
+            1d,
             List.of()
         );
-        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
+        suppliers = anyNullIsNull(true, suppliers);
+
+        // Values out of range
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "AsinEvaluator",
+            "val",
+            k -> null,
+            Double.NEGATIVE_INFINITY,
+            Math.nextDown(-1d),
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Asin input out of range"
+            )
+        ));
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "AsinEvaluator",
+            "val",
+            k -> null,
+            Math.nextUp(1d),
+            Double.POSITIVE_INFINITY,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Asin input out of range"
+            )
+        ));
+        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
@@ -29,11 +29,37 @@ public class CoshTests extends AbstractFunctionTestCase {
             "CoshEvaluator",
             "val",
             Math::cosh,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
+            -710d,
+            710d,  // Hyperbolic Cosine grows extremely fast. Values outside this range return Double.POSITIVE_INFINITY
             List.of()
         );
-        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
+        suppliers = anyNullIsNull(true, suppliers);
+
+
+        // Out of range cases
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "CoshEvaluator",
+            "val",
+            k -> null,
+            Double.NEGATIVE_INFINITY,
+            -711d,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: cosh overflow"
+            )
+        ));
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "CoshEvaluator",
+            "val",
+            k -> null,
+            711d,
+            Double.POSITIVE_INFINITY,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: cosh overflow"
+            )
+        ));
+        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/CoshTests.java
@@ -35,30 +35,33 @@ public class CoshTests extends AbstractFunctionTestCase {
         );
         suppliers = anyNullIsNull(true, suppliers);
 
-
         // Out of range cases
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "CoshEvaluator",
-            "val",
-            k -> null,
-            Double.NEGATIVE_INFINITY,
-            -711d,
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: cosh overflow"
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "CoshEvaluator",
+                "val",
+                k -> null,
+                Double.NEGATIVE_INFINITY,
+                -711d,
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: cosh overflow"
+                )
             )
-        ));
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "CoshEvaluator",
-            "val",
-            k -> null,
-            711d,
-            Double.POSITIVE_INFINITY,
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: cosh overflow"
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "CoshEvaluator",
+                "val",
+                k -> null,
+                711d,
+                Double.POSITIVE_INFINITY,
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: cosh overflow"
+                )
             )
-        ));
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
@@ -35,30 +35,33 @@ public class SinhTests extends AbstractFunctionTestCase {
         );
         suppliers = anyNullIsNull(true, suppliers);
 
-
         // Out of range cases
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "SinhEvaluator",
-            "val",
-            k -> null,
-            Double.NEGATIVE_INFINITY,
-            -711d,
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: sinh overflow"
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "SinhEvaluator",
+                "val",
+                k -> null,
+                Double.NEGATIVE_INFINITY,
+                -711d,
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: sinh overflow"
+                )
             )
-        ));
-        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
-            "SinhEvaluator",
-            "val",
-            k -> null,
-            711d,
-            Double.POSITIVE_INFINITY,
-            List.of(
-                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "java.lang.ArithmeticException: sinh overflow"
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forUnaryCastingToDouble(
+                "SinhEvaluator",
+                "val",
+                k -> null,
+                711d,
+                Double.POSITIVE_INFINITY,
+                List.of(
+                    "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                    "java.lang.ArithmeticException: sinh overflow"
+                )
             )
-        ));
+        );
         return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SinhTests.java
@@ -29,11 +29,37 @@ public class SinhTests extends AbstractFunctionTestCase {
             "SinhEvaluator",
             "val",
             Math::sinh,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
+            -710d,
+            710d,  // Hyperbolic sine grows extremely fast. Values outside this range return Double.POSITIVE_INFINITY
             List.of()
         );
-        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
+        suppliers = anyNullIsNull(true, suppliers);
+
+
+        // Out of range cases
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "SinhEvaluator",
+            "val",
+            k -> null,
+            Double.NEGATIVE_INFINITY,
+            -711d,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: sinh overflow"
+            )
+        ));
+        suppliers.addAll(TestCaseSupplier.forUnaryCastingToDouble(
+            "SinhEvaluator",
+            "val",
+            k -> null,
+            711d,
+            Double.POSITIVE_INFINITY,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: sinh overflow"
+            )
+        ));
+        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SqrtTests.java
@@ -33,12 +33,13 @@ public class SqrtTests extends AbstractFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         String read = "Attribute[channel=0]";
         List<TestCaseSupplier> suppliers = new ArrayList<>();
+        // Valid values
         TestCaseSupplier.forUnaryInt(
             suppliers,
             "SqrtIntEvaluator[val=" + read + "]",
             DataTypes.DOUBLE,
             Math::sqrt,
-            Integer.MIN_VALUE,
+            0,
             Integer.MAX_VALUE,
             List.of()
         );
@@ -47,7 +48,7 @@ public class SqrtTests extends AbstractFunctionTestCase {
             "SqrtLongEvaluator[val=" + read + "]",
             DataTypes.DOUBLE,
             Math::sqrt,
-            Long.MIN_VALUE,
+            0,
             Long.MAX_VALUE,
             List.of()
         );
@@ -65,11 +66,50 @@ public class SqrtTests extends AbstractFunctionTestCase {
             "SqrtDoubleEvaluator[val=" + read + "]",
             DataTypes.DOUBLE,
             Math::sqrt,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
+            -0d,
+            Double.MAX_VALUE,
             List.of()
         );
-        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(anyNullIsNull(true, suppliers)));
+        suppliers = anyNullIsNull(true, suppliers);
+
+        // Out of range values (there are no out of range unsigned longs)
+        TestCaseSupplier.forUnaryInt(
+            suppliers,
+            "SqrtIntEvaluator[val=" + read + "]",
+            DataTypes.DOUBLE,
+            k -> null,
+            Integer.MIN_VALUE,
+            -1,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Square root of negative"
+            )
+        );
+        TestCaseSupplier.forUnaryLong(
+            suppliers,
+            "SqrtLongEvaluator[val=" + read + "]",
+            DataTypes.DOUBLE,
+            k -> null,
+            Long.MIN_VALUE,
+            -1,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Square root of negative"
+            )
+        );
+        TestCaseSupplier.forUnaryDouble(
+            suppliers,
+            "SqrtDoubleEvaluator[val=" + read + "]",
+            DataTypes.DOUBLE,
+            k -> null,
+            Double.NEGATIVE_INFINITY,
+            -Double.MIN_VALUE,
+            List.of(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "java.lang.ArithmeticException: Square root of negative"
+            )
+        );
+        return parameterSuppliersFromTypedData(errorsForCasesWithoutExamples(suppliers));
     }
 
     @Override


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/98698

Add asserts that we aren't returning NaN or Infinite values from scalar functions.  I also fixed the functions that already had test cases returning NaN/Infinite values.  Note that this doesn't fix all our scalar functions, as some may just not have test cases that hit these outputs regularly, which is why this PR doesn't close the above issue.