### PR TITLE
[8.10] [Transform] Do not use PIT in the presence of remote indices in source (#99803)

### DIFF
--- a/docs/changelog/99803.yaml
+++ b/docs/changelog/99803.yaml
@@ -1,0 +1,5 @@
+pr: 99803
+summary: Do not use PIT in the presence of remote indices in source
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -146,7 +146,7 @@ class ClientTransformIndexer extends TransformIndexer {
 
         injectPointInTimeIfNeeded(
             buildSearchRequest(),
-            ActionListener.wrap(pitSearchRequest -> doSearch(pitSearchRequest, nextPhase), nextPhase::onFailure)
+            ActionListener.wrap(searchRequest -> doSearch(searchRequest, nextPhase), nextPhase::onFailure)
         );
     }
 
@@ -435,7 +435,8 @@ class ClientTransformIndexer extends TransformIndexer {
         ActionListener<Tuple<String, SearchRequest>> listener
     ) {
         SearchRequest searchRequest = namedSearchRequest.v2();
-        if (disablePit || searchRequest.indices().length == 0) {
+        // We explicitly disable PIT in the presence of remote clusters in the source due to huge PIT handles causing performance problems.
+        if (disablePit || searchRequest.indices().length == 0 || transformConfig.getSource().requiresRemoteCluster()) {
             listener.onResponse(namedSearchRequest);
             return;
         }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [Transform] Do not use PIT in the presence of remote indices in source (#99803)