### PR TITLE
[8.10] Fix deadlock between Cache.put and invalidateAll (#99480)

### DIFF
--- a/docs/changelog/99480.yaml
+++ b/docs/changelog/99480.yaml
@@ -1,0 +1,6 @@
+pr: 99480
+summary: Fix deadlock between Cache.put and Cache.invalidateAll
+area: Infra/Core
+type: bug
+issues:
+ - 99326

--- a/server/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/server/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -521,12 +521,12 @@ public class Cache<K, V> {
         Entry<K, V> h;
 
         boolean[] haveSegmentLock = new boolean[NUMBER_OF_SEGMENTS];
-        try {
-            for (int i = 0; i < NUMBER_OF_SEGMENTS; i++) {
-                segments[i].segmentLock.writeLock().lock();
-                haveSegmentLock[i] = true;
-            }
-            try (ReleasableLock ignored = lruLock.acquire()) {
+        try (ReleasableLock ignored = lruLock.acquire()) {
+            try {
+                for (int i = 0; i < NUMBER_OF_SEGMENTS; i++) {
+                    segments[i].segmentLock.writeLock().lock();
+                    haveSegmentLock[i] = true;
+                }
                 h = head;
                 for (CacheSegment segment : segments) {
                     segment.map = null;
@@ -539,11 +539,11 @@ public class Cache<K, V> {
                 head = tail = null;
                 count = 0;
                 weight = 0;
-            }
-        } finally {
-            for (int i = NUMBER_OF_SEGMENTS - 1; i >= 0; i--) {
-                if (haveSegmentLock[i]) {
-                    segments[i].segmentLock.writeLock().unlock();
+            } finally {
+                for (int i = NUMBER_OF_SEGMENTS - 1; i >= 0; i--) {
+                    if (haveSegmentLock[i]) {
+                        segments[i].segmentLock.writeLock().unlock();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix deadlock between Cache.put and invalidateAll (#99480)