### PR TITLE
[DOCS] Update query_cache.asciidoc

### DIFF
--- a/docs/reference/modules/indices/query_cache.asciidoc
+++ b/docs/reference/modules/indices/query_cache.asciidoc
@@ -2,7 +2,7 @@
 === Node query cache settings
 
 The results of queries used in the filter context are cached in the node query 
-cache for fast lookup. There is one queries cache per node that is shared by all 
+cache for fast lookup. There is one query cache per node that is shared by all 
 shards. The cache uses an LRU eviction policy: when the cache is full, the least 
 recently used query results are evicted to make way for new data. You cannot 
 inspect the contents of the query cache.


### PR DESCRIPTION
Minor correction on the query cache page `there is one queries cache per node` becomes `there is one query cache per node`

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? Yes

