### PR TITLE
Update ml-delayed-data-detection.asciidoc: Fix Subtitle rendering

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -22,6 +22,7 @@ the value of `query_delay'. If it doesn't help, investigate the ingest latency a
 cause. You can do this by comparing event and ingest timestamps. High latency 
 is often caused by bursts of ingested documents, misconfiguration of the ingest 
 pipeline, or misalignment of system clocks.
+
 == Why worry about delayed data?
 
 If data are delayed randomly (and consequently are missing from analysis), the


### PR DESCRIPTION
Add new line to make the title be rendered as a title.

**Problem**

The documentation about [Handling Delayed Data](https://www.elastic.co/guide/en/machine-learning/current/ml-delayed-data-detection.html) is rendered wrongly:
<img width="542" alt="image" src="https://github.com/elastic/elasticsearch/assets/6976484/ec600317-0fd9-428b-9225-5ba0f91be3b4">

Why worry about delayed data should be a subtitle.


