### PR TITLE
ESQL: Fix block hash test and revert mistaken changes

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
@@ -74,7 +74,6 @@ final class BytesRefLongBlockHash extends BlockHash {
         } else {
             new AddBlock(block1, block2, addInput).add();
         }
-        Releasables.closeExpectNoException(block1, block2);
     }
 
     public IntVector add(BytesRefVector vector1, LongVector vector2) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -20,7 +20,6 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeInt;
-import org.elasticsearch.core.Releasables;
 
 import java.util.BitSet;
 
@@ -53,7 +52,6 @@ final class IntBlockHash extends BlockHash {
         } else {
             addInput.add(0, add(vector));
         }
-        Releasables.closeExpectNoException(block);
     }
 
     private IntVector add(IntVector vector) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongArrayBlock;
@@ -62,7 +63,7 @@ final class LongBlockHash extends BlockHash {
         for (int i = 0; i < vector.getPositionCount(); i++) {
             groups[i] = Math.toIntExact(hashOrdToGroupNullReserved(longHash.add(vector.getLong(i))));
         }
-        return vector.blockFactory().newIntArrayVector(groups, groups.length);
+        return new IntArrayVector(groups, groups.length);
     }
 
     private IntBlock add(LongBlock block) {


### PR DESCRIPTION
This commit fixes block hash test and reverts mistaken changes from a previous commit.