### PR TITLE
Suppress this-escape warning for JDK21

### DIFF
--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationLoaderTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationLoaderTests.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class SslConfigurationLoaderTests extends ESTestCase {
 
+    @SuppressWarnings("this-escape")
     private final Path certRoot = getDataPath("/certs/ca1/ca.crt").getParent().getParent();
 
     private Settings settings;

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Centroid.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Centroid.java
@@ -40,16 +40,19 @@ public class Centroid implements Comparable<Centroid> {
         id = uniqueCount.getAndIncrement();
     }
 
+    @SuppressWarnings("this-escape")
     public Centroid(double x) {
         this();
         start(x, 1, uniqueCount.getAndIncrement());
     }
 
+    @SuppressWarnings("this-escape")
     public Centroid(double x, long w) {
         this();
         start(x, w, uniqueCount.getAndIncrement());
     }
 
+    @SuppressWarnings("this-escape")
     public Centroid(double x, long w, int id) {
         this();
         start(x, w, id);

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -32,6 +32,7 @@ public class TimeSeriesAggregator extends BucketsAggregator {
     private final boolean keyed;
     private final int size;
 
+    @SuppressWarnings("this-escape")
     public TimeSeriesAggregator(
         String name,
         AggregatorFactories factories,

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/metric/ArrayValuesSourceAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/metric/ArrayValuesSourceAggregationBuilder.java
@@ -41,6 +41,7 @@ public abstract class ArrayValuesSourceAggregationBuilder<AB extends ArrayValues
             super(name);
         }
 
+        @SuppressWarnings("this-escape")
         protected LeafOnly(LeafOnly<AB> clone, Builder factoriesBuilder, Map<String, Object> metadata) {
             super(clone, factoriesBuilder, metadata);
             if (factoriesBuilder.count() > 0) {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -63,6 +63,7 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
     private final Encoder encoder;
 
+    @SuppressWarnings("this-escape")
     public CustomMustacheFactory(String mediaType) {
         super();
         setObjectHandler(new CustomReflectionObjectHandler());

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestMultiSearchTemplateActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestSearchTemplateActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
@@ -35,6 +35,7 @@ public class RankEvalRequest extends ActionRequest implements IndicesRequest.Rep
 
     private SearchType searchType = SearchType.DEFAULT;
 
+    @SuppressWarnings("this-escape")
     public RankEvalRequest(RankEvalSpec rankingEvaluationSpec, String[] indices) {
         this.rankingEvaluationSpec = Objects.requireNonNull(rankingEvaluationSpec, "ranking evaluation specification must not be null");
         indices(indices);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 
 public class TransportRankEvalActionTests extends ESTestCase {
 
+    @SuppressWarnings("this-escape")
     private Settings settings = Settings.builder()
         .put("path.home", createTempDir().toString())
         .put("node.name", "test-" + getTestName())

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestDeleteByQueryActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestDeleteByQueryActionTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 public class RestDeleteByQueryActionTests extends RestActionTestCase {
 
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestUpdateByQueryActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestUpdateByQueryActionTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 public class RestUpdateByQueryActionTests extends RestActionTestCase {
 
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePlugin.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePlugin.java
@@ -30,6 +30,7 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
     // package-private for tests
     final GoogleCloudStorageService storageService;
 
+    @SuppressWarnings("this-escape")
     public GoogleCloudStoragePlugin(final Settings settings) {
         this.storageService = createStorageService();
         // eagerly load client settings so that secure settings are readable (not closed)

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/plugin/analysis/phonetic/KoelnerPhonetik.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/plugin/analysis/phonetic/KoelnerPhonetik.java
@@ -46,6 +46,7 @@ public class KoelnerPhonetik implements StringEncoder {
     /**
      * Constructor for  Kölner Phonetik
      */
+    @SuppressWarnings("this-escape")
     public KoelnerPhonetik() {
         init();
     }

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -74,6 +74,7 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Reloa
         this(settings, new AwsEc2ServiceImpl());
     }
 
+    @SuppressWarnings("this-escape")
     protected Ec2DiscoveryPlugin(Settings settings, AwsEc2ServiceImpl ec2Service) {
         this.settings = settings;
         this.ec2Service = ec2Service;

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/GceInstancesServiceImpl.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/GceInstancesServiceImpl.java
@@ -113,6 +113,7 @@ public class GceInstancesServiceImpl implements GceInstancesService {
 
     private final boolean validateCerts;
 
+    @SuppressWarnings("this-escape")
     public GceInstancesServiceImpl(Settings settings) {
         this.settings = settings;
         this.validateCerts = GCE_VALIDATE_CERTIFICATES.get(settings);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -318,6 +318,7 @@ public class Packages {
          * Create a new wrapper for Elasticsearch JournalD logs.
          * @param sh A shell with appropriate permissions.
          */
+        @SuppressWarnings("this-escape")
         public JournaldWrapper(Shell sh) {
             this.sh = sh;
             clear();

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -144,6 +144,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         super(LoggerMessageFormat.format(msg, args), cause);
     }
 
+    @SuppressWarnings("this-escape")
     public ElasticsearchException(StreamInput in) throws IOException {
         super(in.readOptionalString(), in.readException());
         readStackTrace(this, in);

--- a/server/src/main/java/org/elasticsearch/ResourceAlreadyExistsException.java
+++ b/server/src/main/java/org/elasticsearch/ResourceAlreadyExistsException.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 public class ResourceAlreadyExistsException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public ResourceAlreadyExistsException(Index index) {
         this("index {} already exists", index.toString());
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/action/NoShardAvailableActionException.java
+++ b/server/src/main/java/org/elasticsearch/action/NoShardAvailableActionException.java
@@ -28,18 +28,22 @@ public class NoShardAvailableActionException extends ElasticsearchException {
         return new NoShardAvailableActionException(null, msg, null, true);
     }
 
+    @SuppressWarnings("this-escape")
     public NoShardAvailableActionException(ShardId shardId) {
         this(shardId, null, null, false);
     }
 
+    @SuppressWarnings("this-escape")
     public NoShardAvailableActionException(ShardId shardId, String msg) {
         this(shardId, msg, null, false);
     }
 
+    @SuppressWarnings("this-escape")
     public NoShardAvailableActionException(ShardId shardId, String msg, Throwable cause) {
         this(shardId, msg, cause, false);
     }
 
+    @SuppressWarnings("this-escape")
     private NoShardAvailableActionException(ShardId shardId, String msg, Throwable cause, boolean onShardFailureWrapper) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/RoutingMissingException.java
+++ b/server/src/main/java/org/elasticsearch/action/RoutingMissingException.java
@@ -22,6 +22,7 @@ public class RoutingMissingException extends ElasticsearchException {
 
     private final String id;
 
+    @SuppressWarnings("this-escape")
     public RoutingMissingException(String index, String id) {
         super("routing is required for [" + index + "]/[" + id + "]");
         Objects.requireNonNull(index, "index must not be null");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -42,6 +42,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Get information from nodes based on the nodes ids specified. If none are passed, information
      * for all nodes will be returned.
      */
+    @SuppressWarnings("this-escape")
     public NodesInfoRequest(String... nodesIds) {
         super(nodesIds);
         all();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -31,6 +31,7 @@ public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSea
 
     public ClusterSearchShardsRequest() {}
 
+    @SuppressWarnings("this-escape")
     public ClusterSearchShardsRequest(String... indices) {
         indices(indices);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -33,6 +33,7 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
     final long timestamp;
     final String clusterUUID;
 
+    @SuppressWarnings("this-escape")
     public ClusterStatsResponse(StreamInput in) throws IOException {
         super(in);
         timestamp = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -91,6 +91,7 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
          *
          * @param index The text to analyze
          */
+        @SuppressWarnings("this-escape")
         public Request(String index) {
             this.index(index);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -175,6 +175,7 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
             phase1 = in.readBoolean();
         }
 
+        @SuppressWarnings("this-escape")
         public ShardRequest(final ShardId shardId, final ClusterBlock clusterBlock, final boolean phase1, final TaskId parentTaskId) {
             super(shardId);
             this.clusterBlock = Objects.requireNonNull(clusterBlock);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
@@ -166,6 +166,7 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
             clusterBlock = new ClusterBlock(in);
         }
 
+        @SuppressWarnings("this-escape")
         public ShardRequest(final ShardId shardId, final ClusterBlock clusterBlock, final TaskId parentTaskId) {
             super(shardId);
             this.clusterBlock = Objects.requireNonNull(clusterBlock);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -40,6 +40,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
     /**
      * @param flags flags to set. If no flags are supplied, default flags will be set.
      */
+    @SuppressWarnings("this-escape")
     public CommonStatsFlags(Flag... flags) {
         if (flags.length > 0) {
             clear();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -65,6 +65,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
      * Constructs a new validate request against the provided indices. No indices provided means it will
      * run against all indices.
      */
+    @SuppressWarnings("this-escape")
     public ValidateQueryRequest(String... indices) {
         super(indices);
         indicesOptions(DEFAULT_INDICES_OPTIONS);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -35,6 +35,7 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> i
         items = in.readArray(i -> i.readOptionalWriteable(inpt -> new BulkItemRequest(shardId, inpt)), BulkItemRequest[]::new);
     }
 
+    @SuppressWarnings("this-escape")
     public BulkShardRequest(ShardId shardId, RefreshPolicy refreshPolicy, BulkItemRequest[] items) {
         super(shardId);
         this.items = items;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -149,6 +149,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
     /**
      * Constructs a new search request against the provided indices with the given search source.
      */
+    @SuppressWarnings("this-escape")
     public SearchRequest(String[] indices, SearchSourceBuilder source) {
         this();
         if (source == null) {

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationFailedException.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationFailedException.java
@@ -30,6 +30,7 @@ public class BroadcastShardOperationFailedException extends ElasticsearchExcepti
         this(shardId, "", cause);
     }
 
+    @SuppressWarnings("this-escape")
     public BroadcastShardOperationFailedException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -53,6 +53,7 @@ public abstract class TransportBroadcastAction<
     private final String transportShardAction;
     private final Executor executor;
 
+    @SuppressWarnings("this-escape")
     protected TransportBroadcastAction(
         String actionName,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -95,6 +95,7 @@ public abstract class TransportBroadcastByNodeAction<
         this(actionName, clusterService, transportService, actionFilters, indexNameExpressionResolver, request, executor, true);
     }
 
+    @SuppressWarnings("this-escape")
     public TransportBroadcastByNodeAction(
         String actionName,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -27,6 +27,7 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
     private final List<TNodeResponse> nodes;
     private Map<String, TNodeResponse> nodesMap;
 
+    @SuppressWarnings("this-escape")
     protected BaseNodesResponse(StreamInput in) throws IOException {
         super(in);
         clusterName = new ClusterName(in);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -662,10 +662,12 @@ public class ReplicationOperation<
     }
 
     public static class RetryOnPrimaryException extends ElasticsearchException {
+        @SuppressWarnings("this-escape")
         public RetryOnPrimaryException(ShardId shardId, String msg) {
             this(shardId, msg, null);
         }
 
+        @SuppressWarnings("this-escape")
         RetryOnPrimaryException(ShardId shardId, String msg, Throwable cause) {
             super(msg, cause);
             setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -158,6 +158,7 @@ public abstract class TransportReplicationAction<
         );
     }
 
+    @SuppressWarnings("this-escape")
     protected TransportReplicationAction(
         Settings settings,
         String actionName,
@@ -606,6 +607,7 @@ public abstract class TransportReplicationAction<
 
     public static class RetryOnReplicaException extends ElasticsearchException {
 
+        @SuppressWarnings("this-escape")
         public RetryOnReplicaException(ShardId shardId, String msg) {
             super(msg);
             setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -61,6 +61,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
     private final String transportShardAction;
     private final Executor executor;
 
+    @SuppressWarnings("this-escape")
     protected TransportSingleShardAction(
         String actionName,
         ThreadPool threadPool,

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -204,6 +204,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
         this.filterSettings = other.filterSettings();
     }
 
+    @SuppressWarnings("this-escape")
     public TermVectorsRequest(MultiGetRequest.Item item) {
         super(item.index());
         this.id = item.id();

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -49,6 +49,7 @@ public class UpdateResponse extends DocWriteResponse {
         this(new ShardInfo(0, 0), shardId, id, seqNo, primaryTerm, version, result);
     }
 
+    @SuppressWarnings("this-escape")
     public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String id, long seqNo, long primaryTerm, long version, Result result) {
         super(shardId, id, seqNo, primaryTerm, version, result);
         setShardInfo(shardInfo);

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -100,6 +100,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
     private AsyncRefresh currentRefresh;
     private RefreshScheduler refreshScheduler;
 
+    @SuppressWarnings("this-escape")
     public InternalClusterInfoService(Settings settings, ClusterService clusterService, ThreadPool threadPool, Client client) {
         this.leastAvailableSpaceUsages = Map.of();
         this.mostAvailableSpaceUsages = Map.of();

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -843,6 +843,7 @@ public class ShardStateAction {
 
     public static class NoLongerPrimaryShardException extends ElasticsearchException {
 
+        @SuppressWarnings("this-escape")
         public NoLongerPrimaryShardException(ShardId shardId, String msg) {
             super(msg);
             setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -189,6 +189,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
      * @param nodeName The name of the node, used to name the {@link java.util.concurrent.ExecutorService} of the {@link SeedHostsResolver}.
      * @param onJoinValidators A collection of join validators to restrict which nodes may join the cluster.
      */
+    @SuppressWarnings("this-escape")
     public Coordinator(
         String nodeName,
         Settings settings,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -105,6 +105,7 @@ public class FollowersChecker {
     private final NodeHealthService nodeHealthService;
     private volatile FastResponseState fastResponseState;
 
+    @SuppressWarnings("this-escape")
     public FollowersChecker(
         Settings settings,
         TransportService transportService,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/InMemoryPersistedState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/InMemoryPersistedState.java
@@ -14,6 +14,7 @@ public class InMemoryPersistedState implements CoordinationState.PersistedState 
     private long currentTerm;
     private ClusterState acceptedState;
 
+    @SuppressWarnings("this-escape")
     public InMemoryPersistedState(long term, ClusterState acceptedState) {
         this.currentTerm = term;
         this.acceptedState = acceptedState;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
@@ -56,6 +56,7 @@ public class MasterHistory implements ClusterStateListener {
         Setting.Property.NodeScope
     );
 
+    @SuppressWarnings("this-escape")
     public MasterHistory(ThreadPool threadPool, ClusterService clusterService) {
         this.masterHistory = new ArrayList<>();
         this.currentTimeMillisSupplier = threadPool::relativeTimeInMillis;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
@@ -54,6 +54,7 @@ public class Reconfigurator {
 
     private volatile boolean autoShrinkVotingConfiguration;
 
+    @SuppressWarnings("this-escape")
     public Reconfigurator(Settings settings, ClusterSettings clusterSettings) {
         autoShrinkVotingConfiguration = CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION, this::setAutoShrinkVotingConfiguration);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -248,6 +248,7 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
             aliases = new HashMap<>();
         }
 
+        @SuppressWarnings("this-escape")
         public Builder(IndexTemplateMetadata indexTemplateMetadata) {
             this.name = indexTemplateMetadata.name();
             order(indexTemplateMetadata.order());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -48,7 +48,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
         this.routingRequired = docMapper.routingFieldMapper().required();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "this-escape", "unchecked" })
     public MappingMetadata(CompressedXContent mapping) {
         this.source = mapping;
         Map<String, Object> mappingMap = XContentHelper.convertToMap(mapping.compressedReference(), true).v2();
@@ -59,7 +59,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
         this.routingRequired = routingRequired((Map<String, Object>) mappingMap.get(this.type));
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "this-escape", "unchecked" })
     public MappingMetadata(String type, Map<String, Object> mapping) {
         this.type = type;
         try {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1727,6 +1727,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
 
         private final Map<String, MappingMetadata> mappingsByHash;
 
+        @SuppressWarnings("this-escape")
         public Builder() {
             this(Map.of(), 0);
         }
@@ -1749,6 +1750,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
             this.reservedStateMetadata = new HashMap<>(metadata.reservedStateMetadata);
         }
 
+        @SuppressWarnings("this-escape")
         private Builder(Map<String, MappingMetadata> mappingsByHash, int indexCountHint) {
             clusterUUID = UNKNOWN_CLUSTER_UUID;
             indices = ImmutableOpenMap.builder(indexCountHint);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/TemplateUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/TemplateUpgradeService.java
@@ -64,6 +64,7 @@ public class TemplateUpgradeService implements ClusterStateListener {
 
     private Map<String, IndexTemplateMetadata> lastTemplateMetadata;
 
+    @SuppressWarnings("this-escape")
     public TemplateUpgradeService(
         Client client,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -129,6 +129,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
         clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
+    @SuppressWarnings("this-escape")
     @Inject
     public DelayedAllocationService(ThreadPool threadPool, ClusterService clusterService, AllocationService allocationService) {
         this.threadPool = threadPool;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -44,6 +44,7 @@ public class OperationRouting {
     private boolean useAdaptiveReplicaSelection;
     private final boolean isStateless;
 
+    @SuppressWarnings("this-escape")
     public OperationRouting(Settings settings, ClusterSettings clusterSettings) {
         this.isStateless = DiscoveryNode.isStateless(settings);
         this.useAdaptiveReplicaSelection = USE_ADAPTIVE_REPLICA_SELECTION_SETTING.get(settings);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -78,6 +78,7 @@ public class AllocationService {
     private final ShardRoutingRoleStrategy shardRoutingRoleStrategy;
 
     // only for tests that use the GatewayAllocator as the unique ExistingShardsAllocator
+    @SuppressWarnings("this-escape")
     public AllocationService(
         AllocationDeciders allocationDeciders,
         GatewayAllocator gatewayAllocator,

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -38,6 +38,7 @@ public class GeoPoint implements SpatialPoint, ToXContentFragment {
      *
      * @param value String to create the point from
      */
+    @SuppressWarnings("this-escape")
     public GeoPoint(String value) {
         this.resetFromString(value);
     }

--- a/server/src/main/java/org/elasticsearch/common/inject/CreationException.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/CreationException.java
@@ -33,6 +33,7 @@ public class CreationException extends RuntimeException {
     /**
      * Creates a CreationException containing {@code messages}.
      */
+    @SuppressWarnings("this-escape")
     public CreationException(Collection<Message> messages) {
         this.messages = messages;
         if (this.messages.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -23,10 +23,12 @@ public class ByteArrayStreamInput extends StreamInput {
     private int pos;
     private int limit;
 
+    @SuppressWarnings("this-escape")
     public ByteArrayStreamInput() {
         reset(BytesRef.EMPTY_BYTES);
     }
 
+    @SuppressWarnings("this-escape")
     public ByteArrayStreamInput(byte[] bytes) {
         reset(bytes);
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
@@ -19,6 +19,7 @@ import java.io.IOException;
  */
 public class VersionCheckingStreamOutput extends StreamOutput {
 
+    @SuppressWarnings("this-escape")
     public VersionCheckingStreamOutput(TransportVersion version) {
         setTransportVersion(version);
     }

--- a/server/src/main/java/org/elasticsearch/common/logging/ECSJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ECSJsonLayout.java
@@ -39,6 +39,7 @@ public class ECSJsonLayout {
         @PluginAttribute("dataset")
         String dataset;
 
+        @SuppressWarnings("this-escape")
         public Builder() {
             setCharset(StandardCharsets.UTF_8);
         }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
@@ -163,6 +163,7 @@ public class ESJsonLayout extends AbstractStringLayout {
         @PluginConfiguration
         private Configuration config;
 
+        @SuppressWarnings("this-escape")
         public Builder() {
             setCharset(StandardCharsets.UTF_8);
         }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -27,6 +27,7 @@ public class ESLogMessage extends MapMessage<ESLogMessage, Object> {
     private final List<Object> arguments = new ArrayList<>();
     private String messagePattern;
 
+    @SuppressWarnings("this-escape")
     public ESLogMessage(String messagePattern, Object... args) {
         super(new LinkedHashMap<>());
         Collections.addAll(this.arguments, args);

--- a/server/src/main/java/org/elasticsearch/common/metrics/Counters.java
+++ b/server/src/main/java/org/elasticsearch/common/metrics/Counters.java
@@ -32,6 +32,7 @@ public class Counters implements Writeable {
 
     private final ConcurrentMap<String, CounterMetric> counters = new ConcurrentHashMap<>();
 
+    @SuppressWarnings("this-escape")
     public Counters(StreamInput in) throws IOException {
         int numCounters = in.readVInt();
         for (int i = 0; i < numCounters; i++) {

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -52,6 +52,7 @@ public abstract class AbstractScopedSettings {
     private final Setting.Property scope;
     private Settings lastSettingsApplied;
 
+    @SuppressWarnings("this-escape")
     protected AbstractScopedSettings(final Settings settings, final Set<Setting<?>> settingsSet, final Setting.Property scope) {
         this.logger = LogManager.getLogger(this.getClass());
         this.settings = settings;

--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -116,6 +116,7 @@ public class LocallyMountedSecrets implements SecureSettings {
     /**
      * Direct constructor to be used by the CLI
      */
+    @SuppressWarnings("this-escape")
     public LocallyMountedSecrets(Environment environment) {
         var secretsDirPath = resolveSecretsDir(environment);
         var secretsFilePath = resolveSecretsFile(environment);

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -173,6 +173,7 @@ public class Setting<T> implements ToXContentObject {
         Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
 
+    @SuppressWarnings("this-escape")
     private Setting(
         Key key,
         @Nullable Setting<T> fallbackSetting,
@@ -246,6 +247,7 @@ public class Setting<T> implements ToXContentObject {
      * @param validator    a {@link Validator} for validating this setting
      * @param properties   properties for this setting
      */
+    @SuppressWarnings("this-escape")
     public Setting(
         Key key,
         Function<Settings, String> defaultValue,
@@ -317,6 +319,7 @@ public class Setting<T> implements ToXContentObject {
      * @param validator a {@link Validator} for validating this setting
      * @param properties properties for this setting like scope, filtering...
      */
+    @SuppressWarnings("this-escape")
     public Setting(String key, Setting<T> fallbackSetting, Function<String, T> parser, Validator<T> validator, Property... properties) {
         this(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, parser, validator, properties);
     }
@@ -328,6 +331,7 @@ public class Setting<T> implements ToXContentObject {
      * @param parser a parser that parses the string rep into a complex datatype.
      * @param properties properties for this setting like scope, filtering...
      */
+    @SuppressWarnings("this-escape")
     public Setting(Key key, Setting<T> fallbackSetting, Function<String, T> parser, Property... properties) {
         this(key, fallbackSetting, fallbackSetting::getRaw, parser, v -> {}, properties);
     }

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -32,6 +32,7 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
     private ByteArray bytes;
     private long size;
 
+    @SuppressWarnings("this-escape")
     public BytesRefArray(long capacity, BigArrays bigArrays) {
         this.bigArrays = bigArrays;
         boolean success = false;
@@ -48,6 +49,7 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
         size = 0;
     }
 
+    @SuppressWarnings("this-escape")
     public BytesRefArray(StreamInput in, BigArrays bigArrays) throws IOException {
         this.bigArrays = bigArrays;
         // we allocate big arrays so we have to `close` if we fail here or we'll leak them.

--- a/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -26,6 +26,7 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
         this(capacity, DEFAULT_MAX_LOAD_FACTOR, bigArrays);
     }
 
+    @SuppressWarnings("this-escape")
     public LongObjectPagedHashMap(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);
         boolean success = false;

--- a/server/src/main/java/org/elasticsearch/common/util/PlainIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/PlainIterator.java
@@ -20,6 +20,7 @@ public class PlainIterator<T> implements Iterable<T>, Countable {
     // that although nextOrNull might be called from different threads, it can never happen concurrently.
     private volatile int index;
 
+    @SuppressWarnings("this-escape")
     public PlainIterator(List<T> elements) {
         this.elements = elements;
         reset();

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -94,6 +94,7 @@ public abstract class PeerFinder {
     private Optional<DiscoveryNode> leader = Optional.empty();
     private volatile List<TransportAddress> lastResolvedAddresses = emptyList();
 
+    @SuppressWarnings("this-escape")
     public PeerFinder(
         Settings settings,
         TransportService transportService,

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -209,6 +209,7 @@ public final class NodeEnvironment implements Closeable {
          * Tries to acquire a node lock for a node id, throws {@code IOException} if it is unable to acquire it
          * @param pathFunction function to check node path before attempt of acquiring a node lock
          */
+        @SuppressWarnings("this-escape")
         public NodeLock(
             final Logger logger,
             final Environment environment,

--- a/server/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
+++ b/server/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
@@ -19,11 +19,13 @@ import java.io.IOException;
  */
 public class ShardLockObtainFailedException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public ShardLockObtainFailedException(ShardId shardId, String message) {
         super(buildMessage(shardId, message));
         this.setShard(shardId);
     }
 
+    @SuppressWarnings("this-escape")
     public ShardLockObtainFailedException(ShardId shardId, String message, Throwable cause) {
         super(buildMessage(shardId, message), cause);
         this.setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -505,6 +505,7 @@ public class GatewayMetaState implements Closeable {
         private final AtomicReference<PersistedClusterStateService.Writer> persistenceWriter = new AtomicReference<>();
         private boolean writeNextStateFully;
 
+        @SuppressWarnings("this-escape")
         public LucenePersistedState(
             PersistedClusterStateService persistedClusterStateService,
             long currentTerm,

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -160,6 +160,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final ValuesSourceRegistry valuesSourceRegistry;
     private Supplier<DocumentParsingObserver> documentParsingObserverSupplier;
 
+    @SuppressWarnings("this-escape")
     public IndexService(
         IndexSettings indexSettings,
         IndexCreationContext indexCreationContext,

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
@@ -49,6 +49,7 @@ public class PerFieldMapperCodec extends Lucene95Codec {
             : "PerFieldMapperCodec must subclass the latest lucene codec: " + Lucene.LATEST_CODEC;
     }
 
+    @SuppressWarnings("this-escape")
     public PerFieldMapperCodec(Mode compressionMode, MapperService mapperService, BigArrays bigArrays) {
         super(compressionMode);
         this.mapperService = mapperService;

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineException.java
@@ -20,6 +20,7 @@ public class EngineException extends ElasticsearchException {
         this(shardId, msg, null, params);
     }
 
+    @SuppressWarnings("this-escape")
     public EngineException(ShardId shardId, String msg, Throwable cause, Object... params) {
         super(msg, cause, params);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -221,10 +221,12 @@ public class InternalEngine extends Engine {
     protected static final String REAL_TIME_GET_REFRESH_SOURCE = "realtime_get";
     protected static final String UNSAFE_VERSION_MAP_REFRESH_SOURCE = "unsafe_version_map";
 
+    @SuppressWarnings("this-escape")
     public InternalEngine(EngineConfig engineConfig) {
         this(engineConfig, IndexWriter.MAX_DOCS, LocalCheckpointTracker::new);
     }
 
+    @SuppressWarnings("this-escape")
     InternalEngine(EngineConfig engineConfig, int maxDocs, BiFunction<Long, Long, LocalCheckpointTracker> localCheckpointTrackerSupplier) {
         super(engineConfig);
         this.maxDocs = maxDocs;

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -93,6 +93,7 @@ public class ReadOnlyEngine extends Engine {
      * @param requireCompleteHistory indicates whether this engine permits an incomplete history (i.e. LCP &lt; MSN)
      * @param lazilyLoadSoftDeletes indicates whether this engine should load the soft-delete based liveDocs eagerly, or on first access
      */
+    @SuppressWarnings("this-escape")
     public ReadOnlyEngine(
         EngineConfig config,
         SeqNoStats seqNoStats,

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -47,6 +47,7 @@ public class FieldsVisitor extends FieldNamesProvidingStoredFieldsVisitor {
         this(loadSource, SourceFieldMapper.NAME);
     }
 
+    @SuppressWarnings("this-escape")
     public FieldsVisitor(boolean loadSource, String sourceFieldName) {
         this.loadSource = loadSource;
         this.sourceFieldName = sourceFieldName;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -195,6 +195,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
         private final List<byte[]> bytesList;
 
+        @SuppressWarnings("this-escape")
         public CustomBinaryDocValuesField(String name, byte[] bytes) {
             super(name);
             bytesList = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -93,6 +93,7 @@ public class BooleanFieldMapper extends FieldMapper {
 
         private final IndexVersion indexCreatedVersion;
 
+        @SuppressWarnings("this-escape")
         public Builder(String name, ScriptCompiler scriptCompiler, boolean ignoreMalformedByDefault, IndexVersion indexCreatedVersion) {
             super(name);
             this.scriptCompiler = Objects.requireNonNull(scriptCompiler);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ConstantFieldType.java
@@ -31,6 +31,7 @@ import java.util.Map;
  */
 public abstract class ConstantFieldType extends MappedFieldType {
 
+    @SuppressWarnings("this-escape")
     public ConstantFieldType(String name, Map<String, String> meta) {
         super(name, true, false, true, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
         assert isSearchable();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -252,6 +252,7 @@ public final class DateFieldMapper extends FieldMapper {
         private final IndexVersion indexCreatedVersion;
         private final ScriptCompiler scriptCompiler;
 
+        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             Resolution resolution,

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -94,6 +94,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         private final Parameter<Boolean> dimension; // can only support time_series_dimension: false
         private final IndexMode indexMode;  // either STANDARD or TIME_SERIES
 
+        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             ScriptCompiler scriptCompiler,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -88,6 +88,7 @@ public class IpFieldMapper extends FieldMapper {
         private final IndexVersion indexCreatedVersion;
         private final ScriptCompiler scriptCompiler;
 
+        @SuppressWarnings("this-escape")
         public Builder(String name, ScriptCompiler scriptCompiler, boolean ignoreMalformedByDefault, IndexVersion indexCreatedVersion) {
             super(name);
             this.scriptCompiler = Objects.requireNonNull(scriptCompiler);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -184,6 +184,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final ScriptCompiler scriptCompiler;
         private final IndexVersion indexCreatedVersion;
 
+        @SuppressWarnings("this-escape")
         public Builder(String name, IndexAnalyzers indexAnalyzers, ScriptCompiler scriptCompiler, IndexVersion indexCreatedVersion) {
             super(name);
             this.indexAnalyzers = indexAnalyzers;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -157,6 +157,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         );
     }
 
+    @SuppressWarnings("this-escape")
     public MapperService(
         Supplier<TransportVersion> clusterTransportVersion,
         IndexSettings indexSettings,

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -143,6 +143,7 @@ public class NumberFieldMapper extends FieldMapper {
             return builder;
         }
 
+        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             NumberType type,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1130,6 +1130,7 @@ public class TextFieldMapper extends FieldMapper {
     private final SubFieldInfo prefixFieldInfo;
     private final SubFieldInfo phraseFieldInfo;
 
+    @SuppressWarnings("this-escape")
     protected TextFieldMapper(
         String simpleName,
         FieldType fieldType,

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -61,6 +61,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
 
     }
 
+    @SuppressWarnings("this-escape")
     protected AbstractQueryBuilder(StreamInput in) throws IOException {
         boost = in.readFloat();
         checkNegativeBoost(boost);

--- a/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
@@ -109,6 +109,7 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
     /**
      * Constructs a new text query.
      */
+    @SuppressWarnings("this-escape")
     public CombinedFieldsQueryBuilder(Object value, String... fields) {
         if (value == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires query value");

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -185,6 +185,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     /**
      * Constructs a new text query.
      */
+    @SuppressWarnings("this-escape")
     public MultiMatchQueryBuilder(Object value, String... fields) {
         if (value == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires query value");
@@ -202,6 +203,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     public MultiMatchQueryBuilder(StreamInput in) throws IOException {
         super(in);
         value = in.readGenericValue();

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
@@ -32,6 +32,7 @@ public class QueryShardException extends ElasticsearchException {
      * This constructor is provided for use in unit tests where a
      * {@link SearchExecutionContext} may not be available
      */
+    @SuppressWarnings("this-escape")
     public QueryShardException(Index index, String msg, Throwable cause, Object... args) {
         super(msg, cause, args);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -153,6 +153,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     public QueryStringQueryBuilder(StreamInput in) throws IOException {
         super(in);
         queryString = in.readString();

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -142,6 +142,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     public SimpleQueryStringBuilder(StreamInput in) throws IOException {
         super(in);
         queryText = in.readString();

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -72,6 +72,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     /**
      * Convenience constructor that converts its parameters into json to parse on the data nodes.
      */
+    @SuppressWarnings("this-escape")
     protected DecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
         if (fieldName == null) {
             throw new IllegalArgumentException("decay function: field name must not be null");

--- a/server/src/main/java/org/elasticsearch/index/shard/IllegalIndexShardStateException.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IllegalIndexShardStateException.java
@@ -23,6 +23,7 @@ public class IllegalIndexShardStateException extends ElasticsearchException {
         this(shardId, currentState, msg, null, args);
     }
 
+    @SuppressWarnings("this-escape")
     public IllegalIndexShardStateException(ShardId shardId, IndexShardState currentState, String msg, Throwable ex, Object... args) {
         super("CurrentState[" + currentState + "] " + msg, ex, args);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -288,6 +288,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     // the translog keeps track of the GCP, but unpromotable shards have no translog so we need to track the GCP here instead
     private volatile long globalCheckPointIfUnpromotable;
 
+    @SuppressWarnings("this-escape")
     public IndexShard(
         final ShardRouting shardRouting,
         final IndexSettings indexSettings,

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShardRecoveryException.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShardRecoveryException.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import java.io.IOException;
 
 public class IndexShardRecoveryException extends ElasticsearchException {
+    @SuppressWarnings("this-escape")
     public IndexShardRecoveryException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardNotFoundException.java
@@ -26,6 +26,7 @@ public class ShardNotFoundException extends ResourceNotFoundException {
         this(shardId, msg, null, args);
     }
 
+    @SuppressWarnings("this-escape")
     public ShardNotFoundException(ShardId shardId, String msg, Throwable ex, Object... args) {
         super(msg, ex, args);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardRestoreException.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardRestoreException.java
@@ -22,6 +22,7 @@ public class IndexShardRestoreException extends ElasticsearchException {
         this(shardId, msg, null);
     }
 
+    @SuppressWarnings("this-escape")
     public IndexShardRestoreException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotException.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotException.java
@@ -22,6 +22,7 @@ public class IndexShardSnapshotException extends ElasticsearchException {
         this(shardId, msg, null);
     }
 
+    @SuppressWarnings("this-escape")
     public IndexShardSnapshotException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -55,6 +55,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
          * @param metadata  the files meta data
          * @param partSize     size of the single chunk
          */
+        @SuppressWarnings("this-escape")
         public FileInfo(String name, StoreFileMetadata metadata, @Nullable ByteSizeValue partSize) {
             this.name = Objects.requireNonNull(name);
             this.metadata = metadata;

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -144,6 +144,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * @param persistedSequenceNumberConsumer a callback that's called whenever an operation with a given sequence number is successfully
      *                                        persisted.
      */
+    @SuppressWarnings("this-escape")
     public Translog(
         final TranslogConfig config,
         final String translogUUID,

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogException.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogException.java
@@ -20,6 +20,7 @@ public class TranslogException extends ElasticsearchException {
         this(shardId, msg, null);
     }
 
+    @SuppressWarnings("this-escape")
     public TranslogException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/indices/AliasFilterParsingException.java
+++ b/server/src/main/java/org/elasticsearch/indices/AliasFilterParsingException.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 public class AliasFilterParsingException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public AliasFilterParsingException(Index index, String name, String desc, Throwable ex) {
         super("[" + name + "], " + desc, ex);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndexClosedException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexClosedException.java
@@ -20,6 +20,7 @@ import java.io.IOException;
  */
 public class IndexClosedException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public IndexClosedException(Index index) {
         super("closed");
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndexCreationException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexCreationException.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 public class IndexCreationException extends ElasticsearchException implements ElasticsearchWrapperException {
 
+    @SuppressWarnings("this-escape")
     public IndexCreationException(String index, Throwable cause) {
         super("failed to create index [{}]", cause, index);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
@@ -24,6 +24,7 @@ public class IndexPrimaryShardNotAllocatedException extends ElasticsearchExcepti
         super(in);
     }
 
+    @SuppressWarnings("this-escape")
     public IndexPrimaryShardNotAllocatedException(Index index) {
         super("primary not allocated post api");
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -267,6 +267,7 @@ public class IndicesService extends AbstractLifecycleComponent
         clusterService.addStateApplier(timestampFieldMapperService);
     }
 
+    @SuppressWarnings("this-escape")
     public IndicesService(
         Settings settings,
         PluginsService pluginsService,

--- a/server/src/main/java/org/elasticsearch/indices/InvalidAliasNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidAliasNameException.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 public class InvalidAliasNameException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public InvalidAliasNameException(Index index, String name, String desc) {
         super("Invalid alias name [{}], {}", name, desc);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/InvalidIndexNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidIndexNameException.java
@@ -17,11 +17,13 @@ import java.io.IOException;
 
 public class InvalidIndexNameException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public InvalidIndexNameException(String name, String desc) {
         super("Invalid index name [" + name + "], " + desc);
         setIndex(name);
     }
 
+    @SuppressWarnings("this-escape")
     public InvalidIndexNameException(Index index, String name, String desc) {
         super("Invalid index name [" + name + "], " + desc);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -154,6 +154,7 @@ public class SystemIndices {
      *                                These features come from plugins and modules. Non-plugin system
      *                                features such as Tasks will be added automatically.
      */
+    @SuppressWarnings("this-escape")
     public SystemIndices(List<Feature> pluginAndModuleFeatures) {
         featureDescriptors = buildFeatureMap(pluginAndModuleFeatures);
         indexDescriptors = featureDescriptors.values()

--- a/server/src/main/java/org/elasticsearch/indices/TypeMissingException.java
+++ b/server/src/main/java/org/elasticsearch/indices/TypeMissingException.java
@@ -18,16 +18,19 @@ import java.util.Arrays;
 
 public class TypeMissingException extends ElasticsearchException {
 
+    @SuppressWarnings("this-escape")
     public TypeMissingException(Index index, String... types) {
         super("type" + Arrays.toString(types) + " missing");
         setIndex(index);
     }
 
+    @SuppressWarnings("this-escape")
     public TypeMissingException(Index index, Throwable cause, String... types) {
         super("type" + Arrays.toString(types) + " missing", cause);
         setIndex(index);
     }
 
+    @SuppressWarnings("this-escape")
     public TypeMissingException(String index, String... types) {
         super("type[" + Arrays.toString(types) + "] missing");
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
@@ -89,6 +89,7 @@ public class HunspellService {
     private final Path hunspellDir;
     private final Function<String, Dictionary> loadingFunction;
 
+    @SuppressWarnings("this-escape")
     public HunspellService(final Settings settings, final Environment env, final Map<String, Dictionary> knownDictionaries)
         throws IOException {
         this.knownDictionaries = Collections.unmodifiableMap(knownDictionaries);

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -145,10 +145,12 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     private final Function<Boolean, OverLimitStrategy> overLimitStrategyFactory;
     private volatile OverLimitStrategy overLimitStrategy;
 
+    @SuppressWarnings("this-escape")
     public HierarchyCircuitBreakerService(Settings settings, List<BreakerSettings> customBreakers, ClusterSettings clusterSettings) {
         this(settings, customBreakers, clusterSettings, HierarchyCircuitBreakerService::createOverLimitStrategy);
     }
 
+    @SuppressWarnings("this-escape")
     HierarchyCircuitBreakerService(
         Settings settings,
         List<BreakerSettings> customBreakers,

--- a/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -51,6 +51,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     private final IndexFieldDataCache.Listener indicesFieldDataCacheListener;
     private final Cache<Key, Accountable> cache;
 
+    @SuppressWarnings("this-escape")
     public IndicesFieldDataCache(Settings settings, IndexFieldDataCache.Listener indicesFieldDataCacheListener) {
         this.indicesFieldDataCacheListener = indicesFieldDataCacheListener;
         final long sizeInBytes = INDICES_FIELDDATA_CACHE_SIZE_KEY.get(settings).getBytes();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
@@ -24,6 +24,7 @@ public class RecoverFilesRecoveryException extends ElasticsearchException implem
 
     private final ByteSizeValue totalFilesSize;
 
+    @SuppressWarnings("this-escape")
     public RecoverFilesRecoveryException(ShardId shardId, int numberOfFiles, ByteSizeValue totalFilesSize, Throwable cause) {
         super("Failed to transfer [{}] files with total size of [{}]", cause, numberOfFiles, totalFilesSize);
         Objects.requireNonNull(totalFilesSize, "totalFilesSize must not be null");

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCommitTooNewException.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCommitTooNewException.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.shard.ShardId;
 import java.io.IOException;
 
 public class RecoveryCommitTooNewException extends ElasticsearchException {
+    @SuppressWarnings("this-escape")
     public RecoveryCommitTooNewException(ShardId shardId, String message) {
         super(message);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -407,6 +407,7 @@ public class RecoverySettings {
     private final ByteSizeValue availableDiskReadBandwidth;
     private final ByteSizeValue availableDiskWriteBandwidth;
 
+    @SuppressWarnings("this-escape")
     public RecoverySettings(Settings settings, ClusterSettings clusterSettings) {
         this.retryDelayStateSync = INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING.get(settings);
         this.maxConcurrentFileChunks = INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING.get(settings);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -103,6 +103,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
      *                                    preventing the exhaustion of repository resources.
      * @param listener                    called when recovery is completed/failed
      */
+    @SuppressWarnings("this-escape")
     public RecoveryTarget(
         IndexShard indexShard,
         DiscoveryNode sourceNode,

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -88,6 +88,7 @@ public class IndicesStore implements ClusterStateListener, Closeable {
 
     private final TimeValue deleteShardTimeout;
 
+    @SuppressWarnings("this-escape")
     @Inject
     public IndicesStore(
         Settings settings,

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -39,10 +39,12 @@ public class CompoundProcessor implements Processor {
         this(false, List.of(processors), List.of());
     }
 
+    @SuppressWarnings("this-escape")
     public CompoundProcessor(boolean ignoreFailure, List<Processor> processors, List<Processor> onFailureProcessors) {
         this(ignoreFailure, processors, onFailureProcessors, System::nanoTime);
     }
 
+    @SuppressWarnings("this-escape")
     CompoundProcessor(
         boolean ignoreFailure,
         List<Processor> processors,

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -172,6 +172,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
     }
 
+    @SuppressWarnings("this-escape")
     public IngestService(
         ClusterService clusterService,
         ThreadPool threadPool,

--- a/server/src/main/java/org/elasticsearch/lucene/analysis/miscellaneous/DeDuplicatingTokenFilter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/analysis/miscellaneous/DeDuplicatingTokenFilter.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
  * be used to inspect the number of prior sightings when emitDuplicates is true)
  */
 public class DeDuplicatingTokenFilter extends FilteringTokenFilter {
+    @SuppressWarnings("this-escape")
     private final DuplicateSequenceAttribute seqAtt = addAttribute(DuplicateSequenceAttribute.class);
     private final boolean emitDuplicates;
     static final MurmurHash3.Hash128 seed = new MurmurHash3.Hash128();

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -79,6 +79,7 @@ public class CustomUnifiedHighlighter extends UnifiedHighlighter {
      *                          offset source for it because it'd be super slow
      * @param weightMatchesEnabled whether the {@link HighlightFlag#WEIGHT_MATCHES} should be enabled
      */
+    @SuppressWarnings("this-escape")
     public CustomUnifiedHighlighter(
         Builder builder,
         OffsetSource offsetSource,

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsHealthService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsHealthService.java
@@ -82,6 +82,7 @@ public class FsHealthService extends AbstractLifecycleComponent implements NodeH
         Setting.Property.Dynamic
     );
 
+    @SuppressWarnings("this-escape")
     public FsHealthService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, NodeEnvironment nodeEnv) {
         this.threadPool = threadPool;
         this.enabled = ENABLED_SETTING.get(settings);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -350,6 +350,7 @@ public class Node implements Closeable {
      * @param forbidPrivateIndexSettings whether or not private index settings are forbidden when creating an index; this is used in the
      *                                   test framework for tests that rely on being able to set private settings
      */
+    @SuppressWarnings("this-escape")
     protected Node(
         final Environment initialEnvironment,
         final Function<Settings, PluginsService> pluginServiceCtor,

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -65,6 +65,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
     private final PeriodicRechecker periodicRechecker;
     private final AtomicBoolean reassigningTasks = new AtomicBoolean(false);
 
+    @SuppressWarnings("this-escape")
     public PersistentTasksClusterService(
         Settings settings,
         PersistentTasksExecutorRegistry registry,

--- a/server/src/main/java/org/elasticsearch/persistent/decider/EnableAssignmentDecider.java
+++ b/server/src/main/java/org/elasticsearch/persistent/decider/EnableAssignmentDecider.java
@@ -41,6 +41,7 @@ public class EnableAssignmentDecider {
 
     private volatile Allocation enableAssignment;
 
+    @SuppressWarnings("this-escape")
     public EnableAssignmentDecider(final Settings settings, final ClusterSettings clusterSettings) {
         this.enableAssignment = CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING, this::setEnableAssignment);

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -130,6 +130,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * @param modulesDirectory The directory modules exist in, or null if modules should not be loaded from the filesystem
      * @param pluginsDirectory The directory plugins exist in, or null if plugins should not be loaded from the filesystem
      */
+    @SuppressWarnings("this-escape")
     public PluginsService(Settings settings, Path configPath, Path modulesDirectory, Path pluginsDirectory) {
         this.settings = settings;
         this.configPath = configPath;

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -102,6 +102,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
     private final List<BiConsumer<Snapshot, IndexVersion>> preRestoreChecks;
 
+    @SuppressWarnings("this-escape")
     public RepositoriesService(
         Settings settings,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotIndexCommit.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotIndexCommit.java
@@ -25,6 +25,7 @@ public class SnapshotIndexCommit extends AbstractRefCounted {
     private final Runnable releaseInitialRef;
     private final SubscribableListener<Void> completionListeners = new SubscribableListener<>();
 
+    @SuppressWarnings("this-escape")
     public SnapshotIndexCommit(Engine.IndexCommitRef commitRef) {
         this.commitRef = commitRef;
         this.releaseInitialRef = new RunOnce(this::decRef);

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -393,6 +393,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param metadata   The metadata for this repository including name and settings
      * @param clusterService ClusterService
      */
+    @SuppressWarnings("this-escape")
     protected BlobStoreRepository(
         final RepositoryMetadata metadata,
         final NamedXContentRegistry namedXContentRegistry,

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -74,6 +74,7 @@ public class RestRequest implements ToXContent.Params {
         return contentConsumed;
     }
 
+    @SuppressWarnings("this-escape")
     protected RestRequest(
         XContentParserConfiguration parserConfig,
         Map<String, String> params,
@@ -85,6 +86,7 @@ public class RestRequest implements ToXContent.Params {
         this(parserConfig, params, path, headers, httpRequest, httpChannel, requestIdGenerator.incrementAndGet());
     }
 
+    @SuppressWarnings("this-escape")
     private RestRequest(
         XContentParserConfiguration parserConfig,
         Map<String, String> params,

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -107,6 +107,7 @@ public class RestResponse {
         this(channel, ExceptionsHelper.status(e), e);
     }
 
+    @SuppressWarnings("this-escape")
     public RestResponse(RestChannel channel, RestStatus status, Exception e) throws IOException {
         this.status = status;
         ToXContent.Params params = paramsFromRequest(channel.request());

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/AliasesNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/AliasesNotFoundException.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 
 public class AliasesNotFoundException extends ResourceNotFoundException {
 
+    @SuppressWarnings("this-escape")
     public AliasesNotFoundException(String... names) {
         super("aliases " + Arrays.toString(names) + " missing");
         this.setResources("aliases", names);

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -72,6 +72,7 @@ public class Metadata {
      * @param map the backing map for this metadata instance
      * @param properties the immutable map of defined properties for the type of metadata represented by this instance
      */
+    @SuppressWarnings("this-escape")
     protected Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
         this.map = map;
         // we can't tell the compiler that properties must be a java.util.ImmutableCollections.AbstractImmutableMap, but

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -185,6 +185,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
     // package private for tests
     final AtomicReference<CacheHolder> cacheHolder = new AtomicReference<>();
 
+    @SuppressWarnings("this-escape")
     public ScriptService(
         Settings settings,
         Map<String, ScriptEngine> engines,

--- a/server/src/main/java/org/elasticsearch/script/field/WriteField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/WriteField.java
@@ -32,6 +32,7 @@ public class WriteField implements Field<Object> {
 
     private static final Object MISSING = new Object();
 
+    @SuppressWarnings("this-escape")
     public WriteField(String path, Supplier<Map<String, Object>> rootSupplier) {
         this.path = path;
         this.rootSupplier = rootSupplier;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
@@ -26,6 +26,7 @@ public abstract class AdaptingAggregator extends Aggregator {
     private final Aggregator parent;
     private final Aggregator delegate;
 
+    @SuppressWarnings("this-escape")
     public AdaptingAggregator(
         Aggregator parent,
         AggregatorFactories subAggregators,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -58,6 +58,7 @@ public abstract class AggregatorBase extends Aggregator {
      * @param subAggregatorCardinality Upper bound of the number of buckets that sub aggregations will collect
      * @param metadata              The metadata associated with this aggregator
      */
+    @SuppressWarnings("this-escape")
     protected AggregatorBase(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -290,6 +290,7 @@ public class AggregatorFactories {
         /**
          * Read from a stream.
          */
+        @SuppressWarnings("this-escape")
         public Builder(StreamInput in) throws IOException {
             int factoriesSize = in.readVInt();
             for (int i = 0; i < factoriesSize; i++) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -33,6 +33,7 @@ public abstract class AggregatorFactory {
      * @throws IOException
      *             if an error occurs creating the factory
      */
+    @SuppressWarnings("this-escape")
     public AggregatorFactory(
         String name,
         AggregationContext context,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -44,6 +44,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
     protected final DocCountProvider docCountProvider;
     private int callCount;
 
+    @SuppressWarnings("this-escape")
     public BucketsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
@@ -42,6 +42,7 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid<?>> extends Bu
     protected final ValuesSource.Numeric valuesSource;
     protected final LongKeyedBucketOrds bucketOrds;
 
+    @SuppressWarnings("this-escape")
     protected GeoGridAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
@@ -41,6 +41,7 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
         GeoHashGridAggregationBuilder::new
     );
 
+    @SuppressWarnings("this-escape")
     public GeoHashGridAggregationBuilder(String name) {
         super(name);
         precision(DEFAULT_PRECISION);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
@@ -40,6 +40,7 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
         GeoTileGridAggregationBuilder::new
     );
 
+    @SuppressWarnings("this-escape")
     public GeoTileGridAggregationBuilder(String name) {
         super(name);
         precision(DEFAULT_PRECISION);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
@@ -51,7 +51,7 @@ public abstract class InternalGeoGrid<B extends InternalGeoGridBucket> extends I
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "this-escape", "unchecked" })
     public InternalGeoGrid(StreamInput in) throws IOException {
         super(in);
         requiredSize = readSize(in);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 public class GlobalAggregator extends BucketsAggregator implements SingleBucketAggregator {
     private final Weight weight;
 
+    @SuppressWarnings("this-escape")
     public GlobalAggregator(String name, AggregatorFactories subFactories, AggregationContext context, Map<String, Object> metadata)
         throws IOException {
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramAggregator.java
@@ -44,6 +44,7 @@ public abstract class AbstractHistogramAggregator extends BucketsAggregator {
     protected final DoubleBounds hardBounds;
     protected final LongKeyedBucketOrds bucketOrds;
 
+    @SuppressWarnings("this-escape")
     public AbstractHistogramAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -261,6 +261,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     public InternalRange(StreamInput in) throws IOException {
         super(in);
         format = in.readNamedWriteable(DocValueFormat.class);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -68,6 +68,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         BytesRef apply(long ord) throws IOException;
     }
 
+    @SuppressWarnings("this-escape")
     public GlobalOrdinalsStringTermsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -53,6 +53,7 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
     private final BytesKeyedBucketOrds bucketOrds;
     private final IncludeExclude.StringFilter includeExclude;
 
+    @SuppressWarnings("this-escape")
     public MapStringTermsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -51,6 +51,7 @@ public class NumericTermsAggregator extends TermsAggregator {
     private final LongKeyedBucketOrds bucketOrds;
     private final LongFilter longFilter;
 
+    @SuppressWarnings("this-escape")
     public NumericTermsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -193,6 +193,7 @@ public abstract class TermsAggregator extends DeferableBucketAggregator {
     protected final Set<Aggregator> aggsUsedForSorting;
     protected final SubAggCollectionMode collectMode;
 
+    @SuppressWarnings("this-escape")
     public TermsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCentroid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCentroid.java
@@ -56,6 +56,7 @@ public abstract class InternalCentroid extends InternalAggregation implements Ce
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     protected InternalCentroid(StreamInput in, FieldExtractor firstField, FieldExtractor secondField) throws IOException {
         super(in);
         count = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
@@ -134,6 +134,7 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
             this(compression, null);
         }
 
+        @SuppressWarnings("this-escape")
         public TDigest(double compression, TDigestExecutionHint executionHint) {
             super(PercentilesMethod.TDIGEST);
             this.executionHint = executionHint;
@@ -288,6 +289,7 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
             this(DEFAULT_NUMBER_SIG_FIGS);
         }
 
+        @SuppressWarnings("this-escape")
         public Hdr(int numberOfSignificantValueDigits) {
             super(PercentilesMethod.HDR);
             setNumberOfSignificantValueDigits(numberOfSignificantValueDigits);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -38,6 +38,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     // a count per bucket
     LongArray counts;
 
+    @SuppressWarnings("this-escape")
     public ValueCountAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -40,6 +40,7 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
             super(name);
         }
 
+        @SuppressWarnings("this-escape")
         protected LeafOnly(LeafOnly<AB> clone, Builder factoriesBuilder, Map<String, Object> metadata) {
             super(clone, factoriesBuilder, metadata);
             if (factoriesBuilder.count() > 0) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -115,6 +115,7 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
             super(name);
         }
 
+        @SuppressWarnings("this-escape")
         protected LeafOnly(LeafOnly<AB> clone, Builder factoriesBuilder, Map<String, Object> metadata) {
             super(clone, factoriesBuilder, metadata);
             if (factoriesBuilder.count() > 0) {
@@ -215,6 +216,7 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     protected ValuesSourceAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         if (serializeTargetValueType(in.getTransportVersion())) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -281,6 +281,7 @@ public class ValuesSourceConfig {
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings("this-escape")
     public ValuesSourceConfig(
         ValuesSourceType valuesSourceType,
         FieldContext fieldContext,

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
@@ -37,6 +37,7 @@ public class DfsSearchResult extends SearchPhaseResult {
     private int maxDoc;
     private SearchProfileDfsPhaseResult searchProfileDfsPhaseResult;
 
+    @SuppressWarnings("this-escape")
     public DfsSearchResult(StreamInput in) throws IOException {
         super(in);
         contextId = new ShardSearchContextId(in);
@@ -69,6 +70,7 @@ public class DfsSearchResult extends SearchPhaseResult {
         }
     }
 
+    @SuppressWarnings("this-escape")
     public DfsSearchResult(ShardSearchContextId contextId, SearchShardTarget shardTarget, ShardSearchRequest shardSearchRequest) {
         this.setSearchShardTarget(shardTarget);
         this.contextId = contextId;

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -51,6 +51,7 @@ public class FetchPhase {
 
     private final FetchSubPhase[] fetchSubPhases;
 
+    @SuppressWarnings("this-escape")
     public FetchPhase(List<FetchSubPhase> fetchSubPhases) {
         this.fetchSubPhases = fetchSubPhases.toArray(new FetchSubPhase[fetchSubPhases.size() + 1]);
         this.fetchSubPhases[fetchSubPhases.size()] = new InnerHitsPhase(this);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -131,6 +131,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     protected AbstractHighlighterBuilder(StreamInput in) throws IOException {
         preTags(in.readOptionalStringArray());
         postTags(in.readOptionalStringArray());

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -124,6 +124,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     public HighlightBuilder(StreamInput in) throws IOException {
         super(in);
         encoder(in.readOptionalString());
@@ -474,6 +475,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         /**
          * Read from a stream.
          */
+        @SuppressWarnings("this-escape")
         public Field(StreamInput in) throws IOException {
             super(in);
             name = in.readString();

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -96,6 +96,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     private volatile boolean timeExceeded = false;
 
     /** constructor for non-concurrent search */
+    @SuppressWarnings("this-escape")
     public ContextIndexSearcher(
         IndexReader reader,
         Similarity similarity,
@@ -107,6 +108,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     }
 
     /** constructor for concurrent search */
+    @SuppressWarnings("this-escape")
     public ContextIndexSearcher(
         IndexReader reader,
         Similarity similarity,
@@ -130,6 +132,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         );
     }
 
+    @SuppressWarnings("this-escape")
     ContextIndexSearcher(
         IndexReader reader,
         Similarity similarity,

--- a/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
@@ -24,6 +24,7 @@ public class LegacyReaderContext extends ReaderContext {
     private AggregatedDfs aggregatedDfs;
     private RescoreDocIds rescoreDocIds;
 
+    @SuppressWarnings("this-escape")
     public LegacyReaderContext(
         ShardSearchContextId id,
         IndexService indexService,

--- a/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
@@ -53,6 +53,7 @@ public class ReaderContext implements Releasable {
 
     private Map<String, Object> context;
 
+    @SuppressWarnings("this-escape")
     public ReaderContext(
         ShardSearchContextId id,
         IndexService indexService,

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -204,6 +204,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         );
     }
 
+    @SuppressWarnings("this-escape")
     public ShardSearchRequest(
         OriginalIndices originalIndices,
         ShardId shardId,
@@ -246,6 +247,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         this.forceSyntheticSource = forceSyntheticSource;
     }
 
+    @SuppressWarnings("this-escape")
     public ShardSearchRequest(ShardSearchRequest clone) {
         this.shardId = clone.shardId;
         this.shardRequestIndex = clone.shardRequestIndex;

--- a/server/src/main/java/org/elasticsearch/search/sort/BucketedSort.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/BucketedSort.java
@@ -455,6 +455,7 @@ public abstract class BucketedSort implements Releasable {
     public abstract static class ForDoubles extends BucketedSort {
         private DoubleArray values;
 
+        @SuppressWarnings("this-escape")
         public ForDoubles(BigArrays bigArrays, SortOrder sortOrder, DocValueFormat format, int bucketSize, ExtraData extra) {
             super(bigArrays, sortOrder, format, bucketSize, extra);
             boolean success = false;
@@ -555,6 +556,7 @@ public abstract class BucketedSort implements Releasable {
 
         private FloatArray values;
 
+        @SuppressWarnings("this-escape")
         public ForFloats(BigArrays bigArrays, SortOrder sortOrder, DocValueFormat format, int bucketSize, ExtraData extra) {
             super(bigArrays, sortOrder, format, bucketSize, extra);
             if (bucketSize > MAX_BUCKET_SIZE) {
@@ -646,6 +648,7 @@ public abstract class BucketedSort implements Releasable {
     public abstract static class ForLongs extends BucketedSort {
         private LongArray values;
 
+        @SuppressWarnings("this-escape")
         public ForLongs(BigArrays bigArrays, SortOrder sortOrder, DocValueFormat format, int bucketSize, ExtraData extra) {
             super(bigArrays, sortOrder, format, bucketSize, extra);
             boolean success = false;

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -101,6 +101,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     private String format;
 
     /** Copy constructor. */
+    @SuppressWarnings("this-escape")
     public FieldSortBuilder(FieldSortBuilder template) {
         this(template.fieldName);
         this.order(template.order());

--- a/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
@@ -44,6 +44,7 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     /**
      * Build a ScoreSortBuilder default to descending sort order.
      */
+    @SuppressWarnings("this-escape")
     public ScoreSortBuilder() {
         // order defaults to desc when sorting on the _score
         order(SortOrder.DESC);
@@ -52,6 +53,7 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     /**
      * Read from a stream.
      */
+    @SuppressWarnings("this-escape")
     public ScoreSortBuilder(StreamInput in) throws IOException {
         order(SortOrder.readFromStream(in));
     }

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -61,6 +61,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
     private Map<String, Suggestion<? extends Entry<? extends Option>>> suggestMap;
 
+    @SuppressWarnings("this-escape")
     public Suggest(List<Suggestion<? extends Entry<? extends Option>>> suggestions) {
         // we sort suggestions by their names to ensure iteration over suggestions are consistent
         // this is needed as we need to fill in suggestion docs in SearchPhaseController#sortDocs
@@ -70,7 +71,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         this.hasScoreDocs = filter(CompletionSuggestion.class).stream().anyMatch(CompletionSuggestion::hasScoreDocs);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({ "rawtypes", "unchecked", "this-escape" })
     public Suggest(StreamInput in) throws IOException {
         suggestions = (List) in.readNamedWriteableCollectionAsList(Suggestion.class);
         hasScoreDocs = filter(CompletionSuggestion.class).stream().anyMatch(CompletionSuggestion::hasScoreDocs);
@@ -216,6 +217,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
             this.size = size; // The suggested term size specified in request, only used for merging shard responses
         }
 
+        @SuppressWarnings("this-escape")
         public Suggestion(StreamInput in) throws IOException {
             name = in.readString();
             size = in.readVInt();
@@ -405,6 +407,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
             protected Entry() {}
 
+            @SuppressWarnings("this-escape")
             public Entry(StreamInput in) throws IOException {
                 text = in.readText();
                 offset = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -84,6 +84,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
 
     private final Object mutex;
 
+    @SuppressWarnings("this-escape")
     public InternalSnapshotsInfoService(
         final Settings settings,
         final ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -189,6 +189,7 @@ public class RestoreService implements ClusterStateApplier {
 
     private volatile boolean refreshRepositoryUuidOnRestore;
 
+    @SuppressWarnings("this-escape")
     public RestoreService(
         ClusterService clusterService,
         RepositoriesService repositoriesService,

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -88,6 +88,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     // Runs the tasks that promptly notify shards of aborted snapshots so that resources can be released ASAP
     private final ThrottledTaskRunner notifyOnAbortTaskRunner;
 
+    @SuppressWarnings("this-escape")
     public SnapshotShardsService(
         Settings settings,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -197,6 +197,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     private volatile int maxConcurrentOperations;
 
+    @SuppressWarnings("this-escape")
     public SnapshotsService(
         Settings settings,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -136,6 +136,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
     private final AtomicLong outboundConnectionCount = new AtomicLong(); // also used as a correlation ID for open/close logs
 
+    @SuppressWarnings("this-escape")
     public TcpTransport(
         Settings settings,
         TransportVersion version,

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -252,6 +252,7 @@ public class TransportService extends AbstractLifecycleComponent
         );
     }
 
+    @SuppressWarnings("this-escape")
     public TransportService(
         Settings settings,
         Transport transport,

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 
 public class ObjectMapperMergeTests extends ESTestCase {
 
+    @SuppressWarnings("this-escape")
     private final RootObjectMapper rootObjectMapper = createMapping(false, true, true, false);
 
     private RootObjectMapper createMapping(

--- a/server/src/test/java/org/elasticsearch/indices/analysis/lucene/SkipStartingWithDigitTokenFilter.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/lucene/SkipStartingWithDigitTokenFilter.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 public class SkipStartingWithDigitTokenFilter extends FilteringTokenFilter {
 
+    @SuppressWarnings("this-escape")
     private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
     private final long asciiDigitsToSkip;
 

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -24,6 +24,7 @@ import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER
 import static org.mockito.Mockito.mock;
 
 public class RestGetIndicesActionTests extends ESTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     /**

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
@@ -29,6 +29,7 @@ import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER
 import static org.mockito.Mockito.mock;
 
 public class RestPutIndexTemplateActionTests extends ESTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     private RestPutIndexTemplateAction action;

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 public class RestDeleteActionTests extends RestActionTestCase {
 
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class RestGetActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -42,6 +42,7 @@ public class RestGetSourceActionTests extends RestActionTestCase {
     private static RestRequest request = new FakeRestRequest();
     private static FakeRestChannel channel = new FakeRestChannel(request, true, 0);
     private static RestGetSourceResponseListener listener = new RestGetSourceResponseListener(channel, request);
+    @SuppressWarnings("this-escape")
     private final List<String> compatibleMediaType = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class RestIndexActionTests extends RestActionTestCase {
 
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     private final AtomicReference<ClusterState> clusterStateSupplier = new AtomicReference<>();

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class RestMultiGetActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     XContentType VND_TYPE = randomVendorType();
+    @SuppressWarnings("this-escape")
     List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(VND_TYPE, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestMultiTermVectorsActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestTermVectorsActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
@@ -30,6 +30,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.mock;
 
 public class RestUpdateActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     private RestUpdateAction action;

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class RestCountActionTests extends RestActionTestCase {
 
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestExplainActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestMultiSearchActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     private RestMultiSearchAction action;

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RestSearchActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     private RestSearchAction action;

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -292,10 +292,12 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             this(initialNodeCount, true, Settings.EMPTY);
         }
 
+        @SuppressWarnings("this-escape")
         public Cluster(int initialNodeCount, boolean allNodesMasterEligible, Settings nodeSettings) {
             this(initialNodeCount, allNodesMasterEligible, nodeSettings, () -> new StatusInfo(HEALTHY, "healthy-info"));
         }
 
+        @SuppressWarnings("this-escape")
         Cluster(int initialNodeCount, boolean allNodesMasterEligible, Settings nodeSettings, NodeHealthService nodeHealthService) {
             this.nodeHealthService = nodeHealthService;
             this.countingPageCacheRecycler = new CountingPageCacheRecycler();
@@ -975,6 +977,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             private ClearableRecycler clearableRecycler;
             private List<Runnable> blackholedRegisterOperations = new ArrayList<>();
 
+            @SuppressWarnings("this-escape")
             ClusterNode(int nodeIndex, boolean masterEligible, Settings nodeSettings, NodeHealthService nodeHealthService) {
                 this(
                     nodeIndex,

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -183,6 +183,7 @@ public class CoordinationStateTestCluster {
     final CoordinationMetadata.VotingConfiguration initialConfiguration;
     final long initialValue;
 
+    @SuppressWarnings("this-escape")
     public CoordinationStateTestCluster(List<DiscoveryNode> nodes, ElectionStrategy electionStrategy) {
         this.electionStrategy = electionStrategy;
         messages = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBootstrapCheckTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBootstrapCheckTestCase.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 public abstract class AbstractBootstrapCheckTestCase extends ESTestCase {
     protected final BootstrapContext emptyContext;
 
+    @SuppressWarnings("this-escape")
     public AbstractBootstrapCheckTestCase() {
         emptyContext = createTestContext(Settings.EMPTY, Metadata.EMPTY_METADATA);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/BackgroundIndexer.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BackgroundIndexer.java
@@ -98,6 +98,7 @@ public class BackgroundIndexer implements AutoCloseable {
      * @param autoStart   set to true to start indexing as soon as all threads have been created.
      * @param random      random instance to use
      */
+    @SuppressWarnings("this-escape")
     public BackgroundIndexer(
         final String index,
         final Client client,

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -238,8 +238,10 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         }
     };
 
+    @SuppressWarnings("this-escape")
     private final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(getNamedWriteables());
 
+    @SuppressWarnings("this-escape")
     private final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(getNamedXContents());
 
     private static final List<NamedXContentRegistry.Entry> namedXContents;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -78,6 +78,7 @@ public abstract class RestActionTestCase extends ESTestCase {
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeVerifier = new AtomicReference<>();
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeLocallyVerifier = new AtomicReference<>();
 
+        @SuppressWarnings("this-escape")
         public VerifyingClient(String testName) {
             super(testName);
             reset();

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -78,6 +78,7 @@ public class MockTransport extends StubbableTransport {
         );
     }
 
+    @SuppressWarnings("this-escape")
     public MockTransport() {
         super(new FakeTransport());
         setDefaultConnectBehavior(

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.util.resource.Resource;
 
 public class DefaultLocalClusterSpecBuilder extends AbstractLocalClusterSpecBuilder<ElasticsearchCluster> {
 
+    @SuppressWarnings("this-escape")
     public DefaultLocalClusterSpecBuilder() {
         super();
         this.apply(new FipsEnabledClusterConfigProvider());

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregator.java
@@ -29,6 +29,7 @@ public class HistoBackedHistogramAggregator extends AbstractHistogramAggregator 
 
     private final HistogramValuesSource.Histogram valuesSource;
 
+    @SuppressWarnings("this-escape")
     public HistoBackedHistogramAggregator(
         String name,
         AggregatorFactories factories,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/range/HistoBackedRangeAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/range/HistoBackedRangeAggregator.java
@@ -79,6 +79,7 @@ public abstract class HistoBackedRangeAggregator extends RangeAggregator {
         );
     }
 
+    @SuppressWarnings("this-escape")
     public HistoBackedRangeAggregator(
         String name,
         AggregatorFactories factories,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregator.java
@@ -41,6 +41,7 @@ public class HistoBackedAvgAggregator extends NumericMetricsAggregator.SingleVal
     DoubleArray compensations;
     DocValueFormat format;
 
+    @SuppressWarnings("this-escape")
     public HistoBackedAvgAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
@@ -32,6 +32,7 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
     final DocValueFormat formatter;
     DoubleArray maxes;
 
+    @SuppressWarnings("this-escape")
     public HistoBackedMaxAggregator(
         String name,
         ValuesSourceConfig config,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
@@ -32,6 +32,7 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
     final DocValueFormat format;
     DoubleArray mins;
 
+    @SuppressWarnings("this-escape")
     public HistoBackedMinAggregator(
         String name,
         ValuesSourceConfig config,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregator.java
@@ -41,6 +41,7 @@ public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleVal
     private DoubleArray sums;
     private DoubleArray compensations;
 
+    @SuppressWarnings("this-escape")
     public HistoBackedSumAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
@@ -36,6 +36,7 @@ public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.Si
     /** Count per bucket */
     LongArray counts;
 
+    @SuppressWarnings("this-escape")
     public HistoBackedValueCountAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/AbstractRateAggregator.java
@@ -34,6 +34,7 @@ public abstract class AbstractRateAggregator extends NumericMetricsAggregator.Si
     protected DoubleArray sums;
     protected DoubleArray compensations;
 
+    @SuppressWarnings("this-escape")
     public AbstractRateAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregator.java
@@ -48,6 +48,7 @@ public class TimeSeriesRateAggregator extends NumericMetricsAggregator.SingleVal
     private final Rounding.DateTimeUnit rateUnit;
 
     // Unused parameters are so that the constructor implements `RateAggregatorSupplier`
+    @SuppressWarnings("this-escape")
     protected TimeSeriesRateAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -97,10 +97,12 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
     private final AutoscalingLicenseChecker autoscalingLicenseChecker;
     private final SetOnce<ReservedAutoscalingPolicyAction> reservedAutoscalingPolicyAction = new SetOnce<>();
 
+    @SuppressWarnings("this-escape")
     public Autoscaling() {
         this(new AutoscalingLicenseChecker());
     }
 
+    @SuppressWarnings("this-escape")
     Autoscaling(final AutoscalingLicenseChecker autoscalingLicenseChecker) {
         this.autoscalingExtensions = new ArrayList<>(List.of(this));
         this.autoscalingLicenseChecker = Objects.requireNonNull(autoscalingLicenseChecker);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskCleaner.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskCleaner.java
@@ -45,6 +45,7 @@ public class ShardFollowTaskCleaner implements ClusterStateListener {
      */
     private final Set<ShardFollowTask> completing = Collections.synchronizedSet(new HashSet<>());
 
+    @SuppressWarnings("this-escape")
     public ShardFollowTaskCleaner(final ClusterService clusterService, final ThreadPool threadPool, final Client client) {
         this.threadPool = threadPool;
         this.client = client;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -100,6 +100,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
     private final TimeValue retentionLeaseRenewInterval;
     private volatile TimeValue waitForMetadataTimeOut;
 
+    @SuppressWarnings("this-escape")
     public ShardFollowTasksExecutor(Client client, ThreadPool threadPool, ClusterService clusterService, SettingsModule settingsModule) {
         super(ShardFollowTask.NAME, Ccr.CCR_THREAD_POOL_NAME);
         this.client = client;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
@@ -96,6 +96,7 @@ public class ClusterStateLicenseService extends AbstractLifecycleComponent
     private static final String ACKNOWLEDGEMENT_HEADER = "This license update requires acknowledgement. To acknowledge the license, "
         + "please read the following messages and update the license again, this time with the \"acknowledge=true\" parameter:";
 
+    @SuppressWarnings("this-escape")
     public ClusterStateLicenseService(
         Settings settings,
         ThreadPool threadPool,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesResponse.java
@@ -28,6 +28,7 @@ public abstract class AbstractGetResourcesResponse<T extends ToXContent & Writea
 
     protected AbstractGetResourcesResponse() {}
 
+    @SuppressWarnings("this-escape")
     protected AbstractGetResourcesResponse(StreamInput in) throws IOException {
         super(in);
         resources = new QueryPage<>(in, getReader());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
@@ -32,6 +32,7 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
     private final NodeClient client;
     private final List<XPackInfoFeatureAction> infoActions;
 
+    @SuppressWarnings("this-escape")
     @Inject
     public TransportXPackInfoAction(
         TransportService transportService,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
@@ -30,6 +30,7 @@ public class TransportXPackUsageAction extends TransportMasterNodeAction<XPackUs
     private final NodeClient client;
     private final List<XPackUsageFeatureAction> usageActions;
 
+    @SuppressWarnings("this-escape")
     @Inject
     public TransportXPackUsageAction(
         ThreadPool threadPool,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncTask.java
@@ -25,6 +25,7 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
     private volatile long expirationTimeMillis;
     private final List<ActionListener<Response>> completionListeners;
 
+    @SuppressWarnings("this-escape")
     public StoredAsyncTask(
         long id,
         String type,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowParameters.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowParameters.java
@@ -189,6 +189,7 @@ public class FollowParameters implements Writeable, ToXContentObject {
         return e;
     }
 
+    @SuppressWarnings("this-escape")
     public FollowParameters(StreamInput in) throws IOException {
         fromStreamInput(in);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutFollowAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutFollowAction.java
@@ -188,6 +188,7 @@ public final class PutFollowAction extends ActionType<PutFollowAction.Response> 
             return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
         }
 
+        @SuppressWarnings("this-escape")
         public Request(StreamInput in) throws IOException {
             super(in);
             this.remoteCluster = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -45,6 +45,7 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
     // min time to trigger delayed execution, this avoids scheduling tasks with super short amount of time
     private static final TimeValue MIN_THROTTLE_WAIT_TIME = TimeValue.timeValueMillis(10);
 
+    @SuppressWarnings("this-escape")
     private final ActionListener<SearchResponse> searchResponseListener = ActionListener.wrap(
         this::onSearchResponse,
         this::finishWithSearchFailure

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDataFrameAnalyticsAction.java
@@ -48,6 +48,7 @@ public class DeleteDataFrameAnalyticsAction extends ActionType<AcknowledgedRespo
             force = in.readBoolean();
         }
 
+        @SuppressWarnings("this-escape")
         public Request() {
             timeout(DEFAULT_TIMEOUT);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
@@ -31,10 +31,12 @@ public class GetDataFrameAnalyticsAction extends ActionType<GetDataFrameAnalytic
 
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
+        @SuppressWarnings("this-escape")
         public Request() {
             setAllowNoResources(true);
         }
 
+        @SuppressWarnings("this-escape")
         public Request(String id) {
             setResourceId(id);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
@@ -49,6 +49,7 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
         }
 
+        @SuppressWarnings("this-escape")
         public Request() {
             local(true);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
@@ -29,10 +29,12 @@ public class GetFiltersAction extends ActionType<GetFiltersAction.Response> {
 
     public static class Request extends AbstractGetResourcesRequest {
 
+        @SuppressWarnings("this-escape")
         public Request() {
             setAllowNoResources(true);
         }
 
+        @SuppressWarnings("this-escape")
         public Request(String filterId) {
             setResourceId(filterId);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
@@ -47,6 +47,7 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
             this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
         }
 
+        @SuppressWarnings("this-escape")
         public Request() {
             local(true);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -136,6 +136,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
             this(id, null, null);
         }
 
+        @SuppressWarnings("this-escape")
         public Request(String id, List<String> tags, Set<String> includes) {
             setResourceId(id);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
@@ -56,10 +56,12 @@ public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStat
 
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
+        @SuppressWarnings("this-escape")
         public Request() {
             setAllowNoResources(true);
         }
 
+        @SuppressWarnings("this-escape")
         public Request(String id) {
             setResourceId(id);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
@@ -90,6 +90,7 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
             expandedIds = new HashSet<>(Arrays.asList(in.readStringArray()));
         }
 
+        @SuppressWarnings("this-escape")
         public Request() {
             setTimeout(DEFAULT_TIMEOUT);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
@@ -75,6 +75,7 @@ public class Classification implements Evaluation {
      */
     private final List<EvaluationMetric> metrics;
 
+    @SuppressWarnings("this-escape")
     public Classification(
         String actualField,
         @Nullable String predictedField,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
@@ -75,6 +75,7 @@ public class OutlierDetection implements Evaluation {
      */
     private final List<EvaluationMetric> metrics;
 
+    @SuppressWarnings("this-escape")
     public OutlierDetection(String actualField, String predictedProbabilityField, @Nullable List<EvaluationMetric> metrics) {
         this.fields = new EvaluationFields(
             ExceptionsHelper.requireNonNull(actualField, ACTUAL_FIELD),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
@@ -69,6 +69,7 @@ public class Regression implements Evaluation {
      */
     private final List<EvaluationMetric> metrics;
 
+    @SuppressWarnings("this-escape")
     public Regression(String actualField, String predictedField, @Nullable List<EvaluationMetric> metrics) {
         this.fields = new EvaluationFields(
             ExceptionsHelper.requireNonNull(actualField, ACTUAL_FIELD),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -137,6 +137,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             : Math.max(maxAssignedAllocations, totalCurrentAllocations());
     }
 
+    @SuppressWarnings("this-escape")
     public TrainedModelAssignment(StreamInput in) throws IOException {
         this.taskParams = new StartTrainedModelDeploymentAction.TaskParams(in);
         this.nodeRoutingTable = in.readOrderedMap(StreamInput::readString, RoutingInfo::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
@@ -302,6 +302,7 @@ public class Tree implements LenientlyParsedTrainedModel, StrictlyParsedTrainedM
         private TargetType targetType = TargetType.REGRESSION;
         private List<String> classificationLabels;
 
+        @SuppressWarnings("this-escape")
         public Builder() {
             nodes = new ArrayList<>();
             // allocate space in the root node and set to a leaf

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -464,6 +464,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         private Boolean multivariateByFields;
         private TimeValue modelPruneWindow;
 
+        @SuppressWarnings("this-escape")
         public Builder(List<Detector> detectors) {
             setDetectors(detectors);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
@@ -161,6 +161,7 @@ public class DataCounts implements ToXContentObject, Writeable {
     private Date latestSparseBucketTimeStamp;
     private Instant logTime;
 
+    @SuppressWarnings("this-escape")
     public DataCounts(
         String jobId,
         long processedRecordCount,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
@@ -147,6 +147,7 @@ public class ForecastRequestStats implements ToXContentObject, Writeable {
         this.status = forecastRequestStats.status;
     }
 
+    @SuppressWarnings("this-escape")
     public ForecastRequestStats(StreamInput in) throws IOException {
         jobId = in.readString();
         forecastId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/AbstractCreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/AbstractCreateApiKeyRequest.java
@@ -39,6 +39,7 @@ public abstract class AbstractCreateApiKeyRequest extends ActionRequest {
         this.id = UUIDs.base64UUID(); // because auditing can currently only catch requests but not responses,
     }
 
+    @SuppressWarnings("this-escape")
     public AbstractCreateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
         this.id = doReadId(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -34,6 +34,7 @@ public class RealmConfig {
     private final Settings settings;
     private final ThreadContext threadContext;
 
+    @SuppressWarnings("this-escape")
     public RealmConfig(RealmIdentifier identifier, Settings settings, Environment env, ThreadContext threadContext) {
         this.identifier = identifier;
         this.settings = settings;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ActionClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ActionClusterPrivilege.java
@@ -39,6 +39,7 @@ public class ActionClusterPrivilege implements NamedClusterPrivilege {
      * @param allowedActionPatterns  a set of cluster action patterns
      * @param excludedActionPatterns a set of cluster action patterns
      */
+    @SuppressWarnings("this-escape")
     public ActionClusterPrivilege(final String name, final Set<String> allowedActionPatterns, final Set<String> excludedActionPatterns) {
         this.name = name;
         this.allowedActionPatterns = allowedActionPatterns;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -151,6 +151,7 @@ public class SSLService {
      * Create a new SSLService using the provided {@link SslConfiguration} instances. The ssl
      * contexts created from these configurations will be cached.
      */
+    @SuppressWarnings("this-escape")
     public SSLService(Environment environment, Map<String, SslConfiguration> sslConfigurations) {
         this.env = environment;
         this.settings = env.settings();
@@ -159,6 +160,7 @@ public class SSLService {
         this.sslContexts = loadSslConfigurations(this.sslConfigurations);
     }
 
+    @SuppressWarnings("this-escape")
     @Deprecated
     public SSLService(Settings settings, Environment environment) {
         this.env = environment;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoader.java
@@ -40,6 +40,7 @@ public class SslSettingsLoader extends SslConfigurationLoader {
     private final Map<String, Setting<?>> standardSettings;
     private final Map<String, Setting<?>> disabledSettings;
 
+    @SuppressWarnings("this-escape")
     public SslSettingsLoader(Settings settings, String settingPrefix, boolean acceptNonSecurePasswords) {
         super(settingPrefix);
         this.settings = settings;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -86,6 +86,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     protected final ConcurrentMap<String, AtomicBoolean> pipelineCreationsInProgress = new ConcurrentHashMap<>();
     protected final List<LifecyclePolicy> lifecyclePolicies;
 
+    @SuppressWarnings("this-escape")
     public IndexTemplateRegistry(
         Settings nodeSettings,
         ClusterService clusterService,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -51,12 +51,14 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
      * Constructs a new term enum request against the provided indices. No indices provided means it will
      * run against all indices.
      */
+    @SuppressWarnings("this-escape")
     public TermsEnumRequest(String... indices) {
         super(indices);
         indicesOptions(DEFAULT_INDICES_OPTIONS);
         timeout(DEFAULT_TIMEOUT);
     }
 
+    @SuppressWarnings("this-escape")
     public TermsEnumRequest(TermsEnumRequest clone) {
         this.field = clone.field;
         this.string = clone.string;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -553,6 +553,7 @@ public class TextStructure implements ToXContentObject, Writeable {
             this(Format.SEMI_STRUCTURED_TEXT);
         }
 
+        @SuppressWarnings("this-escape")
         public Builder(Format format) {
             setFormat(format);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -58,6 +58,7 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
         // used internally to expand the queried id expression
         private List<String> expandedIds;
 
+        @SuppressWarnings("this-escape")
         public Request(String id, @Nullable TimeValue timeout) {
             setTimeout(timeout);
             if (Strings.isNullOrEmpty(id) || id.equals("*")) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ScheduleNowTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ScheduleNowTransformAction.java
@@ -41,6 +41,7 @@ public class ScheduleNowTransformAction extends ActionType<ScheduleNowTransformA
 
         private final String id;
 
+        @SuppressWarnings("this-escape")
         public Request(String id, TimeValue timeout) {
             this.id = ExceptionsHelper.requireNonNull(id, TransformField.ID.getPreferredName());
             this.setTimeout(ExceptionsHelper.requireNonNull(timeout, TransformField.TIMEOUT.getPreferredName()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
@@ -54,6 +54,7 @@ public class StopTransformAction extends ActionType<StopTransformAction.Response
         private final boolean waitForCheckpoint;
         private Set<String> expandedIds;
 
+        @SuppressWarnings("this-escape")
         public Request(
             String id,
             boolean waitForCompletion,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -50,6 +50,7 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
         private TransformConfig config;
         private AuthorizationState authState;
 
+        @SuppressWarnings("this-escape")
         public Request(TransformConfigUpdate update, String id, boolean deferValidation, TimeValue timeout) {
             this.update = update;
             this.id = id;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -207,6 +207,7 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
         return NAME + "-" + transformId;
     }
 
+    @SuppressWarnings("this-escape")
     public TransformConfig(
         final String id,
         final SourceConfig source,
@@ -242,6 +243,7 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
         this.transformVersion = version == null ? null : TransformConfigVersion.fromString(version);
     }
 
+    @SuppressWarnings("this-escape")
     public TransformConfig(final StreamInput in) throws IOException {
         id = in.readString();
         source = new SourceConfig(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
@@ -107,6 +107,7 @@ public class TransformConfigUpdate implements Writeable {
         this.retentionPolicyConfig = retentionPolicyConfig;
     }
 
+    @SuppressWarnings("this-escape")
     public TransformConfigUpdate(final StreamInput in) throws IOException {
         source = in.readOptionalWriteable(SourceConfig::new);
         dest = in.readOptionalWriteable(DestConfig::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/common/stats/Counters.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/common/stats/Counters.java
@@ -25,6 +25,7 @@ public class Counters implements Writeable {
 
     private Map<String, Long> counters = new HashMap<>();
 
+    @SuppressWarnings("this-escape")
     public Counters(StreamInput in) throws IOException {
         int numCounters = in.readVInt();
         for (int i = 0; i < numCounters; i++) {
@@ -32,6 +33,7 @@ public class Counters implements Writeable {
         }
     }
 
+    @SuppressWarnings("this-escape")
     public Counters(String... names) {
         for (String name : names) {
             set(name);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/TransformRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/TransformRegistry.java
@@ -22,6 +22,7 @@ public class TransformRegistry {
         String,
         TransformFactory<? extends Transform, ? extends Transform.Result, ? extends ExecutableTransform<?, ?>>> factories;
 
+    @SuppressWarnings("this-escape")
     public TransformRegistry(
         Map<String, TransformFactory<? extends Transform, ? extends Transform.Result, ? extends ExecutableTransform<?, ?>>> factories
     ) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/chain/ChainTransform.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/chain/ChainTransform.java
@@ -147,6 +147,7 @@ public class ChainTransform implements Transform {
 
         private final List<Transform> transforms = new ArrayList<>();
 
+        @SuppressWarnings("this-escape")
         public Builder(Transform... transforms) {
             add(transforms);
         }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
@@ -19,6 +19,7 @@ public class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
 
     private final AbstractDownsampleFieldProducer fieldProducer;
 
+    @SuppressWarnings("this-escape")
     protected AggregateMetricFieldValueFetcher(
         MappedFieldType fieldType,
         AggregateDoubleMetricFieldType aggMetricFieldType,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/EqlFunctionRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/EqlFunctionRegistry.java
@@ -42,6 +42,7 @@ import static java.util.Collections.unmodifiableList;
 
 public class EqlFunctionRegistry extends FunctionRegistry {
 
+    @SuppressWarnings("this-escape")
     public EqlFunctionRegistry() {
         register(functions());
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
@@ -40,6 +40,7 @@ public class ToNumber extends ScalarFunction implements OptionalArgument {
 
     private final Expression value, base;
 
+    @SuppressWarnings("this-escape")
     public ToNumber(Source source, Expression value, Expression base) {
         super(source, Arrays.asList(value, base != null ? base : new Literal(source, null, DataTypes.NULL)));
         this.value = value;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
@@ -44,6 +44,7 @@ public class Between extends CaseInsensitiveScalarFunction implements OptionalAr
 
     private final Expression input, left, right, greedy;
 
+    @SuppressWarnings("this-escape")
     public Between(Source source, Expression input, Expression left, Expression right, Expression greedy, boolean caseInsensitive) {
         super(source, Arrays.asList(input, left, right, defaultGreedy(greedy)), caseInsensitive);
         this.input = input;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
@@ -40,6 +40,7 @@ public class IndexOf extends CaseInsensitiveScalarFunction implements OptionalAr
 
     private final Expression input, substring, start;
 
+    @SuppressWarnings("this-escape")
     public IndexOf(Source source, Expression input, Expression substring, Expression start, boolean caseInsensitive) {
         super(source, asList(input, substring, start != null ? start : new Literal(source, null, DataTypes.NULL)), caseInsensitive);
         this.input = input;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
@@ -38,10 +38,12 @@ public class Match extends BaseSurrogateFunction {
     private final List<Expression> patterns;
     private final boolean caseInsensitive;
 
+    @SuppressWarnings("this-escape")
     public Match(Source source, Expression field, List<Expression> patterns, boolean caseInsensitive) {
         this(source, CollectionUtils.combine(singletonList(field), patterns), caseInsensitive);
     }
 
+    @SuppressWarnings("this-escape")
     private Match(Source source, List<Expression> children, boolean caseInsensitive) {
         super(source, children);
         this.field = children().get(0);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
@@ -42,6 +42,7 @@ public class Substring extends ScalarFunction implements OptionalArgument {
 
     private final Expression input, start, end;
 
+    @SuppressWarnings("this-escape")
     public Substring(Source source, Expression input, Expression start, Expression end) {
         super(source, Arrays.asList(input, start, end != null ? end : new Literal(source, null, DataTypes.NULL)));
         this.input = input;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -73,6 +73,7 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
     private final TransportService transportService;
     private final AsyncTaskManagementService<EqlSearchRequest, EqlSearchResponse, EqlSearchTask> asyncTaskManagementService;
 
+    @SuppressWarnings("this-escape")
     @Inject
     public TransportEqlSearchAction(
         Settings settings,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -59,6 +59,7 @@ public class HashAggregationOperator implements Operator {
 
     private final List<GroupingAggregator> aggregators;
 
+    @SuppressWarnings("this-escape")
     public HashAggregationOperator(
         List<GroupingAggregator.Factory> aggregators,
         Supplier<BlockHash> blockHash,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -87,6 +87,7 @@ import java.util.Locale;
 
 public class EsqlFunctionRegistry extends FunctionRegistry {
 
+    @SuppressWarnings("this-escape")
     public EsqlFunctionRegistry() {
         register(functions());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
@@ -42,6 +42,7 @@ public class UnsupportedAttribute extends FieldAttribute implements Unresolvable
         this(source, name, field, customMessage, null);
     }
 
+    @SuppressWarnings("this-escape")
     public UnsupportedAttribute(Source source, String name, UnsupportedEsField field, String customMessage, NameId id) {
         super(source, null, name, field, null, Nullability.TRUE, id, false);
         this.hasCustomMessage = customMessage != null;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -44,6 +44,7 @@ public class Case extends ScalarFunction implements EvaluatorMapper {
     private final Expression elseValue;
     private DataType dataType;
 
+    @SuppressWarnings("this-escape")
     public Case(Source source, Expression first, List<Expression> rest) {
         super(source, Stream.concat(Stream.of(first), rest.stream()).toList());
         int conditionCount = children().size() / 2;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseLexer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseLexer.java
@@ -127,7 +127,7 @@ public class EsqlBaseLexer extends Lexer {
   }
 
 
-  public EsqlBaseLexer(CharStream input) {
+  @SuppressWarnings("this-escape") public EsqlBaseLexer(CharStream input) {
     super(input);
     _interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
   }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParser.java
@@ -138,7 +138,7 @@ public class EsqlBaseParser extends Parser {
   @Override
   public ATN getATN() { return _ATN; }
 
-  public EsqlBaseParser(TokenStream input) {
+  @SuppressWarnings("this-escape") public EsqlBaseParser(TokenStream input) {
     super(input);
     _interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
   }
@@ -212,7 +212,7 @@ public class EsqlBaseParser extends Parser {
     public ProcessingCommandContext processingCommand() {
       return getRuleContext(ProcessingCommandContext.class,0);
     }
-    public CompositeQueryContext(QueryContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public CompositeQueryContext(QueryContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterCompositeQuery(this);
@@ -232,7 +232,7 @@ public class EsqlBaseParser extends Parser {
     public SourceCommandContext sourceCommand() {
       return getRuleContext(SourceCommandContext.class,0);
     }
-    public SingleCommandQueryContext(QueryContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public SingleCommandQueryContext(QueryContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterSingleCommandQuery(this);
@@ -632,7 +632,7 @@ public class EsqlBaseParser extends Parser {
     public BooleanExpressionContext booleanExpression() {
       return getRuleContext(BooleanExpressionContext.class,0);
     }
-    public LogicalNotContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public LogicalNotContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterLogicalNot(this);
@@ -652,7 +652,7 @@ public class EsqlBaseParser extends Parser {
     public ValueExpressionContext valueExpression() {
       return getRuleContext(ValueExpressionContext.class,0);
     }
-    public BooleanDefaultContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public BooleanDefaultContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterBooleanDefault(this);
@@ -675,7 +675,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode IS() { return getToken(EsqlBaseParser.IS, 0); }
     public TerminalNode NULL() { return getToken(EsqlBaseParser.NULL, 0); }
     public TerminalNode NOT() { return getToken(EsqlBaseParser.NOT, 0); }
-    public IsNullContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public IsNullContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterIsNull(this);
@@ -695,7 +695,7 @@ public class EsqlBaseParser extends Parser {
     public RegexBooleanExpressionContext regexBooleanExpression() {
       return getRuleContext(RegexBooleanExpressionContext.class,0);
     }
-    public RegexExpressionContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public RegexExpressionContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterRegexExpression(this);
@@ -726,7 +726,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode COMMA(int i) {
       return getToken(EsqlBaseParser.COMMA, i);
     }
-    public LogicalInContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public LogicalInContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterLogicalIn(this);
@@ -754,7 +754,7 @@ public class EsqlBaseParser extends Parser {
     }
     public TerminalNode AND() { return getToken(EsqlBaseParser.AND, 0); }
     public TerminalNode OR() { return getToken(EsqlBaseParser.OR, 0); }
-    public LogicalBinaryContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public LogicalBinaryContext(BooleanExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterLogicalBinary(this);
@@ -1056,7 +1056,7 @@ public class EsqlBaseParser extends Parser {
     public OperatorExpressionContext operatorExpression() {
       return getRuleContext(OperatorExpressionContext.class,0);
     }
-    public ValueExpressionDefaultContext(ValueExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ValueExpressionDefaultContext(ValueExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterValueExpressionDefault(this);
@@ -1084,7 +1084,7 @@ public class EsqlBaseParser extends Parser {
     public OperatorExpressionContext operatorExpression(int i) {
       return getRuleContext(OperatorExpressionContext.class,i);
     }
-    public ComparisonContext(ValueExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ComparisonContext(ValueExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterComparison(this);
@@ -1157,7 +1157,7 @@ public class EsqlBaseParser extends Parser {
     public PrimaryExpressionContext primaryExpression() {
       return getRuleContext(PrimaryExpressionContext.class,0);
     }
-    public OperatorExpressionDefaultContext(OperatorExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public OperatorExpressionDefaultContext(OperatorExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterOperatorExpressionDefault(this);
@@ -1188,7 +1188,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode PERCENT() { return getToken(EsqlBaseParser.PERCENT, 0); }
     public TerminalNode PLUS() { return getToken(EsqlBaseParser.PLUS, 0); }
     public TerminalNode MINUS() { return getToken(EsqlBaseParser.MINUS, 0); }
-    public ArithmeticBinaryContext(OperatorExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ArithmeticBinaryContext(OperatorExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterArithmeticBinary(this);
@@ -1211,7 +1211,7 @@ public class EsqlBaseParser extends Parser {
     }
     public TerminalNode MINUS() { return getToken(EsqlBaseParser.MINUS, 0); }
     public TerminalNode PLUS() { return getToken(EsqlBaseParser.PLUS, 0); }
-    public ArithmeticUnaryContext(OperatorExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ArithmeticUnaryContext(OperatorExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterArithmeticUnary(this);
@@ -1370,7 +1370,7 @@ public class EsqlBaseParser extends Parser {
     public QualifiedNameContext qualifiedName() {
       return getRuleContext(QualifiedNameContext.class,0);
     }
-    public DereferenceContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public DereferenceContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterDereference(this);
@@ -1390,7 +1390,7 @@ public class EsqlBaseParser extends Parser {
     public ConstantContext constant() {
       return getRuleContext(ConstantContext.class,0);
     }
-    public ConstantDefaultContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ConstantDefaultContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterConstantDefault(this);
@@ -1412,7 +1412,7 @@ public class EsqlBaseParser extends Parser {
       return getRuleContext(BooleanExpressionContext.class,0);
     }
     public TerminalNode RP() { return getToken(EsqlBaseParser.RP, 0); }
-    public ParenthesizedExpressionContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ParenthesizedExpressionContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterParenthesizedExpression(this);
@@ -1444,7 +1444,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode COMMA(int i) {
       return getToken(EsqlBaseParser.COMMA, i);
     }
-    public FunctionExpressionContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public FunctionExpressionContext(PrimaryExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterFunctionExpression(this);
@@ -2355,7 +2355,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode COMMA(int i) {
       return getToken(EsqlBaseParser.COMMA, i);
     }
-    public BooleanArrayLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public BooleanArrayLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterBooleanArrayLiteral(this);
@@ -2375,7 +2375,7 @@ public class EsqlBaseParser extends Parser {
     public DecimalValueContext decimalValue() {
       return getRuleContext(DecimalValueContext.class,0);
     }
-    public DecimalLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public DecimalLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterDecimalLiteral(this);
@@ -2393,7 +2393,7 @@ public class EsqlBaseParser extends Parser {
   @SuppressWarnings("CheckReturnValue")
   public static class NullLiteralContext extends ConstantContext {
     public TerminalNode NULL() { return getToken(EsqlBaseParser.NULL, 0); }
-    public NullLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public NullLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterNullLiteral(this);
@@ -2414,7 +2414,7 @@ public class EsqlBaseParser extends Parser {
       return getRuleContext(IntegerValueContext.class,0);
     }
     public TerminalNode UNQUOTED_IDENTIFIER() { return getToken(EsqlBaseParser.UNQUOTED_IDENTIFIER, 0); }
-    public QualifiedIntegerLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public QualifiedIntegerLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterQualifiedIntegerLiteral(this);
@@ -2443,7 +2443,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode COMMA(int i) {
       return getToken(EsqlBaseParser.COMMA, i);
     }
-    public StringArrayLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public StringArrayLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterStringArrayLiteral(this);
@@ -2463,7 +2463,7 @@ public class EsqlBaseParser extends Parser {
     public StringContext string() {
       return getRuleContext(StringContext.class,0);
     }
-    public StringLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public StringLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterStringLiteral(this);
@@ -2492,7 +2492,7 @@ public class EsqlBaseParser extends Parser {
     public TerminalNode COMMA(int i) {
       return getToken(EsqlBaseParser.COMMA, i);
     }
-    public NumericArrayLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public NumericArrayLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterNumericArrayLiteral(this);
@@ -2510,7 +2510,7 @@ public class EsqlBaseParser extends Parser {
   @SuppressWarnings("CheckReturnValue")
   public static class InputParamContext extends ConstantContext {
     public TerminalNode PARAM() { return getToken(EsqlBaseParser.PARAM, 0); }
-    public InputParamContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public InputParamContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterInputParam(this);
@@ -2530,7 +2530,7 @@ public class EsqlBaseParser extends Parser {
     public IntegerValueContext integerValue() {
       return getRuleContext(IntegerValueContext.class,0);
     }
-    public IntegerLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public IntegerLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterIntegerLiteral(this);
@@ -2550,7 +2550,7 @@ public class EsqlBaseParser extends Parser {
     public BooleanValueContext booleanValue() {
       return getRuleContext(BooleanValueContext.class,0);
     }
-    public BooleanLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public BooleanLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterBooleanLiteral(this);
@@ -4003,7 +4003,7 @@ public class EsqlBaseParser extends Parser {
   public static class ShowInfoContext extends ShowCommandContext {
     public TerminalNode SHOW() { return getToken(EsqlBaseParser.SHOW, 0); }
     public TerminalNode INFO() { return getToken(EsqlBaseParser.INFO, 0); }
-    public ShowInfoContext(ShowCommandContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ShowInfoContext(ShowCommandContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterShowInfo(this);
@@ -4022,7 +4022,7 @@ public class EsqlBaseParser extends Parser {
   public static class ShowFunctionsContext extends ShowCommandContext {
     public TerminalNode SHOW() { return getToken(EsqlBaseParser.SHOW, 0); }
     public TerminalNode FUNCTIONS() { return getToken(EsqlBaseParser.FUNCTIONS, 0); }
-    public ShowFunctionsContext(ShowCommandContext ctx) { copyFrom(ctx); }
+    @SuppressWarnings("this-escape") public ShowFunctionsContext(ShowCommandContext ctx) { copyFrom(ctx); }
     @Override
     public void enterRule(ParseTreeListener listener) {
       if ( listener instanceof EsqlBaseParserListener ) ((EsqlBaseParserListener)listener).enterShowFunctions(this);

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class RestGraphActionTests extends RestActionTestCase {
+    @SuppressWarnings("this-escape")
     private final List<String> compatibleMediaType = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -90,6 +90,7 @@ public class IndexLifecycleService
     private final LongSupplier nowSupplier;
     private SchedulerEngine.Job scheduledJob;
 
+    @SuppressWarnings("this-escape")
     public IndexLifecycleService(
         Settings settings,
         Client client,

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -121,6 +121,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
         private final Parameter<Boolean> ignoreMalformed;
 
+        @SuppressWarnings("this-escape")
         private final Parameter<EnumSet<Metric>> metrics = new Parameter<>(Names.METRICS, false, () -> Defaults.METRICS, (n, c, o) -> {
             @SuppressWarnings("unchecked")
             List<String> metricsList = (List<String>) o;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -99,6 +99,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             this(name, IGNORE_MALFORMED_SETTING.get(settings), mode);
         }
 
+        @SuppressWarnings("this-escape")
         public Builder(String name, boolean ignoreMalformedByDefault, IndexMode mode) {
             super(name);
             this.ignoreMalformed = Parameter.explicitBoolParam(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
@@ -85,6 +85,7 @@ public class MlInitializationService implements ClusterStateListener {
     }
 
     // For testing
+    @SuppressWarnings("this-escape")
     public MlInitializationService(
         Client client,
         ThreadPool threadPool,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -46,6 +46,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
     private volatile boolean isMaster;
     private volatile int allocatedProcessorsScale;
 
+    @SuppressWarnings("this-escape")
     public MlAutoscalingDeciderService(
         MlMemoryTracker memoryTracker,
         Settings settings,
@@ -55,6 +56,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
         this(new NodeLoadDetector(memoryTracker), settings, nodeAvailabilityZoneMapper, clusterService, System::currentTimeMillis);
     }
 
+    @SuppressWarnings("this-escape")
     MlAutoscalingDeciderService(
         NodeLoadDetector nodeLoadDetector,
         Settings settings,

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -39,6 +39,7 @@ public class CleanerService extends AbstractLifecycleComponent {
 
     private volatile TimeValue globalRetention;
 
+    @SuppressWarnings("this-escape")
     CleanerService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, ExecutionScheduler executionScheduler) {
         this.threadPool = threadPool;
         this.genericExecutor = threadPool.generic();
@@ -50,6 +51,7 @@ public class CleanerService extends AbstractLifecycleComponent {
         clusterSettings.addSettingsUpdateConsumer(MonitoringField.HISTORY_DURATION, this::setGlobalRetention);
     }
 
+    @SuppressWarnings("this-escape")
     public CleanerService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool) {
         this(settings, clusterSettings, threadPool, new DefaultExecutionScheduler());
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
@@ -51,6 +51,7 @@ public class Exporters extends AbstractLifecycleComponent {
     private final XPackLicenseState licenseState;
     private final ThreadContext threadContext;
 
+    @SuppressWarnings("this-escape")
     public Exporters(
         Settings settings,
         Map<String, Exporter.Factory> factories,

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -108,6 +108,7 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
 
     private long stateInitializedTime;
 
+    @SuppressWarnings("this-escape")
     public LocalExporter(
         Exporter.Config config,
         Client client,

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpResourceTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
  */
 public class HttpResourceTests extends ESTestCase {
 
+    @SuppressWarnings("this-escape")
     private final String owner = getTestName();
     private final RestClient mockClient = mock(RestClient.class);
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/NodeFailureListenerTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/NodeFailureListenerTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 public class NodeFailureListenerTests extends ESTestCase {
 
     private final Sniffer sniffer = mock(Sniffer.class);
+    @SuppressWarnings("this-escape")
     private final HttpResource resource = new MockHttpResource(getTestName(), false);
     private final Node node = new Node(new HttpHost("localhost", 9200));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
@@ -38,6 +38,7 @@ public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResou
     private final MultiHttpResource mockWatches = mock(MultiHttpResource.class);
 
     private final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, mockWatches);
+    @SuppressWarnings("this-escape")
     private final Map<String, String> expectedParameters = getParameters(resource.getDefaultParameters(), GET_EXISTS, XPACK_DOES_NOT_EXIST);
 
     public void testDoCheckIgnoresClientWhenNotElectedMaster() {

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/FailShardsOnInvalidLicenseClusterListener.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/FailShardsOnInvalidLicenseClusterListener.java
@@ -38,6 +38,7 @@ public class FailShardsOnInvalidLicenseClusterListener implements LicenseStateLi
 
     private boolean allowed;
 
+    @SuppressWarnings("this-escape")
     public FailShardsOnInvalidLicenseClusterListener(XPackLicenseState xPackLicenseState, RerouteService rerouteService) {
         this.xPackLicenseState = xPackLicenseState;
         this.rerouteService = rerouteService;

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene60/Lucene60MetadataOnlyPointsReader.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene60/Lucene60MetadataOnlyPointsReader.java
@@ -41,6 +41,7 @@ public class Lucene60MetadataOnlyPointsReader extends PointsReader {
     final Map<Integer, PointValues> readers = new HashMap<>();
 
     /** Sole constructor */
+    @SuppressWarnings("this-escape")
     public Lucene60MetadataOnlyPointsReader(SegmentReadState readState) throws IOException {
         this.readState = readState;
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/extractor/AbstractFieldHitExtractor.java
@@ -69,6 +69,7 @@ public abstract class AbstractFieldHitExtractor implements HitExtractor {
         }
     }
 
+    @SuppressWarnings("this-escape")
     protected AbstractFieldHitExtractor(StreamInput in) throws IOException {
         fieldName = in.readString();
         String typeName = in.readOptionalString();

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
@@ -169,6 +169,7 @@ public class AttributeMap<E> implements Map<Attribute, E> {
         delegate = new LinkedHashMap<>();
     }
 
+    @SuppressWarnings("this-escape")
     public AttributeMap(Attribute key, E value) {
         delegate = new LinkedHashMap<>();
         add(key, value);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/ExpressionSet.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/ExpressionSet.java
@@ -34,6 +34,7 @@ public class ExpressionSet<E extends Expression> implements Set<E> {
         super();
     }
 
+    @SuppressWarnings("this-escape")
     public ExpressionSet(Collection<? extends E> c) {
         addAll(c);
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedAttribute.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/UnresolvedAttribute.java
@@ -35,6 +35,7 @@ public class UnresolvedAttribute extends Attribute implements Unresolvable {
         this(source, name, qualifier, null, unresolvedMessage, null);
     }
 
+    @SuppressWarnings("this-escape")
     public UnresolvedAttribute(
         Source source,
         String name,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionRegistry.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionRegistry.java
@@ -47,10 +47,12 @@ public class FunctionRegistry {
     /**
      * Register the given function definitions with this registry.
      */
+    @SuppressWarnings("this-escape")
     public FunctionRegistry(FunctionDefinition... functions) {
         register(functions);
     }
 
+    @SuppressWarnings("this-escape")
     public FunctionRegistry(FunctionDefinition[]... groupFunctions) {
         register(groupFunctions);
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/StringQueryPredicate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/StringQueryPredicate.java
@@ -19,6 +19,7 @@ public class StringQueryPredicate extends FullTextPredicate {
 
     private final Map<String, Float> fields;
 
+    @SuppressWarnings("this-escape")
     public StringQueryPredicate(Source source, String query, String options) {
         super(source, query, options, emptyList());
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/RemoteClusterResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/RemoteClusterResolver.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class RemoteClusterResolver extends RemoteClusterAware {
     private final CopyOnWriteArraySet<String> clusters;
 
+    @SuppressWarnings("this-escape")
     public RemoteClusterResolver(Settings settings, ClusterSettings clusterSettings) {
         super(settings);
         clusters = new CopyOnWriteArraySet<>(getEnabledRemoteClusters(settings));

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetResultsAction.java
@@ -37,6 +37,7 @@ public abstract class AbstractTransportQlAsyncGetResultsAction<Response extends 
     private final AsyncResultsService<AsyncTask, StoredAsyncResponse<Response>> resultsService;
     private final TransportService transportService;
 
+    @SuppressWarnings("this-escape")
     public AbstractTransportQlAsyncGetResultsAction(
         String actionName,
         TransportService transportService,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetStatusAction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plugin/AbstractTransportQlAsyncGetStatusAction.java
@@ -42,6 +42,7 @@ public abstract class AbstractTransportQlAsyncGetStatusAction<
     private final Class<? extends AsyncTask> asyncTaskClass;
     private final AsyncTaskIndexService<StoredAsyncResponse<Response>> store;
 
+    @SuppressWarnings("this-escape")
     public AbstractTransportQlAsyncGetStatusAction(
         String actionName,
         TransportService transportService,

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/ScriptQuery.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/query/ScriptQuery.java
@@ -19,6 +19,7 @@ public class ScriptQuery extends LeafQuery {
 
     private final ScriptTemplate script;
 
+    @SuppressWarnings("this-escape")
     public ScriptQuery(Source source, ScriptTemplate script) {
         super(source);
         // make script null safe

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -225,6 +225,7 @@ public class ApiKeyService {
     private final AtomicLong lastEvictionCheckedAt = new AtomicLong(0);
     private final LongAdder evictionCounter = new LongAdder();
 
+    @SuppressWarnings("this-escape")
     public ApiKeyService(
         Settings settings,
         Clock clock,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -79,6 +79,7 @@ public class Realms extends AbstractLifecycleComponent implements Iterable<Realm
     // the realms in current use. This list will change dynamically as the license changes
     private volatile List<Realm> activeRealms;
 
+    @SuppressWarnings("this-escape")
     public Realms(
         Settings settings,
         Environment env,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
@@ -74,6 +74,7 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin {
         }
     }
 
+    @SuppressWarnings("this-escape")
     public LocalStateSecurity(final Settings settings, final Path configPath) throws Exception {
         super(settings, configPath);
         LocalStateSecurity thisVar = this;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/UnstableLocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/UnstableLocalStateSecurity.java
@@ -33,6 +33,7 @@ import java.util.Optional;
  */
 public class UnstableLocalStateSecurity extends LocalStateSecurity {
 
+    @SuppressWarnings("this-escape")
     public UnstableLocalStateSecurity(Settings settings, Path configPath) throws Exception {
         super(settings, configPath);
         // We reuse most of the initialization of LocalStateSecurity, we then just overwrite

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DummyUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DummyUsernamePasswordRealm.java
@@ -25,6 +25,7 @@ public class DummyUsernamePasswordRealm extends UsernamePasswordRealm {
 
     private Map<String, Tuple<SecureString, User>> users;
 
+    @SuppressWarnings("this-escape")
     public DummyUsernamePasswordRealm(RealmConfig config) {
         super(config);
         initRealmRef(

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
@@ -40,6 +40,7 @@ public class NodeSeenService implements ClusterStateListener {
 
     private final MasterServiceTaskQueue<SetSeenNodesShutdownTask> setSeenTaskQueue;
 
+    @SuppressWarnings("this-escape")
     public NodeSeenService(ClusterService clusterService) {
         this.clusterService = clusterService;
         this.setSeenTaskQueue = clusterService.createTaskQueue(

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -83,6 +83,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
     private final ClusterService clusterService;
     private volatile long failedSnapshotWarnThreshold;
 
+    @SuppressWarnings("this-escape")
     public SlmHealthIndicatorService(ClusterService clusterService) {
         this.clusterService = clusterService;
         this.failedSnapshotWarnThreshold = clusterService.getClusterSettings().get(SLM_HEALTH_FAILED_SNAPSHOT_WARN_THRESHOLD_SETTING);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridAggregationBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridAggregationBuilder.java
@@ -51,6 +51,7 @@ public class GeoHexGridAggregationBuilder extends GeoGridAggregationBuilder {
         return XContentMapValues.nodeIntegerValue(node);
     }
 
+    @SuppressWarnings("this-escape")
     public GeoHexGridAggregationBuilder(String name) {
         super(name);
         precision(DEFAULT_PRECISION);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregatorBase.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregatorBase.java
@@ -29,6 +29,7 @@ public abstract class CartesianBoundsAggregatorBase extends MetricsAggregator {
     private DoubleArray lefts;
     private DoubleArray rights;
 
+    @SuppressWarnings("this-escape")
     public CartesianBoundsAggregatorBase(String name, AggregationContext context, Aggregator parent, Map<String, Object> metadata)
         throws IOException {
         super(name, context, parent, metadata);

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/EmbeddedCli.java
@@ -66,6 +66,7 @@ public class EmbeddedCli implements Closeable {
      */
     private boolean closed = false;
 
+    @SuppressWarnings("this-escape")
     public EmbeddedCli(String elasticsearchAddress, boolean checkConnectionOnStartup, @Nullable SecurityConfig security)
         throws IOException {
         PipedOutputStream outgoing = new PipedOutputStream();

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/ConnectionConfiguration.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/ConnectionConfiguration.java
@@ -116,6 +116,7 @@ public class ConnectionConfiguration {
 
     private final boolean allowPartialSearchResults;
 
+    @SuppressWarnings("this-escape")
     public ConnectionConfiguration(URI baseURI, String connectionString, Properties props) throws ClientException {
         this.connectionString = connectionString;
         Properties settings = props != null ? props : new Properties();

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/RequestInfo.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/RequestInfo.java
@@ -46,12 +46,14 @@ public class RequestInfo {
         this(mode, clientId, null);
     }
 
+    @SuppressWarnings("this-escape")
     public RequestInfo(Mode mode, String clientId, String version) {
         mode(mode);
         clientId(clientId);
         version(version);
     }
 
+    @SuppressWarnings("this-escape")
     public RequestInfo(Mode mode, SqlVersion version) {
         mode(mode);
         this.version = version;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -114,6 +114,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
      */
     private final Verifier verifier;
 
+    @SuppressWarnings("this-escape")
     public Analyzer(AnalyzerContext context, Verifier verifier) {
         super(context);
         context.analyzeWithoutVerify().set(this::execute);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
@@ -141,6 +141,7 @@ import static java.util.Collections.unmodifiableList;
 
 public class SqlFunctionRegistry extends FunctionRegistry {
 
+    @SuppressWarnings("this-escape")
     public SqlFunctionRegistry() {
         register(functions());
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Pivot.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Pivot.java
@@ -45,6 +45,7 @@ public class Pivot extends UnaryPlan {
         this(source, child, column, values, aggregates, null);
     }
 
+    @SuppressWarnings("this-escape")
     public Pivot(
         Source source,
         LogicalPlan child,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
@@ -58,6 +58,7 @@ public class SqlPlugin extends Plugin implements ActionPlugin {
     private final LicensedFeature.Momentary JDBC_FEATURE = LicensedFeature.momentary("sql", "jdbc", License.OperationMode.PLATINUM);
     private final LicensedFeature.Momentary ODBC_FEATURE = LicensedFeature.momentary("sql", "odbc", License.OperationMode.PLATINUM);
 
+    @SuppressWarnings("this-escape")
     private final SqlLicenseChecker sqlLicenseChecker = new SqlLicenseChecker((mode) -> {
         XPackLicenseState licenseState = getLicenseState();
         switch (mode) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -74,6 +74,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
     private final TransportService transportService;
     private final AsyncTaskManagementService<SqlQueryRequest, SqlQueryResponse, SqlQueryTask> asyncTaskManagementService;
 
+    @SuppressWarnings("this-escape")
     @Inject
     public TransportSqlQueryAction(
         Settings settings,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -127,6 +127,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     protected volatile boolean indexerThreadShuttingDown = false;
     protected volatile boolean saveStateRequestedDuringIndexerThreadShutdown = false;
 
+    @SuppressWarnings("this-escape")
     public TransformIndexer(
         ThreadPool threadPool,
         TransformServices transformServices,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -70,6 +70,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
     private final TransformContext context;
     private final SetOnce<ClientTransformIndexer> indexer = new SetOnce<>();
 
+    @SuppressWarnings("this-escape")
     public TransformTask(
         long id,
         String type,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/InputRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/InputRegistry.java
@@ -21,6 +21,7 @@ public class InputRegistry {
 
     private final Map<String, InputFactory<?, ?, ?>> factories;
 
+    @SuppressWarnings("this-escape")
     public InputRegistry(Map<String, InputFactory<?, ?, ?>> factories) {
         Map<String, InputFactory<?, ?, ?>> map = new HashMap<>(factories);
         map.put(ChainInput.TYPE, new ChainInputFactory(this));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/NotificationService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/NotificationService.java
@@ -48,6 +48,7 @@ public abstract class NotificationService<Account> {
     // using the new updated cluster settings
     private volatile SecureSettings cachedSecureSettings;
 
+    @SuppressWarnings("this-escape")
     public NotificationService(
         String type,
         Settings settings,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
@@ -68,6 +68,7 @@ public class WebhookService extends NotificationService<WebhookService.WebhookAc
     private final HttpClient httpClient;
     private final boolean additionalTokenEnabled;
 
+    @SuppressWarnings("this-escape")
     public WebhookService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super(NAME, settings, clusterSettings, List.of(), getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/EmailService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/EmailService.java
@@ -168,6 +168,7 @@ public class EmailService extends NotificationService<Account> {
     private final SSLService sslService;
     private volatile Set<String> allowedDomains;
 
+    @SuppressWarnings("this-escape")
     public EmailService(Settings settings, @Nullable CryptoService cryptoService, SSLService sslService, ClusterSettings clusterSettings) {
         super("email", settings, clusterSettings, EmailService.getDynamicSettings(), EmailService.getSecureSettings());
         this.cryptoService = cryptoService;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
@@ -125,6 +125,7 @@ public class ReportingAttachmentParser implements EmailAttachmentParser<Reportin
     private boolean warningEnabled = REPORT_WARNING_ENABLED_SETTING.getDefault(Settings.EMPTY);
     private final Map<String, String> customWarnings = new ConcurrentHashMap<>(1);
 
+    @SuppressWarnings("this-escape")
     public ReportingAttachmentParser(
         Settings settings,
         WebhookService webhookService,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
@@ -64,6 +64,7 @@ public class JiraService extends NotificationService<JiraAccount> {
 
     private final HttpClient httpClient;
 
+    @SuppressWarnings("this-escape")
     public JiraService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("jira", settings, clusterSettings, JiraService.getDynamicSettings(), JiraService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
@@ -44,6 +44,7 @@ public class PagerDutyService extends NotificationService<PagerDutyAccount> {
 
     private final HttpClient httpClient;
 
+    @SuppressWarnings("this-escape")
     public PagerDutyService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("pagerduty", settings, clusterSettings, PagerDutyService.getDynamicSettings(), PagerDutyService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
@@ -48,6 +48,7 @@ public class SlackService extends NotificationService<SlackAccount> {
 
     private final HttpClient httpClient;
 
+    @SuppressWarnings("this-escape")
     public SlackService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("slack", settings, clusterSettings, SlackService.getDynamicSettings(), SlackService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/DayTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/DayTimes.java
@@ -36,10 +36,12 @@ public class DayTimes implements Times {
         this(new int[] { hour }, new int[] { minute });
     }
 
+    @SuppressWarnings("this-escape")
     public DayTimes(int[] hour, int[] minute) {
         this(null, hour, minute);
     }
 
+    @SuppressWarnings("this-escape")
     DayTimes(String time, int[] hour, int[] minute) {
         this.time = time;
         this.hour = hour;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
@@ -37,6 +37,7 @@ public class MonthTimes implements Times {
         this(DEFAULT_DAYS, DEFAULT_TIMES);
     }
 
+    @SuppressWarnings("this-escape")
     public MonthTimes(int[] days, DayTimes[] times) {
         this.days = days.length == 0 ? DEFAULT_DAYS : days;
         Arrays.sort(this.days);

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
@@ -38,6 +38,7 @@ public class YearTimes implements Times {
         this(DEFAULT_MONTHS, DEFAULT_DAYS, DEFAULT_TIMES);
     }
 
+    @SuppressWarnings("this-escape")
     public YearTimes(EnumSet<Month> months, int[] days, DayTimes[] times) {
         this.months = months.isEmpty() ? DEFAULT_MONTHS : months;
         this.days = days.length == 0 ? DEFAULT_DAYS : days;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatchExecutionContextMockBuilder.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatchExecutionContextMockBuilder.java
@@ -27,6 +27,7 @@ public class WatchExecutionContextMockBuilder {
     private final WatchExecutionContext ctx;
     private final Watch watch;
 
+    @SuppressWarnings("this-escape")
     public WatchExecutionContextMockBuilder(String watchId) {
         ctx = mock(WatchExecutionContext.class);
         watch = mock(Watch.class);

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -120,6 +120,7 @@ public class WildcardFieldMapper extends FieldMapper {
     });
 
     public static class PunctuationFoldingFilter extends TokenFilter {
+        @SuppressWarnings("this-escape")
         private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
 
         /**

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
@@ -38,6 +38,7 @@ public class CustomRoleMappingRealm extends Realm implements CachingRealm {
     private final Cache<String, User> cache;
     private final UserRoleMapper roleMapper;
 
+    @SuppressWarnings("this-escape")
     public CustomRoleMappingRealm(RealmConfig config, UserRoleMapper roleMapper) {
         super(config);
         this.cache = CacheBuilder.<String, User>builder().build();


### PR DESCRIPTION
Adds @SuppressWarnings("this-escape") to all necessary places to that Elasticsearch can compile with -Werror on JDK21

No investigation has been done to determine whether any of the cases are a potential source of errors - we have simply suppressed all existing occurrences.

Resolves: #99845
