### PR TITLE
Remove obsolete docs for G1GC check

### DIFF
--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -221,14 +221,6 @@ releases are not suitable for production. The early-access check detects these
 early-access snapshots. To pass this check, you must start Elasticsearch on a
 release build of the JVM.
 
-=== G1GC check
-
-Early versions of the HotSpot JVM that shipped with JDK 8 are known to
-have issues that can lead to index corruption when the G1GC collector is
-enabled. The versions impacted are those earlier than the version of
-HotSpot that shipped with JDK 8u40. The G1GC check detects these early
-versions of the HotSpot JVM.
-
 === All permission check
 
 The all permission check ensures that the security policy used during bootstrap


### PR DESCRIPTION
We removed this bootstrap check in #85361 but didn't remove its docs.
This commit removes the obsolete docs.