### PR TITLE
Take into account shard size forecast when initializing shards

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -83,7 +83,7 @@ public class DesiredBalanceComputer {
         final var knownNodeIds = routingNodes.getAllNodeIds();
         final var changes = routingAllocation.changes();
         final var ignoredShards = getIgnoredShardsWithDiscardedAllocationStatus(desiredBalanceInput.ignoredShards());
-        final var clusterInfoSimulator = new ClusterInfoSimulator(routingAllocation.clusterInfo());
+        final var clusterInfoSimulator = new ClusterInfoSimulator(routingAllocation.metadata(), routingAllocation.clusterInfo());
 
         if (routingNodes.size() == 0) {
             return new DesiredBalance(desiredBalanceInput.index(), Map.of());


### PR DESCRIPTION
This change takes into account shard size forecast (if available) when initializing shard. 
This is required to reserve disk usage for new shards of data stream (that are expected to grow fast) and 
prevent desired balance computation from moving them to the nodes with high disk usage.