### PR TITLE
[Transform] Do not use PIT in the presence of remote indices in source

### DIFF
--- a/docs/changelog/99803.yaml
+++ b/docs/changelog/99803.yaml
@@ -1,0 +1,5 @@
+pr: 99803
+summary: Do not use PIT in the presence of remote indices in source
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -146,7 +146,7 @@ class ClientTransformIndexer extends TransformIndexer {
 
         injectPointInTimeIfNeeded(
             buildSearchRequest(),
-            ActionListener.wrap(pitSearchRequest -> doSearch(pitSearchRequest, nextPhase), nextPhase::onFailure)
+            ActionListener.wrap(searchRequest -> doSearch(searchRequest, nextPhase), nextPhase::onFailure)
         );
     }
 
@@ -435,7 +435,8 @@ class ClientTransformIndexer extends TransformIndexer {
         ActionListener<Tuple<String, SearchRequest>> listener
     ) {
         SearchRequest searchRequest = namedSearchRequest.v2();
-        if (disablePit || searchRequest.indices().length == 0) {
+        // We explicitly disable PIT in the presence of remote clusters in the source due to huge PIT handles causing performance problems.
+        if (disablePit || searchRequest.indices().length == 0 || transformConfig.getSource().requiresRemoteCluster()) {
             listener.onResponse(namedSearchRequest);
             return;
         }


### PR DESCRIPTION
Today transforms defaults to using point-in-time (PIT) readers. These can make the transform more efficient in many scenarios, however, there are some where they can make the transform considerably less efficient.

One of such scenarios is when some of the source indices are on remote clusters.
This PR disables PIT in such a case.

Relates https://github.com/elastic/elasticsearch/issues/99742