### PR TITLE
Increase limit on stdout, stderr in docker tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -202,7 +202,7 @@ public class Shell {
     private String readFileIfExists(Path path) throws IOException {
         if (Files.exists(path)) {
             long size = Files.size(path);
-            final int maxFileSize = 100 * 1024;
+            final int maxFileSize = 1024 * 1024;
             if (size > maxFileSize) {
                 // file is really big, truncate
                 try (var br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {


### PR DESCRIPTION
json logs used in docker tests are consuming more space than the previous 100KB
setting the limit to 1MB
relates #99508

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
