### PR TITLE
Set ParentAggregationBuilder not to support concurrent execution

### DIFF
--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
@@ -32,20 +32,41 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ParentIT extends AbstractParentChildTestCase {
 
-    public void testSimpleParentAgg() throws Exception {
+    public void testSimpleParentAgg() {
         final SearchRequestBuilder searchRequest = client().prepareSearch("test")
-            .setSize(10000)
+            .setSize(0)
             .setQuery(matchQuery("randomized", true))
-            .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
+            .addAggregation(parent("to_article", "comment"));
         SearchResponse searchResponse = searchRequest.get();
-        assertSearchResponse(searchResponse);
 
+        assertSearchResponse(searchResponse);
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
             .count();
-
         Parent parentAgg = searchResponse.getAggregations().get("to_article");
+        assertThat(
+            "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
+            parentAgg.getDocCount(),
+            equalTo(articlesWithComment)
+        );
+    }
+
+
+    public void testSimpleParentAggWithSubAgg() {
+            final SearchRequestBuilder searchRequest = client().prepareSearch("test")
+                .setSize(10000)
+                .setQuery(matchQuery("randomized", true))
+                .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
+            SearchResponse searchResponse = searchRequest.get();
+            assertSearchResponse(searchResponse);
+
+            long articlesWithComment = articleToControl.values()
+                .stream()
+                .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
+                .count();
+
+            Parent parentAgg = searchResponse.getAggregations().get("to_article");
         assertThat(
             "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
             parentAgg.getDocCount(),

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
@@ -52,21 +52,20 @@ public class ParentIT extends AbstractParentChildTestCase {
         );
     }
 
-
     public void testSimpleParentAggWithSubAgg() {
-            final SearchRequestBuilder searchRequest = client().prepareSearch("test")
-                .setSize(10000)
-                .setQuery(matchQuery("randomized", true))
-                .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
-            SearchResponse searchResponse = searchRequest.get();
-            assertSearchResponse(searchResponse);
+        final SearchRequestBuilder searchRequest = client().prepareSearch("test")
+            .setSize(10000)
+            .setQuery(matchQuery("randomized", true))
+            .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
+        SearchResponse searchResponse = searchRequest.get();
+        assertSearchResponse(searchResponse);
 
-            long articlesWithComment = articleToControl.values()
-                .stream()
-                .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
-                .count();
+        long articlesWithComment = articleToControl.values()
+            .stream()
+            .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
+            .count();
 
-            Parent parentAgg = searchResponse.getAggregations().get("to_article");
+        Parent parentAgg = searchResponse.getAggregations().get("to_article");
         assertThat(
             "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
             parentAgg.getDocCount(),

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregationBuilder.java
@@ -91,6 +91,11 @@ public class ParentAggregationBuilder extends ValuesSourceAggregationBuilder<Par
     }
 
     @Override
+    public boolean supportsParallelCollection() {
+        return false;
+    }
+
+    @Override
     protected ValuesSourceAggregatorFactory innerBuild(
         AggregationContext context,
         ValuesSourceConfig config,


### PR DESCRIPTION
The parent-join aggregation is resolved by looking to all segments in the index. Then in the parent aggregation, when finding a children, then it will be resolved to the parent and we count all the children documents, therefore overcounting  in concurrency mode, as every thread will consider all documents in the index.


