### PR TITLE
Default ESQL data partitioning to DOC

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ColumnExtractOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ColumnExtractOperator.java
@@ -57,16 +57,16 @@ public class ColumnExtractOperator extends AbstractPageMappingOperator {
             blockBuilders[i] = types[i].newBlockBuilder(rowsCount);
         }
 
-        BytesRefBlock input = (BytesRefBlock) inputEvaluator.eval(page);
+        Block input = inputEvaluator.eval(page);
         BytesRef spare = new BytesRef();
         for (int row = 0; row < rowsCount; row++) {
             if (input.isNull(row)) {
-                for (int i = 0; i < blockBuilders.length; i++) {
-                    blockBuilders[i].appendNull();
+                for (Block.Builder blockBuilder : blockBuilders) {
+                    blockBuilder.appendNull();
                 }
                 continue;
             }
-            evaluator.computeRow(input, row, blockBuilders, spare);
+            evaluator.computeRow((BytesRefBlock) input, row, blockBuilders, spare);
         }
 
         Block[] blocks = new Block[blockBuilders.length];

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/StringExtractOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/StringExtractOperator.java
@@ -62,7 +62,7 @@ public class StringExtractOperator extends AbstractPageMappingOperator {
             blockBuilders[i] = BytesRefBlock.newBlockBuilder(rowsCount);
         }
 
-        BytesRefBlock input = (BytesRefBlock) inputEvaluator.eval(page);
+        Block input = inputEvaluator.eval(page);
         BytesRef spare = new BytesRef();
         for (int row = 0; row < rowsCount; row++) {
             if (input.isNull(row)) {
@@ -72,10 +72,11 @@ public class StringExtractOperator extends AbstractPageMappingOperator {
                 continue;
             }
 
+            BytesRefBlock bytesInput = (BytesRefBlock) input;
             int position = input.getFirstValueIndex(row);
             int valueCount = input.getValueCount(row);
             if (valueCount == 1) {
-                Map<String, String> items = parser.apply(input.getBytesRef(position, spare).utf8ToString());
+                Map<String, String> items = parser.apply(bytesInput.getBytesRef(position, spare).utf8ToString());
                 if (items == null) {
                     for (int i = 0; i < fieldNames.length; i++) {
                         blockBuilders[i].appendNull();
@@ -91,7 +92,7 @@ public class StringExtractOperator extends AbstractPageMappingOperator {
                 String[] firstValues = new String[fieldNames.length];
                 boolean[] positionEntryOpen = new boolean[fieldNames.length];
                 for (int c = 0; c < valueCount; c++) {
-                    Map<String, String> items = parser.apply(input.getBytesRef(position + c, spare).utf8ToString());
+                    Map<String, String> items = parser.apply(bytesInput.getBytesRef(position + c, spare).utf8ToString());
                     if (items == null) {
                         continue;
                     }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -90,9 +90,26 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     protected final void doTest() throws Throwable {
         RequestObjectBuilder requestBuilder = new RequestObjectBuilder(randomFrom(XContentType.values()));
+        if (randomBoolean()) {
+            Settings.Builder pragmas = Settings.builder();
+            if (randomBoolean()) {
+                pragmas.put("data_partitioning", randomFrom("doc", "segment", "shard"));
+            }
+            if (randomBoolean()) {
+                pragmas.put("exchange_buffer_size", between(1, 5));
+            }
+            if (randomBoolean()) {
+                pragmas.put("exchange_concurrent_clients", between(1, 16));
+            }
+            if (randomBoolean()) {
+                pragmas.put("task_concurrency", between(1, 16));
+            }
+            if (randomBoolean()) {
+                pragmas.put("page_size", between(1, 128));
+            }
+            requestBuilder.pragmas(pragmas.build());
+        }
         requestBuilder.query(testCase.query);
-        // TODO: Randomize the query pragmas
-        requestBuilder.pragmas(Settings.builder().put("data_partitioning", "segment").build());
         Map<String, Object> answer = runEsql(requestBuilder.build(), testCase.expectedWarnings);
         var expectedColumnsWithValues = loadCsvSpecValues(testCase.expectedResults);
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -90,26 +90,9 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     protected final void doTest() throws Throwable {
         RequestObjectBuilder requestBuilder = new RequestObjectBuilder(randomFrom(XContentType.values()));
-        if (randomBoolean()) {
-            Settings.Builder pragmas = Settings.builder();
-            if (randomBoolean()) {
-                pragmas.put("data_partitioning", randomFrom("doc", "segment", "shard"));
-            }
-            if (randomBoolean()) {
-                pragmas.put("exchange_buffer_size", between(1, 5));
-            }
-            if (randomBoolean()) {
-                pragmas.put("exchange_concurrent_clients", between(1, 16));
-            }
-            if (randomBoolean()) {
-                pragmas.put("task_concurrency", between(1, 16));
-            }
-            if (randomBoolean()) {
-                pragmas.put("page_size", between(1, 128));
-            }
-            requestBuilder.pragmas(pragmas.build());
-        }
         requestBuilder.query(testCase.query);
+        // TODO: Randomize the query pragmas
+        requestBuilder.pragmas(Settings.builder().put("data_partitioning", "segment").build());
         Map<String, Object> answer = runEsql(requestBuilder.build(), testCase.expectedWarnings);
         var expectedColumnsWithValues = loadCsvSpecValues(testCase.expectedResults);
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -10,6 +10,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -88,8 +89,11 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     }
 
     protected final void doTest() throws Throwable {
-        RequestObjectBuilder builder = new RequestObjectBuilder(randomFrom(XContentType.values()));
-        Map<String, Object> answer = runEsql(builder.query(testCase.query).build(), testCase.expectedWarnings);
+        RequestObjectBuilder requestBuilder = new RequestObjectBuilder(randomFrom(XContentType.values()));
+        requestBuilder.query(testCase.query);
+        // TODO: Randomize the query pragmas
+        requestBuilder.pragmas(Settings.builder().put("data_partitioning", "segment").build());
+        Map<String, Object> answer = runEsql(requestBuilder.build(), testCase.expectedWarnings);
         var expectedColumnsWithValues = loadCsvSpecValues(testCase.expectedResults);
 
         assertNotNull(answer.get("columns"));

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -208,27 +208,27 @@ public class RestEsqlTestCase extends ESRestTestCase {
     public void testTextMode() throws IOException {
         int count = randomIntBetween(0, 100);
         bulkLoadTestData(count);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
         assertEquals(expectedTextBody("txt", count, null), runEsqlAsTextWithFormat(builder, "txt", null));
     }
 
     public void testCSVMode() throws IOException {
         int count = randomIntBetween(0, 100);
         bulkLoadTestData(count);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
         assertEquals(expectedTextBody("csv", count, '|'), runEsqlAsTextWithFormat(builder, "csv", '|'));
     }
 
     public void testTSVMode() throws IOException {
         int count = randomIntBetween(0, 100);
         bulkLoadTestData(count);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
         assertEquals(expectedTextBody("tsv", count, null), runEsqlAsTextWithFormat(builder, "tsv", null));
     }
 
     public void testCSVNoHeaderMode() throws IOException {
         bulkLoadTestData(1);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
         Request request = prepareRequest();
         String mediaType = attachBody(builder, request);
         RequestOptions.Builder options = request.getOptions().toBuilder();

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -208,27 +208,27 @@ public class RestEsqlTestCase extends ESRestTestCase {
     public void testTextMode() throws IOException {
         int count = randomIntBetween(0, 100);
         bulkLoadTestData(count);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
         assertEquals(expectedTextBody("txt", count, null), runEsqlAsTextWithFormat(builder, "txt", null));
     }
 
     public void testCSVMode() throws IOException {
         int count = randomIntBetween(0, 100);
         bulkLoadTestData(count);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
         assertEquals(expectedTextBody("csv", count, '|'), runEsqlAsTextWithFormat(builder, "csv", '|'));
     }
 
     public void testTSVMode() throws IOException {
         int count = randomIntBetween(0, 100);
         bulkLoadTestData(count);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
         assertEquals(expectedTextBody("tsv", count, null), runEsqlAsTextWithFormat(builder, "tsv", null));
     }
 
     public void testCSVNoHeaderMode() throws IOException {
         bulkLoadTestData(1);
-        var builder = builder().query(fromIndex() + " | keep keyword, integer").build();
+        var builder = builder().query(fromIndex() + " | keep keyword, integer | sort integer").build();
         Request request = prepareRequest();
         String mediaType = attachBody(builder, request);
         RequestOptions.Builder options = request.getOptions().toBuilder();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -33,7 +33,7 @@ public final class QueryPragmas implements Writeable {
     public static final Setting<DataPartitioning> DATA_PARTITIONING = Setting.enumSetting(
         DataPartitioning.class,
         "data_partitioning",
-        DataPartitioning.SEGMENT
+        DataPartitioning.DOC
     );
 
     /**


### PR DESCRIPTION
The DOC data partitioning typically outperforms SEGMENT data partitioning. Since we've capped the number of concurrent operators to the number of threads in the ESQL worker as a safeguard, we should consider changing the default data partitioning from SEGMENT to DOC.

Relates #99189