### PR TITLE
Correctly handle ScriptScoreQuery in plain highlighter

### DIFF
--- a/docs/changelog/99804.yaml
+++ b/docs/changelog/99804.yaml
@@ -1,0 +1,6 @@
+pr: 99804
+summary: Correctly handle `ScriptScoreQuery` in plain highlighter
+area: Highlighting
+type: bug
+issues:
+ - 99700

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -67,6 +67,10 @@ public class ScriptScoreQuery extends Query {
         this.indexVersion = indexVersion;
     }
 
+    public Query getSubQuery() {
+        return subQuery;
+    }
+
     @Override
     public Query rewrite(IndexSearcher searcher) throws IOException {
         Query newQ = subQuery.rewrite(searcher);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -20,7 +20,7 @@ import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.TextFieldMapper;
-import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -50,7 +50,7 @@ public class QueryRewriteContext {
     protected final NamedWriteableRegistry writeableRegistry;
     protected final ValuesSourceRegistry valuesSourceRegistry;
     protected final BooleanSupplier allowExpensiveQueries;
-    protected final ScriptService scriptService;
+    protected final ScriptCompiler scriptService;
     private final XContentParserConfiguration parserConfiguration;
     protected final Client client;
     protected final LongSupplier nowInMillis;
@@ -73,7 +73,7 @@ public class QueryRewriteContext {
         final NamedWriteableRegistry namedWriteableRegistry,
         final ValuesSourceRegistry valuesSourceRegistry,
         final BooleanSupplier allowExpensiveQueries,
-        final ScriptService scriptService
+        final ScriptCompiler scriptService
     ) {
 
         this.parserConfiguration = parserConfiguration;

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -48,9 +48,9 @@ import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptFactory;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.lookup.LeafFieldLookupProvider;
@@ -110,7 +110,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         MapperService mapperService,
         MappingLookup mappingLookup,
         SimilarityService similarityService,
-        ScriptService scriptService,
+        ScriptCompiler scriptService,
         XContentParserConfiguration parserConfiguration,
         NamedWriteableRegistry namedWriteableRegistry,
         Client client,
@@ -183,7 +183,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         MapperService mapperService,
         MappingLookup mappingLookup,
         SimilarityService similarityService,
-        ScriptService scriptService,
+        ScriptCompiler scriptService,
         XContentParserConfiguration parserConfig,
         NamedWriteableRegistry namedWriteableRegistry,
         Client client,

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/CustomQueryScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/CustomQueryScorer.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.search.highlight.WeightedSpanTerm;
 import org.apache.lucene.search.highlight.WeightedSpanTermExtractor;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.index.search.ESToParentBlockJoinQuery;
 
 import java.io.IOException;
@@ -73,6 +74,8 @@ public final class CustomQueryScorer extends QueryScorer {
                 super.extract(((FunctionScoreQuery) query).getSubQuery(), boost, terms);
             } else if (query instanceof ESToParentBlockJoinQuery) {
                 super.extract(((ESToParentBlockJoinQuery) query).getChildQuery(), boost, terms);
+            } else if (query instanceof ScriptScoreQuery ssq) {
+                super.extract(ssq.getSubQuery(), boost, terms);
             } else {
                 super.extract(query, boost, terms);
             }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -652,7 +652,7 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             mapperService,
             mapperService.mappingLookup(),
             similarityService,
-            null,
+            MapperServiceTestCase.this::compileScript,
             parserConfig(),
             writableRegistry(),
             null,


### PR DESCRIPTION
ScriptScoreQuery is an elasticsearch query implementation that the plain
highlighter doesn't know anything about.  To highlight it correctly, we need
to add some custom handling logic in our CustomQueryScorer.

Fixes #99700 