### PR TITLE
Changing DataStreamsRestIT to use a data stream wildcard query that works with or without security enabled

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/DataStreamsRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/DataStreamsRestIT.java
@@ -47,7 +47,7 @@ public class DataStreamsRestIT extends DisabledSecurityDataStreamTestCase {
 
         assertOK(client().performRequest(createDocRequest));
 
-        Request getDataStreamsRequest = new Request("GET", "/_data_stream?expand_wildcards=hidden");
+        Request getDataStreamsRequest = new Request("GET", "/_data_stream/*?expand_wildcards=hidden");
         Response response = client().performRequest(getDataStreamsRequest);
         Map<String, Object> dataStreams = entityAsMap(response);
         assertEquals(Collections.singletonList("hidden"), XContentMapValues.extractValue("data_streams.name", dataStreams));
@@ -77,7 +77,7 @@ public class DataStreamsRestIT extends DisabledSecurityDataStreamTestCase {
 
         assertOK(client().performRequest(createDocRequest));
 
-        Request getDataStreamsRequest = new Request("GET", "/_data_stream?expand_wildcards=hidden");
+        Request getDataStreamsRequest = new Request("GET", "/_data_stream/*?expand_wildcards=hidden");
         Response response = client().performRequest(getDataStreamsRequest);
         Map<String, Object> dataStreams = entityAsMap(response);
         assertEquals(Collections.singletonList(".hidden"), XContentMapValues.extractValue("data_streams.name", dataStreams));


### PR DESCRIPTION
If security is disabled, the following query:
```
GET /_data_stream?expand_wildcards=hidden
```
returns all data streams. However if security is enabled, it returns 0 data streams. However this query:
```
GET /_data_stream/*?expand_wildcards=hidden
```
returns all data streams (that the user is allowed to see) either way. This PR updates DataStreamsRestIT to use the latter format so that it can work in environments where security is enabled.