### PR TITLE
Add utility for loading SPI extensions

### DIFF
--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -14,10 +14,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.internal.BuildExtension;
+import org.elasticsearch.plugins.ExtensionLoader;
 
 import java.io.IOException;
 import java.net.URL;
 import java.security.CodeSource;
+import java.util.ServiceLoader;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
@@ -41,12 +43,8 @@ public record Build(
 
         // finds the pluggable current build, or uses the local build as a fallback
         private static Build findCurrent() {
-            var buildExtension = BuildExtension.load();
-            if (buildExtension == null) {
-                return findLocalBuild();
-            }
-            var build = buildExtension.getCurrentBuild();
-            return build;
+            var buildExtension = ExtensionLoader.loadSingleton(ServiceLoader.load(BuildExtension.class), () -> Build::findLocalBuild);
+            return buildExtension.getCurrentBuild();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -12,8 +12,10 @@ import org.elasticsearch.common.VersionId;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.internal.VersionExtension;
+import org.elasticsearch.plugins.ExtensionLoader;
 
 import java.io.IOException;
+import java.util.ServiceLoader;
 
 /**
  * Represents the version of the wire protocol used to communicate between a pair of ES nodes.
@@ -109,7 +111,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent() {
-            var versionExtension = VersionExtension.load();
+            var versionExtension = ExtensionLoader.loadSingleton(ServiceLoader.load(VersionExtension.class), () -> null);
             if (versionExtension == null) {
                 return TransportVersions.LATEST_DEFINED;
             }

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.internal.VersionExtension;
+import org.elasticsearch.plugins.ExtensionLoader;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -154,7 +156,7 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
 
         // finds the pluggable current version, or uses the given fallback
         private static IndexVersion findCurrent(IndexVersion fallback) {
-            var versionExtension = VersionExtension.load();
+            var versionExtension = ExtensionLoader.loadSingleton(ServiceLoader.load(VersionExtension.class), () -> null);
             if (versionExtension == null) {
                 return fallback;
             }

--- a/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
@@ -21,18 +21,4 @@ public interface BuildExtension {
      * Returns the {@link Build} that represents the running Elasticsearch code.
      */
     Build getCurrentBuild();
-
-    /**
-     * Loads a single BuildExtension, or returns {@code null} if none are found.
-     */
-    static BuildExtension load() {
-        var loader = ServiceLoader.load(BuildExtension.class);
-        var extensions = loader.stream().toList();
-        if (extensions.size() > 1) {
-            throw new IllegalStateException("More than one build extension found");
-        } else if (extensions.size() == 0) {
-            return null;
-        }
-        return extensions.get(0).get();
-    }
 }

--- a/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
@@ -10,8 +10,6 @@ package org.elasticsearch.internal;
 
 import org.elasticsearch.Build;
 
-import java.util.ServiceLoader;
-
 /**
  * Allows plugging in current build info.
  */

--- a/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
@@ -30,18 +30,4 @@ public interface VersionExtension {
      * This must be at least equal to the latest version found in {@link IndexVersion} V_* constants.
      */
     IndexVersion getCurrentIndexVersion();
-
-    /**
-     * Loads a single VersionExtension, or returns {@code null} if none are found.
-     */
-    static VersionExtension load() {
-        var loader = ServiceLoader.load(VersionExtension.class);
-        var extensions = loader.stream().toList();
-        if (extensions.size() > 1) {
-            throw new IllegalStateException("More than one version extension found");
-        } else if (extensions.size() == 0) {
-            return null;
-        }
-        return extensions.get(0).get();
-    }
 }

--- a/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
@@ -11,8 +11,6 @@ package org.elasticsearch.internal;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.index.IndexVersion;
 
-import java.util.ServiceLoader;
-
 /**
  * Allows plugging in current version elements.
  */

--- a/server/src/main/java/org/elasticsearch/plugins/ExtensionLoader.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ExtensionLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+/**
+ * A utility for loading SPI extensions.
+ */
+public class ExtensionLoader {
+
+    /**
+     * Loads a single SPI extension.
+     *
+     * There should be no more than one extension found. If no service providers
+     * are found, the supplied fallback is used.
+     *
+     * Note: A ServiceLoader is needed rather than the service class because ServiceLoaders
+     * must be loaded by a module with the {@code uses} declaration. Since this
+     * utility class is in server, it will not have uses (or even know about) all the
+     * service classes it may load. Thus, the caller must load the ServiceLoader.
+     *
+     * @param loader a service loader instance to find the singleton extension in
+     * @param fallback a supplier for an instance if no extensions are found
+     * @return an instance of the extension
+     * @param <T> the SPI extension type
+     */
+    public static <T> T loadSingleton(ServiceLoader<T> loader, Supplier<T> fallback) {
+        var extensions = loader.stream().toList();
+        if (extensions.size() > 1) {
+            // It would be really nice to give the actual extension class here directly, but that would require passing it
+            // in effectively twice in the call site, once to ServiceLoader, and then to this method directly as well.
+            // It's annoying that ServiceLoader hangs onto the service class, but does not expose it. It does at least
+            // print the service class from its toString, which is better tha nothing
+            throw new IllegalStateException("More than one extension found for %s".formatted(loader));
+        } else if (extensions.size() == 0) {
+            return fallback.get();
+        }
+        return extensions.get(0).get();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/plugins/ExtensionLoader.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ExtensionLoader.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.plugins;
 
+import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
@@ -39,8 +40,8 @@ public class ExtensionLoader {
             // in effectively twice in the call site, once to ServiceLoader, and then to this method directly as well.
             // It's annoying that ServiceLoader hangs onto the service class, but does not expose it. It does at least
             // print the service class from its toString, which is better tha nothing
-            throw new IllegalStateException("More than one extension found for %s".formatted(loader));
-        } else if (extensions.size() == 0) {
+            throw new IllegalStateException(String.format(Locale.ROOT, "More than one extension found for %s", loader));
+        } else if (extensions.isEmpty()) {
             return fallback.get();
         }
         return extensions.get(0).get();

--- a/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.plugins;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.PrivilegedOperations;
 import org.elasticsearch.test.PrivilegedOperations.ClosableURLClassLoader;
 import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
 import org.elasticsearch.test.jar.JarUtils;
@@ -42,8 +41,10 @@ public class ExtensionLoaderTests extends ESTestCase {
             jarEntries.put(filename, classToBytes.get(classname));
         }
         String serviceFile = String.join("\n", sources.keySet());
-        jarEntries.put("META-INF/services/org.elasticsearch.plugins.ExtensionLoaderTests$TestService",
-            serviceFile.getBytes(StandardCharsets.UTF_8));
+        jarEntries.put(
+            "META-INF/services/org.elasticsearch.plugins.ExtensionLoaderTests$TestService",
+            serviceFile.getBytes(StandardCharsets.UTF_8)
+        );
 
         Path topLevelDir = createTempDir(getTestName());
         Path jar = topLevelDir.resolve("provider.jar");
@@ -77,9 +78,9 @@ public class ExtensionLoaderTests extends ESTestCase {
         assertThat(service.getValue(), equalTo(2));
     }
 
-    public void testOneProvider() throws Exception  {
+    public void testOneProvider() throws Exception {
         Map<String, CharSequence> sources = Map.of("p.FooService", defineProvider("FooService", 1));
-        try (var loader = buildProviderJar(sources)){
+        try (var loader = buildProviderJar(sources)) {
             TestService service = ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class, loader.classloader()), () -> null);
             assertThat(service, not(nullValue()));
             assertThat(service.getValue(), equalTo(1));
@@ -88,11 +89,16 @@ public class ExtensionLoaderTests extends ESTestCase {
 
     public void testManyProviders() throws Exception {
         Map<String, CharSequence> sources = Map.of(
-            "p.FooService", defineProvider("FooService", 1),
-            "p.BarService", defineProvider("BarService", 2));
-        try (var loader = buildProviderJar(sources)){
-            var e = expectThrows(IllegalStateException.class, () ->
-                ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class, loader.classloader()), () -> null));
+            "p.FooService",
+            defineProvider("FooService", 1),
+            "p.BarService",
+            defineProvider("BarService", 2)
+        );
+        try (var loader = buildProviderJar(sources)) {
+            var e = expectThrows(
+                IllegalStateException.class,
+                () -> ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class, loader.classloader()), () -> null)
+            );
             assertThat(e.getMessage(), containsString("More than one extension found"));
             assertThat(e.getMessage(), containsString("TestService"));
         }

--- a/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.PrivilegedOperations;
+import org.elasticsearch.test.PrivilegedOperations.ClosableURLClassLoader;
+import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
+import org.elasticsearch.test.jar.JarUtils;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ExtensionLoaderTests extends ESTestCase {
+    public interface TestService {
+        int getValue();
+    }
+
+    private ClosableURLClassLoader buildProviderJar(Map<String, CharSequence> sources) throws Exception {
+        var classToBytes = InMemoryJavaCompiler.compile(sources);
+
+        Map<String, byte[]> jarEntries = new HashMap<>();
+        for (var entry : sources.entrySet()) {
+            var classname = entry.getKey();
+            var filename = classname.replace(".", "/") + ".class";
+            jarEntries.put(filename, classToBytes.get(classname));
+        }
+        String serviceFile = String.join("\n", sources.keySet());
+        jarEntries.put("META-INF/services/org.elasticsearch.plugins.ExtensionLoaderTests$TestService",
+            serviceFile.getBytes(StandardCharsets.UTF_8));
+
+        Path topLevelDir = createTempDir(getTestName());
+        Path jar = topLevelDir.resolve("provider.jar");
+        JarUtils.createJarWithEntries(jar, jarEntries);
+        URL[] urls = new URL[] { jar.toUri().toURL() };
+
+        return new ClosableURLClassLoader(URLClassLoader.newInstance(urls, this.getClass().getClassLoader()));
+    }
+
+    private String defineProvider(String name, int value) {
+        return String.format("""
+            package p;
+            import org.elasticsearch.plugins.ExtensionLoaderTests.TestService;
+            public class %s implements TestService {
+                @Override
+                public int getValue() {
+                    return %d;
+                }
+            }
+            """, name, value);
+    }
+
+    public void testNoProviderNullFallback() {
+        TestService service = ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class), () -> null);
+        assertThat(service, nullValue());
+    }
+
+    public void testNoProvider() {
+        TestService service = ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class), () -> () -> 2);
+        assertThat(service, not(nullValue()));
+        assertThat(service.getValue(), equalTo(2));
+    }
+
+    public void testOneProvider() throws Exception  {
+        Map<String, CharSequence> sources = Map.of("p.FooService", defineProvider("FooService", 1));
+        try (var loader = buildProviderJar(sources)){
+            TestService service = ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class, loader.classloader()), () -> null);
+            assertThat(service, not(nullValue()));
+            assertThat(service.getValue(), equalTo(1));
+        }
+    }
+
+    public void testManyProviders() throws Exception {
+        Map<String, CharSequence> sources = Map.of(
+            "p.FooService", defineProvider("FooService", 1),
+            "p.BarService", defineProvider("BarService", 2));
+        try (var loader = buildProviderJar(sources)){
+            var e = expectThrows(IllegalStateException.class, () ->
+                ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class, loader.classloader()), () -> null));
+            assertThat(e.getMessage(), containsString("More than one extension found"));
+            assertThat(e.getMessage(), containsString("TestService"));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
@@ -18,6 +18,7 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -55,7 +56,7 @@ public class ExtensionLoaderTests extends ESTestCase {
     }
 
     private String defineProvider(String name, int value) {
-        return String.format("""
+        return String.format(Locale.ROOT, """
             package p;
             import org.elasticsearch.plugins.ExtensionLoaderTests.TestService;
             public class %s implements TestService {

--- a/test/framework/src/main/java/org/elasticsearch/test/PrivilegedOperations.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/PrivilegedOperations.java
@@ -53,6 +53,13 @@ public final class PrivilegedOperations {
         }
     }
 
+    public record ClosableURLClassLoader(URLClassLoader classloader) implements AutoCloseable {
+        @Override
+        public void close() throws Exception {
+            closeURLClassLoader(classloader);
+        }
+    }
+
     public static Boolean compilationTaskCall(JavaCompiler.CompilationTask compilationTask) {
         return AccessController.doPrivileged(
             (PrivilegedAction<Boolean>) () -> compilationTask.call(),


### PR DESCRIPTION
A recurring pattern in extension classes is to include a static load method. Extensions are mostly meant as a way for serverless to extend functionality, and no other extensions are acceptable, so there is either one or zero extensions found. This commit adds a utility class for loading SPI extensions, which expects the singleton pattern. BuildExtension and VersionExtension uses are changed to using the new helper class.