### PR TITLE
[7.17] [buildkite] Add more memory to platform-support job agents (#99594)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -27,7 +27,8 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: custom-32-98304
+          machineType: n1-standard-32
+        env: {}
   - group: platform-support-windows
     steps:
       - label: "{{matrix.image}} / {{matrix.GRADLE_TASK}} / platform-support-windows"
@@ -47,7 +48,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: custom-32-98304
+          machineType: n1-standard-32
           diskType: pd-ssd
           diskSizeGb: 350
         env:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[buildkite] Add more memory to platform-support job agents (#99594)](https://github.com/elastic/elasticsearch/pull/99594)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)