### PR TITLE
[buildkite] Re-enable platform-support periodic pipelines

### DIFF
--- a/.buildkite/scripts/periodic.trigger.sh
+++ b/.buildkite/scripts/periodic.trigger.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-exit 0
-
 echo "steps:"
 
 source .buildkite/scripts/branches.sh
@@ -14,18 +12,6 @@ for BRANCH in "${BRANCHES[@]}"; do
   LAST_GOOD_COMMIT=$(echo "${BUILD_JSON}" | jq -r '.commit')
 
   cat <<EOF
-  - trigger: elasticsearch-periodic
-    label: Trigger periodic pipeline for $BRANCH
-    async: true
-    build:
-      branch: "$BRANCH"
-      commit: "$LAST_GOOD_COMMIT"
-  - trigger: elasticsearch-periodic-packaging
-    label: Trigger periodic-packaging pipeline for $BRANCH
-    async: true
-    build:
-      branch: "$BRANCH"
-      commit: "$LAST_GOOD_COMMIT"
   - trigger: elasticsearch-periodic-platform-support
     label: Trigger periodic-platform-support pipeline for $BRANCH
     async: true
@@ -33,4 +19,26 @@ for BRANCH in "${BRANCHES[@]}"; do
       branch: "$BRANCH"
       commit: "$LAST_GOOD_COMMIT"
 EOF
+
+### Only platform-support enabled for right now
+#   cat <<EOF
+#   - trigger: elasticsearch-periodic
+#     label: Trigger periodic pipeline for $BRANCH
+#     async: true
+#     build:
+#       branch: "$BRANCH"
+#       commit: "$LAST_GOOD_COMMIT"
+#   - trigger: elasticsearch-periodic-packaging
+#     label: Trigger periodic-packaging pipeline for $BRANCH
+#     async: true
+#     build:
+#       branch: "$BRANCH"
+#       commit: "$LAST_GOOD_COMMIT"
+#   - trigger: elasticsearch-periodic-platform-support
+#     label: Trigger periodic-platform-support pipeline for $BRANCH
+#     async: true
+#     build:
+#       branch: "$BRANCH"
+#       commit: "$LAST_GOOD_COMMIT"
+# EOF
 done

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -98,45 +98,6 @@ spec:
         build_pull_requests: false
         publish_commit_status: false
         trigger_mode: none
-# ---
-# # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
-# apiVersion: backstage.io/v1alpha1
-# kind: Resource
-# metadata:
-#   name: buildkite-pipeline-elasticsearch-periodic-trigger
-#   description: Triggers periodic pipelines for all required branches
-#   links:
-#     - title: Pipeline
-#       url: https://buildkite.com/elastic/elasticsearch-periodic-trigger
-# spec:
-#   type: buildkite-pipeline
-#   system: buildkite
-#   owner: group:elasticsearch-team
-#   implementation:
-#     apiVersion: buildkite.elastic.dev/v1
-#     kind: Pipeline
-#     metadata:
-#       description: ":elasticsearch: Triggers periodic pipelines for all required branches"
-#       name: elasticsearch / periodic / trigger
-#     spec:
-#       repository: elastic/elasticsearch
-#       pipeline_file: .buildkite/scripts/periodic.trigger.sh
-#       branch_configuration: main
-#       teams:
-#         elasticsearch-team: {}
-#         ml-core: {}
-#         everyone:
-#           access_level: BUILD_AND_READ
-#       provider_settings:
-#         build_branches: false
-#         build_pull_requests: false
-#         publish_commit_status: false
-#         trigger_mode: none
-#       schedules:
-#         Periodically on main:
-#           branch: main
-#           cronline: "0 0,8,16 * * * America/New_York"
-#           message: "Triggers pipelines 3x daily"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
The quota issue has been resolved, so we can enable periodic pipelines again. We are only enabling platform-support while we do some stability testing.

The actual Buildkite pipeline definition has been moved to terraform.