### PR TITLE
[ES|QL] Improve error message in case of unsupported time interval

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -233,7 +233,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                 case "month", "months" -> Period.ofMonths(safeToInt(safeToLong(value)));
                 case "year", "years" -> Period.ofYears(safeToInt(safeToLong(value)));
 
-                default -> throw new ParsingException(source, "Unexpected time interval '{}'", qualifier);
+                default -> throw new ParsingException(source, "Unexpected time interval qualifier: '{}'", qualifier);
             };
             return new Literal(source, quantity, quantity instanceof Duration ? TIME_DURATION : DATE_PERIOD);
         } catch (QlIllegalArgumentException | ArithmeticException e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -233,7 +233,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                 case "month", "months" -> Period.ofMonths(safeToInt(safeToLong(value)));
                 case "year", "years" -> Period.ofYears(safeToInt(safeToLong(value)));
 
-                default -> throw new ParsingException(source, "Unexpected numeric qualifier '{}'", qualifier);
+                default -> throw new ParsingException(source, "Unexpected time interval '{}'", qualifier);
             };
             return new Literal(source, quantity, quantity instanceof Duration ? TIME_DURATION : DATE_PERIOD);
         } catch (QlIllegalArgumentException | ArithmeticException e) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
@@ -410,7 +410,7 @@ public class ExpressionTests extends ESTestCase {
     }
 
     public void testUnknownNumericQualifier() {
-        assertParsingException(() -> whereExpression("1 decade"), "Unexpected numeric qualifier 'decade'");
+        assertParsingException(() -> whereExpression("1 decade"), "Unexpected time interval 'decade'");
     }
 
     public void testQualifiedDecimalLiteral() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
@@ -410,7 +410,7 @@ public class ExpressionTests extends ESTestCase {
     }
 
     public void testUnknownNumericQualifier() {
-        assertParsingException(() -> whereExpression("1 decade"), "Unexpected time interval 'decade'");
+        assertParsingException(() -> whereExpression("1 decade"), "Unexpected time interval qualifier 'decade'");
     }
 
     public void testQualifiedDecimalLiteral() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
@@ -410,7 +410,7 @@ public class ExpressionTests extends ESTestCase {
     }
 
     public void testUnknownNumericQualifier() {
-        assertParsingException(() -> whereExpression("1 decade"), "Unexpected time interval qualifier 'decade'");
+        assertParsingException(() -> whereExpression("1 decade"), "Unexpected time interval qualifier: 'decade'");
     }
 
     public void testQualifiedDecimalLiteral() {


### PR DESCRIPTION
While checking the syntax in Kibana I've noticed in the ES|QL grammar the `qualifiedIntegerLiteral`, and made some attempts to test it, but the error message was a bit obscure.

My test case was:

```
row a = 1 | eval b = 1 + 3 a
```

Which returned the error:
```
Error: line 1:33: Unexpected numeric qualifier 'a'
```

Later on @luigidellaquila confirmed to be a way to handle date interval literals, therefore I've decided to improve the error message here.

Now with the query above I would have:
```
Error: line 1:33: Unexpected time interval 'a'
```

which can hint the user that he should type a time interval unit there instead of `a`