### PR TITLE
Default implementation for deprecated method in PersistedClusterStateServiceFactory

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/ClusterCoordinationPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ClusterCoordinationPlugin.java
@@ -79,22 +79,22 @@ public interface ClusterCoordinationPlugin {
     interface PersistedClusterStateServiceFactory {
 
         @Deprecated(forRemoval = true)
-        PersistedClusterStateService newPersistedClusterStateService(
+        default PersistedClusterStateService newPersistedClusterStateService(
             NodeEnvironment nodeEnvironment,
             NamedXContentRegistry xContentRegistry,
             ClusterSettings clusterSettings,
             ThreadPool threadPool
-        );
+        ) {
+            throw new AssertionError("Should not be called!");
+        }
 
-        default PersistedClusterStateService newPersistedClusterStateService(
+        PersistedClusterStateService newPersistedClusterStateService(
             NodeEnvironment nodeEnvironment,
             NamedXContentRegistry xContentRegistry,
             ClusterSettings clusterSettings,
             ThreadPool threadPool,
             CompatibilityVersions compatibilityVersions
-        ) {
-            return newPersistedClusterStateService(nodeEnvironment, xContentRegistry, clusterSettings, threadPool);
-        }
+        );
     }
 
     interface ReconfiguratorFactory {

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -16,14 +16,12 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkModule;
-import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.core.RestApiVersion;
@@ -635,33 +633,19 @@ public class NodeTests extends ESTestCase {
 
         @Override
         public Optional<PersistedClusterStateServiceFactory> getPersistedClusterStateServiceFactory() {
-            return Optional.of(new PersistedClusterStateServiceFactory() {
-                @Override
-                public PersistedClusterStateService newPersistedClusterStateService(
-                    NodeEnvironment nodeEnvironment,
-                    NamedXContentRegistry xContentRegistry,
-                    ClusterSettings clusterSettings,
-                    ThreadPool threadPool
-                ) {
-                    throw new AssertionError("not called");
-                }
-
-                @Override
-                public PersistedClusterStateService newPersistedClusterStateService(
-                    NodeEnvironment nodeEnvironment,
-                    NamedXContentRegistry namedXContentRegistry,
-                    ClusterSettings clusterSettings,
-                    ThreadPool threadPool,
-                    CompatibilityVersions compatibilityVersions
-                ) {
-                    return persistedClusterStateService = new PersistedClusterStateService(
+            return Optional.of(
+                (
+                    nodeEnvironment,
+                    namedXContentRegistry,
+                    clusterSettings,
+                    threadPool,
+                    compatibilityVersions) -> persistedClusterStateService = new PersistedClusterStateService(
                         nodeEnvironment,
                         namedXContentRegistry,
                         clusterSettings,
                         threadPool::relativeTimeInMillis
-                    );
-                }
-            });
+                    )
+            );
         }
     }
 


### PR DESCRIPTION
This is a followup to #99396.

Downstream projects have switched to using the new method, but still override the deprecated method. Here, we give the deprecated method a default implementation so we can remove it, and remove the default implementation from the new method.

Once this is merged, downstream projects will be able to remove their implementations of the deprecated method.