### PR TITLE
Remove IndexAnalyzers and ScriptCompiler from KeywordFieldMapper

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -183,7 +183,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                         // that only the first pathMatch passed in gets recognized as a time_series_dimension. To counteract
                         // that, we wrap the mappingSnippet in a new HashMap for each pathMatch instance.
                         .parse(pathMatch, new HashMap<>(mappingSnippet), parserContext)
-                        .build(MapperBuilderContext.root(false, false));
+                        .build(MapperBuilderContext.root(false, false, null));
                     extractPath(routingPaths, mapper);
                 }
             }

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingParserContext;
 
@@ -182,9 +181,13 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                         // Since FieldMapper.parse modifies the Map passed in (removing entries for "type"), that means
                         // that only the first pathMatch passed in gets recognized as a time_series_dimension. To counteract
                         // that, we wrap the mappingSnippet in a new HashMap for each pathMatch instance.
-                        .parse(pathMatch, new HashMap<>(mappingSnippet), parserContext)
-                        .build(MapperBuilderContext.root(false, false, null));
-                    extractPath(routingPaths, mapper);
+                        .parse(pathMatch, new HashMap<>(mappingSnippet), parserContext);
+                    // same logic as in #extractPath
+                    if (mapper instanceof KeywordFieldMapper.Builder kwBuilder) {
+                        if (kwBuilder.dimension()) {
+                            routingPaths.add(kwBuilder.name());
+                        }
+                    }
                 }
             }
             return routingPaths;

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
@@ -221,7 +221,7 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
                 ScriptCompiler.NONE,
                 false,
                 IndexVersion.current()
-            ).build(MapperBuilderContext.root(false, false));
+            ).build(MapperBuilderContext.root(false, false, null));
             RootObjectMapper.Builder root = new RootObjectMapper.Builder("_doc", ObjectMapper.Defaults.SUBOBJECTS);
             root.add(
                 new DateFieldMapper.Builder(
@@ -235,7 +235,7 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
             );
             MetadataFieldMapper dtfm = DataStreamTestHelper.getDataStreamTimestampFieldMapper();
             Mapping mapping = new Mapping(
-                root.build(MapperBuilderContext.root(false, false)),
+                root.build(MapperBuilderContext.root(false, false, null)),
                 new MetadataFieldMapper[] { dtfm },
                 Collections.emptyMap()
             );

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/GeoJsonShapeParserTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/GeoJsonShapeParserTests.java
@@ -385,7 +385,7 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
         final IndexVersion version = IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersion.V_8_0_0);
         final LegacyGeoShapeFieldMapper mapperBuilder = new LegacyGeoShapeFieldMapper.Builder("test", version, false, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/GeoWKTShapeParserTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/GeoWKTShapeParserTests.java
@@ -293,7 +293,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
         parser.nextToken();
 
         final LegacyGeoShapeFieldMapper mapperBuilder = new LegacyGeoShapeFieldMapper.Builder("test", IndexVersion.current(), false, true)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         // test store z disabled
         ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> ShapeParser.parse(parser, mapperBuilder));
@@ -325,7 +325,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
 
         final IndexVersion version = IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersion.V_8_0_0);
         final LegacyGeoShapeFieldMapper mapperBuilder = new LegacyGeoShapeFieldMapper.Builder("test", version, false, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
 
         // test store z disabled
@@ -349,7 +349,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
 
         final IndexVersion version = IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersion.V_8_0_0);
         final LegacyGeoShapeFieldMapper mapperBuilder = new LegacyGeoShapeFieldMapper.Builder("test", version, false, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
 
         ShapeBuilder<?, ?, ?> shapeBuilder = ShapeParser.parse(parser, mapperBuilder);
@@ -366,7 +366,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
         final IndexVersion version = IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersion.V_8_0_0);
         final LegacyGeoShapeFieldMapper defaultMapperBuilder = new LegacyGeoShapeFieldMapper.Builder("test", version, false, true).coerce(
             false
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
         ElasticsearchParseException exception = expectThrows(
             ElasticsearchParseException.class,
             () -> ShapeParser.parse(parser, defaultMapperBuilder)
@@ -378,7 +378,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
             IndexVersion.current(),
             false,
             true
-        ).coerce(true).build(MapperBuilderContext.root(false, false));
+        ).coerce(true).build(MapperBuilderContext.root(false, false, null));
         ShapeBuilder<?, ?, ?> shapeBuilder = ShapeParser.parse(parser, coercingMapperBuilder);
         assertNotNull(shapeBuilder);
         assertEquals("polygon ((100.0 5.0, 100.0 10.0, 90.0 10.0, 90.0 5.0, 100.0 5.0))", shapeBuilder.toWKT());

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldTypeTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldTypeTests.java
@@ -37,7 +37,7 @@ public class LegacyGeoShapeFieldTypeTests extends FieldTypeTestCase {
     public void testFetchSourceValue() throws IOException {
         IndexVersion version = IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersion.V_8_0_0);
         MappedFieldType mapper = new LegacyGeoShapeFieldMapper.Builder("field", version, false, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
 
         Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates", List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldTypeTests.java
@@ -25,7 +25,7 @@ public class RankFeatureFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new RankFeatureFieldMapper.Builder("field").nullValue(2.0f)
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
 
         assertEquals(List.of(3.14f), fetchSourceValue(mapper, 3.14));

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -218,7 +218,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new ScaledFloatFieldMapper.Builder("field", false, false, null).scalingFactor(100)
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         assertEquals(List.of(3.14), fetchSourceValue(mapper, 3.1415926));
         assertEquals(List.of(3.14), fetchSourceValue(mapper, "3.1415"));
@@ -226,7 +226,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
 
         MappedFieldType nullValueMapper = new ScaledFloatFieldMapper.Builder("field", false, false, null).scalingFactor(100)
             .nullValue(2.71)
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         assertEquals(List.of(2.71), fetchSourceValue(nullValueMapper, ""));
     }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
@@ -300,7 +300,7 @@ public class ChildrenToParentAggregatorTests extends AggregatorTestCase {
 
         int i = fieldTypes.length;
         result[i++] = new ParentJoinFieldMapper.Builder("join_field").addRelation(PARENT_TYPE, Collections.singleton(CHILD_TYPE))
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         result[i++] = new ParentIdFieldMapper.ParentIdFieldType("join_field#" + PARENT_TYPE, false);
         assert i == result.length;

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/JoinFieldTypeTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/JoinFieldTypeTests.java
@@ -19,7 +19,8 @@ import java.util.Map;
 public class JoinFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType fieldType = new ParentJoinFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false)).fieldType();
+        MappedFieldType fieldType = new ParentJoinFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false, null))
+            .fieldType();
 
         Map<String, String> parentValue = Map.of("relation", "parent");
         assertEquals(List.of(parentValue), fetchSourceValue(fieldType, parentValue));

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -63,7 +63,7 @@ public class QueryBuilderStoreTests extends ESTestCase {
             IndexWriterConfig config = new IndexWriterConfig(new WhitespaceAnalyzer());
             config.setMergePolicy(NoMergePolicy.INSTANCE);
             BinaryFieldMapper fieldMapper = PercolatorFieldMapper.Builder.createQueryBuilderFieldBuilder(
-                MapperBuilderContext.root(false, false)
+                MapperBuilderContext.root(false, false, null)
             );
             MappedFieldType.FielddataOperation fielddataOperation = MappedFieldType.FielddataOperation.SEARCH;
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldTypeTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldTypeTests.java
@@ -19,19 +19,19 @@ public class ICUCollationKeywordFieldTypeTests extends FieldTypeTestCase {
     public void testFetchSourceValue() throws IOException {
 
         ICUCollationKeywordFieldMapper mapper = new ICUCollationKeywordFieldMapper.Builder("field").build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         assertEquals(List.of("42"), fetchSourceValue(mapper.fieldType(), 42L));
         assertEquals(List.of("true"), fetchSourceValue(mapper.fieldType(), true));
 
         ICUCollationKeywordFieldMapper ignoreAboveMapper = new ICUCollationKeywordFieldMapper.Builder("field").ignoreAbove(4)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
         assertEquals(List.of(), fetchSourceValue(ignoreAboveMapper.fieldType(), "value"));
         assertEquals(List.of("42"), fetchSourceValue(ignoreAboveMapper.fieldType(), 42L));
         assertEquals(List.of("true"), fetchSourceValue(ignoreAboveMapper.fieldType(), true));
 
         ICUCollationKeywordFieldMapper nullValueMapper = new ICUCollationKeywordFieldMapper.Builder("field").nullValue("NULL")
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
         assertEquals(List.of("NULL"), fetchSourceValue(nullValueMapper.fieldType(), null));
     }
 }

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -30,7 +30,7 @@ public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType fieldType = new AnnotatedTextFieldMapper.Builder("field", IndexVersion.current(), createDefaultIndexAnalyzers())
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
 
         assertEquals(List.of("value"), fetchSourceValue(fieldType, "value"));

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -27,7 +27,7 @@ public class DocumentMapper {
      */
     public static DocumentMapper createEmpty(MapperService mapperService) {
         RootObjectMapper root = new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME, ObjectMapper.Defaults.SUBOBJECTS).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, mapperService.parserContext())
         );
         MetadataFieldMapper[] metadata = mapperService.getMetadataMappers().values().toArray(new MetadataFieldMapper[0]);
         Mapping mapping = new Mapping(root, metadata, null);
@@ -85,6 +85,10 @@ public class DocumentMapper {
 
     public MappingLookup mappers() {
         return this.mappingLookup;
+    }
+
+    public MappingParserContext mappingParserContext() {
+        return documentParser.mappingParserContext();
     }
 
     public ParsedDocument parse(SourceToParse source) throws DocumentParsingException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -127,6 +127,10 @@ public final class DocumentParser {
         };
     }
 
+    public MappingParserContext mappingParserContext() {
+        return mappingParserContext;
+    }
+
     private static void internalParseDocument(MetadataFieldMapper[] metadataFieldsMappers, DocumentParserContext context) {
 
         try {
@@ -245,7 +249,7 @@ public final class DocumentParser {
         return new DocumentParsingException(context.parser().getTokenLocation(), "failed to parse: " + e.getMessage(), e);
     }
 
-    static Mapping createDynamicUpdate(DocumentParserContext context) {
+    private Mapping createDynamicUpdate(DocumentParserContext context) {
         if (context.getDynamicMappers().isEmpty() && context.getDynamicRuntimeFields().isEmpty()) {
             return null;
         }
@@ -255,7 +259,9 @@ public final class DocumentParser {
         for (RuntimeField runtimeField : context.getDynamicRuntimeFields()) {
             rootBuilder.addRuntimeField(runtimeField);
         }
-        RootObjectMapper root = rootBuilder.build(MapperBuilderContext.root(context.mappingLookup().isSourceSynthetic(), false));
+        RootObjectMapper root = rootBuilder.build(
+            MapperBuilderContext.root(context.mappingLookup().isSourceSynthetic(), false, mappingParserContext)
+        );
         return context.mappingLookup().getMapping().mappingUpdate(root);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -538,7 +538,7 @@ public abstract class DocumentParserContext {
         if (p.endsWith(".")) {
             p = p.substring(0, p.length() - 1);
         }
-        return new MapperBuilderContext(p, mappingLookup().isSourceSynthetic(), false);
+        return new MapperBuilderContext(p, mappingLookup().isSourceSynthetic(), false, mappingParserContext);
     }
 
     public abstract XContentParser parser();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -232,6 +232,10 @@ public final class KeywordFieldMapper extends FieldMapper {
             return this;
         }
 
+        public boolean dimension() {
+            return dimension.getValue();
+        }
+
         @Override
         protected Parameter<?>[] getParameters() {
             return new Parameter<?>[] {
@@ -366,7 +370,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.ignoreAbove = builder.ignoreAbove.getValue();
             this.nullValue = builder.nullValue.getValue();
             this.scriptValues = scriptValues;
-            this.isDimension = builder.dimension.getValue();
+            this.isDimension = builder.dimension();
             this.isSyntheticSource = isSyntheticSource;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
@@ -18,18 +18,25 @@ public class MapperBuilderContext {
     /**
      * The root context, to be used when building a tree of mappers
      */
-    public static MapperBuilderContext root(boolean isSourceSynthetic, boolean isDataStream) {
-        return new MapperBuilderContext(null, isSourceSynthetic, isDataStream);
+    public static MapperBuilderContext root(boolean isSourceSynthetic, boolean isDataStream, MappingParserContext mappingParserContext) {
+        return new MapperBuilderContext(null, isSourceSynthetic, isDataStream, mappingParserContext);
     }
 
     private final String path;
     private final boolean isSourceSynthetic;
     private final boolean isDataStream;
 
-    MapperBuilderContext(String path, boolean isSourceSynthetic, boolean isDataStream) {
+    private final MappingParserContext mappingParserContext;
+
+    MapperBuilderContext(String path, boolean isSourceSynthetic, boolean isDataStream, MappingParserContext mappingParserContext) {
         this.path = path;
         this.isSourceSynthetic = isSourceSynthetic;
         this.isDataStream = isDataStream;
+        this.mappingParserContext = mappingParserContext;
+    }
+
+    public MappingParserContext mappingParserContext() {
+        return mappingParserContext;
     }
 
     /**
@@ -38,7 +45,7 @@ public class MapperBuilderContext {
      * @return a new MapperBuilderContext with this context as its parent
      */
     public MapperBuilderContext createChildContext(String name) {
-        return new MapperBuilderContext(buildFullName(name), isSourceSynthetic, isDataStream);
+        return new MapperBuilderContext(buildFullName(name), isSourceSynthetic, isDataStream, mappingParserContext);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -560,7 +560,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (currentMapper == null) {
             newMapping = incomingMapping;
         } else {
-            newMapping = currentMapper.mapping().merge(incomingMapping, reason);
+            newMapping = currentMapper.mapping().merge(incomingMapping, reason, currentMapper.mappingParserContext());
         }
         return newMapping;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -30,7 +30,7 @@ public final class Mapping implements ToXContentFragment {
 
     public static final Mapping EMPTY = new Mapping(
         new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME, ObjectMapper.Defaults.SUBOBJECTS).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ),
         new MetadataFieldMapper[0],
         null
@@ -135,8 +135,12 @@ public final class Mapping implements ToXContentFragment {
      * @param reason the reason this merge was initiated.
      * @return the resulting merged mapping.
      */
-    Mapping merge(Mapping mergeWith, MergeReason reason) {
-        RootObjectMapper mergedRoot = root.merge(mergeWith.root, reason, MapperBuilderContext.root(isSourceSynthetic(), false));
+    Mapping merge(Mapping mergeWith, MergeReason reason, MappingParserContext parserContext) {
+        RootObjectMapper mergedRoot = root.merge(
+            mergeWith.root,
+            reason,
+            MapperBuilderContext.root(isSourceSynthetic(), false, parserContext)
+        );
 
         // When merging metadata fields as part of applying an index template, new field definitions
         // completely overwrite existing ones instead of being merged. This behavior matches how we
@@ -148,7 +152,10 @@ public final class Mapping implements ToXContentFragment {
             if (mergeInto == null || reason == MergeReason.INDEX_TEMPLATE) {
                 merged = metaMergeWith;
             } else {
-                merged = (MetadataFieldMapper) mergeInto.merge(metaMergeWith, MapperBuilderContext.root(isSourceSynthetic(), false));
+                merged = (MetadataFieldMapper) mergeInto.merge(
+                    metaMergeWith,
+                    MapperBuilderContext.root(isSourceSynthetic(), false, parserContext)
+                );
             }
             mergedMetadataMappers.put(merged.getClass(), merged);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -178,7 +178,7 @@ public final class MappingParser {
         }
 
         return new Mapping(
-            rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic, isDataStream)),
+            rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic, isDataStream, mappingParserContext)),
             metadataMappers.values().toArray(new MetadataFieldMapper[0]),
             meta
         );

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -61,7 +61,11 @@ public class NestedObjectMapper extends ObjectMapper {
                     this.includeInRoot = Explicit.IMPLICIT_FALSE;
                 }
             }
-            NestedMapperBuilderContext nestedContext = new NestedMapperBuilderContext(context.buildFullName(name), parentIncludedInRoot);
+            NestedMapperBuilderContext nestedContext = new NestedMapperBuilderContext(
+                context.buildFullName(name),
+                parentIncludedInRoot,
+                context.mappingParserContext()
+            );
             return new NestedObjectMapper(name, context.buildFullName(name), buildMappers(nestedContext), this);
         }
     }
@@ -99,14 +103,14 @@ public class NestedObjectMapper extends ObjectMapper {
 
         final boolean parentIncludedInRoot;
 
-        NestedMapperBuilderContext(String path, boolean parentIncludedInRoot) {
-            super(path, false, false);
+        NestedMapperBuilderContext(String path, boolean parentIncludedInRoot, MappingParserContext context) {
+            super(path, false, false, context);
             this.parentIncludedInRoot = parentIncludedInRoot;
         }
 
         @Override
         public MapperBuilderContext createChildContext(String name) {
-            return new NestedMapperBuilderContext(buildFullName(name), parentIncludedInRoot);
+            return new NestedMapperBuilderContext(buildFullName(name), parentIncludedInRoot, mappingParserContext());
         }
     }
 
@@ -223,7 +227,11 @@ public class NestedObjectMapper extends ObjectMapper {
         if (mapperBuilderContext instanceof NestedMapperBuilderContext == false) {
             parentIncludedInRoot |= this.includeInParent.value();
         }
-        return new NestedMapperBuilderContext(mapperBuilderContext.buildFullName(name), parentIncludedInRoot);
+        return new NestedMapperBuilderContext(
+            mapperBuilderContext.buildFullName(name),
+            parentIncludedInRoot,
+            mapperBuilderContext.mappingParserContext()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -156,11 +156,11 @@ public class ParsedDocument {
         return dynamicMappingsUpdate;
     }
 
-    public void addDynamicMappingsUpdate(Mapping update) {
+    public void addDynamicMappingsUpdate(Mapping update, MappingParserContext parserContext) {
         if (dynamicMappingsUpdate == null) {
             dynamicMappingsUpdate = update;
         } else {
-            dynamicMappingsUpdate = dynamicMappingsUpdate.merge(update, MergeReason.MAPPING_UPDATE);
+            dynamicMappingsUpdate = dynamicMappingsUpdate.merge(update, MergeReason.MAPPING_UPDATE, parserContext);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -321,7 +321,8 @@ public class RootObjectMapper extends ObjectMapper {
                     validate(
                         template,
                         dynamicType,
-                        (name, mapping) -> typeParser.parse(name, mapping, parserContext).build(MapperBuilderContext.root(false, false))
+                        (name, mapping) -> typeParser.parse(name, mapping, parserContext)
+                            .build(MapperBuilderContext.root(false, false, parserContext))
                     );
                 }
                 lastError = null; // ok, the template is valid for at least one type

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -192,7 +192,7 @@ public class QueryRewriteContext {
             return fieldMapping;
         } else if (mapUnmappedFieldAsString) {
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, getIndexAnalyzers());
-            return builder.build(MapperBuilderContext.root(false, false)).fieldType();
+            return builder.build(MapperBuilderContext.root(false, false, mapperService.parserContext())).fieldType();
         } else {
             throw new QueryShardException(this, "No field mapping can be found for the field with name [{}]", name);
         }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -358,7 +358,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
             throw new IllegalArgumentException("No mapper found for type [" + type + "]");
         }
         Mapper.Builder builder = typeParser.parse("__anonymous_", Collections.emptyMap(), parserContext);
-        Mapper mapper = builder.build(MapperBuilderContext.root(false, false));
+        Mapper mapper = builder.build(MapperBuilderContext.root(false, false, mapperService.parserContext()));
         if (mapper instanceof FieldMapper) {
             return ((FieldMapper) mapper).fieldType();
         }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1012,7 +1012,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // some mappings do exist. It covers for the case of indexing an empty doc (`{}`).
             // TODO this can be removed if we eagerly create mappings as soon as a new index is created, regardless of
             // whether mappings were provided or not.
-            doc.addDynamicMappingsUpdate(mapping);
+            doc.addDynamicMappingsUpdate(mapping, mapperService.parserContext());
         }
         Term uid = new Term(IdFieldMapper.NAME, Uid.encodeId(doc.id()));
         return new Engine.Index(

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -85,7 +85,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
 
     public <IFD extends IndexFieldData<?>> IFD getForField(String type, String fieldName, boolean docValues) {
         final MappedFieldType fieldType;
-        final MapperBuilderContext context = MapperBuilderContext.root(false, false);
+        final MapperBuilderContext context = MapperBuilderContext.root(false, false, null);
         if (type.equals("string")) {
             if (docValues) {
                 fieldType = new KeywordFieldMapper.Builder(fieldName, IndexVersion.current()).build(context).fieldType();

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
@@ -48,7 +48,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         }
         writer.forceMerge(1, true);
         List<LeafReaderContext> contexts = refreshReader();
-        final MapperBuilderContext builderContext = MapperBuilderContext.root(false, false);
+        final MapperBuilderContext builderContext = MapperBuilderContext.root(false, false, null);
 
         {
             indexService.clearCaches(false, true);

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -77,7 +77,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService()
         );
-        MapperBuilderContext context = MapperBuilderContext.root(false, false);
+        MapperBuilderContext context = MapperBuilderContext.root(false, false, null);
         final MappedFieldType stringMapper = new KeywordFieldMapper.Builder("string", IndexVersion.current()).build(context).fieldType();
         ifdService.clear();
         IndexFieldData<?> fd = ifdService.getForField(stringMapper, FieldDataContext.noRuntimeFields("test"));
@@ -156,7 +156,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
             indicesService.getCircuitBreakerService()
         );
 
-        final MapperBuilderContext context = MapperBuilderContext.root(false, false);
+        final MapperBuilderContext context = MapperBuilderContext.root(false, false, null);
         final MappedFieldType mapper1 = new TextFieldMapper.Builder("field_1", createDefaultIndexAnalyzers()).fielddata(true)
             .build(context)
             .fieldType();
@@ -223,7 +223,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
             indicesService.getCircuitBreakerService()
         );
 
-        final MapperBuilderContext context = MapperBuilderContext.root(false, false);
+        final MapperBuilderContext context = MapperBuilderContext.root(false, false, null);
         final MappedFieldType mapper1 = new TextFieldMapper.Builder("s", createDefaultIndexAnalyzers()).fielddata(true)
             .build(context)
             .fieldType();

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptFieldTypeTests.java
@@ -320,7 +320,7 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
 
     public void testDualingQueries() throws IOException {
         BooleanFieldMapper ootb = new BooleanFieldMapper.Builder("foo", ScriptCompiler.NONE, false, IndexVersion.current()).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             List<Boolean> values = randomList(0, 2, ESTestCase::randomBoolean);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -278,7 +278,7 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        merged = merged.merge(updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE);
+        merged = merged.merge(updatedMapper.mapping(), MergeReason.INDEX_TEMPLATE, updatedMapper.mappingParserContext());
 
         expected = Map.of("field", "value", "object", Map.of("field1", "value1", "field2", "new_value", "field3", "value3"));
         assertThat(merged.getMeta(), equalTo(expected));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
@@ -57,7 +57,7 @@ public class DynamicFieldsBuilderTests extends ESTestCase {
         DynamicFieldsBuilder.DYNAMIC_TRUE.createDynamicFieldFromValue(ctx, fieldname);
         Map<String, List<Mapper.Builder>> dynamicMappers = ctx.getDynamicMappers();
         assertEquals(1, dynamicMappers.size());
-        Mapper mapper = dynamicMappers.get(fieldname).get(0).build(MapperBuilderContext.root(false, false));
+        Mapper mapper = dynamicMappers.get(fieldname).get(0).build(MapperBuilderContext.root(false, false, null));
         assertEquals(fieldname, mapper.name());
         assertEquals(expectedType, mapper.typeName());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -159,7 +159,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
 
     private static FieldMapper createFieldMapper(String parent, String name) {
         return new BooleanFieldMapper.Builder(name, ScriptCompiler.NONE, false, IndexVersion.current()).build(
-            new MapperBuilderContext(parent, false, false)
+            new MapperBuilderContext(parent, false, false, null)
         );
     }
 
@@ -168,7 +168,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
     }
 
     private static NestedObjectMapper createNestedObjectMapper(String name) {
-        return new NestedObjectMapper.Builder(name, IndexVersion.current()).build(MapperBuilderContext.root(false, false));
+        return new NestedObjectMapper.Builder(name, IndexVersion.current()).build(MapperBuilderContext.root(false, false, null));
     }
 
     private static MappingLookup createMappingLookup(
@@ -181,7 +181,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
         Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.addRuntimeFields(runtimeFieldTypes);
         Mapping mapping = new Mapping(
-            builder.build(MapperBuilderContext.root(false, false)),
+            builder.build(MapperBuilderContext.root(false, false, null)),
             new MetadataFieldMapper[0],
             Collections.emptyMap()
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -119,10 +119,10 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testSourcePathWithMultiFields() {
         MockFieldMapper field = new MockFieldMapper.Builder("field").addMultiField(new MockFieldMapper.Builder("field.subfield1"))
             .addMultiField(new MockFieldMapper.Builder("field.subfield2.subfield3"))
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         // Adding a subfield that is not multi-field
-        MockFieldMapper subfield = new MockFieldMapper.Builder("field.subfield4").build(MapperBuilderContext.root(false, false));
+        MockFieldMapper subfield = new MockFieldMapper.Builder("field.subfield4").build(MapperBuilderContext.root(false, false, null));
 
         FieldTypeLookup lookup = new FieldTypeLookup(List.of(field, subfield), emptyList(), emptyList());
 
@@ -134,19 +134,19 @@ public class FieldTypeLookupTests extends ESTestCase {
 
     public void testSourcePathsWithCopyTo() {
         MockFieldMapper field = new MockFieldMapper.Builder("field").addMultiField(new MockFieldMapper.Builder("field.subfield1"))
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         MockFieldMapper nestedField = new MockFieldMapper.Builder("field.nested").addMultiField(
             new MockFieldMapper.Builder("field.nested.subfield1")
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
 
         MockFieldMapper otherField = new MockFieldMapper.Builder("other_field").copyTo("field")
             .copyTo("field.nested")
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         MockFieldMapper otherNestedField = new MockFieldMapper.Builder("other_field.nested").copyTo("field")
             .copyTo("field.nested")
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         FieldTypeLookup lookup = new FieldTypeLookup(
             Arrays.asList(field, nestedField, otherField, otherNestedField),
@@ -422,6 +422,6 @@ public class FieldTypeLookupTests extends ESTestCase {
     }
 
     private static FlattenedFieldMapper createFlattenedMapper(String fieldName) {
-        return new FlattenedFieldMapper.Builder(fieldName).build(MapperBuilderContext.root(false, false));
+        return new FlattenedFieldMapper.Builder(fieldName).build(MapperBuilderContext.root(false, false, null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldTypeTests.java
@@ -30,7 +30,7 @@ public class GeoPointFieldTypeTests extends FieldTypeTestCase {
             ignoreMalformed,
             IndexVersion.current(),
             null
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
 
         Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.1));
         Map<String, Object> otherJsonPoint = Map.of("type", "Point", "coordinates", List.of(30.0, 50.0));
@@ -89,7 +89,7 @@ public class GeoPointFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchVectorTile() throws IOException {
         MappedFieldType mapper = new GeoPointFieldMapper.Builder("field", ScriptCompiler.NONE, false, IndexVersion.current(), null).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
         final int z = randomIntBetween(1, 10);
         int x = randomIntBetween(0, (1 << z) - 1);

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldTypeTests.java
@@ -15,7 +15,7 @@ import java.util.Map;
 public class GeoShapeFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType mapper = new GeoShapeFieldMapper.Builder("field", true, true).build(MapperBuilderContext.root(false, false))
+        MappedFieldType mapper = new GeoShapeFieldMapper.Builder("field", true, true).build(MapperBuilderContext.root(false, false, null))
             .fieldType();
 
         Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates", List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
@@ -349,7 +349,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new IpFieldMapper.Builder("field", ScriptCompiler.NONE, true, IndexVersion.current()).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
         assertEquals(List.of("2001:db8::2:1"), fetchSourceValue(mapper, "2001:db8::2:1"));
         assertEquals(List.of("2001:db8::2:1"), fetchSourceValue(mapper, "2001:db8:0:0:0:0:2:1"));
@@ -357,7 +357,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
 
         MappedFieldType nullValueMapper = new IpFieldMapper.Builder("field", ScriptCompiler.NONE, true, IndexVersion.current()).nullValue(
             "2001:db8:0:0:0:0:2:7"
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
         assertEquals(List.of("2001:db8::2:7"), fetchSourceValue(nullValueMapper, null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldTypeTests.java
@@ -15,7 +15,9 @@ import java.util.Map;
 public class IpRangeFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
-        RangeFieldMapper mapper = new RangeFieldMapper.Builder("field", RangeType.IP, true).build(MapperBuilderContext.root(false, false));
+        RangeFieldMapper mapper = new RangeFieldMapper.Builder("field", RangeType.IP, true).build(
+            MapperBuilderContext.root(false, false, null)
+        );
         Map<String, Object> range = Map.of("gte", "2001:db8:0:0:0:0:2:1");
         assertEquals(List.of(Map.of("gte", "2001:db8::2:1")), fetchSourceValue(mapper.fieldType(), range));
         assertEquals(List.of("2001:db8::2:1/32"), fetchSourceValue(mapper.fieldType(), "2001:db8:0:0:0:0:2:1/32"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -43,7 +43,7 @@ public class MappingLookupTests extends ESTestCase {
         Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.addRuntimeFields(runtimeFieldTypes);
         Mapping mapping = new Mapping(
-            builder.build(MapperBuilderContext.root(false, false)),
+            builder.build(MapperBuilderContext.root(false, false, null)),
             new MetadataFieldMapper[0],
             Collections.emptyMap()
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldsSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldsSerializationTests.java
@@ -41,7 +41,7 @@ public class MultiFieldsSerializationTests extends ESTestCase {
         }
 
         Mapper.Builder root = new BooleanFieldMapper.Builder("root", ScriptCompiler.NONE, false, IndexVersion.current());
-        FieldMapper.MultiFields multiFields = builder.build(root, MapperBuilderContext.root(false, false));
+        FieldMapper.MultiFields multiFields = builder.build(root, MapperBuilderContext.root(false, false, null));
 
         String serialized = Strings.toString(multiFields);
         int lastStart = 0;

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedLookupTests.java
@@ -64,7 +64,7 @@ public class NestedLookupTests extends MapperServiceTestCase {
     }
 
     private static NestedObjectMapper buildMapper(String name) {
-        return new NestedObjectMapper.Builder(name, IndexVersion.current()).build(MapperBuilderContext.root(false, false));
+        return new NestedObjectMapper.Builder(name, IndexVersion.current()).build(MapperBuilderContext.root(false, false, null));
     }
 
     public void testAllParentFilters() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -1500,21 +1500,21 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     public void testMergeNested() {
         NestedObjectMapper firstMapper = new NestedObjectMapper.Builder("nested1", IndexVersion.current()).includeInParent(true)
             .includeInRoot(true)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
         NestedObjectMapper secondMapper = new NestedObjectMapper.Builder("nested1", IndexVersion.current()).includeInParent(false)
             .includeInRoot(true)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         MapperException e = expectThrows(
             MapperException.class,
-            () -> firstMapper.merge(secondMapper, MapperBuilderContext.root(false, false))
+            () -> firstMapper.merge(secondMapper, MapperBuilderContext.root(false, false, null))
         );
         assertThat(e.getMessage(), containsString("[include_in_parent] parameter can't be updated on a nested object mapping"));
 
         NestedObjectMapper result = (NestedObjectMapper) firstMapper.merge(
             secondMapper,
             MapperService.MergeReason.INDEX_TEMPLATE,
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         assertFalse(result.isIncludeInParent());
         assertTrue(result.isIncludeInRoot());

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -813,7 +813,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             null
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
         assertEquals(List.of(3), fetchSourceValue(mapper, 3.14));
         assertEquals(List.of(42), fetchSourceValue(mapper, "42.9"));
         assertEquals(List.of(3, 42), fetchSourceValues(mapper, 3.14, "foo", "42.9"));
@@ -826,7 +826,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             null
-        ).nullValue(2.71f).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).nullValue(2.71f).build(MapperBuilderContext.root(false, false, null)).fieldType();
         assertEquals(List.of(2.71f), fetchSourceValue(nullValueMapper, ""));
         assertEquals(List.of(2.71f), fetchSourceValue(nullValueMapper, null));
     }
@@ -840,7 +840,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             true,
             IndexVersion.current(),
             null
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
         /*
          * Half float loses a fair bit of precision compared to float but
          * we still do floating point comparisons. The "funny" trailing

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -33,7 +33,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
             fooBuilder.add(new TextFieldMapper.Builder("baz", createDefaultIndexAnalyzers()));
         }
         rootBuilder.add(fooBuilder);
-        return rootBuilder.build(MapperBuilderContext.root(false, false));
+        return rootBuilder.build(MapperBuilderContext.root(false, false, null));
     }
 
     public void testMerge() {
@@ -41,7 +41,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         ObjectMapper mergeWith = createMapping(false, true, true, true);
 
         // WHEN merging mappings
-        final ObjectMapper merged = rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false));
+        final ObjectMapper merged = rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false, null));
 
         // THEN "baz" new field is added to merged mapping
         final ObjectMapper mergedFoo = (ObjectMapper) merged.getMapper("foo");
@@ -63,7 +63,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         // THEN a MapperException is thrown with an excepted message
         MapperException e = expectThrows(
             MapperException.class,
-            () -> rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false))
+            () -> rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false, null))
         );
         assertEquals("the [enabled] parameter can't be updated for the object mapping [foo]", e.getMessage());
     }
@@ -73,9 +73,9 @@ public class ObjectMapperMergeTests extends ESTestCase {
         // the field is disabled, and we are not trying to re-enable it, hence merge should work
         RootObjectMapper mergeWith = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(
             new ObjectMapper.Builder("disabled", Explicit.IMPLICIT_TRUE)
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
 
-        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false));
+        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false, null));
         assertFalse(((ObjectMapper) merged.getMapper("disabled")).isEnabled());
     }
 
@@ -84,14 +84,14 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
         MapperException e = expectThrows(
             MapperException.class,
-            () -> rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false))
+            () -> rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false, null))
         );
         assertEquals("the [enabled] parameter can't be updated for the object mapping [disabled]", e.getMessage());
 
         ObjectMapper result = rootObjectMapper.merge(
             mergeWith,
             MapperService.MergeReason.INDEX_TEMPLATE,
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         assertTrue(result.isEnabled());
     }
@@ -99,21 +99,21 @@ public class ObjectMapperMergeTests extends ESTestCase {
     public void testMergeEnabledForRootMapper() {
         String type = MapperService.SINGLE_MAPPING_NAME;
         ObjectMapper firstMapper = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         ObjectMapper secondMapper = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).enabled(false)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
         MapperException e = expectThrows(
             MapperException.class,
-            () -> firstMapper.merge(secondMapper, MapperBuilderContext.root(false, false))
+            () -> firstMapper.merge(secondMapper, MapperBuilderContext.root(false, false, null))
         );
         assertEquals("the [enabled] parameter can't be updated for the object mapping [" + type + "]", e.getMessage());
 
         ObjectMapper result = firstMapper.merge(
             secondMapper,
             MapperService.MergeReason.INDEX_TEMPLATE,
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         );
         assertFalse(result.isEnabled());
     }
@@ -122,13 +122,13 @@ public class ObjectMapperMergeTests extends ESTestCase {
         String type = MapperService.SINGLE_MAPPING_NAME;
         final RootObjectMapper rootObjectMapper = (RootObjectMapper) new RootObjectMapper.Builder(type, ObjectMapper.Defaults.SUBOBJECTS)
             .enabled(false)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
         // the root is disabled, and we are not trying to re-enable it, but we do want to be able to add runtime fields
         final RootObjectMapper mergeWith = new RootObjectMapper.Builder(type, ObjectMapper.Defaults.SUBOBJECTS).addRuntimeFields(
             Collections.singletonMap("test", new TestRuntimeField("test", "long"))
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
 
-        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false));
+        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith, MapperBuilderContext.root(false, false, null));
         assertFalse(merged.isEnabled());
         assertEquals(1, merged.runtimeFields().size());
         assertEquals("test", merged.runtimeFields().iterator().next().name());
@@ -138,7 +138,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         RootObjectMapper mergeInto = createRootSubobjectFalseLeafWithDots();
         RootObjectMapper mergeWith = createRootSubobjectFalseLeafWithDots();
 
-        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false));
+        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false, null));
 
         final KeywordFieldMapper keywordFieldMapper = (KeywordFieldMapper) merged.getMapper("host.name");
         assertEquals("host.name", keywordFieldMapper.name());
@@ -148,12 +148,12 @@ public class ObjectMapperMergeTests extends ESTestCase {
     public void testMergedFieldNamesFieldWithDotsSubobjectsFalse() {
         RootObjectMapper mergeInto = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(
             createObjectSubobjectsFalseLeafWithDots()
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
         RootObjectMapper mergeWith = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(
             createObjectSubobjectsFalseLeafWithDots()
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
 
-        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false));
+        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false, null));
 
         ObjectMapper foo = (ObjectMapper) merged.getMapper("foo");
         ObjectMapper metrics = (ObjectMapper) foo.getMapper("metrics");
@@ -164,11 +164,11 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
     public void testMergedFieldNamesMultiFields() {
         RootObjectMapper mergeInto = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(createTextKeywordMultiField("text"))
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
         RootObjectMapper mergeWith = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(createTextKeywordMultiField("text"))
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
 
-        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false));
+        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false, null));
 
         TextFieldMapper text = (TextFieldMapper) merged.getMapper("text");
         assertEquals("text", text.name());
@@ -181,12 +181,12 @@ public class ObjectMapperMergeTests extends ESTestCase {
     public void testMergedFieldNamesMultiFieldsWithinSubobjectsFalse() {
         RootObjectMapper mergeInto = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(
             createObjectSubobjectsFalseLeafWithMultiField()
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
         RootObjectMapper mergeWith = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).add(
             createObjectSubobjectsFalseLeafWithMultiField()
-        ).build(MapperBuilderContext.root(false, false));
+        ).build(MapperBuilderContext.root(false, false, null));
 
-        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false));
+        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.root(false, false, null));
 
         ObjectMapper foo = (ObjectMapper) merged.getMapper("foo");
         ObjectMapper metrics = (ObjectMapper) foo.getMapper("metrics");
@@ -200,16 +200,16 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
     private static RootObjectMapper createRootSubobjectFalseLeafWithDots() {
         FieldMapper.Builder fieldBuilder = new KeywordFieldMapper.Builder("host.name", IndexVersion.current());
-        FieldMapper fieldMapper = fieldBuilder.build(MapperBuilderContext.root(false, false));
+        FieldMapper fieldMapper = fieldBuilder.build(MapperBuilderContext.root(false, false, null));
         assertEquals("host.name", fieldMapper.simpleName());
         assertEquals("host.name", fieldMapper.name());
         return new RootObjectMapper.Builder("_doc", Explicit.EXPLICIT_FALSE).add(fieldBuilder)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
     }
 
     private static ObjectMapper.Builder createObjectSubobjectsFalseLeafWithDots() {
         KeywordFieldMapper.Builder fieldBuilder = new KeywordFieldMapper.Builder("host.name", IndexVersion.current());
-        KeywordFieldMapper fieldMapper = fieldBuilder.build(new MapperBuilderContext("foo.metrics", false, false));
+        KeywordFieldMapper fieldMapper = fieldBuilder.build(new MapperBuilderContext("foo.metrics", false, false, null));
         assertEquals("host.name", fieldMapper.simpleName());
         assertEquals("foo.metrics.host.name", fieldMapper.name());
         return new ObjectMapper.Builder("foo", ObjectMapper.Defaults.SUBOBJECTS).add(
@@ -219,7 +219,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
     private ObjectMapper.Builder createObjectSubobjectsFalseLeafWithMultiField() {
         TextFieldMapper.Builder fieldBuilder = createTextKeywordMultiField("host.name");
-        TextFieldMapper textKeywordMultiField = fieldBuilder.build(new MapperBuilderContext("foo.metrics", false, false));
+        TextFieldMapper textKeywordMultiField = fieldBuilder.build(new MapperBuilderContext("foo.metrics", false, false, null));
         assertEquals("host.name", textKeywordMultiField.simpleName());
         assertEquals("foo.metrics.host.name", textKeywordMultiField.name());
         FieldMapper fieldMapper = textKeywordMultiField.multiFields.iterator().next();

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -120,7 +120,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
             "_doc",
             new CompressedXContent(BytesReference.bytes(topMapping(b -> b.field("dynamic", "strict"))))
         );
-        Mapping merged = mapper.mapping().merge(mergeWith, reason);
+        Mapping merged = mapper.mapping().merge(mergeWith, reason, mapperService.parserContext());
         assertEquals(Dynamic.STRICT, merged.getRoot().dynamic());
     }
 
@@ -465,7 +465,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         }))));
         MapperException exception = expectThrows(
             MapperException.class,
-            () -> mapper.mapping().merge(mergeWith, MergeReason.MAPPING_UPDATE)
+            () -> mapper.mapping().merge(mergeWith, MergeReason.MAPPING_UPDATE, mapperService.parserContext())
         );
         assertEquals("the [subobjects] parameter can't be updated for the object mapping [field]", exception.getMessage());
     }
@@ -479,7 +479,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         }))));
         MapperException exception = expectThrows(
             MapperException.class,
-            () -> mapper.mapping().merge(mergeWith, MergeReason.MAPPING_UPDATE)
+            () -> mapper.mapping().merge(mergeWith, MergeReason.MAPPING_UPDATE, mapperService.parserContext())
         );
         assertEquals("the [subobjects] parameter can't be updated for the object mapping [_doc]", exception.getMessage());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -282,7 +282,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             pc = pc.createDynamicTemplateContext(null);
         }
         return (TestMapper) new TypeParser().parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)
-            .build(MapperBuilderContext.root(false, false));
+            .build(MapperBuilderContext.root(false, false, null));
     }
 
     private static TestMapper fromMapping(String mapping, IndexVersion version, TransportVersion transportVersion) {
@@ -344,7 +344,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             {"type":"test_mapper","fixed":true,"fixed2":true,"required":"value"}""");
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> mapper.merge(badMerge, MapperBuilderContext.root(false, false))
+            () -> mapper.merge(badMerge, MapperBuilderContext.root(false, false, null))
         );
         String expectedError = """
             Mapper for [field] conflicts with existing mapper:
@@ -357,7 +357,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         // TODO: should we have to include 'fixed' here? Or should updates take as 'defaults' the existing values?
         TestMapper goodMerge = fromMapping("""
             {"type":"test_mapper","fixed":false,"variable":"updated","required":"value"}""");
-        TestMapper merged = (TestMapper) mapper.merge(goodMerge, MapperBuilderContext.root(false, false));
+        TestMapper merged = (TestMapper) mapper.merge(goodMerge, MapperBuilderContext.root(false, false, null));
 
         assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper)); // original mapping is unaffected
         assertEquals("""
@@ -375,7 +375,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         String addSubField = """
             {"type":"test_mapper","variable":"foo","required":"value","fields":{"sub2":{"type":"keyword"}}}""";
         TestMapper toMerge = fromMapping(addSubField);
-        TestMapper merged = (TestMapper) mapper.merge(toMerge, MapperBuilderContext.root(false, false));
+        TestMapper merged = (TestMapper) mapper.merge(toMerge, MapperBuilderContext.root(false, false, null));
         assertEquals(XContentHelper.stripWhitespace("""
             {
               "field": {
@@ -398,7 +398,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         TestMapper badToMerge = fromMapping(badSubField);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> merged.merge(badToMerge, MapperBuilderContext.root(false, false))
+            () -> merged.merge(badToMerge, MapperBuilderContext.root(false, false, null))
         );
         assertEquals("mapper [field.sub2] cannot be changed from type [keyword] to [binary]", e.getMessage());
     }
@@ -414,13 +414,13 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
 
         TestMapper toMerge = fromMapping("""
             {"type":"test_mapper","variable":"updated","required":"value","copy_to":["foo","bar"]}""");
-        TestMapper merged = (TestMapper) mapper.merge(toMerge, MapperBuilderContext.root(false, false));
+        TestMapper merged = (TestMapper) mapper.merge(toMerge, MapperBuilderContext.root(false, false, null));
         assertEquals("""
             {"field":{"type":"test_mapper","variable":"updated","required":"value","copy_to":["foo","bar"]}}""", Strings.toString(merged));
 
         TestMapper removeCopyTo = fromMapping("""
             {"type":"test_mapper","variable":"updated","required":"value"}""");
-        TestMapper noCopyTo = (TestMapper) merged.merge(removeCopyTo, MapperBuilderContext.root(false, false));
+        TestMapper noCopyTo = (TestMapper) merged.merge(removeCopyTo, MapperBuilderContext.root(false, false, null));
         assertEquals("""
             {"field":{"type":"test_mapper","variable":"updated","required":"value"}}""", Strings.toString(noCopyTo));
     }
@@ -486,7 +486,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         TestMapper toMerge = fromMapping(conflict);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> mapper.merge(toMerge, MapperBuilderContext.root(false, false))
+            () -> mapper.merge(toMerge, MapperBuilderContext.root(false, false, null))
         );
         assertEquals(
             "Mapper for [field] conflicts with existing mapper:\n"
@@ -575,7 +575,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
 
         TestMapper original = mapper;
         TestMapper toMerge = fromMapping(mapping);
-        e = expectThrows(IllegalArgumentException.class, () -> original.merge(toMerge, MapperBuilderContext.root(false, false)));
+        e = expectThrows(IllegalArgumentException.class, () -> original.merge(toMerge, MapperBuilderContext.root(false, false, null)));
         assertEquals(
             "Mapper for [field] conflicts with existing mapper:\n" + "\tCannot update parameter [analyzer] from [default] to [_standard]",
             e.getMessage()

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -487,13 +487,13 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
         assertEquals(List.of(Map.of("gte", 3L, "lt", 42L)), fetchSourceValue(longMapper, longRange));
 
         MappedFieldType dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE, true).format("yyyy/MM/dd||epoch_millis")
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         Map<String, Object> dateRange = Map.of("lt", "1990/12/29", "gte", 597429487111L);
         assertEquals(List.of(Map.of("lt", "1990/12/29", "gte", "1988/12/06")), fetchSourceValue(dateMapper, dateRange));
@@ -501,13 +501,13 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
     public void testParseSourceValueWithFormat() throws IOException {
         MappedFieldType longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
         assertEquals(List.of(Map.of("gte", 3L, "lt", 42L)), fetchSourceValue(longMapper, longRange));
 
         MappedFieldType dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE, true).format("strict_date_time")
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         Map<String, Object> dateRange = Map.of("lt", "1990-12-29T00:00:00.000Z");
         assertEquals(List.of(Map.of("lt", "1990/12/29")), fetchSourceValue(dateMapper, dateRange, "yyy/MM/dd"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedIndexFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedIndexFieldDataTests.java
@@ -46,7 +46,9 @@ public class FlattenedIndexFieldDataTests extends ESSingleNodeTestCase {
             indicesService.getCircuitBreakerService()
         );
 
-        FlattenedFieldMapper fieldMapper = new FlattenedFieldMapper.Builder("flattened").build(MapperBuilderContext.root(false, false));
+        FlattenedFieldMapper fieldMapper = new FlattenedFieldMapper.Builder("flattened").build(
+            MapperBuilderContext.root(false, false, null)
+        );
         MappedFieldType fieldType1 = fieldMapper.fieldType().getChildFieldType("key");
 
         AtomicInteger onCacheCalled = new AtomicInteger();

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -290,7 +290,7 @@ public class SearchExecutionContextTests extends ESTestCase {
         Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.addRuntimeFields(runtimeFieldTypes);
         Mapping mapping = new Mapping(
-            builder.build(MapperBuilderContext.root(false, false)),
+            builder.build(MapperBuilderContext.root(false, false, null)),
             new MetadataFieldMapper[0],
             Collections.emptyMap()
         );
@@ -383,7 +383,9 @@ public class SearchExecutionContextTests extends ESTestCase {
 
         // Build a mapping using synthetic source
         SourceFieldMapper sourceMapper = new SourceFieldMapper.Builder(null).setSynthetic().build();
-        RootObjectMapper root = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).build(MapperBuilderContext.root(true, false));
+        RootObjectMapper root = new RootObjectMapper.Builder("_doc", Explicit.IMPLICIT_TRUE).build(
+            MapperBuilderContext.root(true, false, null)
+        );
         Mapping mapping = new Mapping(root, new MetadataFieldMapper[] { sourceMapper }, Map.of());
         MappingLookup lookup = MappingLookup.fromMapping(mapping);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -906,6 +906,6 @@ public class NestedAggregatorTests extends AggregatorTestCase {
     );
 
     public static NestedObjectMapper nestedObject(String path) {
-        return new NestedObjectMapper.Builder(path, IndexVersion.current()).build(MapperBuilderContext.root(false, false));
+        return new NestedObjectMapper.Builder(path, IndexVersion.current()).build(MapperBuilderContext.root(false, false, null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -318,7 +318,7 @@ public class HighlightBuilderTests extends ESTestCase {
             @Override
             public MappedFieldType getFieldType(String name) {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, createDefaultIndexAnalyzers());
-                return builder.build(MapperBuilderContext.root(false, false)).fieldType();
+                return builder.build(MapperBuilderContext.root(false, false, null)).fieldType();
             }
         };
         mockContext.setMapUnmappedFieldAsString(true);

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -86,7 +86,7 @@ public class LeafDocLookupTests extends ESTestCase {
         ScriptDocValues<?> docValues2 = mock(ScriptDocValues.class);
         IndexFieldData<?> fieldData2 = createFieldData(docValues2, "flattened.key2");
 
-        FlattenedFieldMapper fieldMapper = new FlattenedFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false));
+        FlattenedFieldMapper fieldMapper = new FlattenedFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false, null));
         DynamicFieldType fieldType = fieldMapper.fieldType();
         MappedFieldType fieldType1 = fieldType.getChildFieldType("key1");
         MappedFieldType fieldType2 = fieldType.getChildFieldType("key2");

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.rescore.QueryRescorer.QueryRescoreContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -156,7 +157,8 @@ public class QueryRescorerBuilderTests extends ESTestCase {
             @Override
             public MappedFieldType getFieldType(String name) {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, createDefaultIndexAnalyzers());
-                return builder.build(MapperBuilderContext.root(false, false)).fieldType();
+                return builder.build(MapperBuilderContext.root(false, false, new AggregatorTestCase.MockParserContext(indexSettings)))
+                    .fieldType();
             }
         };
 
@@ -218,7 +220,8 @@ public class QueryRescorerBuilderTests extends ESTestCase {
             @Override
             public MappedFieldType getFieldType(String name) {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, createDefaultIndexAnalyzers());
-                return builder.build(MapperBuilderContext.root(false, false)).fieldType();
+                return builder.build(MapperBuilderContext.root(false, false, new AggregatorTestCase.MockParserContext(idxSettings)))
+                    .fieldType();
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -39,6 +39,7 @@ import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -194,7 +195,11 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             return builder.build(new IndexFieldDataCache.None(), null);
         };
         NestedLookup nestedLookup = NestedLookup.build(
-            List.of(new NestedObjectMapper.Builder("path", IndexVersion.current()).build(MapperBuilderContext.root(false, false)))
+            List.of(
+                new NestedObjectMapper.Builder("path", IndexVersion.current()).build(
+                    MapperBuilderContext.root(false, false, new AggregatorTestCase.MockParserContext(idxSettings))
+                )
+            )
         );
         return new SearchExecutionContext(
             0,

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -478,7 +478,7 @@ public final class DataStreamTestHelper {
             ScriptCompiler.NONE,
             false,
             IndexVersion.current()
-        ).build(MapperBuilderContext.root(false, true));
+        ).build(MapperBuilderContext.root(false, true, null));
         ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
         Environment env = mock(Environment.class);
         when(env.sharedDataFile()).thenReturn(null);
@@ -500,7 +500,7 @@ public final class DataStreamTestHelper {
             );
             MetadataFieldMapper dtfm = getDataStreamTimestampFieldMapper();
             Mapping mapping = new Mapping(
-                root.build(MapperBuilderContext.root(false, true)),
+                root.build(MapperBuilderContext.root(false, true, null)),
                 new MetadataFieldMapper[] { dtfm },
                 Collections.emptyMap()
             );
@@ -556,7 +556,7 @@ public final class DataStreamTestHelper {
             MapperService mapperService = mock(MapperService.class);
 
             RootObjectMapper root = new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME, ObjectMapper.Defaults.SUBOBJECTS).build(
-                MapperBuilderContext.root(false, false)
+                MapperBuilderContext.root(false, false, null)
             );
             Mapping mapping = new Mapping(root, new MetadataFieldMapper[0], null);
             DocumentMapper documentMapper = mock(DocumentMapper.class);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -1057,8 +1057,9 @@ public abstract class AggregatorTestCase extends ESTestCase {
             }
 
             IndexSettings indexSettings = createIndexSettings();
-            Mapper.Builder builder = mappedType.getValue().parse(fieldName, source, new MockParserContext(indexSettings));
-            FieldMapper mapper = (FieldMapper) builder.build(MapperBuilderContext.root(false, false));
+            var parserContext = new MockParserContext(indexSettings);
+            Mapper.Builder builder = mappedType.getValue().parse(fieldName, source, parserContext);
+            FieldMapper mapper = (FieldMapper) builder.build(MapperBuilderContext.root(false, false, parserContext));
 
             MappedFieldType fieldType = mapper.fieldType();
 
@@ -1236,8 +1237,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
         iw.addDocument(doc);
     }
 
-    private static class MockParserContext extends MappingParserContext {
-        MockParserContext(IndexSettings indexSettings) {
+    public static class MockParserContext extends MappingParserContext {
+        public MockParserContext(IndexSettings indexSettings) {
             super(
                 null,
                 null,

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
@@ -168,15 +168,16 @@ public class UnsignedLongFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType mapper = new UnsignedLongFieldMapper.Builder("field", false, null).build(MapperBuilderContext.root(false, false))
-            .fieldType();
+        MappedFieldType mapper = new UnsignedLongFieldMapper.Builder("field", false, null).build(
+            MapperBuilderContext.root(false, false, null)
+        ).fieldType();
         assertEquals(List.of(0L), fetchSourceValue(mapper, 0L));
         assertEquals(List.of(9223372036854775807L), fetchSourceValue(mapper, 9223372036854775807L));
         assertEquals(List.of(BIGINTEGER_2_64_MINUS_ONE), fetchSourceValue(mapper, "18446744073709551615"));
         assertEquals(List.of(), fetchSourceValue(mapper, ""));
 
         MappedFieldType nullValueMapper = new UnsignedLongFieldMapper.Builder("field", false, null).nullValue("18446744073709551615")
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         assertEquals(List.of(BIGINTEGER_2_64_MINUS_ONE), fetchSourceValue(nullValueMapper, ""));
     }

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldTypeTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldTypeTests.java
@@ -17,7 +17,8 @@ import java.util.List;
 public class VersionStringFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType mapper = new VersionStringFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false)).fieldType();
+        MappedFieldType mapper = new VersionStringFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false, null))
+            .fieldType();
         assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
         assertEquals(List.of("42"), fetchSourceValue(mapper, 42L));
         assertEquals(List.of("true"), fetchSourceValue(mapper, true));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -721,7 +721,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                     false,
                     IndexVersion.current(),
                     null
-                ).build(MapperBuilderContext.root(false, false)).fieldType();
+                ).build(MapperBuilderContext.root(false, false, null)).fieldType();
                 fieldTypes.put(ft.name(), ft);
             }
         }
@@ -729,7 +729,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         if (job.getGroupConfig().getTerms() != null) {
             for (String field : job.getGroupConfig().getTerms().getFields()) {
                 MappedFieldType ft = new KeywordFieldMapper.Builder(field, IndexVersion.current()).build(
-                    MapperBuilderContext.root(false, false)
+                    MapperBuilderContext.root(false, false, null)
                 ).fieldType();
                 fieldTypes.put(ft.name(), ft);
             }
@@ -745,7 +745,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                     false,
                     IndexVersion.current(),
                     null
-                ).build(MapperBuilderContext.root(false, false)).fieldType();
+                ).build(MapperBuilderContext.root(false, false, null)).fieldType();
                 fieldTypes.put(ft.name(), ft);
             }
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
@@ -44,7 +44,7 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             geoFormatterFactory
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
 
         Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates", List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));
         Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(14.0, 15.0));
@@ -99,13 +99,14 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
             new SpatialGeometryFormatterExtension().getGeometryFormatterFactories()
         );
 
+        boolean isSourceSynthetic = randomBoolean();
         final MappedFieldType mapper = new GeoShapeWithDocValuesFieldMapper.Builder(
             "field",
             IndexVersion.current(),
             false,
             false,
             geoFormatterFactory
-        ).setStored(true).build(MapperBuilderContext.root(randomBoolean(), false)).fieldType();
+        ).setStored(true).build(MapperBuilderContext.root(isSourceSynthetic, false, null)).fieldType();
 
         ByteOrder byteOrder = randomBoolean() ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
@@ -149,7 +150,7 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             geoFormatterFactory
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
         final int z = randomIntBetween(1, 10);
         int x = randomIntBetween(0, (1 << z) - 1);
         int y = randomIntBetween(0, (1 << z) - 1);
@@ -261,7 +262,7 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             geoFormatterFactory
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
 
         assertEquals(List.of(jsonValue), fetchSourceValue(mapper, sourceValue, null));
         assertEquals(List.of(wktValue), fetchSourceValue(mapper, sourceValue, "wkt"));
@@ -277,7 +278,7 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             geoFormatterFactory
-        ).setStored(true).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).setStored(true).build(MapperBuilderContext.root(false, false, null)).fieldType();
 
         Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(false), false, wktValue);
 
@@ -297,7 +298,7 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
             false,
             false,
             geoFormatterFactory
-        ).build(MapperBuilderContext.root(false, false)).fieldType();
+        ).build(MapperBuilderContext.root(false, false, null)).fieldType();
 
         final int extent = randomIntBetween(256, 4096);
         List<?> mvtExpected = fetchSourceValue(mapper, mvtEquivalentAsWKT, "mvt(0/0/0@" + extent + ")");

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldTypeTests.java
@@ -18,7 +18,8 @@ import java.util.Map;
 public class PointFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType mapper = new PointFieldMapper.Builder("field", false).build(MapperBuilderContext.root(false, false)).fieldType();
+        MappedFieldType mapper = new PointFieldMapper.Builder("field", false).build(MapperBuilderContext.root(false, false, null))
+            .fieldType();
 
         Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.1));
         String wktPoint = "POINT (42.0 27.1)";

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldTypeTests.java
@@ -20,7 +20,7 @@ public class ShapeFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new ShapeFieldMapper.Builder("field", IndexVersion.current(), false, true).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
 
         Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates", List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldAggregationTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldAggregationTests.java
@@ -39,7 +39,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
     public void setup() {
         WildcardFieldMapper.Builder builder = new WildcardFieldMapper.Builder(WILDCARD_FIELD_NAME, IndexVersion.current());
         builder.ignoreAbove(MAX_FIELD_LENGTH);
-        wildcardFieldMapper = builder.build(MapperBuilderContext.root(false, false));
+        wildcardFieldMapper = builder.build(MapperBuilderContext.root(false, false, null));
 
         wildcardFieldType = wildcardFieldMapper.fieldType();
     }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -123,16 +123,16 @@ public class WildcardFieldMapperTests extends MapperTestCase {
     public void setUp() throws Exception {
         Builder builder = new WildcardFieldMapper.Builder(WILDCARD_FIELD_NAME, IndexVersion.current());
         builder.ignoreAbove(MAX_FIELD_LENGTH);
-        wildcardFieldType = builder.build(MapperBuilderContext.root(false, false));
+        wildcardFieldType = builder.build(MapperBuilderContext.root(false, false, null));
 
         Builder builder79 = new WildcardFieldMapper.Builder(WILDCARD_FIELD_NAME, IndexVersion.V_7_9_0);
-        wildcardFieldType79 = builder79.build(MapperBuilderContext.root(false, false));
+        wildcardFieldType79 = builder79.build(MapperBuilderContext.root(false, false, null));
 
         org.elasticsearch.index.mapper.KeywordFieldMapper.Builder kwBuilder = new KeywordFieldMapper.Builder(
             KEYWORD_FIELD_NAME,
             IndexVersion.current()
         );
-        keywordFieldType = kwBuilder.build(MapperBuilderContext.root(false, false));
+        keywordFieldType = kwBuilder.build(MapperBuilderContext.root(false, false, null));
 
         rewriteDir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldTypeTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldTypeTests.java
@@ -19,21 +19,21 @@ public class WildcardFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new WildcardFieldMapper.Builder("field", IndexVersion.current()).build(
-            MapperBuilderContext.root(false, false)
+            MapperBuilderContext.root(false, false, null)
         ).fieldType();
         assertEquals(List.of("value"), fetchSourceValue(mapper, "value"));
         assertEquals(List.of("42"), fetchSourceValue(mapper, 42L));
         assertEquals(List.of("true"), fetchSourceValue(mapper, true));
 
         MappedFieldType ignoreAboveMapper = new WildcardFieldMapper.Builder("field", IndexVersion.current()).ignoreAbove(4)
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         assertEquals(List.of(), fetchSourceValue(ignoreAboveMapper, "value"));
         assertEquals(List.of("42"), fetchSourceValue(ignoreAboveMapper, 42L));
         assertEquals(List.of("true"), fetchSourceValue(ignoreAboveMapper, true));
 
         MappedFieldType nullValueMapper = new WildcardFieldMapper.Builder("field", IndexVersion.current()).nullValue("NULL")
-            .build(MapperBuilderContext.root(false, false))
+            .build(MapperBuilderContext.root(false, false, null))
             .fieldType();
         assertEquals(List.of("NULL"), fetchSourceValue(nullValueMapper, null));
     }


### PR DESCRIPTION
Another step towards saving heap on mapper instances and reducing their complexity in general.

There's no reason to store a reference to either of these on the mapper itself, these are only required when building a mapper so they should be passed at mapper build time.

setting this to draft for a sec to cleanup a little and see if CI passes 