### PR TITLE
Slightly adjust docs about S3 incompatibilities

### DIFF
--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -226,16 +226,17 @@ emulate S3's behaviour in full. The `repository-s3` type requires full
 compatibility with S3. In particular it must support the same set of API
 endpoints, return the same errors in case of failures, and offer consistency
 and performance at least as good as S3 even when accessed concurrently by
-multiple nodes. Incompatible error codes, consistency or performance may be
-particularly hard to track down since errors, consistency failures, and
-performance issues are usually rare and hard to reproduce.
+multiple nodes. You will need to work with the supplier of your storage system
+to address any incompatibilities you encounter.
 
 You can perform some basic checks of the suitability of your storage system
 using the {ref}/repo-analysis-api.html[repository analysis API]. If this API
 does not complete successfully, or indicates poor performance, then your
 storage system is not fully compatible with AWS S3 and therefore unsuitable for
-use as a snapshot repository. You will need to work with the supplier of your
-storage system to address any incompatibilities you encounter.
+use as a snapshot repository. However these checks do not guarantee full
+compatibility: incompatible error codes, consistency or performance may be
+particularly hard to track down since errors, consistency failures, and
+performance issues are often rare and hard to reproduce.
 
 [[repository-s3-repository]]
 ==== Repository settings

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -233,10 +233,9 @@ You can perform some basic checks of the suitability of your storage system
 using the {ref}/repo-analysis-api.html[repository analysis API]. If this API
 does not complete successfully, or indicates poor performance, then your
 storage system is not fully compatible with AWS S3 and therefore unsuitable for
-use as a snapshot repository. However these checks do not guarantee full
-compatibility: incompatible error codes, consistency or performance may be
-particularly hard to track down since errors, consistency failures, and
-performance issues are often rare and hard to reproduce.
+use as a snapshot repository. However, these checks do not guarantee full
+compatibility. incompatible error codes, consistency or performance may be
+hard to track down. These issues are typically rare and hard to reproduce.
 
 [[repository-s3-repository]]
 ==== Repository settings

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -234,8 +234,8 @@ using the {ref}/repo-analysis-api.html[repository analysis API]. If this API
 does not complete successfully, or indicates poor performance, then your
 storage system is not fully compatible with AWS S3 and therefore unsuitable for
 use as a snapshot repository. However, these checks do not guarantee full
-compatibility. incompatible error codes, consistency or performance may be
-hard to track down. These issues are typically rare and hard to reproduce.
+compatibility. Incompatible error codes and consistency or performance issues
+may be rare and hard to reproduce.
 
 [[repository-s3-repository]]
 ==== Repository settings


### PR DESCRIPTION
It's often useful to quote these docs to users encountering problems
with their not-quite-S3-compatible storage system. In practice we don't
need to quote the bits in the middle but we do need the last sentence
about working with the supplier to address incompatibilities. This
commit reorders things so that the most commonly quoted sentences form a
standalone paragraph.