### PR TITLE
[DOC+][ILM][Troubleshooting] JQ for transient steps

### DIFF
--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -164,6 +164,26 @@ You can override how `min_age` is calculated using the `index.lifecycle.originat
 
 
 [discrete]
+==== Stuck on transient steps
+
+Since {ilm-init} performs some tasks asynchronously, e.g. <<ilm-forcemerge,Force Merge>> and <<ilm-migrate,Migrate>>, then its actions can sometimes get stuck on `step`'s requiring setting line-up to these other cluster features' settings. You can check for indices currently in non-erring but expectedly transient ILM steps by using link:https://stedolan.github.io/jq[third-party tool JQ] to process the JSON response of <<ilm-explain-lifecycle,ILM Explain>>.
+
+To see a summary of `phase/action/step` across all ILM-managed indices:
+
+[source, sh]
+----
+$ cat ilm_explain.json | jq -c '.indices[]|select(.managed==true and .action!="complete" and .step!="check-rollover-ready")|.phase+"/"+.action+"/"+.step' | sort | uniq -c | sort -r
+----
+
+To see a list of indices with their ILM `policy`, `phase`, `action`, and `step`:
+
+[source, sh]
+----
+$ cat ilm_explain.json | jq -c '.indices[]|select(.managed==true and .action!="complete" and .step!="check-rollover-ready")|{phase,action,step,policy,index}' | sort
+----
+
+
+[discrete]
 === Common {ilm-init} errors
 
 Here's how to resolve the most common errors reported in the `ERROR` step.

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -172,7 +172,7 @@ To see a summary of `phase/action/step` across all ILM-managed indices:
 
 [source, sh]
 ----
-$ cat ilm_explain.json | jq -c '.indices[]|select(.managed==true and .action!="complete" and .step!="check-rollover-ready")|.phase+"/"+.action+"/"+.step' | sort | uniq -c | sort -r
+$ cat ilm_explain.json | jq -c '.indices[]|select(.managed==true and .action!="complete" and .step!="check-rollover-ready")|.phase+"/"+.action+"/"+.step' | sort | uniq -c | sort -nr
 ----
 
 To see a list of indices with their ILM `policy`, `phase`, `action`, and `step`:


### PR DESCRIPTION
👋 howdy, team!

Can we add these common JQ queries to the [ILM Troubleshooting Doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-error-handling.html) which check for indices not in "waiting" steps (as defined by me) of `[complete, check-rollover-ready]` and claiming the rest are "transient" steps.

Will still be helpful even after https://github.com/elastic/elasticsearch/issues/93859 .
