### PR TITLE
Make tsdb settings public in Serverless

### DIFF
--- a/docs/changelog/99567.yaml
+++ b/docs/changelog/99567.yaml
@@ -1,0 +1,6 @@
+pr: 99567
+summary: Make tsdb settings public in Serverless
+area: TSDB
+type: bug
+issues:
+ - 99563

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
@@ -102,7 +102,8 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin {
         TimeValue.timeValueMinutes(1),
         TimeValue.timeValueDays(7),
         Setting.Property.IndexScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.ServerlessPublic
     );
     public static final String LIFECYCLE_CUSTOM_INDEX_METADATA_KEY = "data_stream_lifecycle";
     public static final Setting<TimeValue> LOOK_BACK_TIME = Setting.timeSetting(
@@ -111,7 +112,8 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin {
         TimeValue.timeValueMinutes(1),
         TimeValue.timeValueDays(7),
         Setting.Property.IndexScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.ServerlessPublic
     );
     // The dependency of index.look_ahead_time is a cluster setting and currently there is no clean validation approach for this:
     private final SetOnce<UpdateTimeSeriesRangeService> updateTimeSeriesRangeService = new SetOnce<>();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -493,7 +493,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<List<String>> INDEX_ROUTING_PATH = Setting.stringListSetting(
         "index.routing_path",
         Setting.Property.IndexScope,
-        Setting.Property.Final
+        Setting.Property.Final,
+        Property.ServerlessPublic
     );
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -590,7 +590,8 @@ public final class IndexSettings {
         Instant.ofEpochMilli(DateUtils.MAX_MILLIS_BEFORE_MINUS_9999),
         v -> {},
         Property.IndexScope,
-        Property.Final
+        Property.Final,
+        Property.ServerlessPublic
     );
 
     /**
@@ -619,7 +620,8 @@ public final class IndexSettings {
             }
         },
         Property.IndexScope,
-        Property.Dynamic
+        Property.Dynamic,
+        Property.ServerlessPublic
     );
 
     public static final Setting<Boolean> TIME_SERIES_ES87TSDB_CODEC_ENABLED_SETTING = Setting.boolSetting(
@@ -658,7 +660,8 @@ public final class IndexSettings {
             }
         },
         Property.IndexScope,
-        Property.Final
+        Property.Final,
+        Property.ServerlessPublic
     );
 
     /**


### PR DESCRIPTION
Creation of time series indices fails in serverless because some tsdb specific settings are not public. This results in errors when creating time series indices whose settings include:
* index.mode
* index.time_series.start_time
* index.time_series.end_time
* index.look_ahead_time
* index.look_back_time
* index.routing_path

Here we make them public so that users can create time series indices.

Resolves #99563 