### PR TITLE
Avoiding using ILM settings in data streams yaml rest tests

### DIFF
--- a/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
+++ b/modules/data-streams/src/yamlRestTest/java/org/elasticsearch/datastreams/DataStreamsClientYamlTestSuiteIT.java
@@ -40,7 +40,6 @@ public class DataStreamsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .module("reindex")
-        .setting("indices.lifecycle.history_index_enabled", "false")
         .setting("xpack.security.enabled", "true")
         .keystore("bootstrap.password", "x-pack-test-password")
         .user("x_pack_rest_user", "x-pack-test-password")

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
@@ -116,7 +116,7 @@ setup:
 
   - do:
       indices.resolve_index:
-        name: ['*','-.ml*']
+        name: ['*','-.ml*', '-.ds-ilm-history*']
         expand_wildcards: [all]
 
   - match: {indices.0.name: "/\\.ds-simple-data-stream1-(\\d{4}\\.\\d{2}\\.\\d{2}-)?000001/"}


### PR DESCRIPTION
DataStreamsClientYamlTestSuiteIT currently sets `indices.lifecycle.history_index_enabled` to false so that the ilm history datastream is not created so that it is easier to fetch other data streams. However this causes problems if this test is run in an environment without the ILM plugin -- the server will crash on the unknown setting.
This PR removes the use of that property, and updates the code to filter out the ilm history data stream from queries when appropriate.