### PR TITLE
Mute tests that need to wait for the logs template

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
@@ -21,6 +21,9 @@ setup:
 
 ---
 Test Elastic Agent log ECS mappings:
+  - skip:
+      version: " - 99.99.99"
+      reason: "See https://github.com/elastic/elasticsearch/issues/97795"
   - do:
       indices.get_data_stream:
         name: logs-generic-default

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_logs_ecs_mappings.yml
@@ -22,8 +22,8 @@ setup:
 ---
 Test Elastic Agent log ECS mappings:
   - skip:
-      version: " - 99.99.99"
-      reason: "See https://github.com/elastic/elasticsearch/issues/97795"
+      version: all
+      reason: https://github.com/elastic/elasticsearch/issues/97795
   - do:
       indices.get_data_stream:
         name: logs-generic-default

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/stack/10_stack.yml
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/stack/10_stack.yml
@@ -1,4 +1,7 @@
 "Stack templates can be disabled":
+  - skip:
+      version: " - 99.99.99"
+      reason: "See https://github.com/elastic/elasticsearch/issues/98163"
   - do:
       cluster.put_settings:
         body:

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/stack/10_stack.yml
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/stack/10_stack.yml
@@ -1,7 +1,7 @@
 "Stack templates can be disabled":
   - skip:
-      version: " - 99.99.99"
-      reason: "See https://github.com/elastic/elasticsearch/issues/98163"
+      version: all
+      reason: https://github.com/elastic/elasticsearch/issues/98163
   - do:
       cluster.put_settings:
         body:


### PR DESCRIPTION
Both tests require the logs template to be available. Some times the logs template is not initialised when the test starts and it fails. Since in yaml tests we do not have the possibility to wait, we will convert these tests to rest tests. Until then we will mute them.

Relates to: https://github.com/elastic/elasticsearch/issues/97795, https://github.com/elastic/elasticsearch/issues/98163