### PR TITLE
[DSL] Add fixed_interval min value validation for a downsampling round

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -923,7 +923,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             DataStreamLifecycle.newBuilder()
                 .downsampling(
                     new Downsampling(
-                        List.of(new Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("1s"))))
+                        List.of(new Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("5m"))))
                     )
                 )
                 .dataRetention(TimeValue.MAX_VALUE)
@@ -977,7 +977,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         String downsampleIndexName = DownsampleConfig.generateDownsampleIndexName(
             DOWNSAMPLED_INDEX_PREFIX,
             state.metadata().index(firstGenIndex),
-            new DateHistogramInterval("1s")
+            new DateHistogramInterval("5m")
         );
         {
             // let's simulate the in-progress downsampling
@@ -1100,7 +1100,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
             DataStreamLifecycle.newBuilder()
                 .downsampling(
                     new Downsampling(
-                        List.of(new Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("1s"))))
+                        List.of(new Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("5m"))))
                     )
                 )
                 .dataRetention(TimeValue.MAX_VALUE)
@@ -1129,7 +1129,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         String downsampleIndexName = DownsampleConfig.generateDownsampleIndexName(
             DOWNSAMPLED_INDEX_PREFIX,
             state.metadata().index(firstGenIndexName),
-            new DateHistogramInterval("1s")
+            new DateHistogramInterval("5m")
         );
         Metadata.Builder newMetadata = Metadata.builder(state.metadata())
             .put(

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -322,6 +322,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
      */
     public record Downsampling(@Nullable List<Round> rounds) implements Writeable, ToXContentFragment {
 
+        public static final long FIVE_MINUTES_MILLIS = TimeValue.timeValueMinutes(5).getMillis();
+
         /**
          * A round represents the configuration for when and how elasticsearch will downsample a backing index.
          * @param after is a TimeValue configuring how old (based on generation age) should a backing index be before downsampling
@@ -354,6 +356,14 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
             public static Round read(StreamInput in) throws IOException {
                 return new Round(in.readTimeValue(), new DownsampleConfig(in));
+            }
+
+            public Round {
+                if (config.getFixedInterval().estimateMillis() < FIVE_MINUTES_MILLIS) {
+                    throw new IllegalArgumentException(
+                        "A downsampling round must have a fixed interval of at least five minutes but found: " + config.getFixedInterval()
+                    );
+                }
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -233,6 +233,24 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
             );
             assertThat(exception.getMessage(), equalTo("Downsampling configuration supports maximum 10 configured rounds. Found: 12"));
         }
+
+        {
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> new DataStreamLifecycle.Downsampling(
+                    List.of(
+                        new DataStreamLifecycle.Downsampling.Round(
+                            TimeValue.timeValueDays(10),
+                            new DownsampleConfig(new DateHistogramInterval("2m"))
+                        )
+                    )
+                )
+            );
+            assertThat(
+                exception.getMessage(),
+                equalTo("A downsampling round must have a fixed interval of at least five minutes but found: 2m")
+            );
+        }
     }
 
     @Nullable

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1299,15 +1299,15 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                             List.of(
                                 new DataStreamLifecycle.Downsampling.Round(
                                     TimeValue.timeValueMillis(2000),
-                                    new DownsampleConfig(new DateHistogramInterval("10s"))
+                                    new DownsampleConfig(new DateHistogramInterval("10m"))
                                 ),
                                 new DataStreamLifecycle.Downsampling.Round(
                                     TimeValue.timeValueMillis(3200),
-                                    new DownsampleConfig(new DateHistogramInterval("100s"))
+                                    new DownsampleConfig(new DateHistogramInterval("100m"))
                                 ),
                                 new DataStreamLifecycle.Downsampling.Round(
                                     TimeValue.timeValueMillis(3500),
-                                    new DownsampleConfig(new DateHistogramInterval("1000s"))
+                                    new DownsampleConfig(new DateHistogramInterval("1000m"))
                                 )
                             )
                         )
@@ -1360,15 +1360,15 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                             List.of(
                                 new DataStreamLifecycle.Downsampling.Round(
                                     TimeValue.timeValueMillis(2000),
-                                    new DownsampleConfig(new DateHistogramInterval("10s"))
+                                    new DownsampleConfig(new DateHistogramInterval("10m"))
                                 ),
                                 new DataStreamLifecycle.Downsampling.Round(
                                     TimeValue.timeValueMillis(3200),
-                                    new DownsampleConfig(new DateHistogramInterval("100s"))
+                                    new DownsampleConfig(new DateHistogramInterval("100m"))
                                 ),
                                 new DataStreamLifecycle.Downsampling.Round(
                                     TimeValue.timeValueMillis(3500),
-                                    new DownsampleConfig(new DateHistogramInterval("1000s"))
+                                    new DownsampleConfig(new DateHistogramInterval("1000m"))
                                 )
                             )
                         )

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
@@ -71,7 +71,7 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
                         List.of(
                             new DataStreamLifecycle.Downsampling.Round(
                                 TimeValue.timeValueMillis(0),
-                                new DownsampleConfig(new DateHistogramInterval("1s"))
+                                new DownsampleConfig(new DateHistogramInterval("5m"))
                             )
                         )
                     )
@@ -121,7 +121,7 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
             );
             ensureStableCluster(cluster.numDataAndMasterNodes());
 
-            final String targetIndex = "downsample-1s-" + sourceIndex;
+            final String targetIndex = "downsample-5m-" + sourceIndex;
             assertBusy(() -> {
                 try {
                     GetSettingsResponse getSettingsResponse = client().admin()

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleIT.java
@@ -61,8 +61,8 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
             .downsampling(
                 new Downsampling(
                     List.of(
-                        new Downsampling.Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("1s"))),
-                        new Downsampling.Round(TimeValue.timeValueSeconds(10), new DownsampleConfig(new DateHistogramInterval("10s")))
+                        new Downsampling.Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("5m"))),
+                        new Downsampling.Round(TimeValue.timeValueSeconds(10), new DownsampleConfig(new DateHistogramInterval("10m")))
                     )
                 )
             )
@@ -72,8 +72,8 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
 
         List<String> backingIndices = getBackingIndices(client(), dataStreamName);
         String firstGenerationBackingIndex = backingIndices.get(0);
-        String oneSecondDownsampleIndex = "downsample-1s-" + firstGenerationBackingIndex;
-        String tenSecondsDownsampleIndex = "downsample-10s-" + firstGenerationBackingIndex;
+        String oneSecondDownsampleIndex = "downsample-5m-" + firstGenerationBackingIndex;
+        String tenSecondsDownsampleIndex = "downsample-10m-" + firstGenerationBackingIndex;
 
         Set<String> witnessedDownsamplingIndices = new HashSet<>();
         clusterService().addListener(event -> {
@@ -119,10 +119,10 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
             .downsampling(
                 new Downsampling(
                     List.of(
-                        new Downsampling.Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("1s"))),
+                        new Downsampling.Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("5m"))),
                         // data stream lifecycle runs every 1 second, so by the time we forcemerge the backing index it would've been at
                         // least 2 seconds since rollover. only the 10 seconds round should be executed.
-                        new Downsampling.Round(TimeValue.timeValueMillis(10), new DownsampleConfig(new DateHistogramInterval("10s")))
+                        new Downsampling.Round(TimeValue.timeValueMillis(10), new DownsampleConfig(new DateHistogramInterval("10m")))
                     )
                 )
             )
@@ -131,8 +131,8 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
 
         List<String> backingIndices = getBackingIndices(client(), dataStreamName);
         String firstGenerationBackingIndex = backingIndices.get(0);
-        String oneSecondDownsampleIndex = "downsample-1s-" + firstGenerationBackingIndex;
-        String tenSecondsDownsampleIndex = "downsample-10s-" + firstGenerationBackingIndex;
+        String oneSecondDownsampleIndex = "downsample-5m-" + firstGenerationBackingIndex;
+        String tenSecondsDownsampleIndex = "downsample-10m-" + firstGenerationBackingIndex;
 
         Set<String> witnessedDownsamplingIndices = new HashSet<>();
         clusterService().addListener(event -> {
@@ -173,10 +173,10 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
             .downsampling(
                 new Downsampling(
                     List.of(
-                        new Downsampling.Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("1s"))),
+                        new Downsampling.Round(TimeValue.timeValueMillis(0), new DownsampleConfig(new DateHistogramInterval("5m"))),
                         // data stream lifecycle runs every 1 second, so by the time we forcemerge the backing index it would've been at
                         // least 2 seconds since rollover. only the 10 seconds round should be executed.
-                        new Downsampling.Round(TimeValue.timeValueMillis(10), new DownsampleConfig(new DateHistogramInterval("10s")))
+                        new Downsampling.Round(TimeValue.timeValueMillis(10), new DownsampleConfig(new DateHistogramInterval("10m")))
                     )
                 )
             )
@@ -186,8 +186,8 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
 
         List<String> backingIndices = getBackingIndices(client(), dataStreamName);
         String firstGenerationBackingIndex = backingIndices.get(0);
-        String oneSecondDownsampleIndex = "downsample-1s-" + firstGenerationBackingIndex;
-        String tenSecondsDownsampleIndex = "downsample-10s-" + firstGenerationBackingIndex;
+        String oneSecondDownsampleIndex = "downsample-5m-" + firstGenerationBackingIndex;
+        String tenSecondsDownsampleIndex = "downsample-10m-" + firstGenerationBackingIndex;
 
         Set<String> witnessedDownsamplingIndices = new HashSet<>();
         clusterService().addListener(event -> {
@@ -222,7 +222,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
         DataStreamLifecycle updatedLifecycle = DataStreamLifecycle.newBuilder()
             .downsampling(
                 new Downsampling(
-                    List.of(new Downsampling.Round(TimeValue.timeValueMillis(10), new DownsampleConfig(new DateHistogramInterval("30s"))))
+                    List.of(new Downsampling.Round(TimeValue.timeValueMillis(10), new DownsampleConfig(new DateHistogramInterval("20m"))))
                 )
             )
             .build();
@@ -232,7 +232,7 @@ public class DataStreamLifecycleDownsampleIT extends ESIntegTestCase {
             new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, updatedLifecycle)
         );
 
-        String thirtySecondsDownsampleIndex = "downsample-30s-" + firstGenerationBackingIndex;
+        String thirtySecondsDownsampleIndex = "downsample-20m-" + firstGenerationBackingIndex;
 
         assertBusy(() -> {
             assertThat(indexExists(tenSecondsDownsampleIndex), is(false));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleDownsamplingSecurityIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamLifecycleDownsamplingSecurityIT.java
@@ -120,11 +120,11 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
                     List.of(
                         new DataStreamLifecycle.Downsampling.Round(
                             TimeValue.timeValueMillis(0),
-                            new DownsampleConfig(new DateHistogramInterval("1s"))
+                            new DownsampleConfig(new DateHistogramInterval("5m"))
                         ),
                         new DataStreamLifecycle.Downsampling.Round(
                             TimeValue.timeValueSeconds(10),
-                            new DownsampleConfig(new DateHistogramInterval("10s"))
+                            new DownsampleConfig(new DateHistogramInterval("10m"))
                         )
                     )
                 )
@@ -144,11 +144,11 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
                     List.of(
                         new DataStreamLifecycle.Downsampling.Round(
                             TimeValue.timeValueMillis(0),
-                            new DownsampleConfig(new DateHistogramInterval("1s"))
+                            new DownsampleConfig(new DateHistogramInterval("5m"))
                         ),
                         new DataStreamLifecycle.Downsampling.Round(
                             TimeValue.timeValueSeconds(10),
-                            new DownsampleConfig(new DateHistogramInterval("10s"))
+                            new DownsampleConfig(new DateHistogramInterval("10m"))
                         )
                     )
                 )
@@ -188,8 +188,8 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
     private void waitAndAssertDownsamplingCompleted(String dataStreamName) throws Exception {
         List<Index> backingIndices = getDataStreamBackingIndices(dataStreamName);
         String firstGenerationBackingIndex = backingIndices.get(0).getName();
-        String oneSecondDownsampleIndex = "downsample-1s-" + firstGenerationBackingIndex;
-        String tenSecondsDownsampleIndex = "downsample-10s-" + firstGenerationBackingIndex;
+        String oneSecondDownsampleIndex = "downsample-5m-" + firstGenerationBackingIndex;
+        String tenSecondsDownsampleIndex = "downsample-10m-" + firstGenerationBackingIndex;
 
         Set<String> witnessedDownsamplingIndices = new HashSet<>();
         clusterService().addListener(event -> {
@@ -439,11 +439,11 @@ public class DataStreamLifecycleDownsamplingSecurityIT extends SecurityIntegTest
                         List.of(
                             new DataStreamLifecycle.Downsampling.Round(
                                 TimeValue.timeValueMillis(0),
-                                new DownsampleConfig(new DateHistogramInterval("1s"))
+                                new DownsampleConfig(new DateHistogramInterval("5m"))
                             ),
                             new DataStreamLifecycle.Downsampling.Round(
                                 TimeValue.timeValueSeconds(10),
-                                new DownsampleConfig(new DateHistogramInterval("10s"))
+                                new DownsampleConfig(new DateHistogramInterval("10m"))
                             )
                         )
                     )


### PR DESCRIPTION
This adds validation for the downsampling round to have a minimum `fixed_interval` of `5m`.

