### PR TITLE
[DOCS] Time series indices support non-metric/dimension fields

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -56,6 +56,8 @@ documents, the document `_id` is a hash of the document's dimensions and
 * A TSDS uses <<synthetic-source,synthetic `_source`>>, and as a result is
 subject to a number of <<synthetic-source-restrictions,restrictions>>.
 
+Note: a time_series index can have fields that are neither dimmensions nor metrics.
+
 [discrete]
 [[time-series]]
 === What is a time series?

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -56,7 +56,7 @@ documents, the document `_id` is a hash of the document's dimensions and
 * A TSDS uses <<synthetic-source,synthetic `_source`>>, and as a result is
 subject to a number of <<synthetic-source-restrictions,restrictions>>.
 
-Note: a time_series index can have fields that are neither dimmensions nor metrics.
+NOTE: A time series index can contain fields other than dimensions or metrics.
 
 [discrete]
 [[time-series]]


### PR DESCRIPTION
Adding a note that there could be fields in a time_series index that are neither dims nor metrics.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
