### PR TITLE
Fix expectations of IndexVersionTests#testLuceneVersionOnUnknownVersions.

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
@@ -199,23 +199,20 @@ public class IndexVersionTests extends ESTestCase {
 
     public void testLuceneVersionOnUnknownVersions() {
         // between two known versions, should use the lucene version of the previous version
-        IndexVersion version = IndexVersionUtils.getPreviousVersion();
-        final IndexVersion nextVersion = IndexVersion.fromId(version.id() + 100);
-        if (IndexVersionUtils.allReleasedVersions().contains(nextVersion) == false) {
-            // the version is not known, we make an assumption the Lucene version stays the same
-            assertThat(version.luceneVersion(), equalTo(nextVersion.luceneVersion()));
-        } else {
-            // the version is known, the most we can assert is that the Lucene version is not earlier
-            // Version does not implement Comparable :(
-            assertTrue(nextVersion.luceneVersion().onOrAfter(version.luceneVersion()));
-        }
+        IndexVersion previousVersion = IndexVersionUtils.getPreviousVersion();
+        IndexVersion currentVersion = IndexVersion.current();
+        int intermediateVersionId = previousVersion.id() + randomInt(currentVersion.id() - previousVersion.id() - 1);
+        IndexVersion intermediateVersion = IndexVersion.fromId(intermediateVersionId);
+        assertFalse(IndexVersionUtils.allReleasedVersions().contains(intermediateVersion));
+        // the version is not known, we make an assumption the Lucene version stays the same as the previous version
+        assertThat(intermediateVersion.luceneVersion(), equalTo(previousVersion.luceneVersion()));
 
         // too old version, major should be the oldest supported lucene version minus 1
-        version = IndexVersion.fromId(5020199);
-        assertThat(version.luceneVersion().major, equalTo(IndexVersionUtils.getFirstVersion().luceneVersion().major - 1));
+        IndexVersion oldVersion = IndexVersion.fromId(5020199);
+        assertThat(oldVersion.luceneVersion().major, equalTo(IndexVersionUtils.getFirstVersion().luceneVersion().major - 1));
 
         // future version, should be the same version as today
-        version = IndexVersion.fromId(IndexVersion.current().id() + 100);
-        assertThat(version.luceneVersion(), equalTo(IndexVersion.current().luceneVersion()));
+        IndexVersion futureVersion = IndexVersion.fromId(currentVersion.id() + 100);
+        assertThat(futureVersion.luceneVersion(), equalTo(currentVersion.luceneVersion()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
@@ -25,10 +25,8 @@ import java.util.regex.Pattern;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class IndexVersionTests extends ESTestCase {
@@ -205,8 +203,8 @@ public class IndexVersionTests extends ESTestCase {
         IndexVersion currentVersion = IndexVersion.current();
         int intermediateVersionId = previousVersion.id() + randomInt(currentVersion.id() - previousVersion.id() - 1);
         IndexVersion intermediateVersion = IndexVersion.fromId(intermediateVersionId);
-        assertThat(IndexVersionUtils.allReleasedVersions(), not(hasItem(intermediateVersion)));
-        // the version is not known, we make an assumption the Lucene version stays the same as the previous version
+        // the version is either the previous version or between the previous version and the current version excluded, so it is assumed to
+        // use the same Lucene version as the previous version
         assertThat(intermediateVersion.luceneVersion(), equalTo(previousVersion.luceneVersion()));
 
         // too old version, major should be the oldest supported lucene version minus 1

--- a/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
@@ -203,7 +203,7 @@ public class IndexVersionTests extends ESTestCase {
         IndexVersion currentVersion = IndexVersion.current();
         int intermediateVersionId = previousVersion.id() + randomInt(currentVersion.id() - previousVersion.id() - 1);
         IndexVersion intermediateVersion = IndexVersion.fromId(intermediateVersionId);
-        assertFalse(IndexVersionUtils.allReleasedVersions().contains(intermediateVersion));
+assertThat(IndexVersionUtils.allReleasedVersions(), not(hasItem(intermediateVersion)));
         // the version is not known, we make an assumption the Lucene version stays the same as the previous version
         assertThat(intermediateVersion.luceneVersion(), equalTo(previousVersion.luceneVersion()));
 

--- a/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexVersionTests.java
@@ -25,8 +25,10 @@ import java.util.regex.Pattern;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class IndexVersionTests extends ESTestCase {
@@ -203,7 +205,7 @@ public class IndexVersionTests extends ESTestCase {
         IndexVersion currentVersion = IndexVersion.current();
         int intermediateVersionId = previousVersion.id() + randomInt(currentVersion.id() - previousVersion.id() - 1);
         IndexVersion intermediateVersion = IndexVersion.fromId(intermediateVersionId);
-assertThat(IndexVersionUtils.allReleasedVersions(), not(hasItem(intermediateVersion)));
+        assertThat(IndexVersionUtils.allReleasedVersions(), not(hasItem(intermediateVersion)));
         // the version is not known, we make an assumption the Lucene version stays the same as the previous version
         assertThat(intermediateVersion.luceneVersion(), equalTo(previousVersion.luceneVersion()));
 


### PR DESCRIPTION
This test tests the following:
 - an unknown version has the Lucene version of the previous Elasticsearch version
 - an unknown version older than the first known version is on the previous Lucene major version
 - an unknown version in the future is on the same Lucene version as the current Lucene version