### PR TITLE
[buildkite] Add trigger for elasticsearch-pull-request-check-serverless-submodule

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -12,9 +12,26 @@
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "buildkite\\W+elasticsearch-ci.+",
-      "labels": ["buildkite-opt-in"],
+      "labels": [
+        "buildkite-opt-in"
+      ],
       "cancel_intermediate_builds": true,
       "cancel_intermediate_builds_on_comment": false
+    },
+    {
+      "enabled": true,
+      "pipeline_slug": "elasticsearch-pull-request-check-serverless-submodule",
+      "allow_org_users": true,
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "set_commit_status": false,
+      "build_on_commit": true,
+      "build_on_comment": false,
+      "labels": [
+        "test-update-serverless"
+      ]
     }
   ]
 }


### PR DESCRIPTION
As requested by @rjernst, creates a PR trigger for a new pipeline that triggers a validation of the PR against serverless.