### PR TITLE
Fix fields API for geo_point fields inside other arrays

### DIFF
--- a/docs/changelog/99868.yaml
+++ b/docs/changelog/99868.yaml
@@ -1,0 +1,6 @@
+pr: 99868
+summary: Fix fields API for `geo_point` fields inside other arrays
+area: Search
+type: bug
+issues:
+ - 99781

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -195,7 +195,18 @@ public class XContentMapValues {
             for (Object o : valueList) {
                 Object listValue = extractValue(pathElements, index, o, nullValue);
                 if (listValue != null) {
-                    newList.add(listValue);
+                    // we add arrays as list elements only if we are already at leaf,
+                    // otherwise append individual elements to the new list so we don't
+                    // accumulate intermediate array structures
+                    if (listValue instanceof List<?> list) {
+                        if (index == pathElements.length) {
+                            newList.add(list);
+                        } else {
+                            newList.addAll(list);
+                        }
+                    } else {
+                        newList.add(listValue);
+                    }
                 }
             }
             return newList;

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -116,7 +116,6 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             Function<List<T>, List<Object>> formatter = getFormatter(format != null ? format : GeometryFormatterFactory.GEOJSON);
             return new ArraySourceValueFetcher(name(), context) {
-
                 @Override
                 protected Object parseSourceValue(Object value) {
                     final List<T> values = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -116,6 +116,7 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
             Function<List<T>, List<Object>> formatter = getFormatter(format != null ? format : GeometryFormatterFactory.GEOJSON);
             return new ArraySourceValueFetcher(name(), context) {
+
                 @Override
                 protected Object parseSourceValue(Object value) {
                     final List<T> values = new ArrayList<>();

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -561,7 +561,7 @@ public class FieldFetcherTests extends MapperServiceTestCase {
 
         field = fields.get("object.field");
         assertNotNull(field);
-        assertThat(field.getValues().size(), equalTo(3));
+        assertThat(field.getValues(), containsInAnyOrder("foo", "bar", "baz");
     }
 
     public void testFieldNamesWithWildcard() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -458,7 +458,7 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         assertEquals(List.of(lon, lat), pointMap.get("coordinates"));
     }
 
-    public void testDensevectorInObject() throws IOException {
+    public void testDenseVectorInObject() throws IOException {
         MapperService mapperService = createMapperService();
         {
             String source = """

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -561,7 +561,7 @@ public class FieldFetcherTests extends MapperServiceTestCase {
 
         field = fields.get("object.field");
         assertNotNull(field);
-        assertThat(field.getValues(), containsInAnyOrder("foo", "bar", "baz");
+        assertThat(field.getValues(), containsInAnyOrder("foo", "bar", "baz"));
     }
 
     public void testFieldNamesWithWildcard() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -397,25 +397,24 @@ public class FieldFetcherTests extends MapperServiceTestCase {
     public void testGeopointArrayInObject() throws IOException {
         MapperService mapperService = createMapperService();
         {
-            XContentBuilder source = XContentFactory.jsonBuilder()
-                .startObject()
-                .startArray("object")
-                .startObject()
-                .startArray("geo_point_in_obj")
-                .startObject()
-                .field("lat", 42.0)
-                .field("lon", 27.1)
-                .endObject()
-                .startArray()
-                .value(2.1)
-                .value(41.0)
-                .endArray()
-                .endArray()
-                .endObject()
-                .endArray()
-                .endObject();
+            String source = """
+                {
+                    "object" : [
+                        {
+                            "geo_point_in_obj" : [
+                                {"lat" : 42.0, "lon" : 27.1},
+                                [2.1, 41.0]
+                            ]
+                        }
+                    ]
+                }
+                """;
 
-            Map<String, DocumentField> fields = fetchFields(mapperService, source, "object.geo_point_in_obj");
+            Map<String, DocumentField> fields = fetchFields(
+                mapperService,
+                source,
+                fieldAndFormatList("object.geo_point_in_obj", null, false)
+            );
             assertThat(fields.size(), equalTo(1));
 
             DocumentField field = fields.get("object.geo_point_in_obj");
@@ -427,23 +426,22 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         }
         {
             // check the same without the root field as array
-            XContentBuilder source = XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("object")
-                .startArray("geo_point_in_obj")
-                .startObject()
-                .field("lat", 42.0)
-                .field("lon", 27.1)
-                .endObject()
-                .startArray()
-                .value(2.1)
-                .value(41.0)
-                .endArray()
-                .endArray()
-                .endObject()
-                .endObject();
+            String source = """
+                {
+                    "object" : {
+                        "geo_point_in_obj" : [
+                            {"lat" : 42.0, "lon" : 27.1},
+                            [2.1, 41.0]
+                        ]
+                    }
+                }
+                """;
 
-            Map<String, DocumentField> fields = fetchFields(mapperService, source, "object.geo_point_in_obj");
+            Map<String, DocumentField> fields = fetchFields(
+                mapperService,
+                source,
+                fieldAndFormatList("object.geo_point_in_obj", null, false)
+            );
             assertThat(fields.size(), equalTo(1));
 
             DocumentField field = fields.get("object.geo_point_in_obj");
@@ -463,16 +461,21 @@ public class FieldFetcherTests extends MapperServiceTestCase {
     public void testDensevectorInObject() throws IOException {
         MapperService mapperService = createMapperService();
         {
-            XContentBuilder source = XContentFactory.jsonBuilder()
-                .startObject()
-                .startArray("object")
-                .startObject()
-                .array("dense_vector_in_obj", 1, 2, 3)
-                .endObject()
-                .endArray()
-                .endObject();
+            String source = """
+                {
+                    "object" : [
+                        {
+                            "dense_vector_in_obj" : [ 1, 2, 3]
+                        }
+                    ]
+                }
+                """;
 
-            Map<String, DocumentField> fields = fetchFields(mapperService, source, "object.dense_vector_in_obj");
+            Map<String, DocumentField> fields = fetchFields(
+                mapperService,
+                source,
+                fieldAndFormatList("object.dense_vector_in_obj", null, false)
+            );
             assertThat(fields.size(), equalTo(1));
 
             DocumentField field = fields.get("object.dense_vector_in_obj");
@@ -482,14 +485,19 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         }
         {
             // check the same without the root field as array
-            XContentBuilder source = XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("object")
-                .array("dense_vector_in_obj", 1, 2, 3)
-                .endObject()
-                .endObject();
+            String source = """
+                {
+                    "object" : {
+                        "dense_vector_in_obj" : [ 1, 2, 3]
+                    }
+                }
+                """;
 
-            Map<String, DocumentField> fields = fetchFields(mapperService, source, "object.dense_vector_in_obj");
+            Map<String, DocumentField> fields = fetchFields(
+                mapperService,
+                source,
+                fieldAndFormatList("object.dense_vector_in_obj", null, false)
+            );
             assertThat(fields.size(), equalTo(1));
 
             DocumentField field = fields.get("object.dense_vector_in_obj");
@@ -502,30 +510,32 @@ public class FieldFetcherTests extends MapperServiceTestCase {
     public void testKeywordArrayInObject() throws IOException {
         MapperService mapperService = createMapperService();
 
-        XContentBuilder source = XContentFactory.jsonBuilder()
-            .startObject()
-            .startArray("object")
-            .startObject()
-            .array("field", "foo", "bar")
-            .endObject()
-            .endArray()
-            .endObject();
+        String source = """
+            {
+                "object" : [
+                    {
+                        "field" : [ "foo", "bar"]
+                    }
+                ]
+            }
+            """;
 
-        Map<String, DocumentField> fields = fetchFields(mapperService, source, "object.field");
+        Map<String, DocumentField> fields = fetchFields(mapperService, source, fieldAndFormatList("object.field", null, false));
         assertThat(fields.size(), equalTo(1));
 
         DocumentField field = fields.get("object.field");
         assertNotNull(field);
         assertThat(field.getValues().size(), equalTo(2));
 
-        source = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("object")
-            .array("field", "foo", "bar", "baz")
-            .endObject()
-            .endObject();
+        source = """
+            {
+                "object" : {
+                    "field" : [ "foo", "bar", "baz"]
+                }
+            }
+            """;
 
-        fields = fetchFields(mapperService, source, "object.field");
+        fields = fetchFields(mapperService, source, fieldAndFormatList("object.field", null, false));
         assertThat(fields.size(), equalTo(1));
 
         field = fields.get("object.field");
@@ -533,19 +543,20 @@ public class FieldFetcherTests extends MapperServiceTestCase {
         assertThat(field.getValues().size(), equalTo(3));
 
         // mixing array and singleton object on two separate paths
-        source = XContentFactory.jsonBuilder()
-            .startObject()
-            .startArray("object")
-            .startObject()
-            .field("field", "foo")
-            .endObject()
-            .startObject()
-            .array("field", "bar", "baz")
-            .endObject()
-            .endArray()
-            .endObject();
+        source = """
+            {
+                "object" : [
+                    {
+                        "field" : "foo"
+                    },
+                    {
+                        "field" : [ "bar", "baz"]
+                    }
+                ]
+            }
+            """;
 
-        fields = fetchFields(mapperService, source, "object.field");
+        fields = fetchFields(mapperService, source, fieldAndFormatList("object.field", null, false));
         assertThat(fields.size(), equalTo(1));
 
         field = fields.get("object.field");


### PR DESCRIPTION
The fields API currently doesn't work for geopoint arrays inside outer objects
that again are expressed as multi-values arrays. The reason is that upon
extracting the leaf values from source (i.e via Source#extractValue) we
accumulate intermediate array structures as additinal lists in the source value
we then try to parse. For other field types, especially those that use
SourceValueFetcher, this doesn't matter because we have a list-flattening step
in SourceValueFetcher#fetchValues, but for geo_point types the parser cannot
deal with the additional list levels. This change modifies the source extraction
so that we avoid nesting to many list structures inside each other, which I
believe currently is wrong but is masked by the list deduplication mentioned
above.

Closes https://github.com/elastic/elasticsearch/issues/99781