### PR TITLE
Mute `indices.get_index_template/10_basic/Get data stream lifecycle with default rollover`

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -142,8 +142,10 @@ setup:
 ---
 "Get data stream lifecycle with default rollover":
   - skip:
-      version: " - 8.9.99"
-      reason: "Data stream lifecycle in index templates was updated after 8.9"
+      #version: " - 8.9.99"
+      #reason: "Data stream lifecycle in index templates was updated after 8.9"
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/99772"
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/99772