### PR TITLE
Fix -Werror lossy conversion check

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -1242,6 +1242,6 @@ public class ClusterStateTests extends ESTestCase {
             }
         }
 
-        return (int) chunkCount;
+        return Math.toIntExact(chunkCount);
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -1178,7 +1178,7 @@ public class ClusterStateTests extends ESTestCase {
     public static int expectedChunkCount(ToXContent.Params params, ClusterState clusterState) {
         final var metrics = ClusterState.Metric.parseString(params.param("metric", "_all"), true);
 
-        int chunkCount = 0;
+        long chunkCount = 0;
 
         // header chunk
         chunkCount += 1;
@@ -1242,6 +1242,6 @@ public class ClusterStateTests extends ESTestCase {
             }
         }
 
-        return chunkCount;
+        return (int) chunkCount;
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -2216,7 +2216,7 @@ public class MetadataTests extends ESTestCase {
         // 1 chunk to close metadata
         chunkCount += 1;
 
-        return (int) chunkCount;
+        return Math.toIntExact(chunkCount);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -2170,7 +2170,7 @@ public class MetadataTests extends ESTestCase {
         final var context = Metadata.XContentContext.valueOf(params.param(CONTEXT_MODE_PARAM, CONTEXT_MODE_API));
 
         // 2 chunks at the beginning
-        int chunkCount = 2;
+        long chunkCount = 2;
         // 1 optional chunk for persistent settings
         if (context != Metadata.XContentContext.API && metadata.persistentSettings().isEmpty() == false) {
             chunkCount += 1;
@@ -2216,7 +2216,7 @@ public class MetadataTests extends ESTestCase {
         // 1 chunk to close metadata
         chunkCount += 1;
 
-        return chunkCount;
+        return (int) chunkCount;
     }
 
     /**


### PR DESCRIPTION
Compiling with `Werror` indicates these test files implicitly do a lossy conversion.

Making the final conversion explicit in the tests.

Relates: https://github.com/elastic/elasticsearch/pull/99282