### PR TITLE
Improve async chaining in RecoverySourceHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
@@ -331,6 +332,53 @@ public class SubscribableListener<T> implements ActionListener<T> {
                 // nothing more can be done here
             }
         }
+    }
+
+    /**
+     * Creates and returns a new {@link SubscribableListener} {@code L} and subscribes {@code nextStep} to this listener such that if this
+     * listener is completed successfully with result {@code R} then {@code nextStep} is invoked with arguments {@code L} and {@code R}. If
+     * this listener is completed with exception {@code E} then so is {@code L}.
+     * <p>
+     * This can be used to construct a sequence of async actions, each invoked with the result of the previous one:
+     * <pre>
+     * l.andThen((l1, o1) -> forkAction1(o1, args1, l1)).andThen((l2, o2) -> forkAction2(o2, args2, l2)).addListener(finalListener);
+     * </pre>
+     * After creating this chain, completing {@code l} with a successful response will pass the response to {@code forkAction1}, which will
+     * on completion pass its response to {@code forkAction2}, which will in turn pass its response to {@code finalListener}. A failure of
+     * any step will bypass the remaining steps and ultimately fail {@code finalListener}.
+     * <p>
+     * The threading of the {@code nextStep} callback is the same as for listeners added with {@link #addListener}: if this listener is
+     * already complete then {@code nextStep} is invoked on the thread calling {@link #andThen} and in its thread context, but if this
+     * listener is incomplete then {@code nextStep} is invoked on the completing thread and in its thread context.
+     */
+    public <U> SubscribableListener<U> andThen(CheckedBiConsumer<ActionListener<U>, T, ? extends Exception> nextStep) {
+        return andThen(EsExecutors.DIRECT_EXECUTOR_SERVICE, null, nextStep);
+    }
+
+    /**
+     * Creates and returns a new {@link SubscribableListener} {@code L} and subscribes {@code nextStep} to this listener such that if this
+     * listener is completed successfully with result {@code R} then {@code nextStep} is invoked with arguments {@code L} and {@code R}. If
+     * this listener is completed with exception {@code E} then so is {@code L}.
+     * <p>
+     * This can be used to construct a sequence of async actions, each invoked with the result of the previous one:
+     * <pre>
+     * l.andThen(x, t, (l1,o1) -> forkAction1(o1,args1,l1)).andThen(x, t, (l2,o2) -> forkAction2(o2,args2,l2)).addListener(finalListener);
+     * </pre>
+     * After creating this chain, completing {@code l} with a successful response will pass the response to {@code forkAction1}, which will
+     * on completion pass its response to {@code forkAction2}, which will in turn pass its response to {@code finalListener}. A failure of
+     * any step will bypass the remaining steps and ultimately fail {@code finalListener}.
+     * <p>
+     * The threading of the {@code nextStep} callback is the same as for listeners added with {@link #addListener}: if this listener is
+     * already complete then {@code nextStep} is invoked on the thread calling {@link #andThen} and in its thread context, but if this
+     * listener is incomplete then {@code nextStep} is invoked using {@code executor}, in a thread context captured when {@link #andThen}
+     * was called.
+     */
+    public <U> SubscribableListener<U> andThen(
+        Executor executor,
+        @Nullable ThreadContext threadContext,
+        CheckedBiConsumer<ActionListener<U>, T, ? extends Exception> nextStep
+    ) {
+        return newForked(l -> addListener(l.delegateFailureAndWrap(nextStep), executor, threadContext));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -397,5 +398,116 @@ public class SubscribableListenerTests extends ESTestCase {
         final var forkFailed = SubscribableListener.newForked(l -> { throw new ElasticsearchException("simulated fork failure"); });
         assertTrue(forkFailed.isDone());
         assertEquals("simulated fork failure", expectThrows(ElasticsearchException.class, forkFailed::rawResult).getMessage());
+    }
+
+    public void testAndThenSuccess() {
+        final var initialListener = new SubscribableListener<>();
+        final var forked = new AtomicReference<ActionListener<Object>>();
+        final var result = new AtomicReference<>();
+
+        final var chainedListener = initialListener.andThen((l, o) -> {
+            forked.set(l);
+            result.set(o);
+        });
+        assertNull(forked.get());
+        assertNull(result.get());
+
+        final var o1 = new Object();
+        initialListener.onResponse(o1);
+        assertSame(o1, result.get());
+        assertSame(chainedListener, forked.get());
+        assertFalse(chainedListener.isDone());
+    }
+
+    public void testAndThenFailure() {
+        final var initialListener = new SubscribableListener<>();
+
+        final var chainedListener = initialListener.andThen((l, o) -> fail("should not be called"));
+        assertFalse(chainedListener.isDone());
+
+        initialListener.onFailure(new ElasticsearchException("simulated"));
+        assertComplete(chainedListener, "simulated");
+    }
+
+    public void testAndThenThreading() {
+        runAndThenThreadingTest(true);
+        runAndThenThreadingTest(false);
+    }
+
+    private static void runAndThenThreadingTest(boolean testSuccess) {
+        final var completeListener = testSuccess
+            ? SubscribableListener.newSucceeded(new Object())
+            : SubscribableListener.newFailed(new ElasticsearchException("immediate failure"));
+
+        assertComplete(
+            completeListener.andThen(r -> fail("should not fork"), null, ActionListener::onResponse),
+            testSuccess ? null : "immediate failure"
+        );
+
+        final var threadContext = new ThreadContext(Settings.EMPTY);
+        final var headerName = "test-header";
+        final var expectedHeader = randomAlphaOfLength(10);
+
+        final SubscribableListener<Object> deferredListener = new SubscribableListener<>();
+        final SubscribableListener<Object> chainedListener;
+        final AtomicReference<Runnable> forkedRunnable = new AtomicReference<>();
+
+        try (var ignored = threadContext.stashContext()) {
+            threadContext.putHeader(headerName, expectedHeader);
+            chainedListener = deferredListener.andThen(
+                r -> assertTrue(forkedRunnable.compareAndSet(null, r)),
+                threadContext,
+                (l, response) -> {
+                    assertEquals(expectedHeader, threadContext.getHeader(headerName));
+                    l.onResponse(response);
+                }
+            );
+        }
+
+        assertFalse(chainedListener.isDone());
+        assertNull(forkedRunnable.get());
+
+        final AtomicBoolean isComplete = new AtomicBoolean();
+
+        try (var ignored = threadContext.stashContext()) {
+            threadContext.putHeader(headerName, randomAlphaOfLength(10));
+            chainedListener.addListener(ActionListener.running(() -> {
+                assertEquals(expectedHeader, threadContext.getHeader(headerName));
+                assertTrue(isComplete.compareAndSet(false, true));
+            }));
+        }
+
+        try (var ignored = threadContext.stashContext()) {
+            threadContext.putHeader(headerName, randomAlphaOfLength(10));
+            if (testSuccess) {
+                deferredListener.onResponse(new Object());
+            } else {
+                deferredListener.onFailure(new ElasticsearchException("simulated failure"));
+            }
+        }
+
+        assertFalse(chainedListener.isDone());
+        assertFalse(isComplete.get());
+
+        try (var ignored = threadContext.stashContext()) {
+            threadContext.putHeader(headerName, randomAlphaOfLength(10));
+            forkedRunnable.get().run();
+        }
+
+        assertComplete(chainedListener, testSuccess ? null : "simulated failure");
+        assertTrue(isComplete.get());
+    }
+
+    private static void assertComplete(SubscribableListener<Object> listener, @Nullable String expectedFailureMessage) {
+        assertTrue(listener.isDone());
+        if (expectedFailureMessage == null) {
+            try {
+                listener.rawResult();
+            } catch (Exception e) {
+                throw new AssertionError("unexpected", e);
+            }
+        } else {
+            assertEquals(expectedFailureMessage, expectThrows(ElasticsearchException.class, listener::rawResult).getMessage());
+        }
     }
 }


### PR DESCRIPTION
Introduces `SubscribableListener#andThen` which encapsulates a very
common pattern for chaining a sequence of async actions together. With
this utility you can write the actions in their logical order, without
needing to introduce extra local variables for the back-references.

Also adapts some of the async action chains in `RecoverySourceHandler`
to use this new utility.