### PR TITLE
Read index version from the old deployed cluster instead of inferring it in full restart tests

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -12,24 +12,30 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
 
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
 import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.OLD;
 import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.UPGRADED;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 @TestCaseOrdering(FullClusterRestartTestOrdering.class)
 public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTestCase {
     private static final Version MINIMUM_WIRE_COMPATIBLE_VERSION = Version.fromString("7.17.0");
     private static final Version OLD_CLUSTER_VERSION = Version.fromString(System.getProperty("tests.old_cluster_version"));
+    private static IndexVersion oldIndexVersion;
     private static boolean upgradeFailed = false;
     private static boolean upgraded = false;
     private final FullClusterRestartUpgradeStatus requestedUpgradeStatus;
@@ -41,6 +47,38 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return Arrays.stream(FullClusterRestartUpgradeStatus.values()).map(v -> new Object[] { v }).toList();
+    }
+
+    @Before
+    public void extractOldIndexVersion() throws Exception {
+        if (upgraded == false) {
+            IndexVersion indexVersion = null;   // these should all be the same version
+
+            Response response = client().performRequest(new Request("GET", "_nodes"));
+            ObjectPath objectPath = ObjectPath.createFromResponse(response);
+            Map<String, Object> nodeMap = objectPath.evaluate("nodes");
+            for (String id : nodeMap.keySet()) {
+                String name = objectPath.evaluate("nodes." + id + ".name");
+
+                Number ix = objectPath.evaluate("nodes." + id + ".index_version");
+                IndexVersion version;
+                if (ix != null) {
+                    version = IndexVersion.fromId(ix.intValue());
+                } else {
+                    String ver = objectPath.evaluate("nodes." + id + ".version");
+                    version = IndexVersion.fromId(org.elasticsearch.Version.fromString(ver).id);
+                }
+
+                if (indexVersion == null) {
+                    indexVersion = version;
+                } else {
+                    assertThat("Node " + name + " has a different index version to other nodes", version, equalTo(indexVersion));
+                }
+            }
+
+            assertThat("Index version could not be read", indexVersion, notNullValue());
+            oldIndexVersion = indexVersion;
+        }
     }
 
     @Before
@@ -81,13 +119,8 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
     }
 
     public static IndexVersion getOldClusterIndexVersion() {
-        var version = getOldClusterVersion();
-        if (version.equals(org.elasticsearch.Version.CURRENT)) {
-            return IndexVersion.current();
-        } else {
-            assertThat("Index version needs to be added to restart test parameters", version, lessThan(org.elasticsearch.Version.V_8_11_0));
-            return IndexVersion.fromId(version.id);
-        }
+        assert oldIndexVersion != null;
+        return oldIndexVersion;
     }
 
     public static Version getOldClusterTestVersion() {

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -65,8 +65,8 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
                 if (ix != null) {
                     version = IndexVersion.fromId(ix.intValue());
                 } else {
-                    String ver = objectPath.evaluate("nodes." + id + ".version");
-                    version = IndexVersion.fromId(org.elasticsearch.Version.fromString(ver).id);
+                    // it doesn't have index version (pre 8.11) - just infer it from the release version
+                    version = IndexVersion.fromId(getOldClusterVersion().id);
                 }
 
                 if (indexVersion == null) {

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -54,12 +54,12 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
         if (upgraded == false) {
             IndexVersion indexVersion = null;   // these should all be the same version
 
-            Response response = client().performRequest(new Request("GET", "_nodes"));
+            Request request = new Request("GET", "_nodes");
+            request.addParameter("filter_path", "nodes.*.index_version,nodes.*.name");
+            Response response = client().performRequest(request);
             ObjectPath objectPath = ObjectPath.createFromResponse(response);
             Map<String, Object> nodeMap = objectPath.evaluate("nodes");
             for (String id : nodeMap.keySet()) {
-                String name = objectPath.evaluate("nodes." + id + ".name");
-
                 Number ix = objectPath.evaluate("nodes." + id + ".index_version");
                 IndexVersion version;
                 if (ix != null) {
@@ -72,6 +72,7 @@ public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTest
                 if (indexVersion == null) {
                     indexVersion = version;
                 } else {
+                    String name = objectPath.evaluate("nodes." + id + ".name");
                     assertThat("Node " + name + " has a different index version to other nodes", version, equalTo(indexVersion));
                 }
             }


### PR DESCRIPTION
Now index version has been added to node info, read it from the old cluster (or infer it from reported version) and record it as the old index version