### PR TITLE
[main] [DOCS] Time series indices support non-metric/dimension fields (#99709)

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -56,6 +56,8 @@ documents, the document `_id` is a hash of the document's dimensions and
 * A TSDS uses <<synthetic-source,synthetic `_source`>>, and as a result is
 subject to a number of <<synthetic-source-restrictions,restrictions>>.
 
+NOTE: A time series index can contain fields other than dimensions or metrics.
+
 [discrete]
 [[time-series]]
 === What is a time series?


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.10` to `main`:
 - [[DOCS] Time series indices support non-metric/dimension fields (#99709)](https://github.com/elastic/elasticsearch/pull/99709)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)