### PR TITLE
DSL Disable yaml tests for <8.11 as the parser was not enabled

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/10_explain_lifecycle.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/10_explain_lifecycle.yml
@@ -1,8 +1,8 @@
 ---
 "Explain backing index lifecycle":
   - skip:
-      version: " - 8.9.99"
-      reason: "Explain data stream lifecycle API was updated in 8.10"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle was GA in 8.11"
       features: allowed_warnings
   - do:
       allowed_warnings:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/190_create_data_stream_with_lifecycle.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/190_create_data_stream_with_lifecycle.yml
@@ -1,8 +1,8 @@
 ---
 "Create data stream with lifecycle":
   - skip:
-      version: " - 8.9.99"
-      reason: "data stream lifecycle in index templates was added after 8.10"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle was GA in 8.11"
       features: allowed_warnings
   - do:
       allowed_warnings:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/30_not_found.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/lifecycle/30_not_found.yml
@@ -1,8 +1,8 @@
 setup:
   - skip:
       features: allowed_warnings
-      version: " - 8.9.99"
-      reason: "Data stream lifecycles only supported in 8.10+"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle was GA in 8.11"
   - do:
       allowed_warnings:
         - "index template [my-lifecycle] has index patterns [my-data-stream-1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-lifecycle] will take precedence during new index creation"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
@@ -117,8 +117,8 @@
 ---
 "Add data stream lifecycle":
   - skip:
-      version: " - 8.9.99"
-      reason: "Data stream lifecycle template was updated after 8.9"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle was GA in 8.11"
 
   - do:
       cluster.put_component_template:
@@ -145,8 +145,8 @@
 ---
 "Get data stream lifecycle with default rollover":
   - skip:
-      version: " - 8.9.99"
-      reason: "Data stream lifecycle template was added after 8.9"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle was GA in 8.11"
 
   - do:
       cluster.put_component_template:


### PR DESCRIPTION
Fixes #99546