### PR TITLE
Extract expected shard size estimation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardSizeReader.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardSizeReader.java
@@ -54,7 +54,7 @@ public class ShardSizeReader {
         if (shard.active() == false
             && shard.recoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS
             && indexMetadata.getResizeSourceIndex() != null) {
-            return extracted(shard, defaultValue, indexMetadata, clusterInfo, metadata, routingTable);
+            return getExpectedSizeOfClonedShard(shard, defaultValue, indexMetadata, clusterInfo, metadata, routingTable);
         } else if (shard.active() == false && shard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT && shard.primary()) {
             return snapshotShardSizeInfo.getShardSize(shard, defaultValue);
         } else if (indexMetadata.getForecastedShardSizeInBytes().isPresent()) {
@@ -64,7 +64,7 @@ public class ShardSizeReader {
         }
     }
 
-    private static long extracted(
+    private static long getExpectedSizeOfClonedShard(
         ShardRouting shard,
         long defaultValue,
         IndexMetadata indexMetadata,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardSizeReader.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardSizeReader.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+
+import java.util.Set;
+
+public class ShardSizeReader {
+
+    public static long getExpectedShardSize(ShardRouting shard, long defaultValue, RoutingAllocation allocation) {
+        return getExpectedShardSize(
+            shard,
+            defaultValue,
+            allocation.clusterInfo(),
+            allocation.snapshotShardSizeInfo(),
+            allocation.metadata(),
+            allocation.routingTable()
+        );
+    }
+
+    /**
+     * Returns the expected shard size for the given shard. It is estimated using following:
+     * * source shards size when initializing using split/shrink/clone operation
+     * * source shard size when initializing from snapshot
+     * * forecasted shard size
+     * * shard size from ClusterInfo if available
+     */
+    public static long getExpectedShardSize(
+        ShardRouting shard,
+        long defaultValue,
+        ClusterInfo clusterInfo,
+        SnapshotShardSizeInfo snapshotShardSizeInfo,
+        Metadata metadata,
+        RoutingTable routingTable
+    ) {
+        final IndexMetadata indexMetadata = metadata.getIndexSafe(shard.index());
+        if (shard.active() == false
+            && shard.recoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS
+            && indexMetadata.getResizeSourceIndex() != null) {
+            return extracted(shard, defaultValue, indexMetadata, clusterInfo, metadata, routingTable);
+        } else if (shard.active() == false && shard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT && shard.primary()) {
+            return snapshotShardSizeInfo.getShardSize(shard, defaultValue);
+        } else if (indexMetadata.getForecastedShardSizeInBytes().isPresent()) {
+            return Math.max(indexMetadata.getForecastedShardSizeInBytes().getAsLong(), clusterInfo.getShardSize(shard, defaultValue));
+        } else {
+            return clusterInfo.getShardSize(shard, defaultValue);
+        }
+    }
+
+    private static long extracted(
+        ShardRouting shard,
+        long defaultValue,
+        IndexMetadata indexMetadata,
+        ClusterInfo clusterInfo,
+        Metadata metadata,
+        RoutingTable routingTable
+    ) {
+        // in the shrink index case we sum up the source index shards since we basically make a copy of the shard in the worst case
+        long targetShardSize = 0;
+        final Index mergeSourceIndex = indexMetadata.getResizeSourceIndex();
+        final IndexMetadata sourceIndexMetadata = metadata.index(mergeSourceIndex);
+        if (sourceIndexMetadata != null) {
+            final Set<ShardId> shardIds = IndexMetadata.selectRecoverFromShards(
+                shard.id(),
+                sourceIndexMetadata,
+                indexMetadata.getNumberOfShards()
+            );
+            final IndexRoutingTable indexRoutingTable = routingTable.index(mergeSourceIndex.getName());
+            for (int i = 0; i < indexRoutingTable.size(); i++) {
+                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
+                if (shardIds.contains(shardRoutingTable.shardId())) {
+                    targetShardSize += clusterInfo.getShardSize(shardRoutingTable.primaryShard(), 0);
+                }
+            }
+        }
+        return targetShardSize == 0 ? defaultValue : targetShardSize;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.routing.allocation.WriteLoadForecaster;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
-import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -58,6 +57,7 @@ import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Type.REPLACE;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
+import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.getExpectedShardSize;
 import static org.elasticsearch.common.settings.ClusterSettings.createBuiltInClusterSettings;
 
 /**
@@ -1047,11 +1047,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                             logger.trace("Assigned shard [{}] to [{}]", shard, minNode.getNodeId());
                         }
 
-                        final long shardSize = DiskThresholdDecider.getExpectedShardSize(
-                            shard,
-                            ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
-                            allocation
-                        );
+                        final long shardSize = getExpectedShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE, allocation);
                         shard = routingNodes.initializeShard(shard, minNode.getNodeId(), null, shardSize, allocation.changes());
                         minNode.addShard(shard);
                         if (shard.primary() == false) {
@@ -1074,11 +1070,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         if (minNode != null) {
                             // throttle decision scenario
                             assert allocationDecision.getAllocationStatus() == AllocationStatus.DECIDERS_THROTTLED;
-                            final long shardSize = DiskThresholdDecider.getExpectedShardSize(
-                                shard,
-                                ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
-                                allocation
-                            );
+                            final long shardSize = getExpectedShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE, allocation);
                             minNode.addShard(shard.initialize(minNode.getNodeId(), null, shardSize));
                         } else {
                             if (logger.isTraceEnabled()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -21,7 +21,6 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
-import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -40,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Type.REPLACE;
+import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.getExpectedShardSize;
 
 /**
  * Given the current allocation of shards and the desired balance, performs the next (legal) shard movements towards the goal.
@@ -265,13 +265,10 @@ public class DesiredBalanceReconciler {
                             switch (decision.type()) {
                                 case YES -> {
                                     logger.debug("Assigning shard [{}] to {} [{}]", shard, nodeIdsIterator.source, nodeId);
-                                    final long shardSize = DiskThresholdDecider.getExpectedShardSize(
+                                    final long shardSize = getExpectedShardSize(
                                         shard,
                                         ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
-                                        allocation.clusterInfo(),
-                                        allocation.snapshotShardSizeInfo(),
-                                        allocation.metadata(),
-                                        allocation.routingTable()
+                                        allocation
                                     );
                                     routingNodes.initializeShard(shard, nodeId, null, shardSize, allocation.changes());
                                     allocationOrdering.recordAllocation(nodeId);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -15,8 +15,6 @@ import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
-import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -29,12 +27,10 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.Map;
-import java.util.Set;
+
+import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.getExpectedShardSize;
 
 /**
  * The {@link DiskThresholdDecider} checks that the node a shard is potentially
@@ -539,61 +535,6 @@ public class DiskThresholdDecider extends AllocationDecider {
             return YES_USAGES_UNAVAILABLE;
         }
         return null;
-    }
-
-    public static long getExpectedShardSize(ShardRouting shardRouting, long defaultSize, RoutingAllocation allocation) {
-        return DiskThresholdDecider.getExpectedShardSize(
-            shardRouting,
-            defaultSize,
-            allocation.clusterInfo(),
-            allocation.snapshotShardSizeInfo(),
-            allocation.metadata(),
-            allocation.routingTable()
-        );
-    }
-
-    /**
-     * Returns the expected shard size for the given shard or the default value provided if not enough information are available
-     * to estimate the shards size.
-     */
-    public static long getExpectedShardSize(
-        ShardRouting shard,
-        long defaultValue,
-        ClusterInfo clusterInfo,
-        SnapshotShardSizeInfo snapshotShardSizeInfo,
-        Metadata metadata,
-        RoutingTable routingTable
-    ) {
-        final IndexMetadata indexMetadata = metadata.getIndexSafe(shard.index());
-        if (indexMetadata.getResizeSourceIndex() != null
-            && shard.active() == false
-            && shard.recoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS) {
-            // in the shrink index case we sum up the source index shards since we basically make a copy of the shard in
-            // the worst case
-            long targetShardSize = 0;
-            final Index mergeSourceIndex = indexMetadata.getResizeSourceIndex();
-            final IndexMetadata sourceIndexMeta = metadata.index(mergeSourceIndex);
-            if (sourceIndexMeta != null) {
-                final Set<ShardId> shardIds = IndexMetadata.selectRecoverFromShards(
-                    shard.id(),
-                    sourceIndexMeta,
-                    indexMetadata.getNumberOfShards()
-                );
-                final IndexRoutingTable indexRoutingTable = routingTable.index(mergeSourceIndex.getName());
-                for (int i = 0; i < indexRoutingTable.size(); i++) {
-                    IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
-                    if (shardIds.contains(shardRoutingTable.shardId())) {
-                        targetShardSize += clusterInfo.getShardSize(shardRoutingTable.primaryShard(), 0);
-                    }
-                }
-            }
-            return targetShardSize == 0 ? defaultValue : targetShardSize;
-        } else {
-            if (shard.unassigned() && shard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT) {
-                return snapshotShardSizeInfo.getShardSize(shard, defaultValue);
-            }
-            return clusterInfo.getShardSize(shard, defaultValue);
-        }
     }
 
     record DiskUsageWithRelocations(DiskUsage diskUsage, long relocatingShardSize) {

--- a/server/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
@@ -10,7 +10,6 @@ package org.elasticsearch.gateway;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
@@ -22,6 +21,8 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.getExpectedShardSize;
 
 /**
  * An abstract class that implements basic functionality for allocating
@@ -58,23 +59,11 @@ public abstract class BaseGatewayShardAllocator {
             unassignedAllocationHandler.initialize(
                 allocateUnassignedDecision.getTargetNode().getId(),
                 allocateUnassignedDecision.getAllocationId(),
-                getExpectedShardSize(shardRouting, allocation),
+                getExpectedShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE, allocation),
                 allocation.changes()
             );
         } else {
             unassignedAllocationHandler.removeAndIgnore(allocateUnassignedDecision.getAllocationStatus(), allocation.changes());
-        }
-    }
-
-    protected static long getExpectedShardSize(ShardRouting shardRouting, RoutingAllocation allocation) {
-        if (shardRouting.primary()) {
-            if (shardRouting.recoverySource().getType() == RecoverySource.Type.SNAPSHOT) {
-                return allocation.snapshotShardSizeInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
-            } else {
-                return ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE;
-            }
-        } else {
-            return allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardSizeReaderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardSizeReaderTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.InternalSnapshotsInfoService;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ShardSizeReaderTests extends ESAllocationTestCase {
+
+    public void testShouldReadExpectedSizeWhenInitializingFromSnapshot() {
+
+        var state = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(
+                Metadata.builder()
+                    .put(IndexMetadata.builder("my-index").settings(indexSettings(IndexVersion.current(), 1, 0)).build(), false)
+            )
+            .build();
+
+        var snapshot = new Snapshot("repository", new SnapshotId("snapshot-1", "na"));
+        var indexId = new IndexId("my-index", "_na_");
+
+        var shard = newShardRouting(
+            new ShardId("my-index", "_na_", 0),
+            randomIdentifier(),
+            true,
+            ShardRoutingState.INITIALIZING,
+            new RecoverySource.SnapshotRecoverySource(UUIDs.randomBase64UUID(), snapshot, IndexVersion.current(), indexId)
+        );
+
+        var shardSize = randomLongBetween(100, 1000);
+        var defaultValue = randomLongBetween(-1, 0);
+
+        var snapshotShardSizeInfo = new SnapshotShardSizeInfo(
+            Map.of(new InternalSnapshotsInfoService.SnapshotShard(snapshot, indexId, shard.shardId()), shardSize)
+        );
+        var allocation = createRoutingAllocation(state, ClusterInfo.EMPTY, snapshotShardSizeInfo);
+
+        assertThat(ShardSizeReader.getExpectedShardSize(shard, defaultValue, allocation), equalTo(shardSize));
+    }
+
+    public void testShouldReadExpectedSizeFromClusterInfo() {
+
+        var state = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(
+                Metadata.builder()
+                    .put(IndexMetadata.builder("my-index").settings(indexSettings(IndexVersion.current(), 1, 0)).build(), false)
+            )
+            .build();
+        var shard = newShardRouting("my-index", 0, randomIdentifier(), true, ShardRoutingState.INITIALIZING);
+
+        var shardSize = randomLongBetween(100, 1000);
+        var defaultValue = randomLongBetween(-1, 0);
+
+        var clusterInfo = new ClusterInfo(
+            Map.of(),
+            Map.of(),
+            Map.of(ClusterInfo.shardIdentifierFromRouting(shard), shardSize),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+        var allocation = createRoutingAllocation(state, clusterInfo, SnapshotShardSizeInfo.EMPTY);
+
+        assertThat(ShardSizeReader.getExpectedShardSize(shard, defaultValue, allocation), equalTo(shardSize));
+    }
+
+    public void testShouldReadExpectedSizeFromForecast() {
+
+        var observedShardSize = randomLongBetween(100, 1000);
+        var forecastedShardSize = randomLongBetween(100, 1000);
+        var defaultValue = randomLongBetween(-1, 0);
+
+        var state = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(
+                Metadata.builder()
+                    .put(
+                        IndexMetadata.builder("my-index")
+                            .settings(indexSettings(IndexVersion.current(), 1, 0))
+                            .shardSizeInBytesForecast(forecastedShardSize)
+                            .build(),
+                        false
+                    )
+            )
+            .build();
+        var shard = newShardRouting("my-index", 0, randomIdentifier(), true, ShardRoutingState.INITIALIZING);
+
+        var clusterInfo = new ClusterInfo(
+            Map.of(),
+            Map.of(),
+            Map.of(ClusterInfo.shardIdentifierFromRouting(shard), observedShardSize),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+        var allocation = createRoutingAllocation(state, clusterInfo, SnapshotShardSizeInfo.EMPTY);
+
+        assertThat(
+            ShardSizeReader.getExpectedShardSize(shard, defaultValue, allocation),
+            equalTo(Math.max(observedShardSize, forecastedShardSize))
+        );
+    }
+
+    public void testShouldFallbackToDefaultValue() {
+
+        var state = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(
+                Metadata.builder()
+                    .put(IndexMetadata.builder("my-index").settings(indexSettings(IndexVersion.current(), 1, 0)).build(), false)
+            )
+            .build();
+        var shard = newShardRouting("my-index", 0, randomIdentifier(), true, ShardRoutingState.INITIALIZING);
+        var defaultValue = randomLongBetween(-1, 0);
+
+        var allocation = createRoutingAllocation(state, ClusterInfo.EMPTY, SnapshotShardSizeInfo.EMPTY);
+
+        assertThat(ShardSizeReader.getExpectedShardSize(shard, defaultValue, allocation), equalTo(defaultValue));
+    }
+
+    private static RoutingAllocation createRoutingAllocation(
+        ClusterState state,
+        ClusterInfo clusterInfo,
+        SnapshotShardSizeInfo snapshotShardSizeInfo
+    ) {
+        return new RoutingAllocation(new AllocationDeciders(List.of()), state, clusterInfo, snapshotShardSizeInfo, 0);
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.ShardSizeReader;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDeciderTests.DevNullClusterInfo;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -459,9 +460,9 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         test_2 = ShardRoutingHelper.initialize(test_2, "node1");
         test_2 = ShardRoutingHelper.moveToStarted(test_2);
 
-        assertEquals(1000L, DiskThresholdDecider.getExpectedShardSize(test_2, 0L, allocation));
-        assertEquals(100L, DiskThresholdDecider.getExpectedShardSize(test_1, 0L, allocation));
-        assertEquals(10L, DiskThresholdDecider.getExpectedShardSize(test_0, 0L, allocation));
+        assertEquals(1000L, ShardSizeReader.getExpectedShardSize(test_2, 0L, allocation));
+        assertEquals(100L, ShardSizeReader.getExpectedShardSize(test_1, 0L, allocation));
+        assertEquals(10L, ShardSizeReader.getExpectedShardSize(test_0, 0L, allocation));
 
         RoutingNode node = RoutingNodesHelper.routingNode(
             "node1",
@@ -484,7 +485,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         );
         test_3 = ShardRoutingHelper.initialize(test_3, "node1");
         test_3 = ShardRoutingHelper.moveToStarted(test_3);
-        assertEquals(0L, DiskThresholdDecider.getExpectedShardSize(test_3, 0L, allocation));
+        assertEquals(0L, ShardSizeReader.getExpectedShardSize(test_3, 0L, allocation));
 
         boolean primary = randomBoolean();
         ShardRouting other_0 = ShardRouting.newUnassigned(
@@ -725,10 +726,10 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             ShardRouting.Role.DEFAULT
         );
         test_3 = ShardRoutingHelper.initialize(test_3, "node1");
-        assertEquals(500L, DiskThresholdDecider.getExpectedShardSize(test_3, 0L, allocation));
-        assertEquals(500L, DiskThresholdDecider.getExpectedShardSize(test_2, 0L, allocation));
-        assertEquals(100L, DiskThresholdDecider.getExpectedShardSize(test_1, 0L, allocation));
-        assertEquals(10L, DiskThresholdDecider.getExpectedShardSize(test_0, 0L, allocation));
+        assertEquals(500L, ShardSizeReader.getExpectedShardSize(test_3, 0L, allocation));
+        assertEquals(500L, ShardSizeReader.getExpectedShardSize(test_2, 0L, allocation));
+        assertEquals(100L, ShardSizeReader.getExpectedShardSize(test_1, 0L, allocation));
+        assertEquals(10L, ShardSizeReader.getExpectedShardSize(test_0, 0L, allocation));
 
         ShardRouting target = ShardRouting.newUnassigned(
             new ShardId(new Index("target", "5678"), 0),
@@ -737,7 +738,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"),
             ShardRouting.Role.DEFAULT
         );
-        assertEquals(1110L, DiskThresholdDecider.getExpectedShardSize(target, 0L, allocation));
+        assertEquals(1110L, ShardSizeReader.getExpectedShardSize(target, 0L, allocation));
 
         ShardRouting target2 = ShardRouting.newUnassigned(
             new ShardId(new Index("target2", "9101112"), 0),
@@ -746,7 +747,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"),
             ShardRouting.Role.DEFAULT
         );
-        assertEquals(110L, DiskThresholdDecider.getExpectedShardSize(target2, 0L, allocation));
+        assertEquals(110L, ShardSizeReader.getExpectedShardSize(target2, 0L, allocation));
 
         target2 = ShardRouting.newUnassigned(
             new ShardId(new Index("target2", "9101112"), 1),
@@ -755,7 +756,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"),
             ShardRouting.Role.DEFAULT
         );
-        assertEquals(1000L, DiskThresholdDecider.getExpectedShardSize(target2, 0L, allocation));
+        assertEquals(1000L, ShardSizeReader.getExpectedShardSize(target2, 0L, allocation));
 
         // check that the DiskThresholdDecider still works even if the source index has been deleted
         ClusterState clusterStateWithMissingSourceIndex = ClusterState.builder(clusterState)
@@ -765,8 +766,8 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
 
         allocationService.reroute(clusterState, "foo", ActionListener.noop());
         RoutingAllocation allocationWithMissingSourceIndex = new RoutingAllocation(null, clusterStateWithMissingSourceIndex, info, null, 0);
-        assertEquals(42L, DiskThresholdDecider.getExpectedShardSize(target, 42L, allocationWithMissingSourceIndex));
-        assertEquals(42L, DiskThresholdDecider.getExpectedShardSize(target2, 42L, allocationWithMissingSourceIndex));
+        assertEquals(42L, ShardSizeReader.getExpectedShardSize(target, 42L, allocationWithMissingSourceIndex));
+        assertEquals(42L, ShardSizeReader.getExpectedShardSize(target2, 42L, allocationWithMissingSourceIndex));
     }
 
     public void testDiskUsageWithRelocations() {

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.gateway;
 
 import org.apache.lucene.index.CorruptIndexException;
+import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
@@ -519,7 +520,14 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             .routingTable(routingTableBuilder.build())
             .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
             .build();
-        return new RoutingAllocation(deciders, state.mutableRoutingNodes(), state, null, null, System.nanoTime());
+        return new RoutingAllocation(
+            deciders,
+            state.mutableRoutingNodes(),
+            state,
+            ClusterInfo.EMPTY,
+            SnapshotShardSizeInfo.EMPTY,
+            System.nanoTime()
+        );
     }
 
     private void assertClusterHealthStatus(RoutingAllocation allocation, ClusterHealthStatus expectedStatus) {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingRoleStrategy;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.ShardSizeReader;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
@@ -663,7 +664,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         }
 
         private long getExpectedShardSize(ShardRouting shard) {
-            return DiskThresholdDecider.getExpectedShardSize(shard, 0L, info, shardSizeInfo, state.metadata(), state.routingTable());
+            return ShardSizeReader.getExpectedShardSize(shard, 0L, info, shardSizeInfo, state.metadata(), state.routingTable());
         }
 
         long unmovableSize(String nodeId, Collection<ShardRouting> shards) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -30,7 +30,6 @@ import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
-import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -61,6 +60,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static java.util.stream.Collectors.toSet;
+import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.*;
 import static org.elasticsearch.gateway.ReplicaShardAllocator.augmentExplanationsWithStoreInfo;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SNAPSHOT_PARTIAL_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_INDEX_ID_SETTING;
@@ -198,7 +198,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                 unassignedAllocationHandler.initialize(
                     allocateUnassignedDecision.getTargetNode().getId(),
                     allocateUnassignedDecision.getAllocationId(),
-                    DiskThresholdDecider.getExpectedShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE, allocation),
+                    getExpectedShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE, allocation),
                     allocation.changes()
                 );
             } else {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -60,7 +60,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static java.util.stream.Collectors.toSet;
-import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.*;
+import static org.elasticsearch.cluster.routing.allocation.ShardSizeReader.getExpectedShardSize;
 import static org.elasticsearch.gateway.ReplicaShardAllocator.augmentExplanationsWithStoreInfo;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SNAPSHOT_PARTIAL_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_INDEX_ID_SETTING;


### PR DESCRIPTION
BaseGatewayShardAllocator and DiskThresholdDecider have similar code to estimate
 expected shard size. This change extracts this code to a common place and
 covers it with tests.

