### PR TITLE
ESQL: Remove default driver context

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
@@ -142,7 +142,7 @@ public class AggregatorBenchmark {
         return new HashAggregationOperator(
             List.of(supplier(op, dataType, groups.size()).groupingAggregatorFactory(AggregatorMode.SINGLE)),
             () -> BlockHash.build(groups, BIG_ARRAYS, 16 * 1024, false),
-            new DriverContext()
+            new DriverContext(BigArrays.NON_RECYCLING_INSTANCE)
         );
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.benchmark.compute.operator;
 
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
@@ -80,14 +81,14 @@ public class EvalBenchmark {
         return switch (operation) {
             case "abs" -> {
                 FieldAttribute longField = longField();
-                yield EvalMapper.toEvaluator(new Abs(Source.EMPTY, longField), layout(longField)).get(new DriverContext());
+                yield EvalMapper.toEvaluator(new Abs(Source.EMPTY, longField), layout(longField)).get(driverContext());
             }
             case "add" -> {
                 FieldAttribute longField = longField();
                 yield EvalMapper.toEvaluator(
                     new Add(Source.EMPTY, longField, new Literal(Source.EMPTY, 1L, DataTypes.LONG)),
                     layout(longField)
-                ).get(new DriverContext());
+                ).get(driverContext());
             }
             case "date_trunc" -> {
                 FieldAttribute timestamp = new FieldAttribute(
@@ -98,28 +99,28 @@ public class EvalBenchmark {
                 yield EvalMapper.toEvaluator(
                     new DateTrunc(Source.EMPTY, new Literal(Source.EMPTY, Duration.ofHours(24), EsqlDataTypes.TIME_DURATION), timestamp),
                     layout(timestamp)
-                ).get(new DriverContext());
+                ).get(driverContext());
             }
             case "equal_to_const" -> {
                 FieldAttribute longField = longField();
                 yield EvalMapper.toEvaluator(
                     new Equals(Source.EMPTY, longField, new Literal(Source.EMPTY, 100_000L, DataTypes.LONG)),
                     layout(longField)
-                ).get(new DriverContext());
+                ).get(driverContext());
             }
             case "long_equal_to_long" -> {
                 FieldAttribute lhs = longField();
                 FieldAttribute rhs = longField();
-                yield EvalMapper.toEvaluator(new Equals(Source.EMPTY, lhs, rhs), layout(lhs, rhs)).get(new DriverContext());
+                yield EvalMapper.toEvaluator(new Equals(Source.EMPTY, lhs, rhs), layout(lhs, rhs)).get(driverContext());
             }
             case "long_equal_to_int" -> {
                 FieldAttribute lhs = longField();
                 FieldAttribute rhs = intField();
-                yield EvalMapper.toEvaluator(new Equals(Source.EMPTY, lhs, rhs), layout(lhs, rhs)).get(new DriverContext());
+                yield EvalMapper.toEvaluator(new Equals(Source.EMPTY, lhs, rhs), layout(lhs, rhs)).get(driverContext());
             }
             case "mv_min", "mv_min_ascending" -> {
                 FieldAttribute longField = longField();
-                yield EvalMapper.toEvaluator(new MvMin(Source.EMPTY, longField), layout(longField)).get(new DriverContext());
+                yield EvalMapper.toEvaluator(new MvMin(Source.EMPTY, longField), layout(longField)).get(driverContext());
             }
             default -> throw new UnsupportedOperationException();
         };
@@ -258,5 +259,9 @@ public class EvalBenchmark {
             // We only check the last one
             checkExpected(operation, output);
         }
+    }
+
+    static DriverContext driverContext() {
+        return new DriverContext(BigArrays.NON_RECYCLING_INSTANCE);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverContext.java
@@ -35,20 +35,12 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class DriverContext {
 
-    /** A default driver context. The returned bigArrays is non recycling. */
-    public static DriverContext DEFAULT = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE);
-
     // Working set. Only the thread executing the driver will update this set.
     Set<Releasable> workingSet = Collections.newSetFromMap(new IdentityHashMap<>());
 
     private final AtomicReference<Snapshot> snapshot = new AtomicReference<>();
 
     private final BigArrays bigArrays;
-
-    // For testing
-    public DriverContext() {
-        this(BigArrays.NON_RECYCLING_INSTANCE);
-    }
 
     public DriverContext(BigArrays bigArrays) {
         Objects.requireNonNull(bigArrays);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/EvalOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/EvalOperator.java
@@ -25,7 +25,7 @@ public class EvalOperator extends AbstractPageMappingOperator {
 
         @Override
         public String describe() {
-            return "EvalOperator[evaluator=" + evaluator.get(DriverContext.DEFAULT) + "]";
+            return "EvalOperator[evaluator=" + evaluator.get(new ThrowingDriverContext()) + "]";
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
@@ -27,7 +27,7 @@ public class FilterOperator extends AbstractPageMappingOperator {
 
         @Override
         public String describe() {
-            return "FilterOperator[evaluator=" + evaluatorSupplier.get(DriverContext.DEFAULT) + "]";
+            return "FilterOperator[evaluator=" + evaluatorSupplier.get(new ThrowingDriverContext()) + "]";
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ThrowingDriverContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ThrowingDriverContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.common.util.FloatArray;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.core.Releasable;
+
+public class ThrowingDriverContext extends DriverContext {
+    public ThrowingDriverContext() {
+        super(new ThrowingBigArrays());
+    }
+
+    @Override
+    public BigArrays bigArrays() {
+        throw new AssertionError("should not reach here");
+    }
+
+    @Override
+    public boolean addReleasable(Releasable releasable) {
+        throw new AssertionError("should not reach here");
+    }
+
+    static class ThrowingBigArrays extends BigArrays {
+
+        ThrowingBigArrays() {
+            super(null, null, "fake");
+        }
+
+        @Override
+        public ByteArray newByteArray(long size, boolean clearOnResize) {
+            throw new AssertionError("should not reach here");
+        }
+
+        @Override
+        public IntArray newIntArray(long size, boolean clearOnResize) {
+            throw new AssertionError("should not reach here");
+        }
+
+        @Override
+        public LongArray newLongArray(long size, boolean clearOnResize) {
+            throw new AssertionError("should not reach here");
+        }
+
+        @Override
+        public FloatArray newFloatArray(long size, boolean clearOnResize) {
+            throw new AssertionError("should not reach here");
+        }
+
+        @Override
+        public DoubleArray newDoubleArray(long size, boolean clearOnResize) {
+            throw new AssertionError("should not reach here");
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -92,7 +92,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
         int end = between(1_000, 100_000);
         List<Page> results = new ArrayList<>();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(end));
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
 
         try (
             Driver d = new Driver(
@@ -110,14 +110,14 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
 
     public final void testMultivalued() {
         int end = between(1_000, 100_000);
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(new PositionMergingSourceOperator(simpleInput(end)));
         assertSimpleOutput(input, drive(simple(BigArrays.NON_RECYCLING_INSTANCE).get(driverContext), input.iterator()));
     }
 
     public final void testMultivaluedWithNulls() {
         int end = between(1_000, 100_000);
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(
             new NullInsertingSourceOperator(new PositionMergingSourceOperator(simpleInput(end)))
         );
@@ -125,7 +125,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
     }
 
     public final void testEmptyInput() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), List.<Page>of().iterator());
 
         assertThat(results, hasSize(1));
@@ -133,7 +133,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
     }
 
     public final void testEmptyInputInitialFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> results = drive(
             List.of(
                 simpleWithMode(nonBreakingBigArrays().withCircuitBreaking(), AggregatorMode.INITIAL).get(driverContext),
@@ -147,7 +147,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
     }
 
     public final void testEmptyInputInitialIntermediateFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> results = drive(
             List.of(
                 simpleWithMode(nonBreakingBigArrays().withCircuitBreaking(), AggregatorMode.INITIAL).get(driverContext),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionTests.java
@@ -62,7 +62,7 @@ public class CountDistinctIntAggregatorFunctionTests extends AggregatorFunctionT
     }
 
     public void testRejectsDouble() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionTests.java
@@ -63,7 +63,7 @@ public class CountDistinctLongAggregatorFunctionTests extends AggregatorFunction
     }
 
     public void testRejectsDouble() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -145,7 +145,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullGroupsAndValues() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(new NullInsertingSourceOperator(simpleInput(end)));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -153,7 +153,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullGroups() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(nullGroups(simpleInput(end)));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -182,7 +182,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullValues() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(nullValues(simpleInput(end)));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -190,7 +190,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullValuesInitialIntermediateFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(nullValues(simpleInput(end)));
         List<Page> results = drive(
@@ -218,7 +218,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testMultivalued() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(1_000, 100_000);
         List<Page> input = CannedSourceOperator.collectPages(mergeValues(simpleInput(end)));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -226,7 +226,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testMulitvaluedNullGroupsAndValues() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(new NullInsertingSourceOperator(mergeValues(simpleInput(end))));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -234,7 +234,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testMulitvaluedNullGroup() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(nullGroups(mergeValues(simpleInput(end))));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -242,7 +242,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testMulitvaluedNullValues() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         int end = between(50, 60);
         List<Page> input = CannedSourceOperator.collectPages(nullValues(mergeValues(simpleInput(end))));
         List<Page> results = drive(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext), input.iterator());
@@ -250,12 +250,12 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullOnly() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         assertNullOnly(List.of(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext)));
     }
 
     public final void testNullOnlyInputInitialFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         assertNullOnly(
             List.of(
                 simpleWithMode(nonBreakingBigArrays().withCircuitBreaking(), AggregatorMode.INITIAL).get(driverContext),
@@ -265,7 +265,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullOnlyInputInitialIntermediateFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         assertNullOnly(
             List.of(
                 simpleWithMode(nonBreakingBigArrays().withCircuitBreaking(), AggregatorMode.INITIAL).get(driverContext),
@@ -294,12 +294,12 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullSome() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         assertNullSome(List.of(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext)));
     }
 
     public final void testNullSomeInitialFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         assertNullSome(
             List.of(
                 simpleWithMode(nonBreakingBigArrays().withCircuitBreaking(), AggregatorMode.INITIAL).get(driverContext),
@@ -309,7 +309,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     }
 
     public final void testNullSomeInitialIntermediateFinal() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         assertNullSome(
             List.of(
                 simpleWithMode(nonBreakingBigArrays().withCircuitBreaking(), AggregatorMode.INITIAL).get(driverContext),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
@@ -49,7 +49,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
     }
 
     public void testOverflowSucceeds() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
@@ -67,7 +67,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
     }
 
     public void testSummationAccuracy() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
@@ -96,7 +96,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
                 : randomDoubleBetween(Double.MIN_VALUE, Double.MAX_VALUE, true);
             sum += values[i];
         }
-        driverContext = new DriverContext();
+        driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,
@@ -118,7 +118,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         for (int i = 0; i < n; i++) {
             largeValues[i] = Double.MAX_VALUE;
         }
-        driverContext = new DriverContext();
+        driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,
@@ -137,7 +137,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
         for (int i = 0; i < n; i++) {
             largeValues[i] = -Double.MAX_VALUE;
         }
-        driverContext = new DriverContext();
+        driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionTests.java
@@ -49,7 +49,7 @@ public class SumIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     public void testRejectsDouble() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
@@ -49,7 +49,7 @@ public class SumLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     public void testOverflowFails() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,
@@ -65,7 +65,7 @@ public class SumLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     public void testRejectsDouble() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         try (
             Driver d = new Driver(
                 driverContext,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -143,7 +143,7 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
     }
 
     private void testSimple(int size, int limit) {
-        DriverContext ctx = new DriverContext();
+        DriverContext ctx = driverContext();
         LuceneSourceOperator.Factory factory = simple(nonBreakingBigArrays(), DataPartitioning.SHARD, size, limit);
         Operator.OperatorFactory readS = ValuesSourceReaderOperatorTests.factory(
             reader,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorTests.java
@@ -148,7 +148,7 @@ public class LuceneTopNSourceOperatorTests extends AnyOperatorTestCase {
     }
 
     private void testSimple(int size, int limit) {
-        DriverContext ctx = new DriverContext();
+        DriverContext ctx = driverContext();
         LuceneTopNSourceOperator.Factory factory = simple(nonBreakingBigArrays(), DataPartitioning.SHARD, size, limit);
         Operator.OperatorFactory readS = ValuesSourceReaderOperatorTests.factory(
             reader,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
@@ -160,7 +160,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             randomPageSize(),
             LuceneOperator.NO_LIMIT
         );
-        return luceneFactory.get(new DriverContext());
+        return luceneFactory.get(driverContext());
     }
 
     @Override
@@ -226,7 +226,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
     }
 
     private void loadSimpleAndAssert(List<Page> input) {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> results = new ArrayList<>();
         List<Operator> operators = List.of(
             factory(
@@ -390,7 +390,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             reader = w.getReader();
         }
 
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         var luceneFactory = new LuceneSourceOperator.Factory(
             List.of(mockSearchContext(reader)),
             ctx -> new MatchAllDocsQuery(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -60,8 +60,7 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
         Operator.OperatorFactory factory = simple(nonBreakingBigArrays());
         String description = factory.describe();
         assertThat(description, equalTo(expectedDescriptionOfSimple()));
-        DriverContext driverContext = new DriverContext();
-        try (Operator op = factory.get(driverContext)) {
+        try (Operator op = factory.get(driverContext())) {
             if (op instanceof GroupingAggregatorFunction) {
                 assertThat(description, matchesPattern(GROUPING_AGG_FUNCTION_DESCRIBE_PATTERN));
             } else {
@@ -74,7 +73,7 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
      * Makes sure the description of {@link #simple} matches the {@link #expectedDescriptionOfSimple}.
      */
     public final void testSimpleToString() {
-        try (Operator operator = simple(nonBreakingBigArrays()).get(new DriverContext())) {
+        try (Operator operator = simple(nonBreakingBigArrays()).get(driverContext())) {
             assertThat(operator.toString(), equalTo(expectedToStringOfSimple()));
         }
     }
@@ -84,5 +83,12 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
      */
     protected final BigArrays nonBreakingBigArrays() {
         return new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking();
+    }
+
+    /**
+     * A {@link DriverContext} with a nonBreakingBigArrays.
+     */
+    protected final DriverContext driverContext() {
+        return new DriverContext(nonBreakingBigArrays());
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverContextTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverContextTests.java
@@ -41,12 +41,10 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class DriverContextTests extends ESTestCase {
 
-    final BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService());
-
     private static final String ESQL_TEST_EXECUTOR = "esql_test_executor";
 
     public void testEmptyFinished() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new AssertingDriverContext();
         driverContext.finish();
         assertTrue(driverContext.isFinished());
         var snapshot = driverContext.getSnapshot();
@@ -54,7 +52,7 @@ public class DriverContextTests extends ESTestCase {
     }
 
     public void testAddByIdentity() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new AssertingDriverContext();
         ReleasablePoint point1 = new ReleasablePoint(1, 2);
         ReleasablePoint point2 = new ReleasablePoint(1, 2);
         assertThat(point1, equalTo(point2));
@@ -68,9 +66,11 @@ public class DriverContextTests extends ESTestCase {
     }
 
     public void testAddFinish() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new AssertingDriverContext();
         int count = randomInt(128);
-        Set<Releasable> releasables = IntStream.range(0, count).mapToObj(i -> randomReleasable()).collect(toIdentitySet());
+        Set<Releasable> releasables = IntStream.range(0, count)
+            .mapToObj(i -> randomReleasable(driverContext.bigArrays()))
+            .collect(toIdentitySet());
         assertThat(releasables, hasSize(count));
 
         releasables.forEach(driverContext::addReleasable);
@@ -84,7 +84,7 @@ public class DriverContextTests extends ESTestCase {
     }
 
     public void testRemoveAbsent() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new AssertingDriverContext();
         boolean removed = driverContext.removeReleasable(new NoOpReleasable());
         assertThat(removed, equalTo(false));
         driverContext.finish();
@@ -94,9 +94,11 @@ public class DriverContextTests extends ESTestCase {
     }
 
     public void testAddRemoveFinish() {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new AssertingDriverContext();
         int count = randomInt(128);
-        Set<Releasable> releasables = IntStream.range(0, count).mapToObj(i -> randomReleasable()).collect(toIdentitySet());
+        Set<Releasable> releasables = IntStream.range(0, count)
+            .mapToObj(i -> randomReleasable(driverContext.bigArrays()))
+            .collect(toIdentitySet());
         assertThat(releasables, hasSize(count));
 
         releasables.forEach(driverContext::addReleasable);
@@ -112,9 +114,7 @@ public class DriverContextTests extends ESTestCase {
         ExecutorService executor = threadPool.executor(ESQL_TEST_EXECUTOR);
 
         int tasks = randomIntBetween(4, 32);
-        List<TestDriver> testDrivers = IntStream.range(0, tasks)
-            .mapToObj(i -> new TestDriver(new AssertingDriverContext(), randomInt(128), bigArrays))
-            .toList();
+        List<TestDriver> testDrivers = IntStream.range(0, tasks).mapToObj(DriverContextTests::newTestDriver).toList();
         List<Future<Void>> futures = executor.invokeAll(testDrivers, 1, TimeUnit.MINUTES);
         assertThat(futures, hasSize(tasks));
         for (var fut : futures) {
@@ -135,8 +135,17 @@ public class DriverContextTests extends ESTestCase {
         finishedReleasables.stream().flatMap(Set::stream).forEach(Releasable::close);
     }
 
+    static TestDriver newTestDriver(int unused) {
+        var driverContext = new AssertingDriverContext();
+        return new TestDriver(driverContext, randomInt(128), driverContext.bigArrays());
+    }
+
     static class AssertingDriverContext extends DriverContext {
         volatile Thread thread;
+
+        AssertingDriverContext() {
+            super(new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()));
+        }
 
         @Override
         public boolean addReleasable(Releasable releasable) {
@@ -217,10 +226,6 @@ public class DriverContextTests extends ESTestCase {
         assertThat(result.size(), equalTo(n));
         assertTrue(input.containsAll(result));
         return result;
-    }
-
-    Releasable randomReleasable() {
-        return randomReleasable(bigArrays);
     }
 
     static Releasable randomReleasable(BigArrays bigArrays) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -55,7 +55,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
 
     public final void testInitialFinal() {
         BigArrays bigArrays = nonBreakingBigArrays();
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(between(1_000, 100_000)));
         List<Page> results = new ArrayList<>();
 
@@ -79,7 +79,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
 
     public final void testManyInitialFinal() {
         BigArrays bigArrays = nonBreakingBigArrays();
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(between(1_000, 100_000)));
         List<Page> partials = oneDriverPerPage(input, () -> List.of(simpleWithMode(bigArrays, AggregatorMode.INITIAL).get(driverContext)));
         List<Page> results = new ArrayList<>();
@@ -100,7 +100,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
 
     public final void testInitialIntermediateFinal() {
         BigArrays bigArrays = nonBreakingBigArrays();
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(between(1_000, 100_000)));
         List<Page> results = new ArrayList<>();
 
@@ -126,7 +126,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99160")
     public final void testManyInitialManyPartialFinal() {
         BigArrays bigArrays = nonBreakingBigArrays();
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(between(1_000, 100_000)));
 
         List<Page> partials = oneDriverPerPage(input, () -> List.of(simpleWithMode(bigArrays, AggregatorMode.INITIAL).get(driverContext)));
@@ -217,7 +217,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
 
         List<Driver> drivers = new ArrayList<>();
         for (List<Page> pages : splitInput) {
-            DriverContext driver1Context = new DriverContext();
+            DriverContext driver1Context = driverContext();
             drivers.add(
                 new Driver(
                     driver1Context,
@@ -234,7 +234,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
                 )
             );
         }
-        DriverContext driver2Context = new DriverContext();
+        DriverContext driver2Context = driverContext();
         drivers.add(
             new Driver(
                 driver2Context,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -52,7 +52,7 @@ public class LimitOperatorTests extends OperatorTestCase {
     }
 
     public void testStatus() {
-        LimitOperator op = (LimitOperator) simple(BigArrays.NON_RECYCLING_INSTANCE).get(new DriverContext());
+        LimitOperator op = (LimitOperator) simple(BigArrays.NON_RECYCLING_INSTANCE).get(driverContext());
 
         LimitOperator.Status status = op.status();
         assertThat(status.limit(), equalTo(100));
@@ -69,7 +69,7 @@ public class LimitOperatorTests extends OperatorTestCase {
     }
 
     public void testNeedInput() {
-        LimitOperator op = (LimitOperator) simple(BigArrays.NON_RECYCLING_INSTANCE).get(new DriverContext());
+        LimitOperator op = (LimitOperator) simple(BigArrays.NON_RECYCLING_INSTANCE).get(driverContext());
         assertTrue(op.needsInput());
         Page p = new Page(Block.constantNullBlock(10));
         op.addInput(p);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -116,7 +116,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
             List<Page> in = source.next();
             try (
                 Driver d = new Driver(
-                    new DriverContext(),
+                    driverContext(),
                     new CannedSourceOperator(in.iterator()),
                     operators.get(),
                     new PageConsumerOperator(result::add),
@@ -131,7 +131,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
 
     private void assertSimple(BigArrays bigArrays, int size) {
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(size));
-        List<Page> results = drive(simple(bigArrays.withCircuitBreaking()).get(new DriverContext()), input.iterator());
+        List<Page> results = drive(simple(bigArrays.withCircuitBreaking()).get(driverContext()), input.iterator());
         assertSimpleOutput(input, results);
     }
 
@@ -143,7 +143,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         List<Page> results = new ArrayList<>();
         try (
             Driver d = new Driver(
-                new DriverContext(),
+                driverContext(),
                 new CannedSourceOperator(input),
                 operators,
                 new PageConsumerOperator(results::add),
@@ -166,7 +166,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
             drivers.add(
                 new Driver(
                     "dummy-session",
-                    new DriverContext(),
+                    new DriverContext(BigArrays.NON_RECYCLING_INSTANCE),
                     () -> "dummy-driver",
                     new SequenceLongBlockSourceOperator(LongStream.range(0, between(1, 100)), between(1, 100)),
                     List.of(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/RowOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/RowOperatorTests.java
@@ -8,12 +8,15 @@
 package org.elasticsearch.compute.operator;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -22,7 +25,9 @@ import java.util.List;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RowOperatorTests extends ESTestCase {
-    final DriverContext driverContext = new DriverContext();
+    final DriverContext driverContext = new DriverContext(
+        new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking()
+    );
 
     public void testBoolean() {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(List.of(false));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -16,6 +16,8 @@ import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.Block;
@@ -28,6 +30,7 @@ import org.elasticsearch.compute.operator.DriverRunner;
 import org.elasticsearch.compute.operator.SinkOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.test.ESTestCase;
@@ -267,14 +270,14 @@ public class ExchangeServiceTests extends ESTestCase {
         for (int i = 0; i < numSinks; i++) {
             String description = "sink-" + i;
             ExchangeSinkOperator sinkOperator = new ExchangeSinkOperator(exchangeSink.get(), Function.identity());
-            DriverContext dc = new DriverContext();
+            DriverContext dc = driverContext();
             Driver d = new Driver("test-session:1", dc, () -> description, seqNoGenerator.get(dc), List.of(), sinkOperator, () -> {});
             drivers.add(d);
         }
         for (int i = 0; i < numSources; i++) {
             String description = "source-" + i;
             ExchangeSourceOperator sourceOperator = new ExchangeSourceOperator(exchangeSource.get());
-            DriverContext dc = new DriverContext();
+            DriverContext dc = driverContext();
             Driver d = new Driver("test-session:2", dc, () -> description, sourceOperator, List.of(), seqNoCollector.get(dc), () -> {});
             drivers.add(d);
         }
@@ -450,5 +453,14 @@ public class ExchangeServiceTests extends ESTestCase {
         public void sendResponse(Exception exception) throws IOException {
             in.sendResponse(exception);
         }
+    }
+
+    /**
+     * A {@link DriverContext} with a BigArrays that does not circuit break.
+     */
+    DriverContext driverContext() {
+        return new DriverContext(
+            new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking()
+        );
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -183,7 +183,7 @@ public class TopNOperatorTests extends OperatorTestCase {
             List.of(DEFAULT_UNSORTABLE),
             List.of(new TopNOperator.SortOrder(0, true, false)),
             pageSize
-        ).get(new DriverContext());
+        ).get(driverContext());
         long actualEmpty = RamUsageTester.ramUsed(op) - RamUsageTester.ramUsed(LONG) - RamUsageTester.ramUsed(DEFAULT_UNSORTABLE);
         assertThat(op.ramBytesUsed(), both(greaterThan(actualEmpty - underCount)).and(lessThan(actualEmpty)));
         // But when we fill it then we're quite close
@@ -452,7 +452,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         }
 
         List<List<Object>> actualTop = new ArrayList<>();
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         try (
             Driver driver = new Driver(
                 driverContext,
@@ -536,7 +536,7 @@ public class TopNOperatorTests extends OperatorTestCase {
             expectedTop.add(eTop);
         }
 
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<List<Object>> actualTop = new ArrayList<>();
         try (
             Driver driver = new Driver(
@@ -569,7 +569,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<TopNEncoder> encoder,
         List<TopNOperator.SortOrder> sortOrders
     ) {
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = driverContext();
         List<Tuple<Long, Long>> outputValues = new ArrayList<>();
         try (
             Driver driver = new Driver(
@@ -611,7 +611,7 @@ public class TopNOperatorTests extends OperatorTestCase {
             + sorts
             + "]]";
         assertThat(factory.describe(), equalTo("TopNOperator[count=10" + tail));
-        try (Operator operator = factory.get(new DriverContext())) {
+        try (Operator operator = factory.get(driverContext())) {
             assertThat(operator.toString(), equalTo("TopNOperator[count=0/10" + tail));
         }
     }
@@ -831,7 +831,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         int topCount = randomIntBetween(1, values.size());
         try (
             Driver driver = new Driver(
-                new DriverContext(),
+                driverContext(),
                 new CannedSourceOperator(List.of(page).iterator()),
                 List.of(new TopNOperator(topCount, List.of(blockType), List.of(encoder), List.of(sortOrders), randomPageSize())),
                 new PageConsumerOperator(p -> readInto(actualValues, p)),
@@ -965,7 +965,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<List<Object>> actual = new ArrayList<>();
         try (
             Driver driver = new Driver(
-                new DriverContext(),
+                driverContext(),
                 new CannedSourceOperator(List.of(new Page(builder.build())).iterator()),
                 List.of(
                     new TopNOperator(
@@ -1088,7 +1088,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<List<Object>> actual = new ArrayList<>();
         try (
             Driver driver = new Driver(
-                new DriverContext(),
+                driverContext(),
                 new CannedSourceOperator(List.of(new Page(builder.build())).iterator()),
                 List.of(
                     new TopNOperator(
@@ -1169,7 +1169,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         List<List<Object>> actual = new ArrayList<>();
         try (
             Driver driver = new Driver(
-                new DriverContext(),
+                driverContext(),
                 new CannedSourceOperator(List.of(new Page(blocks.toArray(Block[]::new))).iterator()),
                 List.of(
                     new TopNOperator(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;
@@ -96,12 +97,19 @@ public class EnrichLookupService {
     private final SearchService searchService;
     private final TransportService transportService;
     private final Executor executor;
+    private final BigArrays bigArrays;
 
-    public EnrichLookupService(ClusterService clusterService, SearchService searchService, TransportService transportService) {
+    public EnrichLookupService(
+        ClusterService clusterService,
+        SearchService searchService,
+        TransportService transportService,
+        BigArrays bigArrays
+    ) {
         this.clusterService = clusterService;
         this.searchService = searchService;
         this.transportService = transportService;
         this.executor = transportService.getThreadPool().executor(EsqlPlugin.ESQL_THREAD_POOL_NAME);
+        this.bigArrays = bigArrays;
         transportService.registerRequestHandler(LOOKUP_ACTION_NAME, this.executor, LookupRequest::new, new TransportHandler());
     }
 
@@ -200,7 +208,7 @@ public class EnrichLookupService {
             OutputOperator outputOperator = new OutputOperator(List.of(), Function.identity(), result::set);
             Driver driver = new Driver(
                 "enrich-lookup:" + sessionId,
-                new DriverContext(),
+                new DriverContext(bigArrays),
                 () -> lookupDescription(sessionId, shardId, matchType, matchField, extractFields, inputPage.getPositionCount()),
                 queryOperator,
                 intermediateOperators,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/mapper/EvaluatorMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/mapper/EvaluatorMapper.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.esql.evaluator.mapper;
 
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.ThrowingDriverContext;
 import org.elasticsearch.xpack.ql.expression.Expression;
 
 import java.util.function.Function;
@@ -31,7 +31,7 @@ public interface EvaluatorMapper {
      */
     default Object fold() {
         return toJavaObject(
-            toEvaluator(e -> driverContext -> p -> fromArrayRow(e.fold())[0]).get(DriverContext.DEFAULT).eval(new Page(1)),
+            toEvaluator(e -> driverContext -> p -> fromArrayRow(e.fold())[0]).get(new ThrowingDriverContext()).eval(new Page(1)),
             0
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -65,7 +65,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         this.requestExecutor = threadPool.executor(EsqlPlugin.ESQL_THREAD_POOL_NAME);
         exchangeService.registerTransportHandler(transportService);
         this.exchangeService = exchangeService;
-        this.enrichLookupService = new EnrichLookupService(clusterService, searchService, transportService);
+        this.enrichLookupService = new EnrichLookupService(clusterService, searchService, transportService, bigArrays);
         this.computeService = new ComputeService(
             searchService,
             transportService,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -89,9 +88,7 @@ public class CaseTests extends AbstractFunctionTestCase {
     public void testEvalCase() {
         testCase(
             caseExpr -> toJavaObject(
-                caseExpr.toEvaluator(child -> evaluator(child))
-                    .get(new DriverContext())
-                    .eval(new Page(IntBlock.newConstantBlockWith(0, 1))),
+                caseExpr.toEvaluator(child -> evaluator(child)).get(driverContext()).eval(new Page(IntBlock.newConstantBlockWith(0, 1))),
                 0
             )
         );
@@ -157,7 +154,7 @@ public class CaseTests extends AbstractFunctionTestCase {
                 };
             }
             return evaluator(child);
-        }).get(new DriverContext()).eval(new Page(IntBlock.newConstantBlockWith(0, 1))), 0));
+        }).get(driverContext()).eval(new Page(IntBlock.newConstantBlockWith(0, 1))), 0));
     }
 
     private static Case caseExpr(Object... args) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -86,14 +85,14 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
 
     private Object process(Number val) {
         return toJavaObject(
-            evaluator(new Round(Source.EMPTY, field("val", typeOf(val)), null)).get(new DriverContext()).eval(row(List.of(val))),
+            evaluator(new Round(Source.EMPTY, field("val", typeOf(val)), null)).get(driverContext()).eval(row(List.of(val))),
             0
         );
     }
 
     private Object process(Number val, int decimals) {
         return toJavaObject(
-            evaluator(new Round(Source.EMPTY, field("val", typeOf(val)), field("decimals", DataTypes.INTEGER))).get(new DriverContext())
+            evaluator(new Round(Source.EMPTY, field("val", typeOf(val)), field("decimals", DataTypes.INTEGER))).get(driverContext())
                 .eval(row(List.of(val, decimals))),
             0
         );
@@ -119,7 +118,7 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
 
     public void testNoDecimalsToString() {
         assertThat(
-            evaluator(new Round(Source.EMPTY, field("val", DataTypes.DOUBLE), null)).get(new DriverContext()).toString(),
+            evaluator(new Round(Source.EMPTY, field("val", DataTypes.DOUBLE), null)).get(driverContext()).toString(),
             equalTo("RoundDoubleNoDecimalsEvaluator[val=Attribute[channel=0]]")
         );
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.Vector;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
@@ -445,7 +444,7 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
             builder.copyFrom(oneRowBlock, 0, 1);
         }
         Block input = builder.build();
-        Block result = evaluator(buildFieldExpression(testCase)).get(new DriverContext()).eval(new Page(input));
+        Block result = evaluator(buildFieldExpression(testCase)).get(driverContext()).eval(new Page(input));
 
         assertThat(result.getPositionCount(), equalTo(result.getPositionCount()));
         for (int p = 0; p < input.getPositionCount(); p++) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvConcatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvConcatTests.java
@@ -72,7 +72,7 @@ public class MvConcatTests extends AbstractScalarFunctionTestCase {
         BytesRef bar = new BytesRef("bar");
         BytesRef delim = new BytesRef(";");
         Expression expression = buildFieldExpression(testCase);
-        DriverContext dvrCtx = new DriverContext();
+        DriverContext dvrCtx = driverContext();
 
         assertThat(toJavaObject(evaluator(expression).get(dvrCtx).eval(row(Arrays.asList(Arrays.asList(foo, bar), null))), 0), nullValue());
         assertThat(toJavaObject(evaluator(expression).get(dvrCtx).eval(row(Arrays.asList(foo, null))), 0), nullValue());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -11,7 +11,6 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
@@ -88,7 +87,7 @@ public class CoalesceTests extends AbstractFunctionTestCase {
                 return dvrCtx -> page -> { throw new AssertionError("shouldn't be called"); };
             }
             return EvalMapper.toEvaluator(child, layout);
-        }).get(new DriverContext()).eval(row(testCase.getDataValues())), 0), testCase.getMatcher());
+        }).get(driverContext()).eval(row(testCase.getDataValues())), 0), testCase.getMatcher());
     }
 
     public void testCoalesceNullabilityIsUnknown() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ConcatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ConcatTests.java
@@ -11,7 +11,6 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -99,7 +98,7 @@ public class ConcatTests extends AbstractScalarFunctionTestCase {
                         field("a", DataTypes.KEYWORD),
                         IntStream.range(1, 5).mapToObj(i -> field(Integer.toString(i), DataTypes.KEYWORD)).toList()
                     )
-                ).get(new DriverContext()).eval(row(simpleData)),
+                ).get(driverContext()).eval(row(simpleData)),
                 0
             ),
             equalTo(new BytesRef("cats and dogs"))
@@ -121,7 +120,7 @@ public class ConcatTests extends AbstractScalarFunctionTestCase {
                             field("c", DataTypes.KEYWORD)
                         )
                     )
-                ).get(new DriverContext()).eval(row(simpleData)),
+                ).get(driverContext()).eval(row(simpleData)),
                 0
             ),
             equalTo(new BytesRef("cats and dogs"))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LeftTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LeftTests.java
@@ -12,7 +12,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -199,7 +198,7 @@ public class LeftTests extends AbstractScalarFunctionTestCase {
     private String process(String str, int length) {
         Block result = evaluator(
             new Left(Source.EMPTY, field("str", DataTypes.KEYWORD), new Literal(Source.EMPTY, length, DataTypes.INTEGER))
-        ).get(new DriverContext()).eval(row(List.of(new BytesRef(str))));
+        ).get(driverContext()).eval(row(List.of(new BytesRef(str))));
         if (null == result) {
             return null;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RightTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RightTests.java
@@ -12,7 +12,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -201,7 +200,7 @@ public class RightTests extends AbstractScalarFunctionTestCase {
     private String process(String str, int length) {
         Block result = evaluator(
             new Right(Source.EMPTY, field("str", DataTypes.KEYWORD), new Literal(Source.EMPTY, length, DataTypes.INTEGER))
-        ).get(new DriverContext()).eval(row(List.of(new BytesRef(str))));
+        ).get(driverContext()).eval(row(List.of(new BytesRef(str))));
         if (null == result) {
             return null;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
@@ -13,7 +13,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
@@ -86,7 +85,7 @@ public class SplitTests extends AbstractScalarFunctionTestCase {
     public void testConstantDelimiter() {
         EvalOperator.ExpressionEvaluator eval = evaluator(
             new Split(Source.EMPTY, field("str", DataTypes.KEYWORD), new Literal(Source.EMPTY, new BytesRef(":"), DataTypes.KEYWORD))
-        ).get(new DriverContext());
+        ).get(driverContext());
         /*
          * 58 is ascii for : and appears in the toString below. We don't convert the delimiter to a
          * string because we aren't really sure it's printable. It could be a tab or a bell or some

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SubstringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SubstringTests.java
@@ -12,7 +12,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -68,7 +67,7 @@ public class SubstringTests extends AbstractScalarFunctionTestCase {
     public void testNoLengthToString() {
         assertThat(
             evaluator(new Substring(Source.EMPTY, field("str", DataTypes.KEYWORD), field("start", DataTypes.INTEGER), null)).get(
-                new DriverContext()
+                driverContext()
             ).toString(),
             equalTo("SubstringNoLengthEvaluator[str=Attribute[channel=0], start=Attribute[channel=1]]")
         );
@@ -137,7 +136,7 @@ public class SubstringTests extends AbstractScalarFunctionTestCase {
                 new Literal(Source.EMPTY, start, DataTypes.INTEGER),
                 length == null ? null : new Literal(Source.EMPTY, length, DataTypes.INTEGER)
             )
-        ).get(new DriverContext()).eval(row(List.of(new BytesRef(str))));
+        ).get(driverContext()).eval(row(List.of(new BytesRef(str))));
         return result == null ? null : ((BytesRef) toJavaObject(result, 0)).utf8ToString();
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/AbstractBinaryOperatorTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/AbstractBinaryOperatorTestCase.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.predicate.operator;
 
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.analysis.Verifier;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
@@ -93,7 +92,7 @@ public abstract class AbstractBinaryOperatorTestCase extends AbstractFunctionTes
                 Source src = new Source(Location.EMPTY, lhsType.typeName() + " " + rhsType.typeName());
                 if (isRepresentable(lhsType) && isRepresentable(rhsType)) {
                     op = build(src, field("lhs", lhsType), field("rhs", rhsType));
-                    result = toJavaObject(evaluator(op).get(new DriverContext()).eval(row(List.of(lhs.value(), rhs.value()))), 0);
+                    result = toJavaObject(evaluator(op).get(driverContext()).eval(row(List.of(lhs.value(), rhs.value()))), 0);
                 } else {
                     op = build(src, lhs, rhs);
                     result = op.fold();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/NegTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/NegTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -172,7 +171,7 @@ public class NegTests extends AbstractScalarFunctionTestCase {
     private Object process(Object val) {
         if (testCase.allTypesAreRepresentable()) {
             Neg neg = new Neg(Source.EMPTY, field("val", typeOf(val)));
-            return toJavaObject(evaluator(neg).get(new DriverContext()).eval(row(List.of(val))), 0);
+            return toJavaObject(evaluator(neg).get(driverContext()).eval(row(List.of(val))), 0);
         } else { // just fold if type is not representable
             Neg neg = new Neg(Source.EMPTY, new Literal(Source.EMPTY, val, typeOf(val)));
             return neg.fold();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
@@ -10,8 +10,11 @@ package org.elasticsearch.xpack.esql.planner;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.SerializationTestUtils;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
@@ -128,8 +131,8 @@ public class EvalMapperTests extends ESTestCase {
         Layout layout = lb.build();
 
         var supplier = EvalMapper.toEvaluator(expression, layout);
-        EvalOperator.ExpressionEvaluator evaluator1 = supplier.get(new DriverContext());
-        EvalOperator.ExpressionEvaluator evaluator2 = supplier.get(new DriverContext());
+        EvalOperator.ExpressionEvaluator evaluator1 = supplier.get(driverContext());
+        EvalOperator.ExpressionEvaluator evaluator2 = supplier.get(driverContext());
         assertNotNull(evaluator1);
         assertNotNull(evaluator2);
         assertTrue(evaluator1 != evaluator2);
@@ -142,5 +145,11 @@ public class EvalMapperTests extends ESTestCase {
 
     private static FieldAttribute field(String name, DataType type) {
         return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Collections.emptyMap(), false));
+    }
+
+    static DriverContext driverContext() {
+        return new DriverContext(
+            new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking()
+        );
     }
 }


### PR DESCRIPTION
This commit removes the default driver implementation. Follow up to comments in #99518