### PR TITLE
ESQL: Swap arguments of remaining date_xxx() functions

### DIFF
--- a/docs/reference/esql/functions/date_format.asciidoc
+++ b/docs/reference/esql/functions/date_format.asciidoc
@@ -7,5 +7,5 @@ is specified, the `yyyy-MM-dd'T'HH:mm:ss.SSSZ` format is used.
 ----
 FROM employees
 | KEEP first_name, last_name, hire_date
-| EVAL hired = DATE_FORMAT(hire_date, "YYYY-MM-dd")
+| EVAL hired = DATE_FORMAT("YYYY-MM-dd", hire_date)
 ----

--- a/docs/reference/esql/functions/types/date_extract.asciidoc
+++ b/docs/reference/esql/functions/types/date_extract.asciidoc
@@ -1,5 +1,5 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 arg1 | arg2 | result
-datetime | keyword | long
+keyword | datetime | long
 |===

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/70_locale.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/70_locale.yml
@@ -26,7 +26,7 @@ setup:
   - do:
       esql.query:
         body:
-          query: 'FROM events | eval fixed_format = date_format(@timestamp, "MMMM"), variable_format = date_format(@timestamp, format) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
+          query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
 
   - match: { columns.0.name: "@timestamp" }
   - match: { columns.0.type: "date" }
@@ -45,7 +45,7 @@ setup:
   - do:
       esql.query:
         body:
-          query: 'FROM events | eval fixed_format = date_format(@timestamp, "MMMM"), variable_format = date_format(@timestamp, format) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
+          query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
           locale: "it-IT"
 
   - match: { columns.0.name: "@timestamp" }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/blog-ignoreCsvTests.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/blog-ignoreCsvTests.csv-spec
@@ -2,7 +2,7 @@
 
   FROM employees
 | WHERE still_hired == true
-| EVAL hired = DATE_FORMAT(hire_date, "YYYY")
+| EVAL hired = DATE_FORMAT("YYYY", hire_date)
 | STATS avg_salary = AVG(salary) BY languages
 | EVAL avg_salary = ROUND(avg_salary)
 | EVAL lang_code = TO_STRING(languages)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -45,7 +45,7 @@ emp_no:integer | x:date
 
 
 evalDateFormat
-from employees | sort hire_date | eval x = date_format(hire_date), y = date_format(hire_date, "YYYY-MM-dd") | keep emp_no, x, y | limit 5;
+from employees | sort hire_date | eval x = date_format(hire_date), y = date_format("YYYY-MM-dd", hire_date) | keep emp_no, x, y | limit 5;
 
 emp_no:integer | x:keyword                     | y:keyword
 10009          | 1985-02-18T00:00:00.000Z      | 1985-02-18            
@@ -295,7 +295,7 @@ hire_date:date           | hd:date
 ;
 
 now
-row a = now() | eval x = a == now(), y = substring(date_format(a, "yyyy"), 0, 2) | keep x, y;
+row a = now() | eval x = a == now(), y = substring(date_format("yyyy", a), 0, 2) | keep x, y;
 
 x:boolean  | y:keyword
 true       | 20
@@ -338,14 +338,14 @@ AVG(salary):double | bucket:date
 ;
 
 evalDateParseWithSimpleDate
-row a = "2023-02-01" | eval b = date_parse(a, "yyyy-MM-dd") | keep b;
+row a = "2023-02-01" | eval b = date_parse("yyyy-MM-dd", a) | keep b;
 
 b:datetime
 2023-02-01T00:00:00.000Z
 ;
 
 evalDateParseWithDateTime
-row a = "2023-02-01 12:15:55" | eval b = date_parse(a, "yyyy-MM-dd HH:mm:ss") | keep b;
+row a = "2023-02-01 12:15:55" | eval b = date_parse("yyyy-MM-dd HH:mm:ss", a) | keep b;
 
 b:datetime
 2023-02-01T12:15:55.000Z
@@ -359,8 +359,8 @@ b:datetime
 ;
 
 evalDateParseWrongDate
-row a = "2023-02-01 foo" | eval b = date_parse(a, "yyyy-MM-dd") | keep b;
-warning:Line 1:37: evaluation of [date_parse(a, \"yyyy-MM-dd\")] failed, treating result as null. Only first 20 failures recorded.
+row a = "2023-02-01 foo" | eval b = date_parse("yyyy-MM-dd", a) | keep b;
+warning:Line 1:37: evaluation of [date_parse(\"yyyy-MM-dd\", a)] failed, treating result as null. Only first 20 failures recorded.
 warning:java.lang.IllegalArgumentException: failed to parse date field [2023-02-01 foo] with format [yyyy-MM-dd]
 
 b:datetime
@@ -368,16 +368,16 @@ null
 ;
 
 evalDateParseNotMatching
-row a = "2023-02-01" | eval b = date_parse(a, "yyyy-MM") | keep b;
-warning:Line 1:33: evaluation of [date_parse(a, \"yyyy-MM\")] failed, treating result as null. Only first 20 failures recorded.
+row a = "2023-02-01" | eval b = date_parse("yyyy-MM", a) | keep b;
+warning:Line 1:33: evaluation of [date_parse(\"yyyy-MM\", a)] failed, treating result as null. Only first 20 failures recorded.
 warning:java.lang.IllegalArgumentException: failed to parse date field [2023-02-01] with format [yyyy-MM]
 b:datetime
 null
 ;
 
 evalDateParseNotMatching2
-row a = "2023-02-01" | eval b = date_parse(a, "yyyy-MM-dd HH:mm:ss") | keep b;
-warning:Line 1:33: evaluation of [date_parse(a, \"yyyy-MM-dd HH:mm:ss\")] failed, treating result as null. Only first 20 failures recorded.
+row a = "2023-02-01" | eval b = date_parse("yyyy-MM-dd HH:mm:ss", a) | keep b;
+warning:Line 1:33: evaluation of [date_parse(\"yyyy-MM-dd HH:mm:ss\", a)] failed, treating result as null. Only first 20 failures recorded.
 warning:java.lang.IllegalArgumentException: failed to parse date field [2023-02-01] with format [yyyy-MM-dd HH:mm:ss]
 
 b:datetime
@@ -385,7 +385,7 @@ null
 ;
 
 evalDateParseNullPattern
-row a = "2023-02-01" | eval b = date_parse(a, null) | keep b;
+row a = "2023-02-01" | eval b = date_parse(null, a) | keep b;
 
 b:datetime
 null
@@ -393,8 +393,8 @@ null
 
 evalDateParseDynamic
 from employees | where emp_no == 10039 or emp_no == 10040 | sort emp_no 
-| eval birth_date_string = date_format(birth_date, "yyyy-MM-dd")
-| eval new_date = date_parse(birth_date_string, "yyyy-MM-dd") | eval bool = new_date == birth_date | keep emp_no, new_date, birth_date, bool;
+| eval birth_date_string = date_format("yyyy-MM-dd", birth_date)
+| eval new_date = date_parse("yyyy-MM-dd", birth_date_string) | eval bool = new_date == birth_date | keep emp_no, new_date, birth_date, bool;
 
 emp_no:integer  | new_date:datetime | birth_date:datetime | bool:boolean
 10039           | 1959-10-01        | 1959-10-01          | true
@@ -403,8 +403,8 @@ emp_no:integer  | new_date:datetime | birth_date:datetime | bool:boolean
 
 evalDateParseDynamic2
 from employees | where emp_no >= 10047 | sort emp_no | where emp_no <= 10051 
-| eval birth_date_string = date_format(birth_date, "yyyy-MM-dd") 
-| eval new_date = date_parse(birth_date_string, "yyyy-MM-dd") 
+| eval birth_date_string = date_format("yyyy-MM-dd", birth_date) 
+| eval new_date = date_parse("yyyy-MM-dd", birth_date_string) 
 | keep emp_no, new_date, birth_date | eval bool = new_date == birth_date;
 
 emp_no:integer | new_date:datetime        | birth_date:datetime       | bool:boolean      
@@ -418,8 +418,8 @@ emp_no:integer | new_date:datetime        | birth_date:datetime       | bool:boo
 
 evalDateParseDynamicDateAndPattern
 from employees | where emp_no == 10049 or emp_no == 10050 | sort emp_no 
-| eval pattern = "yyyy-MM-dd", birth_date_string = date_format(birth_date, pattern)
-| eval new_date = date_parse(birth_date_string, "yyyy-MM-dd") | eval bool = new_date == birth_date | keep emp_no, new_date, birth_date, bool;
+| eval pattern = "yyyy-MM-dd", birth_date_string = date_format(pattern, birth_date)
+| eval new_date = date_parse("yyyy-MM-dd", birth_date_string) | eval bool = new_date == birth_date | keep emp_no, new_date, birth_date, bool;
 
 emp_no:integer  | new_date:datetime | birth_date:datetime | bool:boolean
 10049           | null              | null                | null
@@ -437,7 +437,7 @@ emp_no:integer  | new_date:datetime          | birth_date:datetime       | bool:
 
 dateFields
 from employees | where emp_no == 10049 or emp_no == 10050 
-| eval year = date_extract(birth_date, "year"), month = date_extract(birth_date, "month_of_year"), day = date_extract(birth_date, "day_of_month")
+| eval year = date_extract("year", birth_date), month = date_extract("month_of_year", birth_date), day = date_extract("day_of_month", birth_date)
 | keep emp_no, year, month, day;
 ignoreOrder:true
 
@@ -449,7 +449,7 @@ emp_no:integer | year:long    | month:long    | day:long
 
 dateFormatLocale
 from employees | where emp_no == 10049 or emp_no == 10050 | sort emp_no 
-| eval birth_month = date_format(birth_date, "MMMM") | keep emp_no, birth_date, birth_month;
+| eval birth_month = date_format("MMMM", birth_date) | keep emp_no, birth_date, birth_month;
 ignoreOrder:true
 
 emp_no:integer  |  birth_date:datetime       | birth_month:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -233,7 +233,7 @@ avg_lang:double | max_lang:integer
 docsStatsGroupByMultipleValues
 // tag::statsGroupByMultipleValues[]
 FROM employees
-| EVAL hired = DATE_FORMAT(hire_date, "YYYY")
+| EVAL hired = DATE_FORMAT("YYYY", hire_date)
 | STATS avg_salary = AVG(salary) BY hired, languages.long
 | EVAL avg_salary = ROUND(avg_salary)
 | SORT hired, languages.long
@@ -293,8 +293,8 @@ Uri            |Lenart         |1.75
 
 dateExtract
 // tag::dateExtract[]
-ROW date = DATE_PARSE("2022-05-06", "yyyy-MM-dd")
-| EVAL year = DATE_EXTRACT(date, "year")
+ROW date = DATE_PARSE("yyyy-MM-dd", "2022-05-06")
+| EVAL year = DATE_EXTRACT("year", date)
 // end::dateExtract[]
 ;
 
@@ -404,7 +404,7 @@ Saniya         |Kalloufi       |2.1          |6.9
 dateParse
 // tag::dateParse[]
 ROW date_string = "2022-05-06"
-| EVAL date = DATE_PARSE(date_string, "yyyy-MM-dd")
+| EVAL date = DATE_PARSE("yyyy-MM-dd", date_string)
 // end::dateParse[]
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -322,7 +322,7 @@ c:long | g:keyword | tws:long
 ;
 
 byStringAndString
-from employees | eval hire_year_str = date_format(hire_date, "yyyy") | stats c = count(gender) by gender, hire_year_str | sort c desc, gender, hire_year_str | where c >= 5;
+from employees | eval hire_year_str = date_format("yyyy", hire_date) | stats c = count(gender) by gender, hire_year_str | sort c desc, gender, hire_year_str | where c >= 5;
 
 c:long | gender:keyword | hire_year_str:keyword
 8 | F | 1989

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -68,7 +68,7 @@ c:long
 ;
 
 countDistinctOfKeywords
-from employees | eval hire_year_str = date_format(hire_date, "yyyy") | stats g = count_distinct(gender), h = count_distinct(hire_year_str);
+from employees | eval hire_year_str = date_format("yyyy", hire_date) | stats g = count_distinct(gender), h = count_distinct(hire_year_str);
 
 g:long | h:long
 2      | 14

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionRuntimeFieldIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionRuntimeFieldIT.java
@@ -88,7 +88,7 @@ public class EsqlActionRuntimeFieldIT extends AbstractEsqlIntegTestCase {
     public void testDate() throws InterruptedException, IOException {
         createIndexWithConstRuntimeField("date");
         EsqlQueryResponse response = run("""
-            from test | eval d=date_format(const, "yyyy") | stats min (foo) by d""");
+            from test | eval d=date_format("yyyy", const) | stats min (foo) by d""");
         assertThat(getValuesList(response), equalTo(List.of(List.of(0L, "2023"))));
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/BinaryDateTimeFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/BinaryDateTimeFunction.java
@@ -17,6 +17,9 @@ import org.elasticsearch.xpack.ql.type.DataTypes;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 
 public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
 
@@ -65,5 +68,13 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
         }
         BinaryDateTimeFunction that = (BinaryDateTimeFunction) o;
         return zoneId().equals(that.zoneId());
+    }
+
+    // TODO: drop check once 8.11 is released
+    static TypeResolution argumentTypesAreSwapped(DataType left, DataType right, Predicate<DataType> rightTest, String source) {
+        if (DataTypes.isDateTime(left) && rightTest.test(right)) {
+            return new TypeResolution(format(null, "function definition has been updated, please swap arguments in [{}]", source));
+        }
+        return TypeResolution.TYPE_RESOLVED;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateFormat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateFormat.java
@@ -24,11 +24,11 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 
+import static org.elasticsearch.xpack.esql.expression.function.scalar.date.BinaryDateTimeFunction.argumentTypesAreSwapped;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.isDate;
@@ -40,10 +40,10 @@ public class DateFormat extends ConfigurationFunction implements OptionalArgumen
     private final Expression field;
     private final Expression format;
 
-    public DateFormat(Source source, Expression field, Expression format, Configuration configuration) {
-        super(source, format != null ? Arrays.asList(field, format) : Arrays.asList(field), configuration);
-        this.field = field;
-        this.format = format;
+    public DateFormat(Source source, Expression first, Expression second, Configuration configuration) {
+        super(source, second != null ? List.of(first, second) : List.of(first), configuration);
+        this.field = second != null ? second : first;
+        this.format = second != null ? first : null;
     }
 
     @Override
@@ -57,12 +57,20 @@ public class DateFormat extends ConfigurationFunction implements OptionalArgumen
             return new TypeResolution("Unresolved children");
         }
 
-        TypeResolution resolution = isDate(field, sourceText(), FIRST);
+        TypeResolution resolution;
+        if (format != null) {
+            resolution = argumentTypesAreSwapped(format.dataType(), field.dataType(), DataTypes::isString, sourceText());
+            if (resolution.unresolved()) {
+                return resolution;
+            }
+        }
+
+        resolution = isDate(field, sourceText(), format == null ? FIRST : SECOND);
         if (resolution.unresolved()) {
             return resolution;
         }
         if (format != null) {
-            resolution = isStringAndExact(format, sourceText(), SECOND);
+            resolution = isStringAndExact(format, sourceText(), FIRST);
             if (resolution.unresolved()) {
                 return resolution;
             }
@@ -125,7 +133,9 @@ public class DateFormat extends ConfigurationFunction implements OptionalArgumen
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, DateFormat::new, field, format, configuration());
+        Expression first = format != null ? format : field;
+        Expression second = format != null ? field : null;
+        return NodeInfo.create(this, DateFormat::new, first, second, configuration());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -915,36 +915,36 @@ public class AnalyzerTests extends ESTestCase {
     public void testDateFormatWithNumericFormat() {
         verifyUnsupported("""
             from test
-            | eval date_format(date, 1)
-            """, "second argument of [date_format(date, 1)] must be [string], found value [1] type [integer]");
+            | eval date_format(1, date)
+            """, "first argument of [date_format(1, date)] must be [string], found value [1] type [integer]");
     }
 
     public void testDateFormatWithDateFormat() {
         verifyUnsupported("""
             from test
             | eval date_format(date, date)
-            """, "second argument of [date_format(date, date)] must be [string], found value [date] type [datetime]");
+            """, "first argument of [date_format(date, date)] must be [string], found value [date] type [datetime]");
     }
 
     public void testDateParseOnInt() {
         verifyUnsupported("""
             from test
-            | eval date_parse(int, keyword)
-            """, "first argument of [date_parse(int, keyword)] must be [string], found value [int] type [integer]");
+            | eval date_parse(keyword, int)
+            """, "second argument of [date_parse(keyword, int)] must be [string], found value [int] type [integer]");
     }
 
     public void testDateParseOnDate() {
         verifyUnsupported("""
             from test
-            | eval date_parse(date, keyword)
-            """, "first argument of [date_parse(date, keyword)] must be [string], found value [date] type [datetime]");
+            | eval date_parse(keyword, date)
+            """, "second argument of [date_parse(keyword, date)] must be [string], found value [date] type [datetime]");
     }
 
     public void testDateParseOnIntPattern() {
         verifyUnsupported("""
             from test
-            | eval date_parse(keyword, int)
-            """, "second argument of [date_parse(keyword, int)] must be [string], found value [int] type [integer]");
+            | eval date_parse(int, keyword)
+            """, "first argument of [date_parse(int, keyword)] must be [string], found value [int] type [integer]");
     }
 
     public void testDateTruncOnInt() {
@@ -973,6 +973,20 @@ public class AnalyzerTests extends ESTestCase {
             from test
             | eval date_trunc(1, date)
             """, "second argument of [date_trunc(1, date)] must be [dateperiod or timeduration], found value [1] type [integer]");
+    }
+
+    public void testDateExtractWithSwappedArguments() {
+        verifyUnsupported("""
+            from test
+            | eval date_extract(date, "year")
+            """, "function definition has been updated, please swap arguments in [date_extract(date, \"year\")]");
+    }
+
+    public void testDateFormatWithSwappedArguments() {
+        verifyUnsupported("""
+            from test
+            | eval date_format(date, "yyyy-MM-dd")
+            """, "function definition has been updated, please swap arguments in [date_format(date, \"yyyy-MM-dd\")]");
     }
 
     public void testDateTruncWithSwappedArguments() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
@@ -39,10 +39,10 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
         return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("Date Extract Year", () -> {
             return new TestCaseSupplier.TestCase(
                 List.of(
-                    new TestCaseSupplier.TypedData(1687944333000L, DataTypes.DATETIME, "date"),
-                    new TestCaseSupplier.TypedData(new BytesRef("YEAR"), DataTypes.KEYWORD, "field")
+                    new TestCaseSupplier.TypedData(new BytesRef("YEAR"), DataTypes.KEYWORD, "field"),
+                    new TestCaseSupplier.TypedData(1687944333000L, DataTypes.DATETIME, "date")
                 ),
-                "DateExtractEvaluator[value=Attribute[channel=0], chronoField=Attribute[channel=1], zone=Z]",
+                "DateExtractEvaluator[value=Attribute[channel=1], chronoField=Attribute[channel=0], zone=Z]",
                 DataTypes.LONG,
                 equalTo(2023L)
             );
@@ -55,8 +55,8 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
         for (ChronoField value : ChronoField.values()) {
             DateExtract instance = new DateExtract(
                 Source.EMPTY,
-                new Literal(Source.EMPTY, epochMilli, DataTypes.DATETIME),
                 new Literal(Source.EMPTY, new BytesRef(value.name()), DataTypes.KEYWORD),
+                new Literal(Source.EMPTY, epochMilli, DataTypes.DATETIME),
                 EsqlTestUtils.TEST_CFG
             );
 
@@ -75,7 +75,7 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected List<ArgumentSpec> argSpec() {
-        return List.of(required(DataTypes.DATETIME), required(strings()));
+        return List.of(required(strings()), required(DataTypes.DATETIME));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -33,10 +33,10 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
         return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("Basic Case", () -> {
             return new TestCaseSupplier.TestCase(
                 List.of(
-                    new TestCaseSupplier.TypedData(new BytesRef("2023-05-05"), DataTypes.KEYWORD, "first"),
-                    new TestCaseSupplier.TypedData(new BytesRef("yyyy-MM-dd"), DataTypes.KEYWORD, "second")
+                    new TestCaseSupplier.TypedData(new BytesRef("yyyy-MM-dd"), DataTypes.KEYWORD, "second"),
+                    new TestCaseSupplier.TypedData(new BytesRef("2023-05-05"), DataTypes.KEYWORD, "first")
                 ),
-                "DateParseEvaluator[val=Attribute[channel=0], formatter=Attribute[channel=1], zoneId=Z]",
+                "DateParseEvaluator[val=Attribute[channel=1], formatter=Attribute[channel=0], zoneId=Z]",
                 DataTypes.DATETIME,
                 equalTo(1683244800000L)
             );
@@ -50,7 +50,7 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected List<ArgumentSpec> argSpec() {
-        return List.of(required(strings()), optional(strings()));
+        return List.of(optional(strings()), required(strings()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
@@ -100,8 +100,8 @@ public class EvalMapperTests extends ESTestCase {
             DOUBLE1,
             literal,
             new Length(Source.EMPTY, literal),
-            new DateFormat(Source.EMPTY, DATE, datePattern, TEST_CONFIG),
-            new DateFormat(Source.EMPTY, literal, datePattern, TEST_CONFIG),
+            new DateFormat(Source.EMPTY, datePattern, DATE, TEST_CONFIG),
+            new DateFormat(Source.EMPTY, datePattern, literal, TEST_CONFIG),
             new StartsWith(Source.EMPTY, literal, literal),
             new Substring(Source.EMPTY, literal, LONG, LONG),
             new DateTrunc(Source.EMPTY, dateInterval, DATE) }) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
@@ -236,8 +236,8 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
             from employees
             | where emp_no == 10039 or emp_no == 10040
             | sort emp_no
-            | eval birth_date_string = date_format(birth_date, "yyyy-MM-dd")
-            | eval new_date = date_parse(birth_date_string, "yyyy-MM-dd")
+            | eval birth_date_string = date_format("yyyy-MM-dd", birth_date)
+            | eval new_date = date_parse("yyyy-MM-dd", birth_date_string)
             | eval bool = new_date == birth_date
             | keep emp_no, new_date, birth_date, bool""", Set.of("emp_no", "emp_no.*", "birth_date", "birth_date.*"));
     }
@@ -246,7 +246,7 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
         assertFieldNames("""
             from employees
             | where emp_no == 10049 or emp_no == 10050
-            | eval year = date_extract(birth_date, "year"), month = date_extract(birth_date, "month_of_year")
+            | eval year = date_extract("year", birth_date), month = date_extract("month_of_year", birth_date)
             | keep emp_no, year, month""", Set.of("emp_no", "emp_no.*", "birth_date", "birth_date.*"));
     }
 
@@ -793,7 +793,7 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
     public void testByStringAndString() {
         assertFieldNames("""
             from employees
-            | eval hire_year_str = date_format(hire_date, "yyyy")
+            | eval hire_year_str = date_format("yyyy", hire_date)
             | stats c = count(gender) by gender, hire_year_str
             | sort c desc, gender, hire_year_str
             | where c >= 5""", Set.of("hire_date", "hire_date.*", "gender", "gender.*"));
@@ -822,7 +822,7 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
         assertFieldNames(
             """
                 from employees
-                | eval hire_year_str = date_format(hire_date, "yyyy")
+                | eval hire_year_str = date_format("yyyy", hire_date)
                 | stats g = count_distinct(gender), h = count_distinct(hire_year_str)""",
             Set.of("hire_date", "hire_date.*", "gender", "gender.*")
         );

--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -2907,7 +2907,7 @@ SELECT DATETIME_FORMAT(CAST('11:22:33.987' AS TIME), 'HH mm ss.S') AS "time";
 
 dateFormatDate
 // tag::dateFormatDate
-SELECT DATE_FORMAT('%d/%m/%Y', CAST('2020-04-05' AS DATE)) AS "date";
+SELECT DATE_FORMAT(CAST('2020-04-05' AS DATE), '%d/%m/%Y') AS "date";
 
       date
 ------------------
@@ -2917,7 +2917,7 @@ SELECT DATE_FORMAT('%d/%m/%Y', CAST('2020-04-05' AS DATE)) AS "date";
 
 dateFormatDateTime
 // tag::dateFormatDateTime
-SELECT DATE_FORMAT('%d/%m/%Y %H:%i:%s.%f', CAST('2020-04-05T11:22:33.987654' AS DATETIME)) AS "datetime";
+SELECT DATE_FORMAT(CAST('2020-04-05T11:22:33.987654' AS DATETIME), '%d/%m/%Y %H:%i:%s.%f') AS "datetime";
 
       datetime
 ------------------
@@ -2927,7 +2927,7 @@ SELECT DATE_FORMAT('%d/%m/%Y %H:%i:%s.%f', CAST('2020-04-05T11:22:33.987654' AS 
 
 dateFormatTime
 // tag::dateFormatTime
-SELECT DATE_FORMAT('%H %i %s.%f', CAST('23:22:33.987' AS TIME)) AS "time";
+SELECT DATE_FORMAT(CAST('23:22:33.987' AS TIME), '%H %i %s.%f') AS "time";
 
       time
 ------------------

--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -2907,7 +2907,7 @@ SELECT DATETIME_FORMAT(CAST('11:22:33.987' AS TIME), 'HH mm ss.S') AS "time";
 
 dateFormatDate
 // tag::dateFormatDate
-SELECT DATE_FORMAT(CAST('2020-04-05' AS DATE), '%d/%m/%Y') AS "date";
+SELECT DATE_FORMAT('%d/%m/%Y', CAST('2020-04-05' AS DATE)) AS "date";
 
       date
 ------------------
@@ -2917,7 +2917,7 @@ SELECT DATE_FORMAT(CAST('2020-04-05' AS DATE), '%d/%m/%Y') AS "date";
 
 dateFormatDateTime
 // tag::dateFormatDateTime
-SELECT DATE_FORMAT(CAST('2020-04-05T11:22:33.987654' AS DATETIME), '%d/%m/%Y %H:%i:%s.%f') AS "datetime";
+SELECT DATE_FORMAT('%d/%m/%Y %H:%i:%s.%f', CAST('2020-04-05T11:22:33.987654' AS DATETIME)) AS "datetime";
 
       datetime
 ------------------
@@ -2927,7 +2927,7 @@ SELECT DATE_FORMAT(CAST('2020-04-05T11:22:33.987654' AS DATETIME), '%d/%m/%Y %H:
 
 dateFormatTime
 // tag::dateFormatTime
-SELECT DATE_FORMAT(CAST('23:22:33.987' AS TIME), '%H %i %s.%f') AS "time";
+SELECT DATE_FORMAT('%H %i %s.%f', CAST('23:22:33.987' AS TIME)) AS "time";
 
       time
 ------------------


### PR DESCRIPTION
This swaps the arguments of `date_extract()`, `date_format()` and `date_parse()` functions, to align with `date_trunc()`. The field argument is now always last, even for _format() and _parse(), whose optional argument will now be provided as the first one.
