### PR TITLE
Determine latest index version dynamically

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -150,17 +150,17 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
      */
 
     private static class CurrentHolder {
-        private static final IndexVersion CURRENT = findCurrent(V_8_500_001);
+        private static final IndexVersion CURRENT = findCurrent();
 
         // finds the pluggable current version, or uses the given fallback
-        private static IndexVersion findCurrent(IndexVersion fallback) {
+        private static IndexVersion findCurrent() {
             var versionExtension = VersionExtension.load();
             if (versionExtension == null) {
-                return fallback;
+                return LATEST_DEFINED;
             }
             var version = versionExtension.getCurrentIndexVersion();
 
-            assert version.onOrAfter(fallback);
+            assert version.onOrAfter(LATEST_DEFINED);
             assert version.luceneVersion.equals(Version.LATEST)
                 : "IndexVersion must be upgraded to ["
                 + Version.LATEST
@@ -173,7 +173,12 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
 
     public static final IndexVersion MINIMUM_COMPATIBLE = V_7_0_0;
 
+    private static final NavigableMap<Integer, IndexVersion> VERSION_IDS = getAllVersionIds(IndexVersion.class);
+
+    static final IndexVersion LATEST_DEFINED;
     static {
+        LATEST_DEFINED = VERSION_IDS.lastEntry().getValue();
+
         // see comment on IDS field
         // now we're registered the index versions, we can clear the map
         IDS = null;
@@ -216,12 +221,6 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
         }
 
         return Collections.unmodifiableNavigableMap(builder);
-    }
-
-    private static final NavigableMap<Integer, IndexVersion> VERSION_IDS;
-
-    static {
-        VERSION_IDS = getAllVersionIds(IndexVersion.class);
     }
 
     static Collection<IndexVersion> getAllVersions() {


### PR DESCRIPTION
This commit reduces some of the boilerplate needed for defining new IndexVersion constants. Previously defining a new constant meant both adding the constant and updating the definition of CURRENT. With this change the CURRENT is automatically figured out. It utilizes the already existing sorted map that we have for finding duplicate index version definitions.