### PR TITLE
Mute `indices.simulate_template/10_basic/Simulate template with lifecycle and include defaults`

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
@@ -202,8 +202,10 @@
 ---
 "Simulate template with lifecycle and include defaults":
   - skip:
-      version: " - 8.9.99"
-      reason: "Lifecycle is only available in 8.10+"
+      #version: " - 8.9.99"
+      #reason: "Lifecycle is only available in 8.10+"
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/99767"
       features: ["default_shards"]
 
   - do:


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/99767


