### PR TITLE
Move test to the correct test case.

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.index.IndexVersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -196,28 +195,6 @@ public class VersionsTests extends ESTestCase {
         // core should be evicted from the map
         assertEquals(size, VersionsAndSeqNoResolver.lookupStates.size());
         dir.close();
-    }
-
-    public void testLuceneVersionOnUnknownVersions() {
-        // between two known versions, should use the lucene version of the previous version
-        IndexVersion version = IndexVersionUtils.getPreviousVersion();
-        final IndexVersion nextVersion = IndexVersion.fromId(version.id() + 100);
-        if (IndexVersionUtils.allReleasedVersions().contains(nextVersion) == false) {
-            // the version is not known, we make an assumption the Lucene version stays the same
-            assertThat(version.luceneVersion(), equalTo(nextVersion.luceneVersion()));
-        } else {
-            // the version is known, the most we can assert is that the Lucene version is not earlier
-            // Version does not implement Comparable :(
-            assertTrue(nextVersion.luceneVersion().onOrAfter(version.luceneVersion()));
-        }
-
-        // too old version, major should be the oldest supported lucene version minus 1
-        version = IndexVersion.fromId(5020199);
-        assertThat(version.luceneVersion().major, equalTo(IndexVersionUtils.getFirstVersion().luceneVersion().major - 1));
-
-        // future version, should be the same version as today
-        version = IndexVersion.fromId(IndexVersion.current().id() + 100);
-        assertThat(version.luceneVersion(), equalTo(IndexVersion.current().luceneVersion()));
     }
 
     public void testTimeSeriesLoadDocIdAndVersion() throws Exception {


### PR DESCRIPTION
`oe.common.lucene.uid.VersionsTests` is actually about testing the `_version` field, but the test that is being moved tests `IndexVersion`.