### PR TITLE
ESQL: Better management of not stored TEXT fiels with synthetic source

### DIFF
--- a/docs/changelog/99695.yaml
+++ b/docs/changelog/99695.yaml
@@ -1,0 +1,5 @@
+pr: 99695
+summary: "ESQL: Better management of not stored TEXT fiels with synthetic source"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValueSources.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValueSources.java
@@ -60,7 +60,7 @@ public final class ValueSources {
                 // MatchOnlyTextFieldMapper class lives in the mapper-extras module. We use string equality
                 // for the field type name to avoid adding a dependency to the module
                 if (fieldType instanceof KeywordFieldMapper.KeywordFieldType
-                    || fieldType instanceof TextFieldMapper.TextFieldType
+                    || fieldType instanceof TextFieldMapper.TextFieldType tft && (tft.isSyntheticSource() == false || tft.isStored())
                     || MATCH_ONLY_TEXT.equals(fieldType.typeName())) {
                     ValuesSource vs = textValueSource(ctx, fieldType);
                     sources.add(new ValueSourceInfo(CoreValuesSourceType.KEYWORD, vs, elementType, ctx.getIndexReader()));

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/80_text.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/80_text.yml
@@ -323,9 +323,7 @@ setup:
 ---
 "text with synthetic source":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/99183"
-
+      features: allowed_warnings_regex
   - do:
       indices.create:
         index: test2
@@ -355,6 +353,8 @@ setup:
           - { "emp_no": 20, "name": "John", "job": "Payroll Specialist" }
 
   - do:
+      allowed_warnings_regex:
+        - "Field \\[job\\] cannot be retrieved, it is unsupported or not indexed; returning null"
       esql.query:
         body:
           query: 'from test2 | sort emp_no | keep job'
@@ -363,8 +363,8 @@ setup:
   - match: { columns.0.type: "text" }
 
   - length: { values: 2 }
-  - match: { values.0.0: "IT Director" }
-  - match: { values.1.0: "Payroll Specialist" }
+  - match: { values.0.0: null } # awaiting a complete fix for https://github.com/elastic/elasticsearch/issues/99183
+  - match: { values.1.0: null } # for now, since we cannot extract text values from synthetic source, we at least avoid to throw exceptions
 
 
 ---


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/99183

Adding a check when loading TEXT fields, so that in case of synthetic source, if the field is not stored, the extraction falls back to an "unsupported" value source instead of throwing an exception. As a result, the returned values will just be `null`.

Keeping the original issue open, because in some cases we could still be able to load field values using subfields.