### PR TITLE
[8.10] [ML] Switching to 1 mb chunks for ELSER model import (#99677)

### DIFF
--- a/docs/changelog/99677.yaml
+++ b/docs/changelog/99677.yaml
@@ -1,0 +1,5 @@
+pr: 99677
+summary: Using 1 MB chunks for elser model storage
+area: Machine Learning
+type: bug
+issues: [ ]

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.core.Strings.format;
  * A helper class for abstracting out the use of the ModelLoaderUtils to make dependency injection testing easier.
  */
 class ModelImporter {
-    private static final int DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+    private static final int DEFAULT_CHUNK_SIZE = 1024 * 1024; // 1MB
     private static final Logger logger = LogManager.getLogger(ModelImporter.class);
     private final Client client;
     private final String modelId;


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [ML] Switching to 1 mb chunks for ELSER model import (#99677)