### PR TITLE
Updating data streams rest tests to use a replica

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/TsdbDataStreamRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/TsdbDataStreamRestIT.java
@@ -50,7 +50,7 @@ public class TsdbDataStreamRestIT extends DisabledSecurityDataStreamTestCase {
             "template": {
                 "settings":{
                     "index": {
-                        "number_of_replicas": 0,
+                        "number_of_replicas": 1,
                         "number_of_shards": 2,
                         "mode": "time_series"
                     }
@@ -117,7 +117,7 @@ public class TsdbDataStreamRestIT extends DisabledSecurityDataStreamTestCase {
             "template": {
                 "settings":{
                     "index": {
-                        "number_of_replicas": 0,
+                        "number_of_replicas": 1,
                         "number_of_shards": 2
                     }
                 },
@@ -408,7 +408,7 @@ public class TsdbDataStreamRestIT extends DisabledSecurityDataStreamTestCase {
         var responseBody = entityAsMap(response);
         assertThat(ObjectPath.evaluate(responseBody, "template.settings.index"), aMapWithSize(6));
         assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.number_of_shards"), equalTo("2"));
-        assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.number_of_replicas"), equalTo("0"));
+        assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.number_of_replicas"), equalTo("1"));
         assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.mode"), equalTo("time_series"));
         assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.time_series.start_time"), notNullValue());
         assertThat(ObjectPath.evaluate(responseBody, "template.settings.index.time_series.end_time"), notNullValue());
@@ -629,7 +629,7 @@ public class TsdbDataStreamRestIT extends DisabledSecurityDataStreamTestCase {
                     "settings":{
                         "index": {
                             "look_back_time": "24h",
-                            "number_of_replicas": 0,
+                            "number_of_replicas": 1,
                             "mode": "time_series"
                         }
                     },
@@ -695,7 +695,7 @@ public class TsdbDataStreamRestIT extends DisabledSecurityDataStreamTestCase {
                 "template": {
                     "settings":{
                         "index": {
-                            "number_of_replicas": 0,
+                            "number_of_replicas": 1,
                             "number_of_shards": 4,
                             "mode": "time_series",
                             "routing_path": ["metricset", "k8s.pod.uid"],

--- a/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
+++ b/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
@@ -37,14 +38,20 @@ public class DataStreamsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
     }
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.DEFAULT)
-        .nodes(2)
-        .setting("indices.lifecycle.history_index_enabled", "false")
-        .setting("xpack.security.enabled", "true")
-        .keystore("bootstrap.password", "x-pack-test-password")
-        .user("x_pack_rest_user", "x-pack-test-password")
-        .build();
+    public static ElasticsearchCluster cluster = createCluster();
+
+    private static ElasticsearchCluster createCluster() {
+        LocalClusterSpecBuilder<ElasticsearchCluster> clusterBuilder = ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .setting("xpack.security.enabled", "true")
+            .keystore("bootstrap.password", "x-pack-test-password")
+            .user("x_pack_rest_user", "x-pack-test-password");
+        boolean setNodes = Boolean.parseBoolean(System.getProperty("yaml.rest.tests.set_num_nodes", "true"));
+        if (setNodes) {
+            clusterBuilder.nodes(2);
+        }
+        return clusterBuilder.build();
+    }
 
     @Override
     protected String getTestRestCluster() {

--- a/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
+++ b/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
@@ -39,7 +39,7 @@ public class DataStreamsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
-        .module("reindex")
+        .nodes(2)
         .setting("indices.lifecycle.history_index_enabled", "false")
         .setting("xpack.security.enabled", "true")
         .keystore("bootstrap.password", "x-pack-test-password")

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -10,7 +10,7 @@ setup:
           index_patterns: [simple-data-stream1]
           template:
             settings:
-              index.number_of_replicas: 0
+              index.number_of_replicas: 1
           data_stream: {}
 
   - do:
@@ -42,6 +42,10 @@ setup:
       indices.create_data_stream:
         name: simple-data-stream2
   - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: green
 
   - do:
       indices.get_data_stream:
@@ -570,13 +574,17 @@ setup:
             managed: true
           template:
             settings:
-              number_of_replicas: 0
+              number_of_replicas: 1
           data_stream: {}
 
   - do:
       indices.create_data_stream:
         name: logs-foobar
   - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: green
 
   - do:
       indices.get_data_stream:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -642,6 +642,10 @@ setup:
   - is_true: acknowledged
 
   - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
       indices.get_data_stream:
         name: "*"
   - match: { data_streams.0.name: simple-data-stream1 }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -574,17 +574,13 @@ setup:
             managed: true
           template:
             settings:
-              number_of_replicas: 1
+              number_of_replicas: 0
           data_stream: {}
 
   - do:
       indices.create_data_stream:
         name: logs-foobar
   - is_true: acknowledged
-
-  - do:
-      cluster.health:
-        wait_for_status: green
 
   - do:
       indices.get_data_stream:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -168,7 +168,7 @@
           index_patterns: [ log-* ]
           template:
             settings:
-              index.number_of_replicas: 1
+              index.number_of_replicas: 0
           data_stream: { }
 
   - do:
@@ -210,7 +210,7 @@
           index_patterns: [ log-* ]
           template:
             settings:
-              index.number_of_replicas: 1
+              index.number_of_replicas: 0
           data_stream: { }
 
   - do:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -14,7 +14,7 @@
           index_patterns: [events-*]
           template:
             settings:
-              index.number_of_replicas: 0
+              index.number_of_replicas: 1
           data_stream: {}
 
   - do:
@@ -88,7 +88,7 @@
           index_patterns: [ log-* ]
           template:
             settings:
-              index.number_of_replicas: 0
+              index.number_of_replicas: 1
           data_stream: { }
 
   - do:
@@ -168,7 +168,7 @@
           index_patterns: [ log-* ]
           template:
             settings:
-              index.number_of_replicas: 0
+              index.number_of_replicas: 1
           data_stream: { }
 
   - do:
@@ -210,7 +210,7 @@
           index_patterns: [ log-* ]
           template:
             settings:
-              index.number_of_replicas: 0
+              index.number_of_replicas: 1
           data_stream: { }
 
   - do:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -16,7 +16,7 @@ setup:
             settings:
               index:
                 mode: time_series
-                number_of_replicas: 0
+                number_of_replicas: 1
                 number_of_shards: 2
                 routing_path: [metricset, time_series_dimension]
                 time_series:
@@ -89,6 +89,10 @@ created the data stream:
   - skip:
       version: " - 8.0.99"
       reason: introduced in 8.1.0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
 
   - do:
       indices.get_data_stream:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/30_auto_create_data_stream.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/30_auto_create_data_stream.yml
@@ -16,7 +16,7 @@
           template:
             settings:
               number_of_shards:   1
-              number_of_replicas: 0
+              number_of_replicas: 1
 
   - do:
       index:


### PR DESCRIPTION
Some elasticsearch environments do not support 0 replicas. This PR changes all data streams rest tests to use indices that have 1 replica.