### PR TITLE
Make transport and index versions easier to extend

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -279,7 +279,11 @@ module org.elasticsearch.server {
     exports org.elasticsearch.indices.recovery.plan;
     exports org.elasticsearch.indices.store;
     exports org.elasticsearch.ingest;
-    exports org.elasticsearch.internal to org.elasticsearch.serverless.version, org.elasticsearch.serverless.buildinfo;
+    exports org.elasticsearch.internal
+        to
+            org.elasticsearch.serverless.version,
+            org.elasticsearch.serverless.buildinfo,
+            org.elasticsearch.serverless.constants;
     exports org.elasticsearch.lucene.analysis.miscellaneous;
     exports org.elasticsearch.lucene.grouping;
     exports org.elasticsearch.lucene.queries;

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -115,7 +115,7 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
             if (versionExtension == null) {
                 return TransportVersions.LATEST_DEFINED;
             }
-            var version = versionExtension.getCurrentTransportVersion();
+            var version = versionExtension.getCurrentTransportVersion(TransportVersions.LATEST_DEFINED);
             assert version.onOrAfter(TransportVersions.LATEST_DEFINED);
             return version;
         }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -216,7 +216,7 @@ public class TransportVersions {
         IDS = null;
     }
 
-    static NavigableMap<Integer, TransportVersion> getAllVersionIds(Class<?> cls) {
+    public static NavigableMap<Integer, TransportVersion> getAllVersionIds(Class<?> cls) {
         Map<Integer, String> versionIdFields = new HashMap<>();
         NavigableMap<Integer, TransportVersion> builder = new TreeMap<>();
 

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -160,7 +160,7 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
             if (versionExtension == null) {
                 return LATEST_DEFINED;
             }
-            var version = versionExtension.getCurrentIndexVersion();
+            var version = versionExtension.getCurrentIndexVersion(LATEST_DEFINED);
 
             assert version.onOrAfter(LATEST_DEFINED);
             assert version.luceneVersion.equals(Version.LATEST)

--- a/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
@@ -18,14 +18,16 @@ public interface VersionExtension {
     /**
      * Returns the {@link TransportVersion} that Elasticsearch should use.
      * <p>
-     * This must be at least equal to the latest version found in {@link TransportVersion} V_* constants.
+     * This must be at least as high as the given fallback.
+     * @param fallback The latest transport version from server
      */
-    TransportVersion getCurrentTransportVersion();
+    TransportVersion getCurrentTransportVersion(TransportVersion fallback);
 
     /**
      * Returns the {@link IndexVersion} that Elasticsearch should use.
      * <p>
-     * This must be at least equal to the latest version found in {@link IndexVersion} V_* constants.
+     * This must be at least as high as the given fallback.
+     * @param fallback The latest index version from server
      */
-    IndexVersion getCurrentIndexVersion();
+    IndexVersion getCurrentIndexVersion(IndexVersion fallback);
 }


### PR DESCRIPTION
When overriding transport and index versions, it is difficult to decide whether a version constant in serverless should be returned, or the latest version constant from serverless should be used, since the latest from serverless is not available. This commit adjust the version extension methods to pass in the latest serverless version constants. It also tweaks module and method visibility for a helper method needed.