### PR TITLE
Treating watcher webhook response header names as case-insensitive

### DIFF
--- a/docs/changelog/99717.yaml
+++ b/docs/changelog/99717.yaml
@@ -1,0 +1,5 @@
+pr: 99717
+summary: Treating watcher webhook response header names as case-insensitive
+area: Watcher
+type: bug
+issues: []

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -72,6 +72,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -274,17 +275,22 @@ public class HttpClient implements Closeable {
             // headers
             Header[] headers = response.getAllHeaders();
             Map<String, String[]> responseHeaders = Maps.newMapWithExpectedSize(headers.length);
+            /*
+             * Headers are not case sensitive, so in the following loop we lowercase all of them. We also roll up all values for the same
+             * case-insensitive header into a list.
+             */
             for (Header header : headers) {
-                if (responseHeaders.containsKey(header.getName())) {
-                    String[] old = responseHeaders.get(header.getName());
+                String lowerCaseHeaderName = header.getName().toLowerCase(Locale.ROOT);
+                if (responseHeaders.containsKey(lowerCaseHeaderName)) {
+                    String[] old = responseHeaders.get(lowerCaseHeaderName);
                     String[] values = new String[old.length + 1];
 
                     System.arraycopy(old, 0, values, 0, old.length);
                     values[values.length - 1] = header.getValue();
 
-                    responseHeaders.put(header.getName(), values);
+                    responseHeaders.put(lowerCaseHeaderName, values);
                 } else {
-                    responseHeaders.put(header.getName(), new String[] { header.getValue() });
+                    responseHeaders.put(lowerCaseHeaderName, new String[] { header.getValue() });
                 }
             }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
@@ -500,6 +500,7 @@ public class HttpClientTests extends ESTestCase {
             .setBody("foo")
             .addHeader("foo", "bar")
             .addHeader("foo", "baz")
+            .addHeader("Foo", "bam")
             .addHeader("Content-Length", "3");
         webServer.enqueue(mockResponse);
 
@@ -509,7 +510,7 @@ public class HttpClientTests extends ESTestCase {
         assertThat(webServer.requests(), hasSize(1));
 
         assertThat(httpResponse.headers(), hasKey("foo"));
-        assertThat(httpResponse.headers().get("foo"), containsInAnyOrder("bar", "baz"));
+        assertThat(httpResponse.headers().get("foo"), containsInAnyOrder("bar", "baz", "bam"));
     }
 
     // finally fixing https://github.com/elastic/x-plugins/issues/1141 - yay! Fixed due to switching to apache http client internally!


### PR DESCRIPTION
If a response returned from a watcher webhook had two headers that differed only by case (like `vary` and `Vary`), then we would get this exception:
```
java.lang.IllegalStateException: Duplicate key vary (attempted merging values [Ljava.lang.String;@53e65f41 and [Ljava.lang.String;@688ae0b9)
        at java.util.stream.Collectors.duplicateKeyException(Collectors.java:135) ~[?:?]
        at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:182) ~[?:?]
        at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]
        at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1858) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at org.elasticsearch.xpack.watcher.common.http.HttpResponse.<init>(HttpResponse.java:69) ~[?:?]
        at org.elasticsearch.xpack.watcher.common.http.HttpResponse.<init>(HttpResponse.java:61) ~[?:?]
        at org.elasticsearch.xpack.watcher.common.http.HttpClient.execute(HttpClient.java:297) ~[?:?]
        at org.elasticsearch.xpack.watcher.actions.webhook.ExecutableWebhookAction.execute(ExecutableWebhookAction.java:43) ~[?:?]
        at org.elasticsearch.xpack.core.watcher.actions.ActionWrapper.execute(ActionWrapper.java:175) ~[?:?]
        at org.elasticsearch.xpack.watcher.execution.ExecutionService.executeInner(ExecutionService.java:560) ~[?:?]
        at org.elasticsearch.xpack.watcher.execution.ExecutionService.execute(ExecutionService.java:342) ~[?:?]
        at org.elasticsearch.xpack.watcher.execution.ExecutionService.lambda$executeAsync$6(ExecutionService.java:440) ~[?:?]
        at org.elasticsearch.xpack.watcher.execution.ExecutionService$WatchExecutionTask.run(ExecutionService.java:666) ~[?:?]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:850) ~[elasticsearch-8.6.2.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1589) ~[?:?]",
```
It is OK to have multiple values for a header (see https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2). In fact, HttpClient was already doing this (https://github.com/elastic/elasticsearch/blob/v8.10.1/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java#L278). The problem happened because HttpResponse was further deduplicating by case (https://github.com/elastic/elasticsearch/blob/v8.10.1/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpResponse.java#L69). Headers are meant to be case insensitive. So I'm adding the case insensitive deduplication to HttpClient. By the time we get to HttpResponse the deduplication will have happened.