### PR TITLE
[8.10] Update version range in jvm.options for the Panama Vector API (#99846)

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -56,7 +56,7 @@
 
 # Leverages accelerated vector hardware instructions; removing this may
 # result in less optimal vector performance
-20:--add-modules=jdk.incubator.vector
+20-:--add-modules=jdk.incubator.vector
 
 ## heap dumps
 

--- a/docs/changelog/99846.yaml
+++ b/docs/changelog/99846.yaml
@@ -1,0 +1,5 @@
+pr: 99846
+summary: Update version range in `jvm.options` for the Panama Vector API
+area: Vector Search
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Update version range in jvm.options for the Panama Vector API (#99846)