### PR TITLE
Expose methods in RecoveryClusterStateDelayListeners

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/RecoveryClusterStateDelayListeners.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/RecoveryClusterStateDelayListeners.java
@@ -50,11 +50,11 @@ public class RecoveryClusterStateDelayListeners implements Releasable {
         clusterStateBarriers.values().forEach(l -> l.onResponse(null));
     }
 
-    void addCleanup(Runnable runnable) {
+    public void addCleanup(Runnable runnable) {
         cleanup.add(runnable);
     }
 
-    SubscribableListener<Void> getClusterStateDelayListener(long clusterStateVersion) {
+    public SubscribableListener<Void> getClusterStateDelayListener(long clusterStateVersion) {
         ESTestCase.assertThat(clusterStateVersion, greaterThanOrEqualTo(initialClusterStateVersion));
         if (refCounted.tryIncRef()) {
             try {
@@ -67,7 +67,7 @@ public class RecoveryClusterStateDelayListeners implements Releasable {
         }
     }
 
-    void onStartRecovery() {
+    public void onStartRecovery() {
         Thread.yield();
         ESTestCase.assertFalse(startRecoveryListener.isDone());
         startRecoveryListener.onResponse(null);


### PR DESCRIPTION
Followup to #99768, these package-private methods need to be public for
this test utility class to be useful.