### PR TITLE
ESQL: Use exact attributes for data source extraction

### DIFF
--- a/docs/changelog/99874.yaml
+++ b/docs/changelog/99874.yaml
@@ -1,0 +1,6 @@
+pr: 99874
+summary: "ESQL: Use exact attributes for data source extraction"
+area: ES|QL
+type: bug
+issues:
+ - 99183

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/80_text.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/80_text.yml
@@ -322,8 +322,6 @@ setup:
 
 ---
 "text with synthetic source":
-  - skip:
-      features: allowed_warnings_regex
   - do:
       indices.create:
         index: test2
@@ -353,8 +351,6 @@ setup:
           - { "emp_no": 20, "name": "John", "job": "Payroll Specialist" }
 
   - do:
-      allowed_warnings_regex:
-        - "Field \\[job\\] cannot be retrieved, it is unsupported or not indexed; returning null"
       esql.query:
         body:
           query: 'from test2 | sort emp_no | keep job'
@@ -363,8 +359,8 @@ setup:
   - match: { columns.0.type: "text" }
 
   - length: { values: 2 }
-  - match: { values.0.0: null } # awaiting a complete fix for https://github.com/elastic/elasticsearch/issues/99183
-  - match: { values.1.0: null } # for now, since we cannot extract text values from synthetic source, we at least avoid to throw exceptions
+  - match: { values.0.0: "IT Director" }
+  - match: { values.1.0: "Payroll Specialist" }
 
 
 ---

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecution
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Attribute;
+import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +62,9 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
         PhysicalOperation op = source;
         for (Attribute attr : fieldExtractExec.attributesToExtract()) {
+            if (attr instanceof FieldAttribute fa && fa.getExactInfo().hasExact()) {
+                attr = fa.exactAttribute();
+            }
             layout.append(attr);
             Layout previousLayout = op.layout;
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/99183

ValueSources will now use exact attributes (ie. exact subfields) when available. 
This will make the extraction faster (eg. using a KEYWORD subfield instead of loading a TEXT value from _source) and will avoid failures in case the original field is not available at all, eg. in case of synthetic source.