### PR TITLE
Remove unused #newPersistedClusterStateService method

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/ClusterCoordinationPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ClusterCoordinationPlugin.java
@@ -77,17 +77,6 @@ public interface ClusterCoordinationPlugin {
     }
 
     interface PersistedClusterStateServiceFactory {
-
-        @Deprecated(forRemoval = true)
-        default PersistedClusterStateService newPersistedClusterStateService(
-            NodeEnvironment nodeEnvironment,
-            NamedXContentRegistry xContentRegistry,
-            ClusterSettings clusterSettings,
-            ThreadPool threadPool
-        ) {
-            throw new AssertionError("Should not be called!");
-        }
-
         PersistedClusterStateService newPersistedClusterStateService(
             NodeEnvironment nodeEnvironment,
             NamedXContentRegistry xContentRegistry,


### PR DESCRIPTION
This deprecated method can go, as its downstream usages have been removed.