### PR TITLE
mute BreakingBytesRefBuilderTests#testGrow

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
@@ -72,6 +72,7 @@ public class BreakingBytesRefBuilderTests extends ESTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99649")
     public void testGrow() {
         testAgainstOracle(() -> new TestIteration() {
             int length = between(1, 100);


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/99649