### PR TITLE
[ML] Adding retries for starting model deployment

### DIFF
--- a/docs/changelog/99673.yaml
+++ b/docs/changelog/99673.yaml
@@ -1,0 +1,5 @@
+pr: 99673
+summary: Reducing chunk size and adding retries for starting model deployment
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/99673.yaml
+++ b/docs/changelog/99673.yaml
@@ -1,5 +1,5 @@
 pr: 99673
-summary: Reducing chunk size and adding retries for starting model deployment
+summary: Adding retry logic for start model deployment API
 area: Machine Learning
 type: bug
-issues: []
+issues: [ ]

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.core.Strings.format;
  * A helper class for abstracting out the use of the ModelLoaderUtils to make dependency injection testing easier.
  */
 class ModelImporter {
-    private static final int DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+    private static final int DEFAULT_CHUNK_SIZE = 1024 * 1024; // 1MB
     private static final Logger logger = LogManager.getLogger(ModelImporter.class);
     private final Client client;
     private final String modelId;

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.core.Strings.format;
  * A helper class for abstracting out the use of the ModelLoaderUtils to make dependency injection testing easier.
  */
 class ModelImporter {
-    private static final int DEFAULT_CHUNK_SIZE = 1024 * 1024; // 1MB
+    private static final int DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024; // 1MB
     private static final Logger logger = LogManager.getLogger(ModelImporter.class);
     private final Client client;
     private final String modelId;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/ChunkedTrainedModelRestorer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/ChunkedTrainedModelRestorer.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.persistence;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
@@ -229,7 +230,15 @@ public class ChunkedTrainedModelRestorer {
 
                 if (failureCount >= retries) {
                     logger.warn(format("[%s] searching for model part failed %s times, returning failure", modelId, retries));
-                    throw e;
+                    throw new ElasticsearchException(
+                        format(
+                            "loading model [%s] failed after [%s] retries. The deployment is now in a failed state, "
+                                + "the error may be transient please stop the deployment and restart",
+                            modelId,
+                            retries
+                        ),
+                        e
+                    );
                 }
 
                 failureCount++;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/ChunkedTrainedModelRestorerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/ChunkedTrainedModelRestorerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.persistence;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ChunkedTrainedModelRestorerTests extends ESTestCase {
+    public void testRetryingSearch_ReturnsSearchResults() throws InterruptedException {
+        var mockClient = mock(Client.class);
+        var mockSearchResponse = mock(SearchResponse.class, RETURNS_DEEP_STUBS);
+
+        PlainActionFuture<SearchResponse> searchFuture = new PlainActionFuture<>();
+        searchFuture.onResponse(mockSearchResponse);
+        when(mockClient.search(any())).thenReturn(searchFuture);
+
+        var request = createSearchRequest();
+
+        assertThat(
+            ChunkedTrainedModelRestorer.retryingSearch(mockClient, request, 5, new TimeValue(1, TimeUnit.NANOSECONDS)),
+            is(mockSearchResponse)
+        );
+
+        verify(mockClient, times(1)).search(any());
+    }
+
+    public void testRetryingSearch_ThrowsSearchPhaseExceptionWithNoRetries() {
+        try (var mockClient = mock(Client.class)) {
+            var searchPhaseException = new SearchPhaseExecutionException("phase", "error", ShardSearchFailure.EMPTY_ARRAY);
+            when(mockClient.search(any())).thenThrow(searchPhaseException);
+
+            var request = createSearchRequest();
+
+            SearchPhaseExecutionException exception = expectThrows(
+                SearchPhaseExecutionException.class,
+                () -> ChunkedTrainedModelRestorer.retryingSearch(mockClient, request, 0, new TimeValue(1, TimeUnit.NANOSECONDS))
+            );
+
+            assertThat(exception, is(searchPhaseException));
+            verify(mockClient, times(1)).search(any());
+        }
+    }
+
+    public void testRetryingSearch_ThrowsSearchPhaseExceptionAfterOneRetry() {
+        try (var mockClient = mock(Client.class)) {
+            var searchPhaseException = new SearchPhaseExecutionException("phase", "error", ShardSearchFailure.EMPTY_ARRAY);
+            when(mockClient.search(any())).thenThrow(searchPhaseException);
+
+            var request = createSearchRequest();
+
+            SearchPhaseExecutionException exception = expectThrows(
+                SearchPhaseExecutionException.class,
+                () -> ChunkedTrainedModelRestorer.retryingSearch(mockClient, request, 1, new TimeValue(1, TimeUnit.NANOSECONDS))
+            );
+
+            assertThat(exception, is(searchPhaseException));
+            verify(mockClient, times(2)).search(any());
+        }
+    }
+
+    public void testRetryingSearch_ThrowsIOExceptionIgnoringRetries() {
+        try (var mockClient = mock(Client.class)) {
+            var exception = new ElasticsearchException("Error");
+            when(mockClient.search(any())).thenThrow(exception);
+
+            var request = createSearchRequest();
+
+            ElasticsearchException thrownException = expectThrows(
+                ElasticsearchException.class,
+                () -> ChunkedTrainedModelRestorer.retryingSearch(mockClient, request, 1, new TimeValue(1, TimeUnit.NANOSECONDS))
+            );
+
+            assertThat(thrownException, is(exception));
+            verify(mockClient, times(1)).search(any());
+        }
+    }
+
+    public void testRetryingSearch_ThrowsSearchPhaseExceptionOnce_ThenReturnsResponse() throws InterruptedException {
+        try (var mockClient = mock(Client.class)) {
+            var mockSearchResponse = mock(SearchResponse.class, RETURNS_DEEP_STUBS);
+
+            PlainActionFuture<SearchResponse> searchFuture = new PlainActionFuture<>();
+            searchFuture.onResponse(mockSearchResponse);
+
+            var searchPhaseException = new SearchPhaseExecutionException("phase", "error", ShardSearchFailure.EMPTY_ARRAY);
+            when(mockClient.search(any())).thenThrow(searchPhaseException).thenReturn(searchFuture);
+
+            var request = createSearchRequest();
+
+            assertThat(
+                ChunkedTrainedModelRestorer.retryingSearch(mockClient, request, 1, new TimeValue(1, TimeUnit.NANOSECONDS)),
+                is(mockSearchResponse)
+            );
+
+            verify(mockClient, times(2)).search(any());
+        }
+    }
+
+    private static SearchRequest createSearchRequest() {
+        return new SearchRequest("index");
+    }
+}


### PR DESCRIPTION
This PR reduces the chunk size when downloading a model to 1 MB. It also adds retry logic for deploying a model specifically for `SearchPhaseException`. This exception is thrown when a CircuitBreakerError occurs during model deployment. By catching the exception and retrying in the restorer logic we can avoid reloading the entire model.

Addresses part of: https://github.com/elastic/elasticsearch/issues/99409

## Testing

Retrying does occur:

![image](https://github.com/elastic/elasticsearch/assets/56361221/ef190c09-fef9-4185-ad5e-8c2eae1afeda)

I can still get CBE to occur though.