### PR TITLE
[main] [DOCS] Fix typo in query_cache.asciidoc (#99713)

### DIFF
--- a/docs/reference/modules/indices/query_cache.asciidoc
+++ b/docs/reference/modules/indices/query_cache.asciidoc
@@ -2,7 +2,7 @@
 === Node query cache settings
 
 The results of queries used in the filter context are cached in the node query 
-cache for fast lookup. There is one queries cache per node that is shared by all 
+cache for fast lookup. There is one query cache per node that is shared by all 
 shards. The cache uses an LRU eviction policy: when the cache is full, the least 
 recently used query results are evicted to make way for new data. You cannot 
 inspect the contents of the query cache.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.10` to `main`:
 - [[DOCS] Fix typo in query_cache.asciidoc (#99713)](https://github.com/elastic/elasticsearch/pull/99713)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)