### PR TITLE
Fixing more tests for Lucene snapshot

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -174,7 +174,9 @@ public final class InnerHitsContext {
         } catch (CollectionTerminatedException e) {
             // collection was terminated prematurely
             // continue with the following leaf
-            leafCollector.finish();
         }
+        // Finish the leaf collection in preparation for the next.
+        // This includes any collection that was terminated early via `CollectionTerminatedException`
+        leafCollector.finish();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
-import org.apache.lucene.search.TimeLimitingCollector;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
@@ -172,15 +171,10 @@ public final class InnerHitsContext {
                     leafCollector.collect(docId);
                 }
             }
-        } catch (CollectionTerminatedException | TimeLimitingCollector.TimeExceededException e) {
-            leafCollector.finish();
-            // We didn't terminate collection early, bubble up the timeout
-            // Otherwise
+        } catch (CollectionTerminatedException e) {
             // collection was terminated prematurely
             // continue with the following leaf
-            if (e instanceof TimeLimitingCollector.TimeExceededException) {
-                throw e;
-            }
+            leafCollector.finish();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
-import org.apache.lucene.search.TimeLimitingCollector;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.suggest.document.CompletionQuery;
 import org.apache.lucene.search.suggest.document.TopSuggestDocs;
@@ -88,17 +87,12 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
                     // We need to call finish as TopSuggestDocsCollector#finish() populates the pendingResults
                     // This is important when skipping duplicates
                     leafCollector.finish();
-                } catch (CollectionTerminatedException | TimeLimitingCollector.TimeExceededException e) {
+                } catch (CollectionTerminatedException e) {
+                    // collection was terminated prematurely
+                    // continue with the following leaf
                     // We can only finish the leaf collector if it was actually created
                     if (leafCollector != null) {
                         leafCollector.finish();
-                    }
-                    // We didn't terminate collection early, bubble up the timeout
-                    // Otherwise
-                    // collection was terminated prematurely
-                    // continue with the following leaf
-                    if (e instanceof TimeLimitingCollector.TimeExceededException) {
-                        throw e;
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -11,6 +11,8 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.TimeLimitingCollector;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.suggest.document.CompletionQuery;
 import org.apache.lucene.search.suggest.document.TopSuggestDocs;
@@ -79,20 +81,32 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
         for (LeafReaderContext context : searcher.getIndexReader().leaves()) {
             BulkScorer scorer = weight.bulkScorer(context);
             if (scorer != null) {
+                LeafCollector leafCollector = null;
                 try {
-                    scorer.score(collector.getLeafCollector(context), context.reader().getLiveDocs());
-                } catch (CollectionTerminatedException e) {
+                    leafCollector = collector.getLeafCollector(context);
+                    scorer.score(leafCollector, context.reader().getLiveDocs());
+                    // We need to call finish as TopSuggestDocsCollector#finish() populates the pendingResults
+                    // This is important when skipping duplicates
+                    leafCollector.finish();
+                } catch (CollectionTerminatedException | TimeLimitingCollector.TimeExceededException e) {
+                    // We can only finish the leaf collector if it was actually created
+                    if (leafCollector != null) {
+                        leafCollector.finish();
+                    }
+                    // We didn't terminate collection early, bubble up the timeout
+                    // Otherwise
                     // collection was terminated prematurely
                     // continue with the following leaf
+                    if (e instanceof TimeLimitingCollector.TimeExceededException) {
+                        throw e;
+                    }
                 }
             }
         }
-        collector.finish();
     }
 
     @Override
-    protected CompletionSuggestion emptySuggestion(String name, CompletionSuggestionContext suggestion, CharsRefBuilder spare)
-        throws IOException {
+    protected CompletionSuggestion emptySuggestion(String name, CompletionSuggestionContext suggestion, CharsRefBuilder spare) {
         CompletionSuggestion completionSuggestion = new CompletionSuggestion(name, suggestion.getSize(), suggestion.isSkipDuplicates());
         spare.copyUTF8Bytes(suggestion.getText());
         CompletionSuggestion.Entry completionSuggestEntry = new CompletionSuggestion.Entry(new Text(spare.toString()), 0, spare.length());

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -84,16 +84,16 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
                 try {
                     leafCollector = collector.getLeafCollector(context);
                     scorer.score(leafCollector, context.reader().getLiveDocs());
-                    // We need to call finish as TopSuggestDocsCollector#finish() populates the pendingResults
-                    // This is important when skipping duplicates
-                    leafCollector.finish();
                 } catch (CollectionTerminatedException e) {
                     // collection was terminated prematurely
                     // continue with the following leaf
-                    // We can only finish the leaf collector if it was actually created
-                    if (leafCollector != null) {
-                        leafCollector.finish();
-                    }
+                }
+                // We can only finish the leaf collector if it was actually created
+                if (leafCollector != null) {
+                    // We need to call finish as TopSuggestDocsCollector#finish() populates the pendingResults
+                    // This is important when skipping duplicates
+                    leafCollector.finish();
+                    leafCollector.finish();
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -93,7 +93,6 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
                     // We need to call finish as TopSuggestDocsCollector#finish() populates the pendingResults
                     // This is important when skipping duplicates
                     leafCollector.finish();
-                    leafCollector.finish();
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTests.java
@@ -44,7 +44,7 @@ public class DfsPhaseTests extends ESTestCase {
         threadPoolExecutor = EsExecutors.newFixed(
             "test",
             numThreads,
-            10,
+            -1,
             EsExecutors.daemonThreadFactory("test"),
             threadPool.getThreadContext(),
             randomFrom(TaskTrackingConfig.DEFAULT, TaskTrackingConfig.DO_NOT_TRACK)

--- a/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTests.java
@@ -16,8 +16,6 @@ import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.EsExecutors.TaskTrackingConfig;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.profile.Profilers;
 import org.elasticsearch.search.profile.SearchProfileDfsPhaseResult;
@@ -25,6 +23,7 @@ import org.elasticsearch.search.profile.query.CollectorResult;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
@@ -39,16 +38,8 @@ public class DfsPhaseTests extends ESTestCase {
 
     @Before
     public final void init() {
-        int numThreads = randomIntBetween(2, 4);
         threadPool = new TestThreadPool(DfsPhaseTests.class.getName());
-        threadPoolExecutor = EsExecutors.newFixed(
-            "test",
-            numThreads,
-            -1,
-            EsExecutors.daemonThreadFactory("test"),
-            threadPool.getThreadContext(),
-            randomFrom(TaskTrackingConfig.DEFAULT, TaskTrackingConfig.DO_NOT_TRACK)
-        );
+        threadPoolExecutor = (ThreadPoolExecutor) threadPool.executor(ThreadPool.Names.SEARCH_WORKER);
     }
 
     @After


### PR DESCRIPTION
Two test failures occur now due to concurrency changes:

 - DfsPhaseTests had a restricted queue size that caused thread rejections
 - CompletionSuggestSearchIT#skipDuplicates failed as it didn't actually skip duplicates

The main cause of the second had to do with `LeafCollector#finish` as the suggestion collector resets some data structures.

To ensure this type of thing doesn't happen again , I tried to call `finish()` in other search focused things where `getLeafCollector` is used and then collected.

I didn't update the aggs. There are many places in aggs where a custom collector is used and then `finish()` isn't called, but I left those.