### PR TITLE
[ML] Make .inference a net new index

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -142,6 +142,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, SystemIndex
                 .setSettings(InferenceIndex.settings())
                 .setVersionMetaKey("version")
                 .setOrigin(ClientHelper.INFERENCE_ORIGIN)
+                .setNetNew()
                 .build()
         );
     }


### PR DESCRIPTION
Net new indices cannot be accessed externally even by admins. 