### PR TITLE
Adjust logging level in ESQL

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -136,7 +136,7 @@ public class ComputeService {
         }
         QueryBuilder requestFilter = PlannerUtils.requestFilter(dataNodePlan);
 
-        LOGGER.info("Sending data node plan\n{}\n with filter [{}]", dataNodePlan, requestFilter);
+        LOGGER.debug("Sending data node plan\n{}\n with filter [{}]", dataNodePlan, requestFilter);
 
         String[] originalIndices = PlannerUtils.planOriginalIndices(physicalPlan);
         computeTargetNodes(


### PR DESCRIPTION
I noticed that when testing with the security track, this logging line produced a large paragraph. It should have the DEBUG level instead of INFO.