### PR TITLE
Fix QuantileStates for non-existent group

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
@@ -57,7 +57,7 @@ class MedianAbsoluteDeviationDoubleAggregator {
         QuantileStates.GroupingState state,
         int statePosition
     ) {
-        current.add(currentGroupId, state.get(statePosition));
+        current.add(currentGroupId, state.getOrNull(statePosition));
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
@@ -57,7 +57,7 @@ class MedianAbsoluteDeviationIntAggregator {
         QuantileStates.GroupingState state,
         int statePosition
     ) {
-        current.add(currentGroupId, state.get(statePosition));
+        current.add(currentGroupId, state.getOrNull(statePosition));
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
@@ -57,7 +57,7 @@ class MedianAbsoluteDeviationLongAggregator {
         QuantileStates.GroupingState state,
         int statePosition
     ) {
-        current.add(currentGroupId, state.get(statePosition));
+        current.add(currentGroupId, state.getOrNull(statePosition));
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
@@ -57,7 +57,7 @@ class PercentileDoubleAggregator {
         QuantileStates.GroupingState state,
         int statePosition
     ) {
-        current.add(currentGroupId, state.get(statePosition));
+        current.add(currentGroupId, state.getOrNull(statePosition));
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
@@ -57,7 +57,7 @@ class PercentileIntAggregator {
         QuantileStates.GroupingState state,
         int statePosition
     ) {
-        current.add(currentGroupId, state.get(statePosition));
+        current.add(currentGroupId, state.getOrNull(statePosition));
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
@@ -57,7 +57,7 @@ class PercentileLongAggregator {
         QuantileStates.GroupingState state,
         int statePosition
     ) {
-        current.add(currentGroupId, state.get(statePosition));
+        current.add(currentGroupId, state.getOrNull(statePosition));
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selectedGroups) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
@@ -148,8 +148,12 @@ public final class QuantileStates {
             getOrAddGroup(groupId).add(deserializeDigest(other));
         }
 
-        TDigestState get(int position) {
-            return digests.get(position);
+        TDigestState getOrNull(int position) {
+            if (position < digests.size()) {
+                return digests.get(position);
+            } else {
+                return null;
+            }
         }
 
         /** Extracts an intermediate view of the contents of this state.  */
@@ -161,7 +165,7 @@ public final class QuantileStates {
                 int group = selected.getInt(i);
                 TDigestState state;
                 if (group < digests.size()) {
-                    state = get(group);
+                    state = getOrNull(group);
                     if (state == null) {
                         state = TDigestState.create(DEFAULT_COMPRESSION);
                     }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1062,9 +1062,13 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             Map<String, Object> source = new HashMap<>();
             source.put("kw", "key-" + randomIntBetween(1, 20));
-            int values = between(0, 2);
-            for (int v = 0; v < values; v++) {
-                source.put("v", randomIntBetween(1, 1000));
+            List<Integer> values = new ArrayList<>();
+            int numValues = between(0, 2);
+            for (int v = 0; v < numValues; v++) {
+                values.add(randomIntBetween(1, 1000));
+            }
+            if (values.isEmpty() == false) {
+                source.put("v", values);
             }
             client().prepareIndex(indexName).setSource(source).get();
             if (randomInt(100) < 20) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.concurrent.CountDownLatch;
@@ -1052,6 +1053,30 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         assertNoNestedDocuments("from " + alias, docsCount * 2, 0L, 100L);
         // simple query against alias with filter that gets pushed to ES
         assertNoNestedDocuments("from " + alias + " | where data >= 50", Arrays.stream(countValuesGreaterThanFifty).sum(), 50L, 100L);
+    }
+
+    public void testGroupingMultiValueByOrdinals() {
+        String indexName = "test-ordinals";
+        assertAcked(client().admin().indices().prepareCreate(indexName).setMapping("kw", "type=keyword", "v", "type=long").get());
+        int numDocs = randomIntBetween(10, 200);
+        for (int i = 0; i < numDocs; i++) {
+            Map<String, Object> source = new HashMap<>();
+            source.put("kw", "key-" + randomIntBetween(1, 20));
+            int values = between(0, 2);
+            for (int v = 0; v < values; v++) {
+                source.put("v", randomIntBetween(1, 1000));
+            }
+            client().prepareIndex(indexName).setSource(source).get();
+            if (randomInt(100) < 20) {
+                client().admin().indices().prepareRefresh(indexName).get();
+            }
+        }
+        client().admin().indices().prepareRefresh(indexName).get();
+        var functions = List.of("min(v)", "max(v)", "count_distinct(v)", "count(v)", "sum(v)", "avg(v)", "percentile(v, 90)");
+        for (String fn : functions) {
+            String query = String.format(Locale.ROOT, "from %s | stats s = %s by kw", indexName, fn);
+            run(query);
+        }
     }
 
     private void createNestedMappingIndex(String indexName) throws IOException {


### PR DESCRIPTION
OrdinalsGroupingOperator can retrieve the state of a group that doesn't exist in the grouping state. The grouping state needs to return null in this case. However, QuantileStates doesn't follow this.