### PR TITLE
Warn about third-party JVM agents in docs

### DIFF
--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -95,7 +95,7 @@ directory. You may remove this directory if using your own JVM.
 === JVM and Java agents
 
 Don't use third-party Java agents that attach to the JVM. These agents
-been observed to reduce {es} performance, or even freeze or crash nodes.
+can reduce {es} performance, including freezing or crashing nodes.
 
 
 include::install/targz.asciidoc[]

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -87,6 +87,10 @@ bundled JVM is treated as an integral part of {es}, which means that Elastic
 takes responsibility for keeping it up to date. Security issues and bugs within
 the bundled JVM are treated as if they were within {es} itself.
 
+You should not use long-running third-party agents that attach to the JVM
+for deep introspection and instrumentation. Such software has been observed
+to reduce Elasticsearch performance, or even freeze or crash nodes.
+
 The bundled JVM is located within the `jdk` subdirectory of the {es} home
 directory. You may remove this directory if using your own JVM.
 

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -87,12 +87,16 @@ bundled JVM is treated as an integral part of {es}, which means that Elastic
 takes responsibility for keeping it up to date. Security issues and bugs within
 the bundled JVM are treated as if they were within {es} itself.
 
-You should not use long-running third-party agents that attach to the JVM
-for deep introspection and instrumentation. Such software has been observed
-to reduce Elasticsearch performance, or even freeze or crash nodes.
-
 The bundled JVM is located within the `jdk` subdirectory of the {es} home
 directory. You may remove this directory if using your own JVM.
+
+[discrete]
+[[jvm-agents]]
+=== JVM and Java Agents
+
+Do not use third-party Java agents that attach to the JVM. Such software has
+been observed to reduce {es} performance, or even freeze or crash nodes.
+
 
 include::install/targz.asciidoc[]
 

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -92,7 +92,7 @@ directory. You may remove this directory if using your own JVM.
 
 [discrete]
 [[jvm-agents]]
-=== JVM and Java Agents
+=== JVM and Java agents
 
 Do not use third-party Java agents that attach to the JVM. Such software has
 been observed to reduce {es} performance, or even freeze or crash nodes.

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -94,7 +94,7 @@ directory. You may remove this directory if using your own JVM.
 [[jvm-agents]]
 === JVM and Java agents
 
-Do not use third-party Java agents that attach to the JVM. Such software has
+Don't use third-party Java agents that attach to the JVM. These agents
 been observed to reduce {es} performance, or even freeze or crash nodes.
 
 


### PR DESCRIPTION
We've had reports of cases where Elasticsearch nodes froze mysteriously or had difficult-to-diagnose performance problems, and the eventual culprit was some monitoring agent that attached into to the JVM and interfered with what Elasticsearch needed to do. We can add a warning about this to our docs so that we have something to reference when this problem comes up again.