### PR TITLE
[DOCS] Add 8.10.1 release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
 * <<release-notes-8.9.2>>
 * <<release-notes-8.9.1>>
@@ -48,6 +49,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.10.1.asciidoc[]
 include::release-notes/8.10.0.asciidoc[]
 include::release-notes/8.9.2.asciidoc[]
 include::release-notes/8.9.1.asciidoc[]

--- a/docs/reference/release-notes/8.10.1.asciidoc
+++ b/docs/reference/release-notes/8.10.1.asciidoc
@@ -1,0 +1,22 @@
+[[release-notes-8.10.1]]
+== {es} version 8.10.1
+
+Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
+
+[[bug-8.10.1]]
+[float]
+=== Bug fixes
+
+Aggregations::
+* Use long in Centroid count {es-pull}99491[#99491] (issue: {es-issue}80153[#80153])
+
+Infra/Core::
+* Fix deadlock between Cache.put and Cache.invalidateAll {es-pull}99480[#99480] (issue: {es-issue}99326[#99326])
+
+Infra/Node Lifecycle::
+* Fork computation in `TransportGetShutdownStatusAction` {es-pull}99490[#99490] (issue: {es-issue}99487[#99487])
+
+Search::
+* Fix PIT when resolving with deleted indices {es-pull}99281[#99281]
+
+


### PR DESCRIPTION
Adds release notes for 8.10.1. Will forward-port to `main` after merge.