### PR TITLE
Tracer requires io.opentelemetry.api in module-info

### DIFF
--- a/modules/apm/src/main/java/module-info.java
+++ b/modules/apm/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module org.elasticsearch.tracing.apm {
     requires org.apache.logging.log4j;
     requires org.apache.lucene.core;
     requires io.opentelemetry.context;
+    requires io.opentelemetry.api;
 
     exports org.elasticsearch.tracing.apm;
 }


### PR DESCRIPTION
Missed dependency on io.opentelemetry.api