### PR TITLE
Make reroute processor GA

### DIFF
--- a/docs/reference/ingest/processors/reroute.asciidoc
+++ b/docs/reference/ingest/processors/reroute.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Reroute</titleabbrev>
 ++++
 
-experimental::[]
-
 The `reroute` processor allows to route a document to another target index or data stream.
 It has two main modes:
 


### PR DESCRIPTION
The reroute processor is now used in integrations. Therefore, I'll consider the processor to be validated by actual usage and we need to maintain backwards compatibility now to not break integrations.


Integrations that are using the reroute processor so far:
- https://github.com/elastic/integrations/pull/7146
- https://github.com/elastic/integrations/pull/7118