### PR TITLE
Mute EsqlActionTaskIT.testCancelRead

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -162,6 +162,7 @@ public class EsqlActionTaskIT extends AbstractEsqlIntegTestCase {
         assertThat(response.get().values(), equalTo(List.of(List.of((long) NUM_DOCS))));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99582")
     public void testCancelRead() throws Exception {
         ActionFuture<EsqlQueryResponse> response = startEsql();
         List<TaskInfo> infos = getTasksStarting();


### PR DESCRIPTION
Related https://github.com/elastic/elasticsearch/issues/99582
