### PR TITLE
Limit test parallelism to 1 for junit bwc tests

### DIFF
--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
 test {
+  // CI doesn't like it when there's multiple clusters running at once
   maxParallelForks = 1
 }
 

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -13,6 +13,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
+test {
+  maxParallelForks = 1
+}
+
 BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -18,6 +18,10 @@ testArtifacts {
   registerTestArtifactFromSourceSet(sourceSets.javaRestTest)
 }
 
+test {
+  maxParallelForks = 1
+}
+
 BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -19,6 +19,7 @@ testArtifacts {
 }
 
 test {
+  // CI doesn't like it when there's multiple clusters running at once
   maxParallelForks = 1
 }
 


### PR DESCRIPTION
Junit test tasks can run in parallel. This overloads CI when lots of clusters are run in parallel. This limits the tests to 1 at a time for each task.

This fixes #99727