### PR TITLE
[DOCS] Stop linking to indices.templates.html page

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.delete_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html",
       "description":"Deletes an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -1,7 +1,7 @@
 {
   "indices.delete_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template-v1.html",
       "description":"Deletes an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.exists_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html",
       "description":"Returns information about whether a particular index template exists."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -1,7 +1,7 @@
 {
   "indices.exists_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-template-exists-v1.html",
       "description":"Returns information about whether a particular index template exists."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.get_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html",
       "description":"Returns an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -1,7 +1,7 @@
 {
   "indices.get_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html",
       "description":"Returns an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.put_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html",
       "description":"Creates or updates an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -1,7 +1,7 @@
 {
   "indices.put_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html",
       "description":"Creates or updates an index template."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.simulate_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html",
       "description": "Simulate matching the given index name against the index templates in the system"
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -1,7 +1,7 @@
 {
   "indices.simulate_index_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html",
       "description": "Simulate matching the given index name against the index templates in the system"
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -1,7 +1,7 @@
 {
   "indices.simulate_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html",
       "description": "Simulate resolving the given template name or body"
     },
     "stability":"stable",


### PR DESCRIPTION
Right now, the Elasticsearch Python client docs about index templates (legacy and composable) link to https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html. This page used to look like this: https://www.elastic.co/guide/en/elasticsearch/reference/7.7/indices-templates.html but is no longer useful.