### PR TITLE
Infer index version for 8.10 patches (#99501)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/VersionInformation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/VersionInformation.java
@@ -32,7 +32,8 @@ public record VersionInformation(Version nodeVersion, IndexVersion minIndexVersi
             return null;
         } else if (nodeVersion.equals(Version.CURRENT)) {
             return CURRENT;
-        } else if (nodeVersion.before(Version.V_8_10_0)) {
+        } else if (nodeVersion.before(Version.CURRENT)) {
+            // CURRENT here is always before 8.11.0
             return new VersionInformation(
                 nodeVersion,
                 IndexVersion.fromId(nodeVersion.minimumIndexCompatibilityVersion().id),


### PR DESCRIPTION
This commit fixes a missed poison pill for inferring index version. The changed logic allows inferring to work on 8.10 patches, not just 8.10.0.

see #99003