### PR TITLE
[8.10] Fix test number generation for UL testing (#99862)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -814,8 +814,8 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         updateMappingForNumericValuesTests("test", singletonList(UNSIGNED_LONG_FIELD));
 
         byte randomNonNegativeByte = randomNonNegativeByte();
-        short randomNonNegativeShort = (short) (Math.abs(randomShort()) - 1);
-        int randomNonNegativeInt = Math.abs(randomInt()) - 1;
+        short randomNonNegativeShort = (short) (randomShort() & Short.MAX_VALUE);
+        int randomNonNegativeInt = randomNonNegativeInt();
         long randomNonNegativeLong = randomNonNegativeLong();
         double randomNonNegativeFloat = (float) randomDoubleBetween(0, UNSIGNED_LONG_MAX.doubleValue(), true);
         double randomNonNegativeDouble = randomDoubleBetween(0, UNSIGNED_LONG_MAX.doubleValue(), true);


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix test number generation for UL testing (#99862)