### PR TITLE
[buildkite] Add more memory to platform-support job agents

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -27,7 +27,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: custom-32-98304
+          machineType: n1-standard-32
         env: {}
   - group: platform-support-windows
     steps:
@@ -50,7 +50,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: custom-32-98304
+          machineType: n1-standard-32
           diskType: pd-ssd
           diskSizeGb: 350
         env:


### PR DESCRIPTION
Going from 92GB to 120GB to cut down on memory pressure and OOM kills.