### PR TITLE
[8.10] [Transform] Ignore "index not found" error when `delete_dest_index` flag is set but the dest index doesn't exist (#99738)

### DIFF
--- a/docs/changelog/99738.yaml
+++ b/docs/changelog/99738.yaml
@@ -1,0 +1,6 @@
+pr: 99738
+summary: Ignore "index not found" error when `delete_dest_index` flag is set but the
+  dest index doesn't exist
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDeleteIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDeleteIT.java
@@ -108,7 +108,7 @@ public class TransformDeleteIT extends TransformRestTestCase {
         assertTrue(indexExists(transformDest));
         assertTrue(aliasExists(transformDestAlias));
 
-        deleteTransform(transformId, true);
+        deleteTransform(transformId, false, true);
         assertFalse(indexExists(transformDest));
         assertFalse(aliasExists(transformDest));
     }
@@ -134,7 +134,7 @@ public class TransformDeleteIT extends TransformRestTestCase {
         assertTrue(indexExists(transformDest));
         assertTrue(aliasExists(transformDestAlias));
 
-        deleteTransform(transformId, true);
+        deleteTransform(transformId, false, true);
         assertFalse(indexExists(transformDest));
         assertFalse(aliasExists(transformDestAlias));
     }
@@ -158,7 +158,7 @@ public class TransformDeleteIT extends TransformRestTestCase {
         assertTrue(indexExists(transformDest));
         assertTrue(aliasExists(transformDestAlias));
 
-        ResponseException e = expectThrows(ResponseException.class, () -> deleteTransform(transformId, true));
+        ResponseException e = expectThrows(ResponseException.class, () -> deleteTransform(transformId, false, true));
         assertThat(
             e.getMessage(),
             containsString(
@@ -168,6 +168,21 @@ public class TransformDeleteIT extends TransformRestTestCase {
                 )
             )
         );
+    }
+
+    public void testDeleteDestinationIndexIsNoOpWhenNoDestinationIndexExists() throws Exception {
+        String transformId = "transform-5";
+        String transformDest = transformId + "_idx";
+        String transformDestAlias = transformId + "_alias";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformDest, transformDestAlias);
+
+        createTransform(transformId, transformDest, transformDestAlias);
+        assertFalse(indexExists(transformDest));
+        assertFalse(aliasExists(transformDestAlias));
+
+        deleteTransform(transformId, false, true);
+        assertFalse(indexExists(transformDest));
+        assertFalse(aliasExists(transformDestAlias));
     }
 
     private void createTransform(String transformId, String destIndex, String destAlias) throws IOException {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -611,12 +611,15 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     protected static void deleteTransform(String transformId) throws IOException {
-        deleteTransform(transformId, false);
+        // Ignore 404s because they imply someone was racing us to delete this transform.
+        deleteTransform(transformId, true, false);
     }
 
-    protected static void deleteTransform(String transformId, boolean deleteDestIndex) throws IOException {
+    protected static void deleteTransform(String transformId, boolean ignoreNotFound, boolean deleteDestIndex) throws IOException {
         Request request = new Request("DELETE", getTransformEndpoint() + transformId);
-        request.addParameter("ignore", "404"); // Ignore 404s because they imply someone was racing us to delete this
+        if (ignoreNotFound) {
+            request.addParameter("ignore", "404");
+        }
         if (deleteDestIndex) {
             request.addParameter(TransformField.DELETE_DEST_INDEX.getPreferredName(), Boolean.TRUE.toString());
         }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [Transform] Ignore "index not found" error when `delete_dest_index` flag is set but the dest index doesn't exist (#99738)