### PR TITLE
Fix assertions in GeoIpDownloaderIT.testGeoIpDatabasesDownloadNoGeoipProcessors() (#98413)

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -272,13 +272,11 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
         assertBusy(() -> {
             PersistentTasksCustomMetadata.PersistentTask<PersistentTaskParams> task = getTask();
             assertNotNull(task);
-            assertNull(task.getState());
-            putGeoIpPipeline(); // This is to work around the race condition described in #92888
+            assertNotNull(task.getState());
+            putGeoIpPipeline(pipelineId); // This is to work around the race condition described in #92888
         });
         putNonGeoipPipeline(pipelineId);
-        assertBusy(() -> { assertNull(getTask().getState()); });
-        putNonGeoipPipeline(pipelineId);
-        assertNull(getTask().getState());
+        assertNotNull(getTask().getState()); // removing all geoip processors should not result in the task being stopped
         putGeoIpPipeline();
         assertBusy(() -> {
             GeoIpTaskState state = getGeoIpTaskState();


### PR DESCRIPTION
GeoIpDownloaderIT.testGeoIpDatabasesDownloadNoGeoipProcessors() is incorrectly asserting that we stop the geoip downloader if all pipelines with geoip processors are removed. That is not the case -- once the downloader has been started we leave it up.
Closes https://github.com/elastic/elasticsearch/issues/97793
Closes https://github.com/elastic/elasticsearch/issues/99424