### PR TITLE
[main] [DOCS] Add 8.10.2 release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.11.0>>
+* <<release-notes-8.10.2>>
 * <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
 * <<release-notes-8.9.2>>
@@ -51,6 +52,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.11.0.asciidoc[]
+include::release-notes/8.10.2.asciidoc[]
 include::release-notes/8.10.1.asciidoc[]
 include::release-notes/8.10.0.asciidoc[]
 include::release-notes/8.9.2.asciidoc[]

--- a/docs/reference/release-notes/8.10.2.asciidoc
+++ b/docs/reference/release-notes/8.10.2.asciidoc
@@ -1,0 +1,6 @@
+[[release-notes-8.10.2]]
+== {es} version 8.10.2
+
+8.10.2 contains no significant changes.
+
+Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/99721 to `main`.