### PR TITLE
Remove exception-mangling from RecoverySourceHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -19,7 +19,6 @@ import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -33,7 +32,6 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CancellableThreads;
 import org.elasticsearch.common.util.concurrent.CountDown;
-import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.IOUtils;
@@ -84,6 +82,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
@@ -120,7 +119,7 @@ public class RecoverySourceHandler {
     private final RecoveryPlannerService recoveryPlannerService;
     private final CancellableThreads cancellableThreads = new CancellableThreads();
     private final List<Closeable> resources = new CopyOnWriteArrayList<>();
-    private final ListenableActionFuture<RecoveryResponse> future = new ListenableActionFuture<>();
+    private final SubscribableListener<RecoveryResponse> future = new SubscribableListener<>();
 
     public RecoverySourceHandler(
         IndexShard shard,
@@ -231,10 +230,13 @@ public class RecoverySourceHandler {
             logger.trace("history is retained by retention lock");
         }
 
-        final ListenableFuture<SendFileResult> sendFileStep = new ListenableFuture<>();
-        final ListenableFuture<TimeValue> prepareEngineStep = new ListenableFuture<>();
-        final ListenableFuture<SendSnapshotResult> sendSnapshotStep = new ListenableFuture<>();
-        final ListenableFuture<Void> finalizeStep = new ListenableFuture<>();
+        final SubscribableListener<SendFileResult> sendFileStep = new SubscribableListener<>();
+        final SubscribableListener<TimeValue> prepareEngineStep = new SubscribableListener<>();
+        final SubscribableListener<SendSnapshotResult> sendSnapshotStep = new SubscribableListener<>();
+        final SubscribableListener<Void> finalizeStep = new SubscribableListener<>();
+        final AtomicReference<SendSnapshotResult> sendSnapshotStepResult = new AtomicReference<>();
+        final AtomicReference<SendFileResult> sendFileStepResult = new AtomicReference<>();
+        final AtomicLong prepareEngineTimeMillisRef = new AtomicLong();
 
         if (isSequenceNumberBasedRecovery) {
             logger.trace("performing sequence numbers based recovery. starting at [{}]", request.startingSeqNo());
@@ -294,12 +296,14 @@ public class RecoverySourceHandler {
 
         sendFileStep.addListener(ActionListener.wrap(r -> {
             assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[prepareTargetForTranslog]");
+            sendFileStepResult.set(r);
             // For a sequence based recovery, the target can keep its local translog
             prepareTargetForTranslog(estimateNumberOfHistoryOperations(startingSeqNo), prepareEngineStep);
         }, onFailure));
 
         prepareEngineStep.addListener(ActionListener.wrap(prepareEngineTime -> {
             assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[phase2]");
+            prepareEngineTimeMillisRef.set(prepareEngineTime.millis());
             /*
              * add shard to replication group (shard will receive replication requests from this point on) now that engine is open.
              * This means that any document indexed into the primary after this will be replicated to this replica as well
@@ -346,14 +350,15 @@ public class RecoverySourceHandler {
 
         // Recovery target can trim all operations >= startingSeqNo as we have sent all these operations in the phase 2
         final long trimAboveSeqNo = startingSeqNo - 1;
-        sendSnapshotStep.addListener(
-            ActionListener.wrap(r -> finalizeRecovery(r.targetLocalCheckpoint, trimAboveSeqNo, finalizeStep), onFailure)
-        );
+        sendSnapshotStep.addListener(ActionListener.wrap(r -> {
+            sendSnapshotStepResult.set(r);
+            finalizeRecovery(r.targetLocalCheckpoint, trimAboveSeqNo, finalizeStep);
+        }, onFailure));
 
         finalizeStep.addListener(ActionListener.wrap(r -> {
             final long phase1ThrottlingWaitTime = 0L; // TODO: return the actual throttle time
-            final SendSnapshotResult sendSnapshotResult = sendSnapshotStep.result();
-            final SendFileResult sendFileResult = sendFileStep.result();
+            final SendSnapshotResult sendSnapshotResult = sendSnapshotStepResult.get();
+            final SendFileResult sendFileResult = sendFileStepResult.get();
             final RecoveryResponse response = new RecoveryResponse(
                 sendFileResult.phase1FileNames,
                 sendFileResult.phase1FileSizes,
@@ -363,7 +368,7 @@ public class RecoverySourceHandler {
                 sendFileResult.existingTotalSize,
                 sendFileResult.took.millis(),
                 phase1ThrottlingWaitTime,
-                prepareEngineStep.result().millis(),
+                prepareEngineTimeMillisRef.get(),
                 sendSnapshotResult.sentOperations,
                 sendSnapshotResult.tookTime.millis()
             );
@@ -553,7 +558,7 @@ public class RecoverySourceHandler {
                 logger.trace("skipping [phase1] since source and target have identical sync id [{}]", recoverySourceMetadata.getSyncId());
 
                 // but we must still create a retention lease
-                final ListenableFuture<RetentionLease> createRetentionLeaseStep = new ListenableFuture<>();
+                final SubscribableListener<RetentionLease> createRetentionLeaseStep = new SubscribableListener<>();
                 createRetentionLease(startingSeqNo, createRetentionLeaseStep);
                 createRetentionLeaseStep.addListener(listener.delegateFailureAndWrap((l, retentionLease) -> {
                     final TimeValue took = stopWatch.totalTime();
@@ -661,11 +666,12 @@ public class RecoverySourceHandler {
         // since the plan can change after a failure recovering files from the snapshots that cannot be
         // recovered from the source node, in that case we have to start from scratch using the fallback
         // recovery plan that would be used in subsequent steps.
-        final ListenableFuture<Void> sendFileInfoStep = new ListenableFuture<>();
-        final ListenableFuture<Tuple<ShardRecoveryPlan, List<StoreFileMetadata>>> recoverSnapshotFilesStep = new ListenableFuture<>();
-        final ListenableFuture<ShardRecoveryPlan> sendFilesStep = new ListenableFuture<>();
-        final ListenableFuture<Tuple<ShardRecoveryPlan, RetentionLease>> createRetentionLeaseStep = new ListenableFuture<>();
-        final ListenableFuture<ShardRecoveryPlan> cleanFilesStep = new ListenableFuture<>();
+        final SubscribableListener<Void> sendFileInfoStep = new SubscribableListener<>();
+        final SubscribableListener<Tuple<ShardRecoveryPlan, List<StoreFileMetadata>>> recoverSnapshotFilesStep =
+            new SubscribableListener<>();
+        final SubscribableListener<ShardRecoveryPlan> sendFilesStep = new SubscribableListener<>();
+        final SubscribableListener<Tuple<ShardRecoveryPlan, RetentionLease>> createRetentionLeaseStep = new SubscribableListener<>();
+        final SubscribableListener<ShardRecoveryPlan> cleanFilesStep = new SubscribableListener<>();
 
         final int translogOps = shardRecoveryPlan.getTranslogOps();
         recoveryTarget.receiveFileInfo(
@@ -790,7 +796,9 @@ public class RecoverySourceHandler {
         private final CountDown countDown;
         private final BlockingQueue<BlobStoreIndexShardSnapshot.FileInfo> pendingSnapshotFilesToRecover;
         private final AtomicBoolean cancelled = new AtomicBoolean();
-        private final Set<ListenableFuture<Void>> outstandingRequests = Sets.newHashSetWithExpectedSize(maxConcurrentSnapshotFileDownloads);
+        private final Set<SubscribableListener<Void>> outstandingRequests = Sets.newHashSetWithExpectedSize(
+            maxConcurrentSnapshotFileDownloads
+        );
         private List<StoreFileMetadata> filesFailedToDownloadFromSnapshot;
 
         SnapshotRecoverFileRequestsSender(ShardRecoveryPlan shardRecoveryPlan, ActionListener<List<StoreFileMetadata>> listener) {
@@ -813,7 +821,7 @@ public class RecoverySourceHandler {
                 return;
             }
 
-            final ListenableFuture<Void> requestFuture = new ListenableFuture<>();
+            final SubscribableListener<Void> requestFuture = new SubscribableListener<>();
             try {
                 cancellableThreads.checkForCancel();
 
@@ -899,7 +907,7 @@ public class RecoverySourceHandler {
             return Objects.requireNonNullElse(filesFailedToDownloadFromSnapshot, Collections.emptyList());
         }
 
-        private void trackOutstandingRequest(ListenableFuture<Void> future) {
+        private void trackOutstandingRequest(SubscribableListener<Void> future) {
             boolean cancelled;
             synchronized (outstandingRequests) {
                 cancelled = cancellableThreads.isCancelled() || this.cancelled.get();
@@ -919,7 +927,7 @@ public class RecoverySourceHandler {
             }
         }
 
-        private void unTrackOutstandingRequest(ListenableFuture<Void> future) {
+        private void unTrackOutstandingRequest(SubscribableListener<Void> future) {
             synchronized (outstandingRequests) {
                 outstandingRequests.remove(future);
             }
@@ -928,7 +936,7 @@ public class RecoverySourceHandler {
         private void notifyFailureOnceAllOutstandingRequestAreDone(Exception e) {
             assert cancelled.get();
 
-            final Set<ListenableFuture<Void>> pendingRequests;
+            final Set<SubscribableListener<Void>> pendingRequests;
             synchronized (outstandingRequests) {
                 pendingRequests = new HashSet<>(outstandingRequests);
             }
@@ -941,7 +949,7 @@ public class RecoverySourceHandler {
             // new requests and therefore we can safely use to wait until all the pending requests complete
             // to notify the listener about the cancellation
             final CountDown pendingRequestsCountDown = new CountDown(pendingRequests.size());
-            for (ListenableFuture<Void> outstandingFuture : pendingRequests) {
+            for (SubscribableListener<Void> outstandingFuture : pendingRequests) {
                 outstandingFuture.addListener(ActionListener.running(() -> {
                     if (pendingRequestsCountDown.countDown()) {
                         listener.onFailure(e);
@@ -1111,7 +1119,7 @@ public class RecoverySourceHandler {
         }
         logger.trace("recovery [phase2]: sending transaction log operations (from [" + startingSeqNo + "] to [" + endingSeqNo + "]");
         final StopWatch stopWatch = new StopWatch().start();
-        final ListenableFuture<Void> sendListener = new ListenableFuture<>();
+        final SubscribableListener<Void> sendListener = new SubscribableListener<>();
         final OperationBatchSender sender = new OperationBatchSender(
             startingSeqNo,
             endingSeqNo,
@@ -1252,7 +1260,7 @@ public class RecoverySourceHandler {
          * marking the shard as in-sync. If the relocation handoff holds all the permits then after the handoff completes and we acquire
          * the permit then the state of the shard will be relocated and this recovery will fail.
          */
-        final ListenableFuture<Void> markInSyncStep = new ListenableFuture<>();
+        final SubscribableListener<Void> markInSyncStep = new SubscribableListener<>();
         runUnderPrimaryPermit(
             () -> shard.markAllocationIdAsInSync(request.targetAllocationId(), targetLocalCheckpoint),
             shard,
@@ -1260,14 +1268,14 @@ public class RecoverySourceHandler {
             markInSyncStep
         );
 
-        final ListenableFuture<Long> finalizeListener = new ListenableFuture<>();
+        final SubscribableListener<Long> finalizeListener = new SubscribableListener<>();
         markInSyncStep.addListener(listener.delegateFailureAndWrap((l, ignored) -> {
             final long globalCheckpoint = shard.getLastKnownGlobalCheckpoint(); // this global checkpoint is persisted in finalizeRecovery
             cancellableThreads.checkForCancel();
             recoveryTarget.finalizeRecovery(globalCheckpoint, trimAboveSeqNo, finalizeListener.map(ignored2 -> globalCheckpoint));
         }));
 
-        final ListenableFuture<Void> updateGlobalCheckpointStep = new ListenableFuture<>();
+        final SubscribableListener<Void> updateGlobalCheckpointStep = new SubscribableListener<>();
         finalizeListener.addListener(
             listener.delegateFailureAndWrap(
                 (l, globalCheckpoint) -> runUnderPrimaryPermit(
@@ -1279,9 +1287,9 @@ public class RecoverySourceHandler {
             )
         );
 
-        final ListenableFuture<Void> finalStep;
+        final SubscribableListener<Void> finalStep;
         if (request.isPrimaryRelocation()) {
-            finalStep = new ListenableFuture<>();
+            finalStep = new SubscribableListener<>();
             updateGlobalCheckpointStep.addListener(listener.delegateFailureAndWrap((l, ignored) -> {
                 logger.trace("performing relocation hand-off");
                 cancellableThreads.execute(


### PR DESCRIPTION
`RecoverySourceHandler` uses `Listenable*Future` in several places that
do not need the exception-mangling behaviour, so this commit replaces
them with `SubscribableListener`.