### PR TITLE
ESQL: Make Blocks and Vectors Releasable

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -95,4 +95,9 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
             + Arrays.toString(values)
             + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -77,4 +77,9 @@ public final class BooleanArrayVector extends AbstractVector implements BooleanV
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -71,4 +71,9 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
     public String toString() {
         return getClass().getSimpleName() + "[vector=" + vector + "]";
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Block view of a BooleanVector.
@@ -74,6 +75,6 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -96,4 +96,9 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
             + values.size()
             + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -81,6 +81,6 @@ public final class BytesRefArrayVector extends AbstractVector implements BytesRe
 
     @Override
     public void close() {
-        Releasables.close(values);
+        Releasables.closeExpectNoException(values);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Vector implementation that stores an array of BytesRef values.
@@ -76,5 +77,10 @@ public final class BytesRefArrayVector extends AbstractVector implements BytesRe
     @Override
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ']';
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -10,7 +10,6 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.BigArrays;
 
 import java.io.IOException;
 
@@ -79,7 +78,7 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
         if (constant && positions > 0) {
             return new ConstantBytesRefVector(in.readBytesRef(), positions);
         } else {
-            var builder = BytesRefVector.newVectorBuilder(positions, BigArrays.NON_RECYCLING_INSTANCE);
+            var builder = BytesRefVector.newVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.appendBytesRef(in.readBytesRef());
             }
@@ -101,12 +100,8 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
         }
     }
 
-    static Builder newVectorBuilder(int estimatedSize) { // For now
-        return new BytesRefVectorBuilder(estimatedSize, BigArrays.NON_RECYCLING_INSTANCE);
-    }
-
-    static Builder newVectorBuilder(int estimatedSize, BigArrays bigArrays) {
-        return new BytesRefVectorBuilder(estimatedSize, bigArrays);
+    static Builder newVectorBuilder(int estimatedSize) {
+        return new BytesRefVectorBuilder(estimatedSize);
     }
 
     sealed interface Builder extends Vector.Builder permits BytesRefVectorBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.BigArrays;
 
 import java.io.IOException;
 
@@ -78,7 +79,7 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
         if (constant && positions > 0) {
             return new ConstantBytesRefVector(in.readBytesRef(), positions);
         } else {
-            var builder = BytesRefVector.newVectorBuilder(positions);
+            var builder = BytesRefVector.newVectorBuilder(positions, BigArrays.NON_RECYCLING_INSTANCE);
             for (int i = 0; i < positions; i++) {
                 builder.appendBytesRef(in.readBytesRef());
             }
@@ -100,8 +101,12 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
         }
     }
 
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new BytesRefVectorBuilder(estimatedSize);
+    static Builder newVectorBuilder(int estimatedSize) { // For now
+        return new BytesRefVectorBuilder(estimatedSize, BigArrays.NON_RECYCLING_INSTANCE);
+    }
+
+    static Builder newVectorBuilder(int estimatedSize, BigArrays bigArrays) {
+        return new BytesRefVectorBuilder(estimatedSize, bigArrays);
     }
 
     sealed interface Builder extends Vector.Builder permits BytesRefVectorBuilder {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Block view of a BytesRefVector.
@@ -75,6 +76,6 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -72,4 +72,9 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     public String toString() {
         return getClass().getSimpleName() + "[vector=" + vector + "]";
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
@@ -70,4 +70,9 @@ public final class ConstantBooleanVector extends AbstractVector implements Boole
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -71,4 +71,9 @@ public final class ConstantBytesRefVector extends AbstractVector implements Byte
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -70,4 +70,9 @@ public final class ConstantDoubleVector extends AbstractVector implements Double
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -70,4 +70,9 @@ public final class ConstantIntVector extends AbstractVector implements IntVector
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
@@ -70,4 +70,9 @@ public final class ConstantLongVector extends AbstractVector implements LongVect
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -95,4 +95,9 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
             + Arrays.toString(values)
             + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -77,4 +77,9 @@ public final class DoubleArrayVector extends AbstractVector implements DoubleVec
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -71,4 +71,9 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
     public String toString() {
         return getClass().getSimpleName() + "[vector=" + vector + "]";
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Block view of a DoubleVector.
@@ -74,6 +75,6 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
@@ -122,4 +122,9 @@ final class FilterBooleanBlock extends AbstractFilterBlock implements BooleanBlo
             sb.append(']');
         }
     }
+
+    @Override
+    public void close() {
+        block.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter block for BooleanBlocks.
@@ -125,6 +126,6 @@ final class FilterBooleanBlock extends AbstractFilterBlock implements BooleanBlo
 
     @Override
     public void close() {
-        block.close();
+        Releasables.closeExpectNoException(block);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVector.java
@@ -88,4 +88,9 @@ public final class FilterBooleanVector extends AbstractFilterVector implements B
             sb.append(getBoolean(i));
         }
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVector.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter vector for BooleanVectors.
@@ -91,6 +92,6 @@ public final class FilterBooleanVector extends AbstractFilterVector implements B
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter block for BytesRefBlocks.
@@ -128,6 +129,6 @@ final class FilterBytesRefBlock extends AbstractFilterBlock implements BytesRefB
 
     @Override
     public void close() {
-        block.close();
+        Releasables.closeExpectNoException(block);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -125,4 +125,9 @@ final class FilterBytesRefBlock extends AbstractFilterBlock implements BytesRefB
             sb.append(']');
         }
     }
+
+    @Override
+    public void close() {
+        block.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVector.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter vector for BytesRefVectors.
@@ -92,6 +93,6 @@ public final class FilterBytesRefVector extends AbstractFilterVector implements 
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVector.java
@@ -89,4 +89,9 @@ public final class FilterBytesRefVector extends AbstractFilterVector implements 
             sb.append(getBytesRef(i, new BytesRef()));
         }
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -122,4 +122,9 @@ final class FilterDoubleBlock extends AbstractFilterBlock implements DoubleBlock
             sb.append(']');
         }
     }
+
+    @Override
+    public void close() {
+        block.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter block for DoubleBlocks.
@@ -125,6 +126,6 @@ final class FilterDoubleBlock extends AbstractFilterBlock implements DoubleBlock
 
     @Override
     public void close() {
-        block.close();
+        Releasables.closeExpectNoException(block);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVector.java
@@ -88,4 +88,9 @@ public final class FilterDoubleVector extends AbstractFilterVector implements Do
             sb.append(getDouble(i));
         }
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVector.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter vector for DoubleVectors.
@@ -91,6 +92,6 @@ public final class FilterDoubleVector extends AbstractFilterVector implements Do
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -122,4 +122,9 @@ final class FilterIntBlock extends AbstractFilterBlock implements IntBlock {
             sb.append(']');
         }
     }
+
+    @Override
+    public void close() {
+        block.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter block for IntBlocks.
@@ -125,6 +126,6 @@ final class FilterIntBlock extends AbstractFilterBlock implements IntBlock {
 
     @Override
     public void close() {
-        block.close();
+        Releasables.closeExpectNoException(block);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVector.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter vector for IntVectors.
@@ -91,6 +92,6 @@ public final class FilterIntVector extends AbstractFilterVector implements IntVe
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVector.java
@@ -88,4 +88,9 @@ public final class FilterIntVector extends AbstractFilterVector implements IntVe
             sb.append(getInt(i));
         }
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -122,4 +122,9 @@ final class FilterLongBlock extends AbstractFilterBlock implements LongBlock {
             sb.append(']');
         }
     }
+
+    @Override
+    public void close() {
+        block.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter block for LongBlocks.
@@ -125,6 +126,6 @@ final class FilterLongBlock extends AbstractFilterBlock implements LongBlock {
 
     @Override
     public void close() {
-        block.close();
+        Releasables.closeExpectNoException(block);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVector.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter vector for LongVectors.
@@ -91,6 +92,6 @@ public final class FilterLongVector extends AbstractFilterVector implements Long
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVector.java
@@ -88,4 +88,9 @@ public final class FilterLongVector extends AbstractFilterVector implements Long
             sb.append(getLong(i));
         }
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -95,4 +95,9 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
             + Arrays.toString(values)
             + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -77,4 +77,9 @@ public final class IntArrayVector extends AbstractVector implements IntVector {
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -71,4 +71,9 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
     public String toString() {
         return getClass().getSimpleName() + "[vector=" + vector + "]";
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Block view of a IntVector.
@@ -74,6 +75,6 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -95,4 +95,9 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
             + Arrays.toString(values)
             + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -77,4 +77,9 @@ public final class LongArrayVector extends AbstractVector implements LongVector 
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Block view of a LongVector.
@@ -74,6 +75,6 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -71,4 +71,9 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
     public String toString() {
         return getClass().getSimpleName() + "[vector=" + vector + "]";
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.core.Releasable;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ import java.util.List;
  *
  * <p> Block are immutable and can be passed between threads.
  */
-public interface Block extends Accountable, NamedWriteable {
+public interface Block extends Accountable, NamedWriteable, Releasable {
 
     /**
      * {@return an efficient dense single-value view of this block}.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -119,6 +119,11 @@ public final class ConstantNullBlock extends AbstractBlock {
         return "ConstantNullBlock[positions=" + getPositionCount() + "]";
     }
 
+    @Override
+    public void close() {
+        // no-op
+    }
+
     static class Builder implements Block.Builder {
         private int positionCount;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
 
@@ -54,6 +55,11 @@ public class DocBlock extends AbstractVectorBlock implements Block {
     @Override
     public long ramBytesUsed() {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(vector);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(vector);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -59,7 +59,7 @@ public class DocBlock extends AbstractVectorBlock implements Block {
 
     @Override
     public void close() {
-        Releasables.close(vector);
+        Releasables.closeExpectNoException(vector);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.IntroSorter;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * {@link Vector} where each entry references a lucene document.
@@ -197,5 +198,10 @@ public class DocVector extends AbstractVector implements Vector {
     @Override
     public long ramBytesUsed() {
         return ramBytesEstimated(shards, segments, docs, shardSegmentDocMapForwards, shardSegmentDocMapBackwards);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(shards, segments, docs);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -202,6 +202,6 @@ public class DocVector extends AbstractVector implements Vector {
 
     @Override
     public void close() {
-        Releasables.close(shards, segments, docs);
+        Releasables.closeExpectNoException(shards, segments, docs);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -8,11 +8,12 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.core.Releasable;
 
 /**
  * A dense Vector of single values.
  */
-public interface Vector extends Accountable {
+public interface Vector extends Accountable, Releasable {
 
     /**
      * {@return Returns a Block view over this vector.}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -121,4 +121,9 @@ $else$
 $endif$
             + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -11,6 +11,7 @@ $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.core.Releasables;
 
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
@@ -103,6 +104,15 @@ $if(BytesRef)$
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ']';
 $else$
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
+$endif$
+    }
+
+    @Override
+    public void close() {
+$if(BytesRef)$
+        Releasables.close(values);
+$else$
+        // no-op
 $endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -110,7 +110,7 @@ $endif$
     @Override
     public void close() {
 $if(BytesRef)$
-        Releasables.close(values);
+        Releasables.closeExpectNoException(values);
 $else$
         // no-op
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -77,4 +77,9 @@ $endif$
     public String toString() {
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
     }
+
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -11,6 +11,7 @@ $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter block for $Type$Blocks.
@@ -149,6 +150,6 @@ $endif$
 
     @Override
     public void close() {
-        block.close();
+        Releasables.closeExpectNoException(block);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -146,4 +146,9 @@ $endif$
             sb.append(']');
         }
     }
+
+    @Override
+    public void close() {
+        block.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVector.java.st
@@ -100,4 +100,9 @@ $else$
 $endif$
         }
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVector.java.st
@@ -11,6 +11,7 @@ $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Filter vector for $Type$Vectors.
@@ -103,6 +104,6 @@ $endif$
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -13,7 +13,6 @@ $endif$
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 $if(BytesRef)$
-import org.elasticsearch.common.util.BigArrays;
 
 $else$
 $endif$
@@ -117,7 +116,7 @@ $endif$
         if (constant && positions > 0) {
             return new Constant$Type$Vector(in.read$Type$(), positions);
         } else {
-            var builder = $Type$Vector.newVectorBuilder(positions$if(BytesRef)$, BigArrays.NON_RECYCLING_INSTANCE$endif$);
+            var builder = $Type$Vector.newVectorBuilder(positions);
             for (int i = 0; i < positions; i++) {
                 builder.append$Type$(in.read$Type$());
             }
@@ -147,14 +146,8 @@ $endif$
         }
     }
 
-$if(BytesRef)$
-    static Builder newVectorBuilder(int estimatedSize) { // For now
-        return new $Type$VectorBuilder(estimatedSize, BigArrays.NON_RECYCLING_INSTANCE);
-    }
-$endif$
-
-    static Builder newVectorBuilder(int estimatedSize$if(BytesRef)$, BigArrays bigArrays$endif$) {
-        return new $Type$VectorBuilder(estimatedSize$if(BytesRef)$, bigArrays$endif$);
+    static Builder newVectorBuilder(int estimatedSize) {
+        return new $Type$VectorBuilder(estimatedSize);
     }
 
 $if(int)$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -12,6 +12,11 @@ import org.apache.lucene.util.BytesRef;
 $endif$
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+$if(BytesRef)$
+import org.elasticsearch.common.util.BigArrays;
+
+$else$
+$endif$
 
 import java.io.IOException;
 
@@ -112,7 +117,7 @@ $endif$
         if (constant && positions > 0) {
             return new Constant$Type$Vector(in.read$Type$(), positions);
         } else {
-            var builder = $Type$Vector.newVectorBuilder(positions);
+            var builder = $Type$Vector.newVectorBuilder(positions$if(BytesRef)$, BigArrays.NON_RECYCLING_INSTANCE$endif$);
             for (int i = 0; i < positions; i++) {
                 builder.append$Type$(in.read$Type$());
             }
@@ -142,8 +147,14 @@ $endif$
         }
     }
 
-    static Builder newVectorBuilder(int estimatedSize) {
-        return new $Type$VectorBuilder(estimatedSize);
+$if(BytesRef)$
+    static Builder newVectorBuilder(int estimatedSize) { // For now
+        return new $Type$VectorBuilder(estimatedSize, BigArrays.NON_RECYCLING_INSTANCE);
+    }
+$endif$
+
+    static Builder newVectorBuilder(int estimatedSize$if(BytesRef)$, BigArrays bigArrays$endif$) {
+        return new $Type$VectorBuilder(estimatedSize$if(BytesRef)$, bigArrays$endif$);
     }
 
 $if(int)$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -12,10 +12,6 @@ import org.apache.lucene.util.BytesRef;
 $endif$
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-$if(BytesRef)$
-
-$else$
-$endif$
 
 import java.io.IOException;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -11,6 +11,7 @@ $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.Releasables;
 
 /**
  * Block view of a $Type$Vector.
@@ -82,6 +83,6 @@ $endif$
 
     @Override
     public void close() {
-        vector.close();
+        Releasables.closeExpectNoException(vector);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -79,4 +79,9 @@ $endif$
     public String toString() {
         return getClass().getSimpleName() + "[vector=" + vector + "]";
     }
+
+    @Override
+    public void close() {
+        vector.close();
+    }
 }


### PR DESCRIPTION
This commit makes Blocks and Vectors Releasable.

We moving to a model where operators will release blocks that are unused as pages are processed. This allows to release things like BytesRefArrays, bigArrays, etc. As well as eventually to perform circuit breaker accountancy, when a block is no longer needed.

relates #99173