### PR TITLE
Infer index version for 8.10 patches

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/VersionInformation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/VersionInformation.java
@@ -32,7 +32,7 @@ public record VersionInformation(Version nodeVersion, IndexVersion minIndexVersi
             return null;
         } else if (nodeVersion.equals(Version.CURRENT)) {
             return CURRENT;
-        } else if (nodeVersion.onOrBefore(Version.V_8_10_0)) {
+        } else if (nodeVersion.before(Version.V_8_11_0)) {
             return new VersionInformation(
                 nodeVersion,
                 IndexVersion.getMinimumCompatibleIndexVersion(nodeVersion.id),


### PR DESCRIPTION
This commit fixes a missed poison pill for inferring index version. The changed logic allows inferring to work on 8.10 patches, not just 8.10.0.

see #99003