### PR TITLE
[buildkite] Disable all jenkins PR jobs when buildkite-opt-in label is present

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
@@ -34,6 +34,8 @@
             - ^x-pack/docs/.*
           white-list-labels:
             - 'build-benchmark'
+          black-list-labels:
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
@@ -34,6 +34,8 @@
             - ^x-pack/docs/.*
           white-list-labels:
             - 'build-benchmark'
+          black-list-labels:
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
@@ -29,6 +29,7 @@
             - 'test-windows'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: slave

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
@@ -26,6 +26,7 @@
           black-list-labels:
             - '>test-mute'
             - 'test-full-bwc'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: slave

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
@@ -26,6 +26,8 @@
             - ^x-pack/docs/.*
           white-list-labels:
             - 'cloud-deploy'
+          black-list-labels:
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
@@ -23,6 +23,7 @@
             - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
@@ -25,6 +25,7 @@
             - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+example-plugins.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+example-plugins.yml
@@ -23,6 +23,8 @@
             - build-tools/.*
             - build-tools-internal/.*
             - plugins/examples/.*
+          black-list-labels:
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
@@ -27,6 +27,7 @@
             - 'test-full-bwc'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: slave

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
@@ -27,6 +27,7 @@
           black-list-labels:
             - '>test-mute'
             - ':Delivery/Packaging'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
@@ -28,6 +28,7 @@
             - ':Delivery/Packaging'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
@@ -32,6 +32,7 @@
             - ':Delivery/Packaging'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
@@ -31,6 +31,7 @@
           black-list-labels:
             - '>test-mute'
             - ':Delivery/Packaging'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
@@ -30,6 +30,7 @@
           black-list-labels:
             - '>test-mute'
             - ':Delivery/Packaging'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
@@ -32,6 +32,7 @@
             - ':Delivery/Packaging'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
@@ -29,6 +29,7 @@
             - ':Delivery/Packaging'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
@@ -27,6 +27,7 @@
             - 'Team:Security'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           # Use FIPS-specific Java versions

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
@@ -28,6 +28,7 @@
             - 'test-windows'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
@@ -27,6 +27,7 @@
             - 'Team:Security'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           # Use FIPS-specific Java versions

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
@@ -28,6 +28,7 @@
             - 'test-windows'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
@@ -28,6 +28,7 @@
             - 'Team:Security'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           # Use FIPS-specific Java versions

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
@@ -29,6 +29,7 @@
             - 'test-windows'
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
@@ -23,6 +23,7 @@
             - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
           black-list-target-branches:
             - 6.8
             - 7.17

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+precommit.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+precommit.yml
@@ -20,6 +20,8 @@
           cancel-builds-on-update: true
           white-list-labels:
             - '>test-mute'
+          black-list-labels:
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
@@ -25,6 +25,8 @@
             - ^x-pack/docs/.*
           white-list-labels:
             - 'test-release'
+          black-list-labels:
+            - 'buildkite-opt-in'
           black-list-target-branches:
             - 7.15
             - 6.8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
@@ -28,6 +28,7 @@
             - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/templates.t/pull-request-gradle-unix.yml
+++ b/.ci/templates.t/pull-request-gradle-unix.yml
@@ -23,6 +23,7 @@
             - ^x-pack/docs/.*
           black-list-labels:
             - '>test-mute'
+            - 'buildkite-opt-in'
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'


### PR DESCRIPTION
When using the `buildkite-opt-in` label for testing PRs in Buildkite, we should not run anything in Jenkins. Not only is it a waste of resources, but they will compete for commit statuses.

I checked the source code of GHPRB (ugh), and it looks like if labels in `white-list-labels` and `black-list-labels` are both present, it will honor the `black-list-labels` label, which is what we want.