### PR TITLE
ESQL: Prevent topn from using too much memory

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/TopNBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/TopNBenchmark.java
@@ -9,6 +9,9 @@
 package org.elasticsearch.benchmark.compute.operator;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -20,6 +23,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.topn.TopNEncoder;
 import org.elasticsearch.compute.operator.topn.TopNOperator;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -96,7 +101,13 @@ public class TopNBenchmark {
             case LONGS_AND_BYTES_REFS -> List.of(TopNEncoder.DEFAULT_SORTABLE, TopNEncoder.UTF8);
             default -> throw new IllegalArgumentException("unsupported data type [" + data + "]");
         };
+        CircuitBreakerService breakerService = new HierarchyCircuitBreakerService(
+            Settings.EMPTY,
+            List.of(),
+            ClusterSettings.createBuiltInClusterSettings()
+        );
         return new TopNOperator(
+            breakerService.getBreaker(CircuitBreaker.REQUEST),
             topCount,
             elementTypes,
             encoders,

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -685,5 +685,10 @@ public class MockBigArrays extends BigArrays {
         public void addWithoutBreaking(long bytes) {
             used.addAndGet(bytes);
         }
+
+        @Override
+        public long getUsed() {
+            return used.get();
+        }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -675,9 +675,15 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
-            long total = used.addAndGet(bytes);
-            if (total > max.getBytes()) {
-                throw new CircuitBreakingException(ERROR_MESSAGE, bytes, max.getBytes(), Durability.TRANSIENT);
+            while (true) {
+                long old = used.get();
+                long total = old + bytes;
+                if (total > max.getBytes()) {
+                    throw new CircuitBreakingException(ERROR_MESSAGE, bytes, max.getBytes(), Durability.TRANSIENT);
+                }
+                if (used.compareAndSet(old, total)) {
+                    break;
+                }
             }
         }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForBoolean.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForBoolean.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class KeyExtractorForBoolean implements KeyExtractor {
     static KeyExtractorForBoolean extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, BooleanBlock block) {
@@ -37,13 +37,13 @@ abstract class KeyExtractorForBoolean implements KeyExtractor {
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BytesRefBuilder key, boolean value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, boolean value) {
         key.append(nonNul);
         TopNEncoder.DEFAULT_SORTABLE.encodeBoolean(value, key);
         return Byte.BYTES + 1;
     }
 
-    protected final int nul(BytesRefBuilder key) {
+    protected final int nul(BreakingBytesRefBuilder key) {
         key.append(nul);
         return 1;
     }
@@ -57,7 +57,7 @@ abstract class KeyExtractorForBoolean implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             return nonNul(key, vector.getBoolean(position));
         }
     }
@@ -71,7 +71,7 @@ abstract class KeyExtractorForBoolean implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -88,7 +88,7 @@ abstract class KeyExtractorForBoolean implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -105,7 +105,7 @@ abstract class KeyExtractorForBoolean implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);
@@ -130,7 +130,7 @@ abstract class KeyExtractorForBoolean implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForBytesRef.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class KeyExtractorForBytesRef implements KeyExtractor {
     static KeyExtractorForBytesRef extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, BytesRefBlock block) {
@@ -40,12 +40,12 @@ abstract class KeyExtractorForBytesRef implements KeyExtractor {
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BytesRefBuilder key, BytesRef value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, BytesRef value) {
         key.append(nonNul);
         return encoder.encodeBytesRef(value, key) + 1;
     }
 
-    protected final int nul(BytesRefBuilder key) {
+    protected final int nul(BreakingBytesRefBuilder key) {
         key.append(nul);
         return 1;
     }
@@ -59,7 +59,7 @@ abstract class KeyExtractorForBytesRef implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             return nonNul(key, vector.getBytesRef(position, scratch));
         }
     }
@@ -73,7 +73,7 @@ abstract class KeyExtractorForBytesRef implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -90,7 +90,7 @@ abstract class KeyExtractorForBytesRef implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -109,7 +109,7 @@ abstract class KeyExtractorForBytesRef implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);
@@ -140,7 +140,7 @@ abstract class KeyExtractorForBytesRef implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForDouble.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class KeyExtractorForDouble implements KeyExtractor {
     static KeyExtractorForDouble extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, DoubleBlock block) {
@@ -37,13 +37,13 @@ abstract class KeyExtractorForDouble implements KeyExtractor {
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BytesRefBuilder key, double value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, double value) {
         key.append(nonNul);
         TopNEncoder.DEFAULT_SORTABLE.encodeDouble(value, key);
         return Double.BYTES + 1;
     }
 
-    protected final int nul(BytesRefBuilder key) {
+    protected final int nul(BreakingBytesRefBuilder key) {
         key.append(nul);
         return 1;
     }
@@ -57,7 +57,7 @@ abstract class KeyExtractorForDouble implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             return nonNul(key, vector.getDouble(position));
         }
     }
@@ -71,7 +71,7 @@ abstract class KeyExtractorForDouble implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -88,7 +88,7 @@ abstract class KeyExtractorForDouble implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -105,7 +105,7 @@ abstract class KeyExtractorForDouble implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);
@@ -129,7 +129,7 @@ abstract class KeyExtractorForDouble implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForInt.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class KeyExtractorForInt implements KeyExtractor {
     static KeyExtractorForInt extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, IntBlock block) {
@@ -37,13 +37,13 @@ abstract class KeyExtractorForInt implements KeyExtractor {
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BytesRefBuilder key, int value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, int value) {
         key.append(nonNul);
         TopNEncoder.DEFAULT_SORTABLE.encodeInt(value, key);
         return Integer.BYTES + 1;
     }
 
-    protected final int nul(BytesRefBuilder key) {
+    protected final int nul(BreakingBytesRefBuilder key) {
         key.append(nul);
         return 1;
     }
@@ -57,7 +57,7 @@ abstract class KeyExtractorForInt implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             return nonNul(key, vector.getInt(position));
         }
     }
@@ -71,7 +71,7 @@ abstract class KeyExtractorForInt implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -88,7 +88,7 @@ abstract class KeyExtractorForInt implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -105,7 +105,7 @@ abstract class KeyExtractorForInt implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);
@@ -129,7 +129,7 @@ abstract class KeyExtractorForInt implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForLong.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class KeyExtractorForLong implements KeyExtractor {
     static KeyExtractorForLong extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, LongBlock block) {
@@ -37,13 +37,13 @@ abstract class KeyExtractorForLong implements KeyExtractor {
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BytesRefBuilder key, long value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, long value) {
         key.append(nonNul);
         TopNEncoder.DEFAULT_SORTABLE.encodeLong(value, key);
         return Long.BYTES + 1;
     }
 
-    protected final int nul(BytesRefBuilder key) {
+    protected final int nul(BreakingBytesRefBuilder key) {
         key.append(nul);
         return 1;
     }
@@ -57,7 +57,7 @@ abstract class KeyExtractorForLong implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             return nonNul(key, vector.getLong(position));
         }
     }
@@ -71,7 +71,7 @@ abstract class KeyExtractorForLong implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -88,7 +88,7 @@ abstract class KeyExtractorForLong implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -105,7 +105,7 @@ abstract class KeyExtractorForLong implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);
@@ -129,7 +129,7 @@ abstract class KeyExtractorForLong implements KeyExtractor {
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForBoolean.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForBoolean.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class ValueExtractorForBoolean implements ValueExtractor {
     static ValueExtractorForBoolean extractorFor(TopNEncoder encoder, boolean inKey, BooleanBlock block) {
@@ -27,11 +27,11 @@ abstract class ValueExtractorForBoolean implements ValueExtractor {
         this.inKey = inKey;
     }
 
-    protected final void writeCount(BytesRefBuilder values, int count) {
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BytesRefBuilder values, boolean value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, boolean value) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeBoolean(value, values);
     }
 
@@ -44,7 +44,7 @@ abstract class ValueExtractorForBoolean implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             writeCount(values, 1);
             if (inKey) {
                 // will read results from the key
@@ -63,7 +63,7 @@ abstract class ValueExtractorForBoolean implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             int size = block.getValueCount(position);
             writeCount(values, size);
             if (size == 1 && inKey) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForBytesRef.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class ValueExtractorForBytesRef implements ValueExtractor {
     static ValueExtractorForBytesRef extractorFor(TopNEncoder encoder, boolean inKey, BytesRefBlock block) {
@@ -32,11 +32,11 @@ abstract class ValueExtractorForBytesRef implements ValueExtractor {
         this.inKey = inKey;
     }
 
-    protected final void writeCount(BytesRefBuilder values, int count) {
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BytesRefBuilder values, BytesRef value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, BytesRef value) {
         encoder.encodeBytesRef(value, values);
     }
 
@@ -49,7 +49,7 @@ abstract class ValueExtractorForBytesRef implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             writeCount(values, 1);
             if (inKey) {
                 // will read results from the key
@@ -68,7 +68,7 @@ abstract class ValueExtractorForBytesRef implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             int size = block.getValueCount(position);
             writeCount(values, size);
             if (size == 1 && inKey) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForDouble.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class ValueExtractorForDouble implements ValueExtractor {
     static ValueExtractorForDouble extractorFor(TopNEncoder encoder, boolean inKey, DoubleBlock block) {
@@ -27,11 +27,11 @@ abstract class ValueExtractorForDouble implements ValueExtractor {
         this.inKey = inKey;
     }
 
-    protected final void writeCount(BytesRefBuilder values, int count) {
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BytesRefBuilder values, double value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, double value) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeDouble(value, values);
     }
 
@@ -44,7 +44,7 @@ abstract class ValueExtractorForDouble implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             writeCount(values, 1);
             if (inKey) {
                 // will read results from the key
@@ -63,7 +63,7 @@ abstract class ValueExtractorForDouble implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             int size = block.getValueCount(position);
             writeCount(values, size);
             if (size == 1 && inKey) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForInt.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class ValueExtractorForInt implements ValueExtractor {
     static ValueExtractorForInt extractorFor(TopNEncoder encoder, boolean inKey, IntBlock block) {
@@ -27,11 +27,11 @@ abstract class ValueExtractorForInt implements ValueExtractor {
         this.inKey = inKey;
     }
 
-    protected final void writeCount(BytesRefBuilder values, int count) {
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BytesRefBuilder values, int value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, int value) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeInt(value, values);
     }
 
@@ -44,7 +44,7 @@ abstract class ValueExtractorForInt implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             writeCount(values, 1);
             if (inKey) {
                 // will read results from the key
@@ -63,7 +63,7 @@ abstract class ValueExtractorForInt implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             int size = block.getValueCount(position);
             writeCount(values, size);
             if (size == 1 && inKey) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForLong.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class ValueExtractorForLong implements ValueExtractor {
     static ValueExtractorForLong extractorFor(TopNEncoder encoder, boolean inKey, LongBlock block) {
@@ -27,11 +27,11 @@ abstract class ValueExtractorForLong implements ValueExtractor {
         this.inKey = inKey;
     }
 
-    protected final void writeCount(BytesRefBuilder values, int count) {
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BytesRefBuilder values, long value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, long value) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeLong(value, values);
     }
 
@@ -44,7 +44,7 @@ abstract class ValueExtractorForLong implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             writeCount(values, 1);
             if (inKey) {
                 // will read results from the key
@@ -63,7 +63,7 @@ abstract class ValueExtractorForLong implements ValueExtractor {
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             int size = block.getValueCount(position);
             writeCount(values, size);
             if (size == 1 && inKey) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Releasable;
+
+/**
+ * Builder for bytes arrays.
+ */
+public class BreakingBytesRefBuilder implements Accountable, Releasable {
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(BreakingBytesRefBuilder.class) + RamUsageEstimator
+        .shallowSizeOfInstance(BytesRef.class);
+
+    private final BytesRef bytes = new BytesRef();
+
+    private final CircuitBreaker breaker;
+    private final String label;
+
+    public BreakingBytesRefBuilder(CircuitBreaker breaker, String label) {
+        this.breaker = breaker;
+        this.label = label;
+    }
+
+    /**
+     * Make sure that the underlying bytes has a capacity of at least
+     * {@code capacity}.
+     */
+    public void grow(int capacity) {
+        int oldSize = bytes.bytes.length;
+        if (oldSize > capacity) {
+            return;
+        }
+        int newSize = ArrayUtil.oversize(capacity, Byte.BYTES);
+        breaker.addEstimateBytesAndMaybeBreak(newSize, label);
+        bytes.bytes = ArrayUtil.growExact(bytes.bytes, newSize);
+        breaker.addWithoutBreaking(-oldSize);
+    }
+
+    /**
+     * Return the underlying bytes being built for direct manipulation.
+     * Callers will typically use this in combination with {@link #grow},
+     * {@link #length} and {@link #setLength} like this:
+     * {@code<pre>
+     *     bytesRefBuilder.grow(bytesRefBuilder.length() + Long.BYTES);
+     *     LONG.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), value);
+     *     bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES);
+     * </pre>}
+     */
+    public byte[] bytes() {
+        return bytes.bytes;
+    }
+
+    /**
+     * The number of bytes in to this buffer. It is <strong>not></strong>
+     * the capacity of the buffer.
+     */
+    public int length() {
+        return bytes.length;
+    }
+
+    /**
+     * Set the number of bytes in this buffer. Does not deallocate the
+     * underlying buffer, only the length once built.
+     */
+    public void setLength(int length) {
+        bytes.length = length;
+    }
+
+    /**
+     * Append a byte.
+     */
+    public void append(byte b) {
+        grow(bytes.length + 1);
+        bytes.bytes[bytes.length++] = b;
+    }
+
+    /**
+     * Append bytes.
+     */
+    public void append(byte[] b, int off, int len) {
+        grow(bytes.length + len);
+        System.arraycopy(b, off, bytes.bytes, bytes.length, len);
+        bytes.length += len;
+    }
+
+    /**
+     * Append bytes.
+     */
+    public void append(BytesRef bytes) {
+        append(bytes.bytes, bytes.offset, bytes.length);
+    }
+
+    /**
+     * Reset the builder to an empty bytes array. Doesn't deallocate any memory.
+     */
+    public void clear() {
+        bytes.length = 0;
+    }
+
+    /**
+     * Returns a view of the data added as a {@link BytesRef}. Importantly, this does not
+     * copy the bytes and any further modification to the {@link BreakingBytesRefBuilder}
+     * will modify the returned {@link BytesRef}. The called must copy the bytes
+     * if they wish to keep them.
+     */
+    public BytesRef bytesRefView() {
+        assert bytes.offset == 0;
+        return bytes;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(bytes.bytes);
+    }
+
+    @Override
+    public void close() {
+        breaker.addWithoutBreaking(-bytes.bytes.length);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableTopNEncoder.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class DefaultSortableTopNEncoder extends SortableTopNEncoder {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableTopNEncoder.java
@@ -9,10 +9,11 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class DefaultSortableTopNEncoder extends SortableTopNEncoder {
     @Override
-    public int encodeBytesRef(BytesRef value, BytesRefBuilder bytesRefBuilder) {
+    public int encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {
         throw new IllegalStateException("Cannot find encoder for BytesRef value");
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -24,7 +24,7 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     public static final VarHandle DOUBLE = MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.nativeOrder());
 
     @Override
-    public void encodeLong(long value, BytesRefBuilder bytesRefBuilder) {
+    public void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Long.BYTES);
         LONG.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), value);
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES);
@@ -46,7 +46,7 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
      * five bytes. Smaller values take fewer bytes. Negative numbers
      * will always use all 5 bytes.
      */
-    public void encodeVInt(int value, BytesRefBuilder bytesRefBuilder) {
+    public void encodeVInt(int value, BreakingBytesRefBuilder bytesRefBuilder) {
         while ((value & ~0x7F) != 0) {
             bytesRefBuilder.append(((byte) ((value & 0x7f) | 0x80)));
             value >>>= 7;
@@ -103,7 +103,7 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public void encodeInt(int value, BytesRefBuilder bytesRefBuilder) {
+    public void encodeInt(int value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Integer.BYTES);
         INT.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), value);
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Integer.BYTES);
@@ -121,7 +121,7 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public void encodeDouble(double value, BytesRefBuilder bytesRefBuilder) {
+    public void encodeDouble(double value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Double.BYTES);
         DOUBLE.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), value);
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES);
@@ -139,7 +139,7 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public void encodeBoolean(boolean value, BytesRefBuilder bytesRefBuilder) {
+    public void encodeBoolean(boolean value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.append(value ? (byte) 1 : (byte) 0);
     }
 
@@ -155,7 +155,7 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public int encodeBytesRef(BytesRef value, BytesRefBuilder bytesRefBuilder) {
+    public int encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {
         throw new UnsupportedOperationException();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/FixedLengthTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/FixedLengthTopNEncoder.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class FixedLengthTopNEncoder extends SortableTopNEncoder {
     private final int length;
@@ -18,7 +18,7 @@ class FixedLengthTopNEncoder extends SortableTopNEncoder {
     }
 
     @Override
-    public int encodeBytesRef(BytesRef value, BytesRefBuilder bytesRefBuilder) {
+    public int encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {
         if (value.length != length) {
             throw new IllegalArgumentException("expected exactly [" + length + "] bytes but got [" + value.length + "]");
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractor.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -15,12 +14,13 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
- * Extracts keys into a {@link BytesRefBuilder}.
+ * Extracts keys into a {@link BreakingBytesRefBuilder}.
  */
 interface KeyExtractor {
-    int writeKey(BytesRefBuilder key, int position);
+    int writeKey(BreakingBytesRefBuilder key, int position);
 
     static KeyExtractor extractorFor(ElementType elementType, TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, Block block) {
         if (false == (elementType == block.elementType() || ElementType.NULL == block.elementType())) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractorForNull.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractorForNull.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class KeyExtractorForNull implements KeyExtractor {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractorForNull.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractorForNull.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class KeyExtractorForNull implements KeyExtractor {
     private final byte nul;
@@ -17,7 +18,7 @@ class KeyExtractorForNull implements KeyExtractor {
     }
 
     @Override
-    public int writeKey(BytesRefBuilder values, int position) {
+    public int writeKey(BreakingBytesRefBuilder values, int position) {
         values.append(nul);
         return 1;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableTopNEncoder.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableTopNEncoder.java
@@ -10,13 +10,14 @@ package org.elasticsearch.compute.operator.topn;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
  * A {@link TopNEncoder} that encodes values to byte arrays that may be sorted directly.
  */
 public abstract class SortableTopNEncoder implements TopNEncoder {
     @Override
-    public final void encodeLong(long value, BytesRefBuilder bytesRefBuilder) {
+    public final void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Long.BYTES);
         NumericUtils.longToSortableBytes(value, bytesRefBuilder.bytes(), bytesRefBuilder.length());
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES);
@@ -34,7 +35,7 @@ public abstract class SortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public final void encodeInt(int value, BytesRefBuilder bytesRefBuilder) {
+    public final void encodeInt(int value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Integer.BYTES);
         NumericUtils.intToSortableBytes(value, bytesRefBuilder.bytes(), bytesRefBuilder.length());
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Integer.BYTES);
@@ -52,7 +53,7 @@ public abstract class SortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public final void encodeDouble(double value, BytesRefBuilder bytesRefBuilder) {
+    public final void encodeDouble(double value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Long.BYTES);
         NumericUtils.longToSortableBytes(NumericUtils.doubleToSortableLong(value), bytesRefBuilder.bytes(), bytesRefBuilder.length());
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES);
@@ -70,7 +71,7 @@ public abstract class SortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public final void encodeBoolean(boolean value, BytesRefBuilder bytesRefBuilder) {
+    public final void encodeBoolean(boolean value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.append(value ? (byte) 1 : (byte) 0);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.operator.topn;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
  * Encodes values for {@link TopNOperator}. Some encoders encode values so sorting
@@ -41,23 +42,23 @@ public interface TopNEncoder {
      */
     VersionTopNEncoder VERSION = new VersionTopNEncoder();
 
-    void encodeLong(long value, BytesRefBuilder bytesRefBuilder);
+    void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder);
 
     long decodeLong(BytesRef bytes);
 
-    void encodeInt(int value, BytesRefBuilder bytesRefBuilder);
+    void encodeInt(int value, BreakingBytesRefBuilder bytesRefBuilder);
 
     int decodeInt(BytesRef bytes);
 
-    void encodeDouble(double value, BytesRefBuilder bytesRefBuilder);
+    void encodeDouble(double value, BreakingBytesRefBuilder bytesRefBuilder);
 
     double decodeDouble(BytesRef bytes);
 
-    void encodeBoolean(boolean value, BytesRefBuilder bytesRefBuilder);
+    void encodeBoolean(boolean value, BreakingBytesRefBuilder bytesRefBuilder);
 
     boolean decodeBoolean(BytesRef bytes);
 
-    int encodeBytesRef(BytesRef value, BytesRefBuilder bytesRefBuilder);
+    int encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder);
 
     BytesRef decodeBytesRef(BytesRef bytes, BytesRef scratch);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
@@ -9,14 +9,17 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.PriorityQueue;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,12 +48,15 @@ public class TopNOperator implements Operator, Accountable {
      * It mirrors somehow the Block build in the sense that it keeps around an array of offsets and a count of values (to account for
      * multivalues) to reference each position in each block of the Page.
      */
-    static final class Row implements Accountable {
-        private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Row.class) + 2 * (RamUsageEstimator
-            .shallowSizeOfInstance(BytesRefBuilder.class) + RamUsageEstimator.shallowSizeOfInstance(BytesRef.class)) + RamUsageEstimator
-                .shallowSizeOfInstance(BitSet.class);
+    static final class Row implements Accountable, Releasable {
+        private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Row.class) + RamUsageEstimator
+            .shallowSizeOfInstance(BitSet.class);
 
-        final BytesRefBuilder keys = new BytesRefBuilder(); // BytesRef used to sort rows between each other
+        /**
+         * The sort key.
+         */
+        final BreakingBytesRefBuilder keys;
+
         /**
          * A true/false value (bit set/unset) for each byte in the BytesRef above corresponding to an asc/desc ordering.
          * For ex, if a Long is represented as 8 bytes, each of these bytes will have the same value (set/unset) if the respective Long
@@ -58,22 +64,50 @@ public class TopNOperator implements Operator, Accountable {
          */
         final BitSet orderByCompositeKeyAscending = new BitSet();
 
-        final BytesRefBuilder values = new BytesRefBuilder();
+        /**
+         * Values to reconstruct the row. Sort of. When we reconstruct the row we read
+         * from both the {@link #keys} and the {@link #values}. So this only contains
+         * what is required to reconstruct the row that isn't already stored in {@link #values}.
+         */
+        final BreakingBytesRefBuilder values;
+
+        Row(CircuitBreaker breaker) {
+            keys = new BreakingBytesRefBuilder(breaker, "topn");
+            values = new BreakingBytesRefBuilder(breaker, "topn");
+        }
 
         @Override
         public long ramBytesUsed() {
-            return SHALLOW_SIZE + RamUsageEstimator.sizeOf(keys.bytes()) + orderByCompositeKeyAscending.size() / Byte.SIZE
-                + RamUsageEstimator.sizeOf(values.bytes());
+            return SHALLOW_SIZE + keys.ramBytesUsed() + orderByCompositeKeyAscending.size() / Byte.SIZE + values.ramBytesUsed();
+        }
+
+        private void clear() {
+            keys.clear();
+            orderByCompositeKeyAscending.clear();
+            values.clear();
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(keys, values);
         }
     }
 
     record KeyFactory(KeyExtractor extractor, boolean ascending) {}
 
     static final class RowFactory {
+        private final CircuitBreaker breaker;
         private final ValueExtractor[] valueExtractors;
         private final KeyFactory[] keyFactories;
 
-        RowFactory(List<ElementType> elementTypes, List<TopNEncoder> encoders, List<SortOrder> sortOrders, Page page) {
+        RowFactory(
+            CircuitBreaker breaker,
+            List<ElementType> elementTypes,
+            List<TopNEncoder> encoders,
+            List<SortOrder> sortOrders,
+            Page page
+        ) {
+            this.breaker = breaker;
             valueExtractors = new ValueExtractor[page.getBlockCount()];
             for (int b = 0; b < valueExtractors.length; b++) {
                 valueExtractors[b] = ValueExtractor.extractorFor(
@@ -101,7 +135,7 @@ public class TopNOperator implements Operator, Accountable {
         Row row(int position, Row spare) {
             Row result;
             if (spare == null) {
-                result = new Row();
+                result = new Row(breaker);
             } else {
                 result = spare;
                 result.keys.clear();
@@ -128,7 +162,7 @@ public class TopNOperator implements Operator, Accountable {
             }
         }
 
-        private void writeValues(int position, BytesRefBuilder values) {
+        private void writeValues(int position, BreakingBytesRefBuilder values) {
             for (ValueExtractor e : valueExtractors) {
                 e.writeValue(values, position);
             }
@@ -180,7 +214,14 @@ public class TopNOperator implements Operator, Accountable {
 
         @Override
         public TopNOperator get(DriverContext driverContext) {
-            return new TopNOperator(topCount, elementTypes, encoders, sortOrders, maxPageSize);
+            return new TopNOperator(
+                driverContext.bigArrays().breakerService().getBreaker(CircuitBreaker.REQUEST),
+                topCount,
+                elementTypes,
+                encoders,
+                sortOrders,
+                maxPageSize
+            );
         }
 
         @Override
@@ -197,6 +238,7 @@ public class TopNOperator implements Operator, Accountable {
         }
     }
 
+    private final CircuitBreaker breaker;
     private final Queue inputQueue;
 
     private final int maxPageSize;
@@ -208,12 +250,14 @@ public class TopNOperator implements Operator, Accountable {
     private Iterator<Page> output;
 
     public TopNOperator(
+        CircuitBreaker breaker,
         int topCount,
         List<ElementType> elementTypes,
         List<TopNEncoder> encoders,
         List<SortOrder> sortOrders,
         int maxPageSize
     ) {
+        this.breaker = breaker;
         this.maxPageSize = maxPageSize;
         this.elementTypes = elementTypes;
         this.encoders = encoders;
@@ -224,8 +268,8 @@ public class TopNOperator implements Operator, Accountable {
     static int compareRows(Row r1, Row r2) {
         // This is similar to r1.key.compareTo(r2.key) but stopping somewhere in the middle so that
         // we check the byte that mismatched
-        BytesRef br1 = r1.keys.get();
-        BytesRef br2 = r2.keys.get();
+        BytesRef br1 = r1.keys.bytesRefView();
+        BytesRef br2 = r2.keys.bytesRefView();
         int mismatchedByteIndex = Arrays.mismatch(
             br1.bytes,
             br1.offset,
@@ -249,10 +293,7 @@ public class TopNOperator implements Operator, Accountable {
             }
         } else {
             // compare the byte that mismatched accounting for that respective byte asc/desc ordering
-            int c = Byte.compareUnsigned(
-                r1.keys.bytes()[br1.offset + mismatchedByteIndex],
-                r2.keys.bytes()[br2.offset + mismatchedByteIndex]
-            );
+            int c = Byte.compareUnsigned(br1.bytes[br1.offset + mismatchedByteIndex], br2.bytes[br2.offset + mismatchedByteIndex]);
             return r1.orderByCompositeKeyAscending.get(mismatchedByteIndex) ? -c : c;
         }
     }
@@ -264,7 +305,7 @@ public class TopNOperator implements Operator, Accountable {
 
     @Override
     public void addInput(Page page) {
-        RowFactory rowFactory = new RowFactory(elementTypes, encoders, sortOrders, page);
+        RowFactory rowFactory = new RowFactory(breaker, elementTypes, encoders, sortOrders, page);
 
         Row removed = null;
         for (int i = 0; i < page.getPositionCount(); i++) {
@@ -285,62 +326,70 @@ public class TopNOperator implements Operator, Accountable {
             return Collections.emptyIterator();
         }
         List<Row> list = new ArrayList<>(inputQueue.size());
-        while (inputQueue.size() > 0) {
-            list.add(inputQueue.pop());
-        }
-        Collections.reverse(list);
-
-        List<Page> result = new ArrayList<>();
-        ResultBuilder[] builders = null;
-        int p = 0;
-        int size = 0;
-        for (int i = 0; i < list.size(); i++) {
-            if (builders == null) {
-                size = Math.min(maxPageSize, list.size() - i);
-                builders = new ResultBuilder[elementTypes.size()];
-                for (int b = 0; b < builders.length; b++) {
-                    builders[b] = ResultBuilder.resultBuilderFor(
-                        elementTypes.get(b),
-                        encoders.get(b).toUnsortable(),
-                        channelInKey(sortOrders, b),
-                        size
-                    );
-                }
-                p = 0;
+        try {
+            while (inputQueue.size() > 0) {
+                list.add(inputQueue.pop());
             }
+            Collections.reverse(list);
 
-            Row row = list.get(i);
-            BytesRef keys = row.keys.get();
-            for (SortOrder so : sortOrders) {
-                if (keys.bytes[keys.offset] == so.nul()) {
+            List<Page> result = new ArrayList<>();
+            ResultBuilder[] builders = null;
+            int p = 0;
+            int size = 0;
+            for (int i = 0; i < list.size(); i++) {
+                if (builders == null) {
+                    size = Math.min(maxPageSize, list.size() - i);
+                    builders = new ResultBuilder[elementTypes.size()];
+                    for (int b = 0; b < builders.length; b++) {
+                        builders[b] = ResultBuilder.resultBuilderFor(
+                            elementTypes.get(b),
+                            encoders.get(b).toUnsortable(),
+                            channelInKey(sortOrders, b),
+                            size
+                        );
+                    }
+                    p = 0;
+                }
+
+                Row row = list.get(i);
+                BytesRef keys = row.keys.bytesRefView();
+                for (SortOrder so : sortOrders) {
+                    if (keys.bytes[keys.offset] == so.nul()) {
+                        keys.offset++;
+                        keys.length--;
+                        continue;
+                    }
                     keys.offset++;
                     keys.length--;
-                    continue;
+                    builders[so.channel].decodeKey(keys);
                 }
-                keys.offset++;
-                keys.length--;
-                builders[so.channel].decodeKey(keys);
-            }
-            if (keys.length != 0) {
-                throw new IllegalArgumentException("didn't read all keys");
-            }
+                if (keys.length != 0) {
+                    throw new IllegalArgumentException("didn't read all keys");
+                }
 
-            BytesRef values = row.values.get();
-            for (ResultBuilder builder : builders) {
-                builder.decodeValue(values);
-            }
-            if (values.length != 0) {
-                throw new IllegalArgumentException("didn't read all values");
-            }
+                BytesRef values = row.values.bytesRefView();
+                for (ResultBuilder builder : builders) {
+                    builder.decodeValue(values);
+                }
+                if (values.length != 0) {
+                    throw new IllegalArgumentException("didn't read all values");
+                }
 
-            p++;
-            if (p == size) {
-                result.add(new Page(Arrays.stream(builders).map(ResultBuilder::build).toArray(Block[]::new)));
-                builders = null;
+                list.set(i, null);
+                row.close();
+
+                p++;
+                if (p == size) {
+                    result.add(new Page(Arrays.stream(builders).map(ResultBuilder::build).toArray(Block[]::new)));
+                    builders = null;
+                }
+
             }
+            assert builders == null;
+            return result.iterator();
+        } finally {
+            Releasables.closeExpectNoException(() -> Releasables.close(list));
         }
-        assert builders == null;
-        return result.iterator();
     }
 
     private static boolean channelInKey(List<SortOrder> sortOrders, int channel) {
@@ -367,7 +416,7 @@ public class TopNOperator implements Operator, Accountable {
 
     @Override
     public void close() {
-
+        // NOCOMMIT all rows. There should be a test failure pointing you here.
     }
 
     private static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TopNOperator.class) + RamUsageEstimator
@@ -404,6 +453,10 @@ public class TopNOperator implements Operator, Accountable {
             + ", sortOrders="
             + sortOrders
             + "]";
+    }
+
+    CircuitBreaker breaker() {
+        return breaker;
     }
 
     private static class Queue extends PriorityQueue<Row> implements Accountable {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
@@ -416,7 +416,7 @@ public class TopNOperator implements Operator, Accountable {
 
     @Override
     public void close() {
-        // NOCOMMIT all rows. There should be a test failure pointing you here.
+        Releasables.closeExpectNoException(() -> Releasables.close(inputQueue));
     }
 
     private static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TopNOperator.class) + RamUsageEstimator

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/UTF8TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/UTF8TopNEncoder.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import java.util.Arrays;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/UTF8TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/UTF8TopNEncoder.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import java.util.Arrays;
 
@@ -28,7 +29,7 @@ final class UTF8TopNEncoder extends SortableTopNEncoder {
     static final byte TERMINATOR = 0x00;
 
     @Override
-    public int encodeBytesRef(BytesRef value, BytesRefBuilder bytesRefBuilder) {
+    public int encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {
         // add one bit to every byte so that there are no "0" bytes in the provided bytes. The only "0" bytes are
         // those defined as separators
         int end = value.offset + value.length;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -16,12 +15,13 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
- * Extracts values into a {@link BytesRefBuilder}.
+ * Extracts values into a {@link BreakingBytesRefBuilder}.
  */
 interface ValueExtractor {
-    void writeValue(BytesRefBuilder values, int position);
+    void writeValue(BreakingBytesRefBuilder values, int position);
 
     static ValueExtractor extractorFor(ElementType elementType, TopNEncoder encoder, boolean inKey, Block block) {
         if (false == (elementType == block.elementType() || ElementType.NULL == block.elementType())) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractorForDoc.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractorForDoc.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractorForDoc.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractorForDoc.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class ValueExtractorForDoc implements ValueExtractor {
     private final DocVector vector;
@@ -19,7 +20,7 @@ class ValueExtractorForDoc implements ValueExtractor {
     }
 
     @Override
-    public void writeValue(BytesRefBuilder values, int position) {
+    public void writeValue(BreakingBytesRefBuilder values, int position) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeInt(vector.shards().getInt(position), values);
         TopNEncoder.DEFAULT_UNSORTABLE.encodeInt(vector.segments().getInt(position), values);
         TopNEncoder.DEFAULT_UNSORTABLE.encodeInt(vector.docs().getInt(position), values);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractorForNull.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractorForNull.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class ValueExtractorForNull implements ValueExtractor {
     @Override
-    public void writeValue(BytesRefBuilder values, int position) {
+    public void writeValue(BreakingBytesRefBuilder values, int position) {
         /*
          * Write 0 values which can be read by *any* result builder and will always
          * make a null value.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionTopNEncoder.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class VersionTopNEncoder extends SortableTopNEncoder {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionTopNEncoder.java
@@ -9,10 +9,11 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class VersionTopNEncoder extends SortableTopNEncoder {
     @Override
-    public int encodeBytesRef(BytesRef value, BytesRefBuilder bytesRefBuilder) {
+    public int encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {
         // TODO versions can contain nul so we need to delegate to the utf-8 encoder for the utf-8 parts of a version
         for (int i = value.offset; i < value.length; i++) {
             if (value.bytes[i] == UTF8TopNEncoder.TERMINATOR) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st
@@ -10,10 +10,10 @@ package org.elasticsearch.compute.operator.topn;
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class KeyExtractorFor$Type$ implements KeyExtractor {
     static KeyExtractorFor$Type$ extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, $Type$Block block) {
@@ -48,7 +48,7 @@ $endif$
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BytesRefBuilder key, $type$ value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, $type$ value) {
         key.append(nonNul);
 $if(BytesRef)$
         return encoder.encodeBytesRef(value, key) + 1;
@@ -61,7 +61,7 @@ $else$
 $endif$
     }
 
-    protected final int nul(BytesRefBuilder key) {
+    protected final int nul(BreakingBytesRefBuilder key) {
         key.append(nul);
         return 1;
     }
@@ -75,7 +75,7 @@ $endif$
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
 $if(BytesRef)$
             return nonNul(key, vector.get$Type$(position, scratch));
 $else$
@@ -93,7 +93,7 @@ $endif$
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -114,7 +114,7 @@ $endif$
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             if (block.isNull(position)) {
                 return nul(key);
             }
@@ -139,7 +139,7 @@ $endif$
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);
@@ -187,7 +187,7 @@ $endif$
         }
 
         @Override
-        public int writeKey(BytesRefBuilder key, int position) {
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
             int size = block.getValueCount(position);
             if (size == 0) {
                 return nul(key);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st
@@ -10,9 +10,9 @@ package org.elasticsearch.compute.operator.topn;
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 abstract class ValueExtractorFor$Type$ implements ValueExtractor {
     static ValueExtractorFor$Type$ extractorFor(TopNEncoder encoder, boolean inKey, $Type$Block block) {
@@ -40,11 +40,11 @@ $endif$
         this.inKey = inKey;
     }
 
-    protected final void writeCount(BytesRefBuilder values, int count) {
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BytesRefBuilder values, $type$ value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, $type$ value) {
 $if(BytesRef)$
         encoder.encodeBytesRef(value, values);
 $else$
@@ -61,7 +61,7 @@ $endif$
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             writeCount(values, 1);
             if (inKey) {
                 // will read results from the key
@@ -84,7 +84,7 @@ $endif$
         }
 
         @Override
-        public void writeValue(BytesRefBuilder values, int position) {
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
             int size = block.getValueCount(position);
             writeCount(values, size);
             if (size == 1 && inKey) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
@@ -80,9 +82,13 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
 
     /**
      * A {@link BigArrays} that won't throw {@link CircuitBreakingException}.
+     * <p>
+     *     Rather than using the {@link NoneCircuitBreakerService} we use a
+     *     very large limit so tests can call {@link CircuitBreaker#getUsed()}.
+     * </p>
      */
     protected final BigArrays nonBreakingBigArrays() {
-        return new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking();
+        return new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(Integer.MAX_VALUE)).withCircuitBreaking();
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -60,7 +60,7 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
         Operator.OperatorFactory factory = simple(nonBreakingBigArrays());
         String description = factory.describe();
         assertThat(description, equalTo(expectedDescriptionOfSimple()));
-        DriverContext driverContext = new DriverContext();
+        DriverContext driverContext = new DriverContext(nonBreakingBigArrays());
         try (Operator op = factory.get(driverContext)) {
             if (op instanceof GroupingAggregatorFunction) {
                 assertThat(description, matchesPattern(GROUPING_AGG_FUNCTION_DESCRIBE_PATTERN));
@@ -74,7 +74,7 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
      * Makes sure the description of {@link #simple} matches the {@link #expectedDescriptionOfSimple}.
      */
     public final void testSimpleToString() {
-        try (Operator operator = simple(nonBreakingBigArrays()).get(new DriverContext())) {
+        try (Operator operator = simple(nonBreakingBigArrays()).get(new DriverContext(nonBreakingBigArrays()))) {
             assertThat(operator.toString(), equalTo(expectedToStringOfSimple()));
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class BreakingBytesRefBuilderTests extends ESTestCase {
+    public void testAddByte() {
+        testAgainstOracle(() -> new TestIteration() {
+            byte b = randomByte();
+
+            @Override
+            public int size() {
+                return 1;
+            }
+
+            @Override
+            public void applyToBuilder(BreakingBytesRefBuilder builder) {
+                builder.append(b);
+            }
+
+            @Override
+            public void applyToOracle(BytesRefBuilder oracle) {
+                oracle.append(b);
+            }
+        });
+    }
+
+    public void testAddBytesRef() {
+        testAgainstOracle(() -> new TestIteration() {
+            BytesRef ref = new BytesRef(randomAlphaOfLengthBetween(1, 100));
+
+            @Override
+            public int size() {
+                return ref.length;
+            }
+
+            @Override
+            public void applyToBuilder(BreakingBytesRefBuilder builder) {
+                builder.append(ref);
+            }
+
+            @Override
+            public void applyToOracle(BytesRefBuilder oracle) {
+                oracle.append(ref);
+            }
+        });
+    }
+
+    public void testGrow() {
+        testAgainstOracle(() -> new TestIteration() {
+            int length = between(1, 100);
+            byte b = randomByte();
+
+            @Override
+            public int size() {
+                return length;
+            }
+
+            @Override
+            public void applyToBuilder(BreakingBytesRefBuilder builder) {
+                builder.grow(builder.length() + length);
+                builder.bytes()[builder.length()] = b;
+                builder.setLength(builder.length() + length);
+            }
+
+            @Override
+            public void applyToOracle(BytesRefBuilder oracle) {
+                oracle.grow(oracle.length() + length);
+                oracle.bytes()[oracle.length()] = b;
+                oracle.setLength(oracle.length() + length);
+            }
+        });
+    }
+
+    interface TestIteration {
+        int size();
+
+        void applyToBuilder(BreakingBytesRefBuilder builder);
+
+        void applyToOracle(BytesRefBuilder oracle);
+    }
+
+    private void testAgainstOracle(Supplier<TestIteration> iterations) {
+        int limit = between(1_000, 10_000);
+        String label = randomAlphaOfLength(4);
+        CircuitBreaker breaker = new MockBigArrays.LimitedBreaker(CircuitBreaker.REQUEST, ByteSizeValue.ofBytes(limit));
+        BreakingBytesRefBuilder builder = new BreakingBytesRefBuilder(breaker, label);
+        BytesRefBuilder oracle = new BytesRefBuilder();
+
+        assertThat(builder.bytesRefView(), equalTo(oracle.get()));
+        while (true) {
+            TestIteration iteration = iterations.get();
+            boolean willResize = builder.length() + iteration.size() >= builder.bytes().length;
+            if (willResize) {
+                int resizeMemoryUsage = builder.bytes().length + ArrayUtil.oversize(builder.bytes().length + iteration.size(), Byte.BYTES);
+                if (resizeMemoryUsage > limit) {
+                    Exception e = expectThrows(CircuitBreakingException.class, () -> iteration.applyToBuilder(builder));
+                    assertThat(e.getMessage(), equalTo("over test limit"));
+                    break;
+                }
+            }
+            iteration.applyToBuilder(builder);
+            iteration.applyToOracle(oracle);
+            assertThat(builder.bytesRefView(), equalTo(oracle.get()));
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import com.carrotsearch.randomizedtesting.annotations.Seed;
-
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.operator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -62,14 +63,14 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
      * are more likely to discover accidental behavior for clumped inputs.
      */
     public final void testSimpleSmallInput() {
-        assertSimple(nonBreakingBigArrays(), between(10, 100));
+        assertSimple(driverContext(), between(10, 100));
     }
 
     /**
      * Test a larger input set against {@link #simple}.
      */
     public final void testSimpleLargeInput() {
-        assertSimple(nonBreakingBigArrays(), between(1_000, 10_000));
+        assertSimple(driverContext(), between(1_000, 10_000));
     }
 
     /**
@@ -79,8 +80,12 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
      */
     public final void testSimpleCircuitBreaking() {
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, smallEnoughToCircuitBreak());
-        Exception e = expectThrows(CircuitBreakingException.class, () -> assertSimple(bigArrays, between(1_000, 10_000)));
+        Exception e = expectThrows(
+            CircuitBreakingException.class,
+            () -> assertSimple(new DriverContext(bigArrays), between(1_000, 10_000))
+        );
         assertThat(e.getMessage(), equalTo(MockBigArrays.ERROR_MESSAGE));
+        assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     /**
@@ -93,7 +98,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         CrankyCircuitBreakerService breaker = new CrankyCircuitBreakerService();
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breaker).withCircuitBreaking();
         try {
-            assertSimple(bigArrays, between(1_000, 10_000));
+            assertSimple(new DriverContext(bigArrays), between(1_000, 10_000));
             // Either we get lucky and cranky doesn't throw and the test completes or we don't and it throws
         } catch (CircuitBreakingException e) {
             assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
@@ -129,10 +134,12 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         return result;
     }
 
-    private void assertSimple(BigArrays bigArrays, int size) {
+    private void assertSimple(DriverContext context, int size) {
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(size));
-        List<Page> results = drive(simple(bigArrays.withCircuitBreaking()).get(driverContext()), input.iterator());
+        BigArrays bigArrays = context.bigArrays().withCircuitBreaking();
+        List<Page> results = drive(simple(bigArrays).get(context), input.iterator());
         assertSimpleOutput(input, results);
+        assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     protected final List<Page> drive(Operator operator, Iterator<Page> input) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -131,7 +131,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
 
     private void assertSimple(BigArrays bigArrays, int size) {
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(size));
-        List<Page> results = drive(simple(bigArrays.withCircuitBreaking()).get(new DriverContext()), input.iterator());
+        List<Page> results = drive(simple(bigArrays.withCircuitBreaking()).get(new DriverContext(bigArrays)), input.iterator());
         assertSimpleOutput(input, results);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoderTests.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.test.ESTestCase;
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoderTests.java
@@ -8,7 +8,9 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -39,10 +41,10 @@ public class DefaultUnsortableTopNEncoderTests extends ESTestCase {
     }
 
     private void testVInt(int v, int expectedBytes) {
-        BytesRefBuilder builder = new BytesRefBuilder();
+        BreakingBytesRefBuilder builder = ExtractorTests.nonBreakingBytesRefBuilder();
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(v, builder);
         assertThat(builder.length(), equalTo(expectedBytes));
-        BytesRef bytes = builder.toBytesRef();
+        BytesRef bytes = builder.bytesRefView();
         assertThat(TopNEncoder.DEFAULT_UNSORTABLE.decodeVInt(bytes), equalTo(v));
         assertThat(bytes.length, equalTo(0));
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNEncoderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNEncoderTests.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.versionfield.Version;
 
@@ -38,37 +39,37 @@ public class TopNEncoderTests extends ESTestCase {
     }
 
     public void testLong() {
-        BytesRefBuilder builder = new BytesRefBuilder();
+        BreakingBytesRefBuilder builder = ExtractorTests.nonBreakingBytesRefBuilder();
         long v = randomLong();
         encoder.encodeLong(v, builder);
-        BytesRef encoded = builder.toBytesRef();
+        BytesRef encoded = builder.bytesRefView();
         assertThat(encoder.decodeLong(encoded), equalTo(v));
         assertThat(encoded.length, equalTo(0));
     }
 
     public void testInt() {
-        BytesRefBuilder builder = new BytesRefBuilder();
+        BreakingBytesRefBuilder builder = ExtractorTests.nonBreakingBytesRefBuilder();
         int v = randomInt();
         encoder.encodeInt(v, builder);
-        BytesRef encoded = builder.toBytesRef();
+        BytesRef encoded = builder.bytesRefView();
         assertThat(encoder.decodeInt(encoded), equalTo(v));
         assertThat(encoded.length, equalTo(0));
     }
 
     public void testDouble() {
-        BytesRefBuilder builder = new BytesRefBuilder();
+        BreakingBytesRefBuilder builder = ExtractorTests.nonBreakingBytesRefBuilder();
         double v = randomDouble();
         encoder.encodeDouble(v, builder);
-        BytesRef encoded = builder.toBytesRef();
+        BytesRef encoded = builder.bytesRefView();
         assertThat(encoder.decodeDouble(encoded), equalTo(v));
         assertThat(encoded.length, equalTo(0));
     }
 
     public void testBoolean() {
-        BytesRefBuilder builder = new BytesRefBuilder();
+        BreakingBytesRefBuilder builder = ExtractorTests.nonBreakingBytesRefBuilder();
         boolean v = randomBoolean();
         encoder.encodeBoolean(v, builder);
-        BytesRef encoded = builder.toBytesRef();
+        BytesRef encoded = builder.bytesRefView();
         assertThat(encoder.decodeBoolean(encoded), equalTo(v));
         assertThat(encoded.length, equalTo(0));
     }
@@ -110,9 +111,9 @@ public class TopNEncoderTests extends ESTestCase {
     }
 
     private void roundTripBytesRef(BytesRef v) {
-        BytesRefBuilder builder = new BytesRefBuilder();
+        BreakingBytesRefBuilder builder = ExtractorTests.nonBreakingBytesRefBuilder();
         int reportedSize = encoder.encodeBytesRef(v, builder);
-        BytesRef encoded = builder.toBytesRef();
+        BytesRef encoded = builder.bytesRefView();
         assertThat(encoded.length, equalTo(reportedSize));
         assertThat(encoder.decodeBytesRef(encoded, new BytesRef()), equalTo(v));
         assertThat(encoded.length, equalTo(0));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNEncoderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNEncoderTests.java
@@ -11,7 +11,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.versionfield.Version;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNRowTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNRowTests.java
@@ -8,30 +8,45 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.tests.util.RamUsageTester;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class TopNRowTests extends ESTestCase {
+    private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
+
     public void testRamBytesUsedEmpty() {
-        TopNOperator.Row row = new TopNOperator.Row();
-        // We double count the shared empty array for empty rows. This overcounting is *fine*, but throws off the test.
-        assertThat(row.ramBytesUsed(), equalTo(RamUsageTester.ramUsed(row) + RamUsageTester.ramUsed(new byte[0])));
+        TopNOperator.Row row = new TopNOperator.Row(breaker);
+        assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
     }
 
     public void testRamBytesUsedSmall() {
-        TopNOperator.Row row = new TopNOperator.Row();
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
         row.keys.append(randomByte());
         row.values.append(randomByte());
-        assertThat(row.ramBytesUsed(), equalTo(RamUsageTester.ramUsed(row)));
+        assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
     }
 
     public void testRamBytesUsedBig() {
-        TopNOperator.Row row = new TopNOperator.Row();
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
         for (int i = 0; i < 10000; i++) {
             row.keys.append(randomByte());
             row.values.append(randomByte());
         }
-        assertThat(row.ramBytesUsed(), equalTo(RamUsageTester.ramUsed(row)));
+        assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
+    }
+
+    private long expectedRamBytesUsed(TopNOperator.Row row) {
+        long expected = RamUsageTester.ramUsed(row);
+        if (row.values.bytes().length == 0) {
+            // We double count the shared empty array for empty rows. This overcounting is *fine*, but throws off the test.
+            expected += RamUsageTester.ramUsed(new byte[0]);
+        }
+        // The breaker is shared infrastructure so we don't count it but RamUsageTester does
+        expected -= RamUsageTester.ramUsed(breaker);
+        expected -= RamUsageTester.ramUsed("topn");
+        return expected;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -14,7 +14,8 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
@@ -24,6 +25,7 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.CancellableTask;
@@ -327,7 +329,7 @@ public class CsvTests extends ESTestCase {
         LocalExecutionPlanner executionPlanner = new LocalExecutionPlanner(
             sessionId,
             new CancellableTask(1, "transport", "esql", null, TaskId.EMPTY_TASK_ID, Map.of()),
-            BigArrays.NON_RECYCLING_INSTANCE,
+            new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking(),
             configuration,
             exchangeSource,
             exchangeSink,


### PR DESCRIPTION
This prevents topn operations from using too much memory by hooking them
into circuit breaking framework. It builds on the work done in https://github.com/elastic/elasticsearch/pull/99316
that moved all topn storage to byte arrays by adding circuit breaking to
process of growing the underlying byte array.