### PR TITLE
[Transform] Remove toVersion method from TransformConfigVersion

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -71,7 +71,8 @@ public final class SourceDestValidator {
         + "alias [{0}], license is not active";
     public static final String REMOTE_SOURCE_INDICES_NOT_SUPPORTED = "remote source indices are not supported";
     public static final String REMOTE_CLUSTERS_TOO_OLD =
-        "remote clusters are expected to run at least version [{0}] (reason: [{1}]), but the following clusters were too old: [{2}]";
+        "remote clusters are expected to run at least transport version [{0}] (reason: [{1}]),"
+            + " but the following clusters were too old: [{2}]";
     public static final String PIPELINE_MISSING = "Pipeline with id [{0}] could not be found";
 
     private final IndexNameExpressionResolver indexNameExpressionResolver;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.core.common.validation;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -223,8 +223,8 @@ public final class SourceDestValidator {
         }
 
         // convenience method to make testing easier
-        public Version getRemoteClusterVersion(String cluster) {
-            return remoteClusterService.getConnection(cluster).getVersion();
+        public TransportVersion getRemoteClusterVersion(String cluster) {
+            return remoteClusterService.getConnection(cluster).getTransportVersion();
         }
 
         private void resolveLocalAndRemoteSource() {
@@ -448,15 +448,15 @@ public final class SourceDestValidator {
 
     public static class RemoteClusterMinimumVersionValidation implements SourceDestValidation {
 
-        private final Version minExpectedVersion;
+        private final TransportVersion minExpectedVersion;
         private final String reason;
 
-        public RemoteClusterMinimumVersionValidation(Version minExpectedVersion, String reason) {
+        public RemoteClusterMinimumVersionValidation(TransportVersion minExpectedVersion, String reason) {
             this.minExpectedVersion = minExpectedVersion;
             this.reason = reason;
         }
 
-        public Version getMinExpectedVersion() {
+        public TransportVersion getMinExpectedTransportVersion() {
             return minExpectedVersion;
         }
 
@@ -467,7 +467,7 @@ public final class SourceDestValidator {
         @Override
         public void validate(Context context, ActionListener<Context> listener) {
             List<String> remoteIndices = new ArrayList<>(context.resolveRemoteSource());
-            Map<String, Version> remoteClusterVersions;
+            Map<String, TransportVersion> remoteClusterVersions;
             try {
                 List<String> remoteAliases = RemoteClusterLicenseChecker.remoteClusterAliases(
                     context.getRegisteredRemoteClusterNames(),
@@ -483,7 +483,7 @@ public final class SourceDestValidator {
                 listener.onResponse(context);
                 return;
             }
-            Map<String, Version> oldRemoteClusterVersions = remoteClusterVersions.entrySet()
+            Map<String, TransportVersion> oldRemoteClusterVersions = remoteClusterVersions.entrySet()
                 .stream()
                 .filter(entry -> entry.getValue().before(minExpectedVersion))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -70,8 +70,11 @@ public final class SourceDestValidator {
     public static final String REMOTE_CLUSTER_LICENSE_INACTIVE = "License check failed for remote cluster "
         + "alias [{0}], license is not active";
     public static final String REMOTE_SOURCE_INDICES_NOT_SUPPORTED = "remote source indices are not supported";
-    public static final String REMOTE_CLUSTERS_TOO_OLD =
+    public static final String REMOTE_CLUSTERS_TRANSPORT_TOO_OLD =
         "remote clusters are expected to run at least transport version [{0}] (reason: [{1}]),"
+            + " but the following clusters were too old: [{2}]";
+    public static final String REMOTE_CLUSTERS_CONFIG_TOO_OLD =
+        "remote clusters are expected to run at least config version [{0}] (reason: [{1}]),"
             + " but the following clusters were too old: [{2}]";
     public static final String PIPELINE_MISSING = "Pipeline with id [{0}] could not be found";
 
@@ -490,7 +493,7 @@ public final class SourceDestValidator {
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
             if (oldRemoteClusterVersions.isEmpty() == false) {
                 context.addValidationError(
-                    REMOTE_CLUSTERS_TOO_OLD,
+                    REMOTE_CLUSTERS_TRANSPORT_TOO_OLD,
                     minExpectedVersion,
                     reason,
                     oldRemoteClusterVersions.entrySet()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformConfigVersion.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformConfigVersion.java
@@ -311,7 +311,7 @@ public record TransformConfigVersion(int id) implements VersionId<TransformConfi
         }
         return fromId(version.id);
     }
-    
+
     public static TransformConfigVersion getMinTransformConfigVersion(DiscoveryNodes nodes) {
         return getMinMaxTransformConfigVersion(nodes).v1();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformConfigVersion.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformConfigVersion.java
@@ -311,14 +311,7 @@ public record TransformConfigVersion(int id) implements VersionId<TransformConfi
         }
         return fromId(version.id);
     }
-
-    public static Version toVersion(TransformConfigVersion TransformConfigVersion) {
-        if (TransformConfigVersion.before(FIRST_TRANSFORM_VERSION) || TransformConfigVersion.onOrAfter(V_8_10_0)) {
-            throw new IllegalArgumentException("Cannot convert " + TransformConfigVersion + ". Incompatible version");
-        }
-        return Version.fromId(TransformConfigVersion.id);
-    }
-
+    
     public static TransformConfigVersion getMinTransformConfigVersion(DiscoveryNodes nodes) {
         return getMinMaxTransformConfigVersion(nodes).v1();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.core.transform.transforms;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.Strings;
@@ -62,7 +64,7 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
     public static final String NAME = "data_frame_transform_config";
     public static final ParseField HEADERS = new ParseField("headers");
     /** Version in which {@code FieldCapabilitiesRequest.runtime_fields} field was introduced. */
-    private static final TransformConfigVersion FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION = TransformConfigVersion.V_7_12_0;
+    private static final TransportVersion FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_TRANSPORT_VERSION = TransportVersions.V_7_12_0;
 
     /** Specifies all the possible transform functions. */
     public enum Function {
@@ -343,7 +345,7 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
     public List<SourceDestValidation> getAdditionalSourceDestValidations() {
         if ((source.getRuntimeMappings() == null || source.getRuntimeMappings().isEmpty()) == false) {
             SourceDestValidation validation = new SourceDestValidator.RemoteClusterMinimumVersionValidation(
-                TransformConfigVersion.toVersion(FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION),
+                FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_TRANSPORT_VERSION,
                 "source.runtime_mappings field was set"
             );
             return Collections.singletonList(validation);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -82,8 +82,8 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
                     contains(
-                        "remote clusters are expected to run at least version [7.11.0] (reason: [some reason]), "
-                            + "but the following clusters were too old: [cluster-A (7.10.2)]"
+                        "remote clusters are expected to run at least transport version [7110099] (reason: [some reason]), "
+                            + "but the following clusters were too old: [cluster-A (7100099)]"
                     )
                 )
             )
@@ -100,8 +100,8 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
                     contains(
-                        "remote clusters are expected to run at least version [7.11.2] (reason: [some reason]), "
-                            + "but the following clusters were too old: [cluster-A (7.10.2), cluster-B (7.11.0)]"
+                        "remote clusters are expected to run at least transport version [7120099] (reason: [some reason]), "
+                            + "but the following clusters were too old: [cluster-A (7100099), cluster-B (7110099)]"
                     )
                 )
             )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -7,7 +7,8 @@
 
 package org.elasticsearch.xpack.core.common.validation;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.spy;
 
 public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
 
-    private static final Version MIN_EXPECTED_VERSION = Version.V_7_11_0;
+    private static final TransportVersion MIN_EXPECTED_VERSION = TransportVersions.V_7_11_0;
     private static final String REASON = "some reason";
 
     private Context context;
@@ -40,14 +41,14 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
     @Before
     public void setUpMocks() {
         context = spy(new Context(null, null, null, null, null, null, null, null, null, null));
-        doReturn(Version.V_7_10_2).when(context).getRemoteClusterVersion("cluster-A");
-        doReturn(Version.V_7_11_0).when(context).getRemoteClusterVersion("cluster-B");
-        doReturn(Version.V_7_11_2).when(context).getRemoteClusterVersion("cluster-C");
+        doReturn(TransportVersions.V_7_10_0).when(context).getRemoteClusterVersion("cluster-A");
+        doReturn(TransportVersions.V_7_11_0).when(context).getRemoteClusterVersion("cluster-B");
+        doReturn(TransportVersions.V_7_12_0).when(context).getRemoteClusterVersion("cluster-C");
     }
 
     public void testGetters() {
         RemoteClusterMinimumVersionValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
-        assertThat(validation.getMinExpectedVersion(), is(equalTo(MIN_EXPECTED_VERSION)));
+        assertThat(validation.getMinExpectedTransportVersion(), is(equalTo(MIN_EXPECTED_VERSION)));
         assertThat(validation.getReason(), is(equalTo(REASON)));
     }
 
@@ -92,7 +93,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
     public void testValidate_TwoRemoteClusterVersionsTooLow() {
         doReturn(new HashSet<>(Arrays.asList("cluster-A", "cluster-B", "cluster-C"))).when(context).getRegisteredRemoteClusterNames();
         doReturn(new TreeSet<>(Arrays.asList("cluster-A:dummy", "cluster-B:dummy", "cluster-C:dummy"))).when(context).resolveRemoteSource();
-        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(Version.V_7_11_2, REASON);
+        SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(TransportVersions.V_7_12_0, REASON);
         validation.validate(
             context,
             ActionTestUtils.assertNoFailureListener(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformConfigVersionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformConfigVersionTests.java
@@ -264,17 +264,6 @@ public class TransformConfigVersionTests extends ESTestCase {
         assertEquals("Cannot convert " + Version.fromId(8_11_00_99) + ". Incompatible version", e.getMessage());
     }
 
-    public void testToVersion() {
-        TransformConfigVersion TransformConfigVersion_V_7_7_0 = TransformConfigVersion.V_7_7_0;
-        Version version_V_7_7_0 = TransformConfigVersion.toVersion(TransformConfigVersion_V_7_7_0);
-        assertEquals(version_V_7_7_0.id, TransformConfigVersion_V_7_7_0.id());
-
-        // There's no mapping between Version and TransformConfigVersion values from TransformConfigVersion.V_10 onwards.
-        TransformConfigVersion TransformConfigVersion_V_10 = TransformConfigVersion.V_10;
-        Exception e = expectThrows(IllegalArgumentException.class, () -> TransformConfigVersion.toVersion(TransformConfigVersion_V_10));
-        assertEquals("Cannot convert " + TransformConfigVersion_V_10 + ". Incompatible version", e.getMessage());
-    }
-
     public void testVersionConstantPresent() {
         Set<TransformConfigVersion> ignore = Set.of(
             TransformConfigVersion.ZERO,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -828,7 +828,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         assertThat(additiionalValidations.get(0), is(instanceOf(RemoteClusterMinimumVersionValidation.class)));
         RemoteClusterMinimumVersionValidation remoteClusterMinimumVersionValidation =
             (RemoteClusterMinimumVersionValidation) additiionalValidations.get(0);
-        assertThat(remoteClusterMinimumVersionValidation.getMinExpectedVersion(), is(equalTo(Version.V_7_12_0)));
+        assertThat(remoteClusterMinimumVersionValidation.getMinExpectedTransportVersion(), is(equalTo(Version.V_7_12_0)));
         assertThat(remoteClusterMinimumVersionValidation.getReason(), is(equalTo("source.runtime_mappings field was set")));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.core.transform.transforms;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -603,7 +603,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                 "max_page_search_size": 111
               },
               "version": "%s"
-            }""", Version.V_7_6_0.toString());
+            }""", TransformConfigVersion.V_7_6_0.toString());
 
         TransformConfig transformConfig = createTransformConfigFromString(pivotTransform, "body_id", true);
         TransformConfig transformConfigRewritten = TransformConfig.rewriteForUpdate(transformConfig);
@@ -645,7 +645,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                 }
               },
               "version": "%s"
-            }""", Version.V_7_12_0.toString());
+            }""", TransformConfigVersion.V_7_12_0.toString());
 
         TransformConfig transformConfig = createTransformConfigFromString(pivotTransform, "body_id", true);
         TransformConfig transformConfigRewritten = TransformConfig.rewriteForUpdate(transformConfig);
@@ -693,7 +693,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                 "max_page_search_size": 555
               },
               "version": "%s"
-            }""", Version.V_7_5_0.toString());
+            }""", TransformConfigVersion.V_7_5_0.toString());
 
         TransformConfig transformConfig = createTransformConfigFromString(pivotTransform, "body_id", true);
         TransformConfig transformConfigRewritten = TransformConfig.rewriteForUpdate(transformConfig);
@@ -828,7 +828,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
         assertThat(additiionalValidations.get(0), is(instanceOf(RemoteClusterMinimumVersionValidation.class)));
         RemoteClusterMinimumVersionValidation remoteClusterMinimumVersionValidation =
             (RemoteClusterMinimumVersionValidation) additiionalValidations.get(0);
-        assertThat(remoteClusterMinimumVersionValidation.getMinExpectedTransportVersion(), is(equalTo(Version.V_7_12_0)));
+        assertThat(remoteClusterMinimumVersionValidation.getMinExpectedTransportVersion(), is(equalTo(TransportVersions.V_7_12_0)));
         assertThat(remoteClusterMinimumVersionValidation.getReason(), is(equalTo("source.runtime_mappings field was set")));
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -79,7 +79,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.REMOTE_CLUSTERS_TOO_OLD;
+import static org.elasticsearch.xpack.core.common.validation.SourceDestValidator.REMOTE_CLUSTERS_CONFIG_TOO_OLD;
 
 /* This class extends from TransportMasterNodeAction for cluster state observing purposes.
  The stop datafeed api also redirect the elected master node.
@@ -316,7 +316,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
         throw ExceptionsHelper.badRequestException(
             Messages.getMessage(
-                REMOTE_CLUSTERS_TOO_OLD,
+                REMOTE_CLUSTERS_CONFIG_TOO_OLD,
                 minVersion.toString(),
                 reason,
                 Strings.collectionToCommaDelimitedString(clustersTooOld)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedActionTests.java
@@ -137,7 +137,7 @@ public class TransportStartDatafeedActionTests extends ESTestCase {
         assertThat(
             ex.getMessage(),
             containsString(
-                "remote clusters are expected to run at least version [7.11.0] (reason: [runtime_mappings]), "
+                "remote clusters are expected to run at least config version [7.11.0] (reason: [runtime_mappings]), "
                     + "but the following clusters were too old: [old_cluster_1]"
             )
         );


### PR DESCRIPTION
There's no need for a toVersion method in TransformConfigVersion.