### PR TITLE
Inline & remove ChunkedRestResponseBody overrides

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -614,7 +614,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
                     channel.sendResponse(
                         RestResponse.chunked(OK, ChunkedRestResponseBody.fromXContent(ignored -> Iterators.single((builder, params) -> {
                             throw new AssertionError("should not be called for HEAD REQUEST");
-                        }), ToXContent.EMPTY_PARAMS, channel))
+                        }), ToXContent.EMPTY_PARAMS, channel, null))
                     );
                 } catch (IOException e) {
                     throw new AssertionError(e);

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
@@ -63,21 +63,6 @@ public interface ChunkedRestResponseBody extends Releasable {
      * @param chunkedToXContent chunked x-content instance to serialize
      * @param params parameters to use for serialization
      * @param channel channel the response will be written to
-     * @return chunked rest response body
-     * @deprecated Use {@link #fromXContent(ChunkedToXContent, ToXContent.Params, RestChannel, Releasable)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    static ChunkedRestResponseBody fromXContent(ChunkedToXContent chunkedToXContent, ToXContent.Params params, RestChannel channel)
-        throws IOException {
-        return fromXContent(chunkedToXContent, params, channel, null);
-    }
-
-    /**
-     * Create a chunked response body to be written to a specific {@link RestChannel} from a {@link ChunkedToXContent}.
-     *
-     * @param chunkedToXContent chunked x-content instance to serialize
-     * @param params parameters to use for serialization
-     * @param channel channel the response will be written to
      * @param releasable resource to release when the response is fully sent, or {@code null} if nothing to release
      * @return chunked rest response body
      */
@@ -160,17 +145,6 @@ public interface ChunkedRestResponseBody extends Releasable {
                 Releasables.closeExpectNoException(releasable);
             }
         };
-    }
-
-    /**
-     * Create a chunked response body to be written to a specific {@link RestChannel} from a stream of text chunks, each represented as a
-     * consumer of a {@link Writer}. The last chunk that the iterator yields must write at least one byte.
-     *
-     * @deprecated Use {@link #fromTextChunks(String, Iterator, Releasable)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    static ChunkedRestResponseBody fromTextChunks(String contentType, Iterator<CheckedConsumer<Writer, IOException>> chunkIterator) {
-        return fromTextChunks(contentType, chunkIterator, null);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
@@ -37,7 +37,7 @@ public class RestChunkedToXContentListener<Response extends ChunkedToXContent> e
     @Override
     protected void processResponse(Response response) throws IOException {
         channel.sendResponse(
-            RestResponse.chunked(getRestStatus(response), ChunkedRestResponseBody.fromXContent(response, params, channel))
+            RestResponse.chunked(getRestStatus(response), ChunkedRestResponseBody.fromXContent(response, params, channel, null))
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -115,7 +115,7 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
         return channel -> client.admin().cluster().nodesHotThreads(nodesHotThreadsRequest, new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(NodesHotThreadsResponse response) {
-                return RestResponse.chunked(RestStatus.OK, fromTextChunks(TEXT_CONTENT_TYPE, response.getTextChunks()));
+                return RestResponse.chunked(RestStatus.OK, fromTextChunks(TEXT_CONTENT_TYPE, response.getTextChunks(), null));
             }
         });
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -77,7 +77,8 @@ public class RestTable {
                     Iterators.single((builder, params) -> builder.endArray())
                 ),
                 ToXContent.EMPTY_PARAMS,
-                channel
+                channel,
+                null
             )
         );
     }
@@ -126,7 +127,8 @@ public class RestTable {
                         }
                         writer.append("\n");
                     })
-                )
+                ),
+                null
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
@@ -129,7 +129,8 @@ public class RestClusterInfoAction extends BaseRestHandler {
                                 ChunkedToXContentHelper.endObject()
                             ),
                             EMPTY_PARAMS,
-                            channel
+                            channel,
+                            null
                         )
                     );
                 }

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -69,7 +69,7 @@ public class RestResponseTests extends ESTestCase {
     public void testEmptyChunkedBody() {
         RestResponse response = RestResponse.chunked(
             RestStatus.OK,
-            ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator())
+            ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator(), null)
         );
         assertFalse(response.isChunked());
         assertNotNull(response.content());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -122,12 +122,12 @@ public class EsqlResponseListener extends RestResponseListener<EsqlQueryResponse
         if (mediaType instanceof TextFormat format) {
             restResponse = RestResponse.chunked(
                 RestStatus.OK,
-                ChunkedRestResponseBody.fromTextChunks(format.contentType(restRequest), format.format(restRequest, esqlResponse))
+                ChunkedRestResponseBody.fromTextChunks(format.contentType(restRequest), format.format(restRequest, esqlResponse), null)
             );
         } else {
             restResponse = RestResponse.chunked(
                 RestStatus.OK,
-                ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel)
+                ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel, null)
             );
         }
         long tookNanos = stopWatch.stop().getNanos();


### PR DESCRIPTION
Follow-up to #99871 to inline and remove the deprecated overrides which
do not take a `Releasable` parameter.