### PR TITLE
Fix mock plugin service when loading service providers

### DIFF
--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -705,10 +705,10 @@ public class PluginsServiceTests extends ESTestCase {
             .instance();
 
         // We shouldn't find the FooTestService implementation with PluginOther
-        assertThat(MockPluginsService.createExtensions(TestService.class, othPlugin), empty());
+        assertThat(MockPluginsService.createExtensions(TestService.class, othPlugin, e -> false), empty());
 
         // We should find the FooTestService implementation when we use FooPlugin, because it matches the constructor arg.
-        var providers = MockPluginsService.createExtensions(TestService.class, fooPlugin);
+        var providers = MockPluginsService.createExtensions(TestService.class, fooPlugin, e -> false);
 
         assertThat(providers, allOf(hasSize(1), everyItem(instanceOf(BarTestService.class))));
     }


### PR DESCRIPTION
When tests run with a mock plugin service, they may load service providers. Normally each plugin would be in its own classloader. However, in the test case, there is usually a single classloader. This means any service provider implementations appear in the system classloader of the test. The mock plugin service attempts to workaround this fact by detecting when a service provider comes from the system classloader and using a Set to avoid creating duplicates. However, this does not work since the servic providers are already instance and have identity.

In this commit we track the created service providers differently, collecting by the concrete SPI type. When the concrete type is already loaded, we skip instantiating multiple times.