### PR TITLE
[main] [DOCS] Add 8.10.1 release notes (#99634)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.11.0>>
+* <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
 * <<release-notes-8.9.2>>
 * <<release-notes-8.9.1>>
@@ -50,6 +51,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.11.0.asciidoc[]
+include::release-notes/8.10.1.asciidoc[]
 include::release-notes/8.10.0.asciidoc[]
 include::release-notes/8.9.2.asciidoc[]
 include::release-notes/8.9.1.asciidoc[]

--- a/docs/reference/release-notes/8.10.1.asciidoc
+++ b/docs/reference/release-notes/8.10.1.asciidoc
@@ -1,0 +1,22 @@
+[[release-notes-8.10.1]]
+== {es} version 8.10.1
+
+Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
+
+[[bug-8.10.1]]
+[float]
+=== Bug fixes
+
+Aggregations::
+* Use long in Centroid count {es-pull}99491[#99491] (issue: {es-issue}80153[#80153])
+
+Infra/Core::
+* Fix deadlock between Cache.put and Cache.invalidateAll {es-pull}99480[#99480] (issue: {es-issue}99326[#99326])
+
+Infra/Node Lifecycle::
+* Fork computation in `TransportGetShutdownStatusAction` {es-pull}99490[#99490] (issue: {es-issue}99487[#99487])
+
+Search::
+* Fix PIT when resolving with deleted indices {es-pull}99281[#99281]
+
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.10` to `main`:
 - [[DOCS] Add 8.10.1 release notes (#99634)](https://github.com/elastic/elasticsearch/pull/99634)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)