### PR TITLE
Expose private APM info to subclasses, constructor takes enabled boolean

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APM.java
@@ -33,6 +33,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.tracing.apm.APMAgentSettings.APM_ENABLED_SETTING;
+
 /**
  * This module integrates Elastic's APM product with Elasticsearch. Elasticsearch has
  * a {@link org.elasticsearch.tracing.Tracer} interface, which this module implements via
@@ -54,7 +56,7 @@ import java.util.function.Supplier;
  * and applies the new settings values, provided those settings can be dynamically updated.
  */
 public class APM extends Plugin implements NetworkPlugin, TracerPlugin {
-    private final SetOnce<APMTracer> tracer = new SetOnce<>();
+    protected final SetOnce<APMTracer> tracer = new SetOnce<>();
     private final Settings settings;
 
     public APM(Settings settings) {
@@ -63,7 +65,7 @@ public class APM extends Plugin implements NetworkPlugin, TracerPlugin {
 
     @Override
     public Tracer getTracer(Settings settings) {
-        final APMTracer apmTracer = new APMTracer(settings);
+        final APMTracer apmTracer = new APMTracer(settings, APM_ENABLED_SETTING.get(settings));
         tracer.set(apmTracer);
         return apmTracer;
     }

--- a/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMAgentSettings.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.common.settings.Setting.Property.OperatorDynamic
  * This class is responsible for APM settings, both for Elasticsearch and the APM Java agent.
  * The methods could all be static, however they are not in order to make unit testing easier.
  */
-class APMAgentSettings {
+public class APMAgentSettings {
 
     private static final Logger LOGGER = LogManager.getLogger(APMAgentSettings.class);
 
@@ -154,7 +154,7 @@ class APMAgentSettings {
         NodeScope
     );
 
-    static final Setting<Boolean> APM_ENABLED_SETTING = Setting.boolSetting(
+    public static final Setting<Boolean> APM_ENABLED_SETTING = Setting.boolSetting(
         APM_SETTING_PREFIX + "enabled",
         false,
         OperatorDynamic,

--- a/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMTracer.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.tracing.apm.APMAgentSettings.APM_ENABLED_SETTING;
 import static org.elasticsearch.tracing.apm.APMAgentSettings.APM_TRACING_NAMES_EXCLUDE_SETTING;
 import static org.elasticsearch.tracing.apm.APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING;
 import static org.elasticsearch.tracing.apm.APMAgentSettings.APM_TRACING_SANITIZE_FIELD_NAMES;
@@ -88,17 +87,17 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
      */
     record APMServices(Tracer tracer, OpenTelemetry openTelemetry) {}
 
-    public APMTracer(Settings settings) {
+    public APMTracer(Settings settings, boolean enabled) {
         this.includeNames = APM_TRACING_NAMES_INCLUDE_SETTING.get(settings);
         this.excludeNames = APM_TRACING_NAMES_EXCLUDE_SETTING.get(settings);
         this.labelFilters = APM_TRACING_SANITIZE_FIELD_NAMES.get(settings);
 
         this.filterAutomaton = buildAutomaton(includeNames, excludeNames);
         this.labelFilterAutomaton = buildAutomaton(labelFilters, List.of());
-        this.enabled = APM_ENABLED_SETTING.get(settings);
+        this.enabled = enabled;
     }
 
-    void setEnabled(boolean enabled) {
+    public void setEnabled(boolean enabled) {
         this.enabled = enabled;
         if (enabled) {
             this.services = createApmServices();

--- a/modules/apm/src/test/java/org/elasticsearch/tracing/apm/APMTracerTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/tracing/apm/APMTracerTests.java
@@ -256,7 +256,7 @@ public class APMTracerTests extends ESTestCase {
         Map<String, Instant> spanStartTimeMap;
 
         SpyAPMTracer(Settings settings) {
-            super(settings);
+            super(settings, APM_ENABLED_SETTING.get(settings));
             this.spanStartTimeMap = new HashMap<>();
         }
 


### PR DESCRIPTION
Expose some information necessary for subclasses to override `enabled`.
