### PR TITLE
[8.10] Fix cardinality agg for const_keyword (#99814)

### DIFF
--- a/docs/changelog/99814.yaml
+++ b/docs/changelog/99814.yaml
@@ -1,0 +1,6 @@
+pr: 99814
+summary: Fix cardinality agg for `const_keyword`
+area: Aggregations
+type: bug
+issues:
+ - 99776

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
@@ -252,17 +252,14 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
                 }
             } else {
                 final FieldInfo fi = aggCtx.getLeafReaderContext().reader().getFieldInfos().fieldInfo(field);
-                if (fi == null) {
-                    // The field doesn't exist at all, we can skip the segment entirely
-                    noData++;
-                    return LeafBucketCollector.NO_OP_COLLECTOR;
-                } else if (fi.getIndexOptions() != IndexOptions.NONE) {
+                if (fi != null && fi.getIndexOptions() != IndexOptions.NONE) {
                     // The field doesn't have terms while index options are not NONE. This means that this segment doesn't have a single
                     // value for the field.
                     noData++;
                     return LeafBucketCollector.NO_OP_COLLECTOR;
                 }
-                // Otherwise we might be aggregating e.g. an IP field, which indexes data using points rather than an inverted index.
+                // Otherwise we might be aggregating e.g. an IP or a const_keyword field, which index data using points rather than an
+                // inverted index.
             }
         }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/constant_keyword/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/constant_keyword/10_basic.yml
@@ -413,3 +413,40 @@ setup:
   - match: { aggregations.agg.buckets.1.0-bucket.doc_count: 0 }
   - match: { aggregations.agg.buckets.2.key: 200.0 }
   - match: { aggregations.agg.buckets.2.0-bucket.doc_count: 0 }
+
+
+---
+Cardinality agg:
+  - skip:
+      version: " - 7.6.99, 8.9.00 - 8.10.99"
+      reason: "constant_keyword was added in 7.7, bug introduced in 8.9 and fixed in 8.11"
+
+  - do:
+      indices.create:
+        index: test3
+        body:
+          mappings:
+            properties:
+              test:
+                type: constant_keyword
+                value: value1
+
+  - do:
+      bulk:
+        index: test3
+        refresh: true
+        body: |
+          {"index":{}}
+          { "test": "value1" }
+
+  - do:
+      search:
+        index: test3
+        body:
+          size: 0
+          aggs:
+            card:
+              cardinality:
+                field: test
+
+  - match: { aggregations.card.value: 1 }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix cardinality agg for const_keyword (#99814)