### PR TITLE
[DOCS] Remove unneeded ifevals

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -143,11 +143,6 @@ curl --cacert http_ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200/_c
 [[run-kibana-docker]]
 ===== Run {kib}
 
-ifeval::["{version}"=="8.10.0"]
-IMPORTANT: {kib} 8.10.0 has been withdrawn.
-endif::[]
-
-ifeval::["{version}"!="8.10.0"]
 . Pull the {kib} Docker image.
 +
 --
@@ -176,7 +171,6 @@ cosign verify --key cosign.pub {kib-docker-image}
 ----
 docker run --name kib01 --net elastic -p 5601:5601 {kib-docker-image}
 ----
-endif::[]
 
 . When {kib} starts, it outputs a unique generated link to the terminal. To
 access {kib}, open this link in a web browser.
@@ -233,11 +227,6 @@ lets you start multiple containers with a single command.
 
 ===== Configure and start the cluster
 
-ifeval::["{version}"=="8.10.0"]
-IMPORTANT: {kib} 8.10.0 has been withdrawn.
-endif::[]
-
-ifeval::["{version}"!="8.10.0"]
 . Install Docker Compose. Visit the
 https://docs.docker.com/compose/install/[Docker Compose docs] to install Docker
 Compose for your environment.
@@ -308,7 +297,6 @@ access {kib}.
 
 . Log in to {kib} as the `elastic` user using the `ELASTIC_PASSWORD` you set
 earlier.
-endif::[]
 
 ===== Stop and remove the cluster
 To stop the cluster, run `docker-compose down`. The data in the Docker volumes

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -61,27 +61,19 @@ You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
 Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
 
 . In a new terminal session, start Kibana and connect it to your Elasticsearch container:
-+
---
 ifeval::["{release-state}"=="unreleased"]
++
 WARNING: Version {version} of {kib} has not yet been released, so no
 Docker image is currently available for this version.
 endif::[]
-
-ifeval::["{version}"=="8.10.0"]
-IMPORTANT: {kib} 8.10.0 has been withdrawn.
-endif::[]
-
-ifeval::["{version}"!="8.10.0"]
++
 [source,sh,subs="attributes"]
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
 docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
-endif::[]
-
++
 When you start Kibana, a unique URL is output to your terminal.
---
 
 . To access Kibana, open the generated URL in your browser.
 


### PR DESCRIPTION
Removes ifevals and admons added as part of #99608. These are no longer needed.

This reverts commit 809c557da49cfe09cda6b0851e719111dbda8638.