### PR TITLE
Discovery troubleshooting next steps

### DIFF
--- a/docs/reference/troubleshooting/network-timeouts.asciidoc
+++ b/docs/reference/troubleshooting/network-timeouts.asciidoc
@@ -1,11 +1,17 @@
 tag::troubleshooting-network-timeouts-gc-vm[]
 * GC pauses are recorded in the GC logs that {es} emits by default, and also
 usually by the `JvmMonitorService` in the main node logs. Use these logs to
-confirm whether or not GC is resulting in delays.
+confirm whether or not the node is experiencing high heap usage with long GC
+pauses. If so, <<high-jvm-memory-pressure,the troubleshooting guide for high
+heap usage>> has some suggestions for further investigation but typically you
+will need to capture a heap dump during a time of high heap usage to fully
+understand the problem.
 
 * VM pauses also affect other processes on the same host. A VM pause also
 typically causes a discontinuity in the system clock, which {es} will report in
-its logs.
+its logs. If you see evidence of other processes pausing at the same time, or
+unexpected clock discontinuities, investigate the infrastructure on which you
+are running {es}.
 end::troubleshooting-network-timeouts-gc-vm[]
 
 tag::troubleshooting-network-timeouts-packet-capture-elections[]


### PR DESCRIPTION
Adds a little more detail on how to react if you see evidence that the
Elasticsearch process is pausing for a long time due to long GCs or VM
pauses.