### PR TITLE
Bump version of mixed tests to after Data Stream Lifecycle went GA

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -107,8 +107,8 @@ setup:
 ---
 "Add data stream lifecycle":
   - skip:
-      version: " - 8.9.99"
-      reason: "Data stream lifecycle in index templates was updated after 8.9"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle in index templates was updated after 8.10"
       features: allowed_warnings
 
   - do:
@@ -142,8 +142,8 @@ setup:
 ---
 "Get data stream lifecycle with default rollover":
   - skip:
-      version: " - 8.9.99"
-      reason: "Data stream lifecycle in index templates was updated after 8.9"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle in index templates was updated after 8.10"
       features: allowed_warnings
 
   - do:
@@ -171,8 +171,8 @@ setup:
 ---
 "Reject data stream lifecycle without data stream configuration":
   - skip:
-      version: " - 8.9.99"
-      reason: "Data stream lifecycle in index templates was updated after 8.9"
+      version: " - 8.10.99"
+      reason: "Data stream lifecycle in index templates was updated after 8.10"
   - do:
       catch:  bad_request
       indices.put_index_template:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -227,8 +227,8 @@
 ---
 "Simulate index template with lifecycle and include defaults":
   - skip:
-      version: " - 8.9.99"
-      reason: "Lifecycle is only available in 8.10+"
+      version: " - 8.10.99"
+      reason: "Lifecycle is only available in 8.11+"
       features: ["default_shards"]
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
@@ -202,8 +202,8 @@
 ---
 "Simulate template with lifecycle and include defaults":
   - skip:
-      version: " - 8.9.99"
-      reason: "Lifecycle is only available in 8.10+"
+      version: " - 8.10.99"
+      reason: "Lifecycle is only available in 8.11+"
       features: ["default_shards"]
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/dlm/10_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/dlm/10_usage.yml
@@ -1,8 +1,8 @@
 ---
 "Test data stream lifecycle usage stats":
   - skip:
-      version: "- 8.9.99"
-      reason: "the data stream lifecycle stats were updated to the usage api in 8.10"
+      version: "- 8.10.99"
+      reason: "the data stream lifecycle stats were updated to the usage api in 8.11"
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
When data stream lifecycle went GA we removed the feature flag which is causing the mixed tests on release versions to fail because `8.10` does not receive the feature flag any more. 

With this PR we bump version the tests get applied on to `8.11`.

Closes: https://github.com/elastic/elasticsearch/issues/99794, https://github.com/elastic/elasticsearch/issues/99793, https://github.com/elastic/elasticsearch/issues/99779, https://github.com/elastic/elasticsearch/issues/99772, https://github.com/elastic/elasticsearch/issues/99767
