### PR TITLE
Drop unnecessary exception mangling

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
@@ -381,4 +381,17 @@ public class SubscribableListenerTests extends ESTestCase {
         assertTrue(listener.isDone());
     }
 
+    public void testCreateUtils() throws Exception {
+        final var succeeded = SubscribableListener.newSucceeded("result");
+        assertTrue(succeeded.isDone());
+        assertEquals("result", succeeded.rawResult());
+
+        final var failed = SubscribableListener.newFailed(new ElasticsearchException("simulated"));
+        assertTrue(failed.isDone());
+        assertEquals("simulated", expectThrows(ElasticsearchException.class, failed::rawResult).getMessage());
+
+        final var forkedListenerRef = new AtomicReference<ActionListener<Object>>();
+        final var forked = SubscribableListener.newForked(forkedListenerRef::set);
+        assertSame(forked, forkedListenerRef.get());
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
@@ -393,5 +393,9 @@ public class SubscribableListenerTests extends ESTestCase {
         final var forkedListenerRef = new AtomicReference<ActionListener<Object>>();
         final var forked = SubscribableListener.newForked(forkedListenerRef::set);
         assertSame(forked, forkedListenerRef.get());
+
+        final var forkFailed = SubscribableListener.newForked(l -> { throw new ElasticsearchException("simulated fork failure"); });
+        assertTrue(forkFailed.isDone());
+        assertEquals("simulated fork failure", expectThrows(ElasticsearchException.class, forkFailed::rawResult).getMessage());
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -9,7 +9,7 @@ package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.index.seqno.LocalCheckpointTracker;
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AsyncOperator implements Operator {
 
-    private volatile ListenableActionFuture<Void> blockedFuture;
+    private volatile SubscribableListener<Void> blockedFuture;
 
     private final Map<Long, Page> buffers = ConcurrentCollections.newConcurrentMap();
     private final AtomicReference<Exception> failure = new AtomicReference<>();
@@ -109,7 +109,7 @@ public abstract class AsyncOperator implements Operator {
 
     private void notifyIfBlocked() {
         if (blockedFuture != null) {
-            final ListenableActionFuture<Void> future;
+            final SubscribableListener<Void> future;
             synchronized (this) {
                 future = blockedFuture;
                 this.blockedFuture = null;
@@ -153,7 +153,7 @@ public abstract class AsyncOperator implements Operator {
     }
 
     @Override
-    public ListenableActionFuture<Void> isBlocked() {
+    public SubscribableListener<Void> isBlocked() {
         if (finished) {
             return Operator.NOT_BLOCKED;
         }
@@ -167,7 +167,7 @@ public abstract class AsyncOperator implements Operator {
                 return Operator.NOT_BLOCKED;
             }
             if (blockedFuture == null) {
-                blockedFuture = new ListenableActionFuture<>();
+                blockedFuture = new SubscribableListener<>();
             }
             return blockedFuture;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Page;
@@ -48,7 +48,7 @@ public class Driver implements Releasable, Describable {
     private final Releasable releasable;
 
     private final AtomicReference<String> cancelReason = new AtomicReference<>();
-    private final AtomicReference<ListenableActionFuture<Void>> blocked = new AtomicReference<>();
+    private final AtomicReference<SubscribableListener<Void>> blocked = new AtomicReference<>();
     private final AtomicReference<DriverStatus> status;
 
     /**
@@ -107,12 +107,12 @@ public class Driver implements Releasable, Describable {
      * Returns a blocked future when the chain of operators is blocked, allowing the caller
      * thread to do other work instead of blocking or busy-spinning on the blocked operator.
      */
-    private ListenableActionFuture<Void> run(TimeValue maxTime, int maxIterations) {
+    private SubscribableListener<Void> run(TimeValue maxTime, int maxIterations) {
         long maxTimeNanos = maxTime.nanos();
         long startTime = System.nanoTime();
         int iter = 0;
         while (isFinished() == false) {
-            ListenableActionFuture<Void> fut = runSingleLoopIteration();
+            SubscribableListener<Void> fut = runSingleLoopIteration();
             if (fut.isDone() == false) {
                 return fut;
             }
@@ -146,7 +146,7 @@ public class Driver implements Releasable, Describable {
         drainAndCloseOperators(null);
     }
 
-    private ListenableActionFuture<Void> runSingleLoopIteration() {
+    private SubscribableListener<Void> runSingleLoopIteration() {
         ensureNotCancelled();
         boolean movedPage = false;
 
@@ -207,7 +207,7 @@ public class Driver implements Releasable, Describable {
     public void cancel(String reason) {
         if (cancelReason.compareAndSet(null, reason)) {
             synchronized (this) {
-                ListenableActionFuture<Void> fut = this.blocked.get();
+                SubscribableListener<Void> fut = this.blocked.get();
                 if (fut != null) {
                     fut.onFailure(new TaskCancelledException(reason));
                 }
@@ -256,7 +256,7 @@ public class Driver implements Releasable, Describable {
                     listener.onResponse(null);
                     return;
                 }
-                ListenableActionFuture<Void> fut = driver.run(maxTime, maxIterations);
+                SubscribableListener<Void> fut = driver.run(maxTime, maxIterations);
                 if (fut.isDone()) {
                     schedule(maxTime, maxIterations, executor, driver, listener);
                 } else {
@@ -279,15 +279,15 @@ public class Driver implements Releasable, Describable {
         });
     }
 
-    private static ListenableActionFuture<Void> oneOf(List<ListenableActionFuture<Void>> futures) {
+    private static SubscribableListener<Void> oneOf(List<SubscribableListener<Void>> futures) {
         if (futures.isEmpty()) {
             return Operator.NOT_BLOCKED;
         }
         if (futures.size() == 1) {
             return futures.get(0);
         }
-        ListenableActionFuture<Void> oneOf = new ListenableActionFuture<>();
-        for (ListenableActionFuture<Void> fut : futures) {
+        SubscribableListener<Void> oneOf = new SubscribableListener<>();
+        for (SubscribableListener<Void> fut : futures) {
             fut.addListener(oneOf);
         }
         return oneOf;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.Describable;
@@ -88,17 +88,11 @@ public interface Operator extends Releasable {
      * If the operator is not blocked, this method returns {@link #NOT_BLOCKED} which is an already
      * completed future.
      */
-    default ListenableActionFuture<Void> isBlocked() {
+    default SubscribableListener<Void> isBlocked() {
         return NOT_BLOCKED;
     }
 
-    ListenableActionFuture<Void> NOT_BLOCKED = newCompletedFuture();
-
-    static ListenableActionFuture<Void> newCompletedFuture() {
-        ListenableActionFuture<Void> fut = new ListenableActionFuture<>();
-        fut.onResponse(null);
-        return fut;
-    }
+    SubscribableListener<Void> NOT_BLOCKED = SubscribableListener.newSucceeded(null);
 
     /**
      * A factory for creating intermediate operators.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSink.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSink.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.compute.operator.exchange;
 
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -33,5 +33,5 @@ public interface ExchangeSink {
     /**
      * Whether the sink is blocked on adding more pages
      */
-    ListenableActionFuture<Void> waitForWriting();
+    SubscribableListener<Void> waitForWriting();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.compute.operator.exchange;
 
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -67,7 +67,7 @@ public class ExchangeSinkOperator extends SinkOperator {
     }
 
     @Override
-    public ListenableActionFuture<Void> isBlocked() {
+    public SubscribableListener<Void> isBlocked() {
         return sink.waitForWriting();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSource.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSource.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.compute.operator.exchange;
 
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 
 /**
@@ -38,5 +38,5 @@ public interface ExchangeSource {
     /**
      * Allows callers to stop reading from the source when it's blocked
      */
-    ListenableActionFuture<Void> waitForReading();
+    SubscribableListener<Void> waitForReading();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceHandler.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceHandler.java
@@ -9,7 +9,7 @@ package org.elasticsearch.compute.operator.exchange;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.AbstractRefCounted;
@@ -34,7 +34,7 @@ public final class ExchangeSourceHandler extends AbstractRefCounted {
     private final PendingInstances outstandingSinks = new PendingInstances();
     private final PendingInstances outstandingSources = new PendingInstances();
     private final AtomicReference<Exception> failure = new AtomicReference<>();
-    private final ListenableActionFuture<Void> completionFuture = new ListenableActionFuture<>();
+    private final SubscribableListener<Void> completionFuture = new SubscribableListener<>();
 
     public ExchangeSourceHandler(int maxBufferSize, Executor fetchExecutor) {
         this.buffer = new ExchangeBuffer(maxBufferSize);
@@ -68,7 +68,7 @@ public final class ExchangeSourceHandler extends AbstractRefCounted {
         }
 
         @Override
-        public ListenableActionFuture<Void> waitForReading() {
+        public SubscribableListener<Void> waitForReading() {
             return buffer.waitForReading();
         }
 
@@ -164,7 +164,7 @@ public final class ExchangeSourceHandler extends AbstractRefCounted {
                     if (resp.finished()) {
                         onSinkComplete();
                     } else {
-                        ListenableActionFuture<Void> future = buffer.waitForWriting();
+                        SubscribableListener<Void> future = buffer.waitForWriting();
                         if (future.isDone()) {
                             if (loopControl.tryResume() == false) {
                                 fetchPage();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceOperator.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.compute.operator.exchange;
 
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
 public class ExchangeSourceOperator extends SourceOperator {
 
     private final ExchangeSource source;
-    private ListenableActionFuture<Void> isBlocked = NOT_BLOCKED;
+    private SubscribableListener<Void> isBlocked = NOT_BLOCKED;
     private int pagesEmitted;
 
     public record ExchangeSourceOperatorFactory(Supplier<ExchangeSource> exchangeSources) implements SourceOperatorFactory {
@@ -68,7 +68,7 @@ public class ExchangeSourceOperator extends SourceOperator {
     }
 
     @Override
-    public ListenableActionFuture<Void> isBlocked() {
+    public SubscribableListener<Void> isBlocked() {
         if (isBlocked.isDone()) {
             isBlocked = source.waitForReading();
             if (isBlocked.isDone()) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -10,8 +10,8 @@ package org.elasticsearch.compute.operator;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.Block;
@@ -145,7 +145,7 @@ public class AsyncOperatorTests extends ESTestCase {
         Page page1 = new Page(Block.constantNullBlock(1));
         operator.addInput(page1);
         assertFalse(operator.isBlocked().isDone());
-        ListenableActionFuture<Void> blocked1 = operator.isBlocked();
+        SubscribableListener<Void> blocked1 = operator.isBlocked();
         assertTrue(operator.needsInput());
 
         Page page2 = new Page(Block.constantNullBlock(2));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -10,8 +10,8 @@ package org.elasticsearch.compute.operator.exchange;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -93,7 +93,7 @@ public class ExchangeServiceTests extends ESTestCase {
         assertThat(sourceExchanger.refCount(), equalTo(2));
         sourceExchanger.addRemoteSink(sinkExchanger::fetchPageAsync, 1);
         assertThat(sourceExchanger.refCount(), equalTo(3));
-        ListenableActionFuture<Void> waitForReading = source.waitForReading();
+        SubscribableListener<Void> waitForReading = source.waitForReading();
         assertFalse(waitForReading.isDone());
         assertNull(source.pollPage());
         assertTrue(sink1.waitForWriting().isDone());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -16,9 +16,9 @@ import org.elasticsearch.action.search.SearchShardsRequest;
 import org.elasticsearch.action.search.SearchShardsResponse;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.RefCountingRunnable;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -186,7 +186,7 @@ public class ComputeService {
         Supplier<ActionListener<DataNodeResponse>> listener
     ) {
         // Do not complete the exchange sources until we have linked all remote sinks
-        final ListenableActionFuture<Void> blockingSinkFuture = new ListenableActionFuture<>();
+        final SubscribableListener<Void> blockingSinkFuture = new SubscribableListener<>();
         exchangeSource.addRemoteSink(
             (sourceFinished, l) -> blockingSinkFuture.addListener(l.map(ignored -> new ExchangeResponse(null, true))),
             1


### PR DESCRIPTION
Today the ESQL module uses `ListenableActionFuture` throughout, but this
is just the same as `SubscribableListener` except for the way it mangles
exceptions. The exception-mangling behaviour is unnecessary, so this
commit removes it.