### PR TITLE
ESQL: Document the existing result-set limitations

### DIFF
--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -92,6 +92,9 @@ POST /_query?format=txt
 ----
 // TEST[setup:library]
 
+NOTE: if no {esql-limit} command is provided within the query, this will only
+return up to 500 rows.
+
 [discrete]
 ==== {kib}
 
@@ -120,6 +123,10 @@ with the time filter.
 - `unsigned_long`
 - `version`
 --
+
+There is a global limitation on how many rows a query can return. This applies
+irrespective of the user-provided argument to a {esql-limit} command.
+The limit is set to a default of 10000.
 
 include::esql-get-started.asciidoc[]
 

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -94,8 +94,8 @@ POST /_query?format=txt
 
 The above query's `LIMIT` command limits results to 5 rows.
 
-If not specified, `LIMIT` defaults to `500`. A single query can't return more
-than 10,000 rows, regardless of the `LIMIT` value.
+If not specified, `LIMIT` defaults to `500`. A single query will not return
+more than 10,000 rows, regardless of the `LIMIT` value.
 
 [discrete]
 ==== {kib}
@@ -125,8 +125,8 @@ with the time filter.
 ** `unsigned_long`
 ** `version`
 
-* A single query can't return more than 10,000 rows, regardless of the `LIMIT`
-command's value.
+* A single query will not return more than 10,000 rows, regardless of the
+`LIMIT` command's value.
 --
 
 include::esql-get-started.asciidoc[]

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -92,8 +92,10 @@ POST /_query?format=txt
 ----
 // TEST[setup:library]
 
-NOTE: if no {esql-limit} command is provided within the query, this will only
-return up to 500 rows.
+The above query's `LIMIT` command limits results to 5 rows.
+
+If not specified, `LIMIT` defaults to `500`. A single query can't return more
+than 10,000 rows, regardless of the `LIMIT` value.
 
 [discrete]
 ==== {kib}
@@ -108,25 +110,24 @@ with the time filter.
 [[esql-limitations]]
 === Limitations
 
-{esql} currently supports the following <<mapping-types,field types>>:
+* {esql} currently supports the following <<mapping-types,field types>>:
 
-- `alias`
-- `boolean`
-- `date`
-- `double` (`float`, `half_float`, `scaled_float` are represented as `double`)
-- `ip`
-- `keyword` family including `keyword`, `constant_keyword`, and `wildcard`
-- `int` (`short` and `byte` are represented as `int`)
-- `long`
-- `null`
-- `text`
-- `unsigned_long`
-- `version`
+** `alias`
+** `boolean`
+** `date`
+** `double` (`float`, `half_float`, `scaled_float` are represented as `double`)
+** `ip`
+** `keyword` family including `keyword`, `constant_keyword`, and `wildcard`
+** `int` (`short` and `byte` are represented as `int`)
+** `long`
+** `null`
+** `text`
+** `unsigned_long`
+** `version`
+
+* A single query can't return more than 10,000 rows, regardless of the `LIMIT`
+command's value.
 --
-
-There is a global limitation on how many rows a query can return. This applies
-irrespective of the user-provided argument to a {esql-limit} command.
-The limit is set to a default of 10000.
 
 include::esql-get-started.asciidoc[]
 

--- a/docs/reference/esql/processing-commands/limit.asciidoc
+++ b/docs/reference/esql/processing-commands/limit.asciidoc
@@ -9,5 +9,4 @@ include::{esql-specs}/docs.csv-spec[tag=limit]
 ----
 
 If not specified, `LIMIT` defaults to `500`. A single query can't return more
-than 10,000 rows, regardless of the `LIMIT` value. {es} ignores `LIMIT` values
-exceeding `10000`.
+than 10,000 rows, regardless of the `LIMIT` value.

--- a/docs/reference/esql/processing-commands/limit.asciidoc
+++ b/docs/reference/esql/processing-commands/limit.asciidoc
@@ -8,5 +8,6 @@ The `LIMIT` processing command enables you to limit the number of rows:
 include::{esql-specs}/docs.csv-spec[tag=limit]
 ----
 
-NOTE: if the query contains no `LIMIT` command, an implicit limit of 500 will
-be applied.
+If not specified, `LIMIT` defaults to `500`. A single query can't return more
+than 10,000 rows, regardless of the `LIMIT` value. {es} ignores `LIMIT` values
+exceeding `10000`.

--- a/docs/reference/esql/processing-commands/limit.asciidoc
+++ b/docs/reference/esql/processing-commands/limit.asciidoc
@@ -7,3 +7,6 @@ The `LIMIT` processing command enables you to limit the number of rows:
 ----
 include::{esql-specs}/docs.csv-spec[tag=limit]
 ----
+
+NOTE: if the query contains no `LIMIT` command, an implicit limit of 500 will
+be applied.

--- a/docs/reference/esql/processing-commands/limit.asciidoc
+++ b/docs/reference/esql/processing-commands/limit.asciidoc
@@ -8,5 +8,5 @@ The `LIMIT` processing command enables you to limit the number of rows:
 include::{esql-specs}/docs.csv-spec[tag=limit]
 ----
 
-If not specified, `LIMIT` defaults to `500`. A single query can't return more
-than 10,000 rows, regardless of the `LIMIT` value.
+If not specified, `LIMIT` defaults to `500`. A single query will not return
+more than 10,000 rows, regardless of the `LIMIT` value.


### PR DESCRIPTION
Document the newly implicit limit of 500 (if no other limit is provided), as well as the global 10K one.

Related: #99816
