### PR TITLE
Run SignificanceLookup BackgroundFrequency query in its own IndexSearcher

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -472,7 +472,6 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         indexRandom(true, false, indexRequestBuilders);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99690")
     public void testScriptScore() throws ExecutionException, InterruptedException, IOException {
         String type = randomBoolean() ? "text" : "long";
         indexRandomFrequencies01(type);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookup.java
@@ -233,7 +233,8 @@ class SignificanceLookup {
         if (backgroundFilter != null) {
             query = new BooleanQuery.Builder().add(query, Occur.FILTER).add(backgroundFilter, Occur.FILTER).build();
         }
-        return context.searcher().count(query);
+        // use a brand new index searcher as we want to run this query on the current thread
+        return new IndexSearcher(context.searcher().getIndexReader()).count(query);
     }
 
     private TermsEnum getTermsEnum(String field) throws IOException {


### PR DESCRIPTION
Use a brand new index searcher so the query runs on the current thread. Label as non-issue as this is due to an unreleased change.

fixes https://github.com/elastic/elasticsearch/issues/99690
