### PR TITLE
[Profiling] Allow to wait until resources created

### DIFF
--- a/docs/changelog/99655.yaml
+++ b/docs/changelog/99655.yaml
@@ -1,0 +1,5 @@
+pr: 99655
+summary: "[Profiling] Allow to wait until resources created"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -10,11 +10,6 @@ package org.elasticsearch.xpack.profiling;
 import java.util.List;
 
 public class GetStackTracesActionIT extends ProfilingTestCase {
-    @Override
-    protected boolean useOnlyAllEvents() {
-        return randomBoolean();
-    }
-
     public void testGetStackTracesUnfiltered() throws Exception {
         GetStackTracesRequest request = new GetStackTracesRequest(1, null);
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStatusActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStatusActionIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
+
+public class GetStatusActionIT extends ProfilingTestCase {
+    @Override
+    protected boolean requiresDataSetup() {
+        // We need explicit control whether index template management is enabled, and thus we skip data setup.
+        return false;
+    }
+
+    public void testTimeoutIfResourcesNotCreated() throws Exception {
+        updateProfilingTemplatesEnabled(false);
+        GetStatusAction.Request request = new GetStatusAction.Request();
+        request.waitForResourcesCreated(true);
+        // shorter than the default timeout to avoid excessively long execution
+        request.timeout(TimeValue.timeValueSeconds(15));
+
+        GetStatusAction.Response response = client().execute(GetStatusAction.INSTANCE, request).get();
+        assertEquals(RestStatus.REQUEST_TIMEOUT, response.status());
+        assertFalse(response.isResourcesCreated());
+    }
+
+    public void testNoTimeoutIfNotWaiting() throws Exception {
+        updateProfilingTemplatesEnabled(false);
+        GetStatusAction.Request request = new GetStatusAction.Request();
+        request.waitForResourcesCreated(false);
+
+        GetStatusAction.Response response = client().execute(GetStatusAction.INSTANCE, request).get();
+        assertEquals(RestStatus.OK, response.status());
+        assertFalse(response.isResourcesCreated());
+    }
+
+    public void testWaitsUntilResourcesAreCreated() throws Exception {
+        updateProfilingTemplatesEnabled(true);
+        GetStatusAction.Request request = new GetStatusAction.Request();
+        request.waitForResourcesCreated(true);
+
+        GetStatusAction.Response response = client().execute(GetStatusAction.INSTANCE, request).get();
+        assertEquals(RestStatus.OK, response.status());
+        assertTrue(response.isResourcesCreated());
+    }
+}

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
@@ -84,7 +84,16 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
      *
      * @return <code>true</code> iff this test should rely on only "profiling-events-all" being present.
      */
-    protected abstract boolean useOnlyAllEvents();
+    protected boolean useOnlyAllEvents() {
+        return randomBoolean();
+    }
+
+    /**
+     * @return <code>true</code> iff this test relies that data (and the corresponding indices / data streams) are present for this test.
+     */
+    protected boolean requiresDataSetup() {
+        return true;
+    }
 
     protected void waitForIndices() throws Exception {
         assertBusy(() -> {
@@ -110,6 +119,9 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
 
     @Before
     public void setupData() throws Exception {
+        if (requiresDataSetup() == false) {
+            return;
+        }
         // only enable index management while setting up indices to avoid interfering with the rest of the test infrastructure
         updateProfilingTemplatesEnabled(true);
         Collection<String> eventsIndices = useOnlyAllEvents() ? List.of(EventsIndex.FULL_INDEX.getName()) : EventsIndex.indexNames();

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
@@ -14,7 +14,8 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.StatusToXContentObject;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -28,12 +29,13 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
         super(NAME, GetStatusAction.Response::new);
     }
 
-    public static class Response extends ActionResponse implements ToXContentObject {
+    public static class Response extends ActionResponse implements StatusToXContentObject {
 
         private boolean profilingEnabled;
         private boolean resourceManagementEnabled;
         private boolean resourcesCreated;
         private boolean pre891Data;
+        private boolean timedOut;
 
         public Response(StreamInput in) throws IOException {
             super(in);
@@ -41,6 +43,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             resourceManagementEnabled = in.readBoolean();
             resourcesCreated = in.readBoolean();
             pre891Data = in.readBoolean();
+            timedOut = in.readBoolean();
         }
 
         public Response(boolean profilingEnabled, boolean resourceManagementEnabled, boolean resourcesCreated, boolean pre891Data) {
@@ -48,6 +51,14 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             this.resourceManagementEnabled = resourceManagementEnabled;
             this.resourcesCreated = resourcesCreated;
             this.pre891Data = pre891Data;
+        }
+
+        public void setTimedOut(boolean timedOut) {
+            this.timedOut = timedOut;
+        }
+
+        public boolean isResourcesCreated() {
+            return resourcesCreated;
         }
 
         @Override
@@ -66,6 +77,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             out.writeBoolean(resourceManagementEnabled);
             out.writeBoolean(resourcesCreated);
             out.writeBoolean(pre891Data);
+            out.writeBoolean(timedOut);
         }
 
         @Override
@@ -76,12 +88,13 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             return profilingEnabled == response.profilingEnabled
                 && resourceManagementEnabled == response.resourceManagementEnabled
                 && resourcesCreated == response.resourcesCreated
-                && pre891Data == response.pre891Data;
+                && pre891Data == response.pre891Data
+                && timedOut == response.timedOut;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, pre891Data);
+            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, pre891Data, timedOut);
         }
 
         @Override
@@ -89,15 +102,29 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             return Strings.toString(this, true, true);
         }
 
+        @Override
+        public RestStatus status() {
+            return timedOut ? RestStatus.REQUEST_TIMEOUT : RestStatus.OK;
+        }
     }
 
     public static class Request extends AcknowledgedRequest<GetStatusAction.Request> {
+        private boolean waitForResourcesCreated;
 
         public Request(StreamInput in) throws IOException {
             super(in);
+            waitForResourcesCreated = in.readBoolean();
         }
 
         public Request() {}
+
+        public boolean waitForResourcesCreated() {
+            return waitForResourcesCreated;
+        }
+
+        public void waitForResourcesCreated(boolean waitForResourcesCreated) {
+            this.waitForResourcesCreated = waitForResourcesCreated;
+        }
 
         @Override
         public ActionRequestValidationException validate() {
@@ -107,6 +134,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
+            out.writeBoolean(waitForResourcesCreated);
         }
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetStatusAction.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.profiling;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestStatusToXContentListener;
 
 import java.util.List;
 
@@ -33,6 +33,7 @@ public class RestGetStatusAction extends BaseRestHandler {
         GetStatusAction.Request request = new GetStatusAction.Request();
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
-        return channel -> client.execute(GetStatusAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        request.waitForResourcesCreated(restRequest.paramAsBoolean("wait_for_resources_created", false));
+        return channel -> client.execute(GetStatusAction.INSTANCE, request, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -7,23 +7,33 @@
 
 package org.elasticsearch.xpack.profiling;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatusAction.Request, GetStatusAction.Response> {
+    private static final Logger log = LogManager.getLogger(TransportGetStatusAction.class);
+
+    private final StatusResolver resolver;
+
     @Inject
     public TransportGetStatusAction(
         TransportService transportService,
@@ -43,6 +53,7 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
             GetStatusAction.Response::new,
             ThreadPool.Names.SAME
         );
+        this.resolver = new StatusResolver(clusterService);
     }
 
     @Override
@@ -52,33 +63,107 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
         ClusterState state,
         ActionListener<GetStatusAction.Response> listener
     ) {
-        IndexStateResolver indexStateResolver = new IndexStateResolver(getValue(state, ProfilingPlugin.PROFILING_CHECK_OUTDATED_INDICES));
-
-        boolean pluginEnabled = getValue(state, XPackSettings.PROFILING_ENABLED);
-        boolean resourceManagementEnabled = getValue(state, ProfilingPlugin.PROFILING_TEMPLATES_ENABLED);
-
-        boolean templatesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state, clusterService.getSettings());
-        boolean indicesCreated = ProfilingIndexManager.isAllResourcesCreated(state, indexStateResolver);
-        boolean dataStreamsCreated = ProfilingDataStreamManager.isAllResourcesCreated(state, indexStateResolver);
-        boolean resourcesCreated = templatesCreated && indicesCreated && dataStreamsCreated;
-
-        boolean indicesPre891 = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
-        boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
-        boolean anyPre891Data = indicesPre891 || dataStreamsPre891;
-        listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data));
+        if (request.waitForResourcesCreated()) {
+            log.info("waitForResourcesCreated == true");
+            createAndRegisterListener(listener, request.timeout());
+        } else {
+            log.info("waitForResourcesCreated == false");
+            listener.onResponse(resolver.getResponse(state));
+        }
     }
 
-    private boolean getValue(ClusterState state, Setting<Boolean> setting) {
-        Metadata metadata = state.getMetadata();
-        if (metadata.settings().hasValue(setting.getKey())) {
-            return setting.get(metadata.settings());
-        } else {
-            return setting.get(clusterService.getSettings());
-        }
+    private void createAndRegisterListener(ActionListener<GetStatusAction.Response> listener, TimeValue timeout) {
+        final DiscoveryNode localNode = clusterService.localNode();
+        ClusterStateObserver.waitForState(
+            clusterService,
+            threadPool.getThreadContext(),
+            new StatusListener(listener, localNode, clusterService, resolver),
+            clusterState -> resolver.getResponse(clusterState).isResourcesCreated(),
+            timeout,
+            log
+        );
     }
 
     @Override
     protected ClusterBlockException checkBlock(GetStatusAction.Request request, ClusterState state) {
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+
+    private static class StatusListener implements ClusterStateObserver.Listener {
+        private final ActionListener<GetStatusAction.Response> listener;
+        private final DiscoveryNode localNode;
+
+        private final ClusterService clusterService;
+
+        private final StatusResolver resolver;
+
+        private StatusListener(
+            ActionListener<GetStatusAction.Response> listener,
+            DiscoveryNode localNode,
+            ClusterService clusterService,
+            StatusResolver resolver
+        ) {
+            this.listener = listener;
+            this.localNode = localNode;
+            this.clusterService = clusterService;
+            this.resolver = resolver;
+        }
+
+        @Override
+        public void onNewClusterState(ClusterState state) {
+            log.info("onNewClusterState");
+            listener.onResponse(resolver.getResponse(state));
+        }
+
+        @Override
+        public void onClusterServiceClose() {
+            listener.onFailure(new NodeClosedException(localNode));
+        }
+
+        @Override
+        public void onTimeout(TimeValue timeout) {
+            log.info("onTimeout");
+            GetStatusAction.Response response = resolver.getResponse(clusterService.state());
+            response.setTimedOut(true);
+            listener.onResponse(response);
+        }
+    }
+
+    private static class StatusResolver {
+        private final ClusterService clusterService;
+
+        private StatusResolver(ClusterService clusterService) {
+            this.clusterService = clusterService;
+        }
+
+        private GetStatusAction.Response getResponse(ClusterState state) {
+            IndexStateResolver indexStateResolver = new IndexStateResolver(
+                getValue(state, ProfilingPlugin.PROFILING_CHECK_OUTDATED_INDICES)
+            );
+
+            boolean pluginEnabled = getValue(state, XPackSettings.PROFILING_ENABLED);
+            boolean resourceManagementEnabled = getValue(state, ProfilingPlugin.PROFILING_TEMPLATES_ENABLED);
+
+            boolean templatesCreated = ProfilingIndexTemplateRegistry.isAllResourcesCreated(state, clusterService.getSettings());
+            boolean indicesCreated = ProfilingIndexManager.isAllResourcesCreated(state, indexStateResolver);
+            boolean dataStreamsCreated = ProfilingDataStreamManager.isAllResourcesCreated(state, indexStateResolver);
+            boolean resourcesCreated = templatesCreated && indicesCreated && dataStreamsCreated;
+
+            boolean indicesPre891 = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
+            boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
+            boolean anyPre891Data = indicesPre891 || dataStreamsPre891;
+            log.info("resources created=[{}]", resourcesCreated);
+
+            return new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data);
+        }
+
+        private boolean getValue(ClusterState state, Setting<Boolean> setting) {
+            Metadata metadata = state.getMetadata();
+            if (metadata.settings().hasValue(setting.getKey())) {
+                return setting.get(metadata.settings());
+            } else {
+                return setting.get(clusterService.getSettings());
+            }
+        }
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -64,10 +64,8 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
         ActionListener<GetStatusAction.Response> listener
     ) {
         if (request.waitForResourcesCreated()) {
-            log.info("waitForResourcesCreated == true");
             createAndRegisterListener(listener, request.timeout());
         } else {
-            log.info("waitForResourcesCreated == false");
             listener.onResponse(resolver.getResponse(state));
         }
     }
@@ -111,7 +109,6 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
 
         @Override
         public void onNewClusterState(ClusterState state) {
-            log.info("onNewClusterState");
             listener.onResponse(resolver.getResponse(state));
         }
 
@@ -122,7 +119,6 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
 
         @Override
         public void onTimeout(TimeValue timeout) {
-            log.info("onTimeout");
             GetStatusAction.Response response = resolver.getResponse(clusterService.state());
             response.setTimedOut(true);
             listener.onResponse(response);
@@ -152,7 +148,6 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
             boolean indicesPre891 = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
             boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
             boolean anyPre891Data = indicesPre891 || dataStreamsPre891;
-            log.info("resources created=[{}]", resourcesCreated);
 
             return new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data);
         }


### PR DESCRIPTION
With this commit we introduce a new request parameter `wait_for_resources_created` to the profiling status API. This parameter allows callers to wait until all profiling resources have been created (or the request times out). The default behavior remains the same (i.e. the API call returns immediately).