### PR TITLE
Use Build.current().minCompat methods instead of Version when building strings

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.env;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -140,9 +141,9 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
                 startsWith("cannot upgrade a node from version ["),
                 endsWith(
                     "] directly to version ["
-                        + Version.CURRENT
+                        + Build.current().version()
                         + "], upgrade to version ["
-                        + Version.CURRENT.minimumCompatibilityVersion()
+                        + Build.current().minWireCompatVersion()
                         + "] first."
                 )
             )

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -20,6 +20,7 @@ import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NativeFSLockFactory;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -511,9 +512,9 @@ public final class NodeEnvironment implements Closeable {
         if (metadata == null) {
             throw new CorruptStateException(
                 "Format version is not supported. Upgrading to ["
-                    + Version.CURRENT
+                    + Build.current().version()
                     + "] is only supported from version ["
-                    + Version.CURRENT.minimumCompatibilityVersion()
+                    + Build.current().minWireCompatVersion()
                     + "]."
             );
         }
@@ -527,13 +528,13 @@ public final class NodeEnvironment implements Closeable {
                 "Cannot start this node because it holds metadata for indices with version ["
                     + metadata.oldestIndexVersion()
                     + "] with which this node of version ["
-                    + Version.CURRENT
+                    + Build.current().version()
                     + "] is incompatible. Revert this node to version ["
                     + Version.max(Version.CURRENT.minimumCompatibilityVersion(), metadata.previousNodeVersion())
                     + "] and delete any indices with versions earlier than ["
                     + IndexVersion.MINIMUM_COMPATIBLE
                     + "] before upgrading to version ["
-                    + Version.CURRENT
+                    + Build.current().version()
                     + "]. If all such indices have already been deleted, revert this node to version ["
                     + Version.max(Version.CURRENT.minimumCompatibilityVersion(), metadata.previousNodeVersion())
                     + "] and wait for it to join the cluster to clean up any older indices from its metadata."

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.env;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.IndexVersion;
@@ -117,10 +118,10 @@ public final class NodeMetadata {
                 "cannot upgrade a node from version ["
                     + nodeVersion
                     + "] directly to version ["
-                    + Version.CURRENT
+                    + Build.current().version()
                     + "], "
                     + "upgrade to version ["
-                    + Version.CURRENT.minimumCompatibilityVersion()
+                    + Build.current().minWireCompatVersion()
                     + "] first."
             );
         }

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -619,7 +620,7 @@ public class NodeEnvironmentTests extends ESTestCase {
             );
 
             assertThat(ex.getMessage(), startsWith("cannot upgrade a node from version [" + oldVersion + "] directly"));
-            assertThat(ex.getMessage(), containsString("upgrade to version [" + Version.CURRENT.minimumCompatibilityVersion()));
+            assertThat(ex.getMessage(), containsString("upgrade to version [" + Build.current().minWireCompatVersion()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.env;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.gateway.MetadataStateFormat;
@@ -137,9 +138,9 @@ public class NodeMetadataTests extends ESTestCase {
                 startsWith("cannot upgrade a node from version ["),
                 endsWith(
                     "] directly to version ["
-                        + Version.CURRENT
+                        + Build.current().version()
                         + "], upgrade to version ["
-                        + Version.CURRENT.minimumCompatibilityVersion()
+                        + Build.current().version()
                         + "] first."
                 )
             )

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -140,7 +140,7 @@ public class NodeMetadataTests extends ESTestCase {
                     "] directly to version ["
                         + Build.current().version()
                         + "], upgrade to version ["
-                        + Build.current().version()
+                        + Build.current().minWireCompatVersion()
                         + "] first."
                 )
             )

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -20,6 +20,7 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -311,9 +312,9 @@ public abstract class ESRestTestCase extends ESTestCase {
     public static class VersionSensitiveWarningsHandler implements WarningsHandler {
         Set<String> requiredSameVersionClusterWarnings = new HashSet<>();
         Set<String> allowedWarnings = new HashSet<>();
-        final Set<Version> testNodeVersions;
+        final Set<String> testNodeVersions;
 
-        public VersionSensitiveWarningsHandler(Set<Version> nodeVersions) {
+        public VersionSensitiveWarningsHandler(Set<String> nodeVersions) {
             this.testNodeVersions = nodeVersions;
         }
 
@@ -355,14 +356,16 @@ public abstract class ESRestTestCase extends ESTestCase {
 
         private boolean isExclusivelyTargetingCurrentVersionCluster() {
             assertFalse("Node versions running in the cluster are missing", testNodeVersions.isEmpty());
-            return testNodeVersions.size() == 1 && testNodeVersions.iterator().next().equals(Version.CURRENT);
+            return testNodeVersions.size() == 1 && testNodeVersions.iterator().next().equals(Build.current().version());
         }
 
     }
 
     public static RequestOptions expectVersionSpecificWarnings(Consumer<VersionSensitiveWarningsHandler> expectationsSetter) {
         Builder builder = RequestOptions.DEFAULT.toBuilder();
-        VersionSensitiveWarningsHandler warningsHandler = new VersionSensitiveWarningsHandler(nodeVersions);
+        VersionSensitiveWarningsHandler warningsHandler = new VersionSensitiveWarningsHandler(
+            nodeVersions.stream().map(Version::toString).collect(Collectors.toSet())
+        );
         expectationsSetter.accept(warningsHandler);
         builder.setWarningsHandler(warningsHandler);
         return builder.build();

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/VersionSensitiveWarningsHandlerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/VersionSensitiveWarningsHandlerTests.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.test.rest;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.Build;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.ESRestTestCase.VersionSensitiveWarningsHandler;
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 public class VersionSensitiveWarningsHandlerTests extends ESTestCase {
 
     public void testSameVersionCluster() throws IOException {
-        WarningsHandler handler = expectVersionSpecificWarnings(Set.of(Version.CURRENT), v -> v.current("expectedCurrent1"));
+        WarningsHandler handler = expectVersionSpecificWarnings(Set.of(Build.current().version()), v -> v.current("expectedCurrent1"));
         assertFalse(handler.warningsShouldFailRequest(List.of("expectedCurrent1")));
         assertTrue(handler.warningsShouldFailRequest(List.of("expectedCurrent1", "unexpected")));
         assertTrue(handler.warningsShouldFailRequest(List.of()));
@@ -30,7 +30,7 @@ public class VersionSensitiveWarningsHandlerTests extends ESTestCase {
 
     public void testMixedVersionCluster() throws IOException {
         WarningsHandler handler = expectVersionSpecificWarnings(
-            Set.of(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion()),
+            Set.of(Build.current().version(), Build.current().minWireCompatVersion()),
             v -> {
                 v.current("expectedCurrent1");
                 v.compatible("Expected legacy warning");
@@ -45,7 +45,7 @@ public class VersionSensitiveWarningsHandlerTests extends ESTestCase {
     }
 
     private static WarningsHandler expectVersionSpecificWarnings(
-        Set<Version> nodeVersions,
+        Set<String> nodeVersions,
         Consumer<VersionSensitiveWarningsHandler> expectationsSetter
     ) {
         // Based on EsRestTestCase.expectVersionSpecificWarnings helper method but without ESRestTestCase dependency


### PR DESCRIPTION
We can remove uses of the Version class by getting a string representation of the version from the `Build.current()` object.