### PR TITLE
Avoid using query pragmas in ESQL tests

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -85,8 +85,7 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
 
     protected static QueryPragmas randomPragmas() {
         Settings.Builder settings = Settings.builder();
-        // pragmas are only enabled on snapshot builds
-        if (Build.current().isSnapshot()) {
+        if (canUseQueryPragmas()) {
             if (randomBoolean()) {
                 settings.put("task_concurrency", randomLongBetween(1, 10));
             }
@@ -118,4 +117,7 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
         return new QueryPragmas(settings.build());
     }
 
+    protected static boolean canUseQueryPragmas() {
+        return Build.current().isSnapshot();
+    }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -445,8 +445,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         assertEquals(0.034d, (double) getValuesList(results).get(0).get(0), 0.001d);
     }
 
-    public void testFromStatsEvalWithPragma() {
-        assumeTrue("pragmas only enabled on snapshot builds", Build.current().isSnapshot());
+    public void testFromStatsThenEval() {
         EsqlQueryResponse results = run("from test | stats avg_count = avg(count) | eval x = avg_count + 7");
         logger.info(results);
         Assert.assertEquals(1, getValuesList(results).size());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -80,6 +80,7 @@ public class EsqlActionTaskIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void setupIndex() throws IOException {
+        assumeTrue("requires query pragmas", canUseQueryPragmas());
         PAGE_SIZE = between(10, 100);
         NUM_DOCS = between(4 * PAGE_SIZE, 5 * PAGE_SIZE);
         READ_DESCRIPTION = """

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ManyShardsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ManyShardsIT.java
@@ -59,11 +59,11 @@ public class ManyShardsIT extends AbstractEsqlIntegTestCase {
                 } catch (InterruptedException e) {
                     throw new AssertionError(e);
                 }
-                var pragmas = Settings.builder()
-                    .put(randomPragmas().getSettings())
-                    .put("exchange_concurrent_clients", between(1, 2))
-                    .build();
-                run("from test-* | stats count(user) by tags", new QueryPragmas(pragmas));
+                final var pragmas = Settings.builder();
+                if (canUseQueryPragmas()) {
+                    pragmas.put(randomPragmas().getSettings()).put("exchange_concurrent_clients", between(1, 2));
+                }
+                run("from test-* | stats count(user) by tags", new QueryPragmas(pragmas.build()));
             });
         }
         for (Thread thread : threads) {


### PR DESCRIPTION
This PR avoids enabling QueryPragmas in ESQL tests since it's only available in the snapshot build.