### PR TITLE
APM module-info

### DIFF
--- a/modules/apm/src/main/java/module-info.java
+++ b/modules/apm/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module org.elasticsearch.tracing.apm {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.xcontent;
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.core;
+    requires io.opentelemetry.context;
+
+    exports org.elasticsearch.tracing.apm;
+}


### PR DESCRIPTION
Add module-info.java for APM.  This allows it to be excluded in other builds.