### PR TITLE
Remove ownership hack in ExchangeResponse

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeResponse.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeResponse.java
@@ -23,13 +23,7 @@ public final class ExchangeResponse extends TransportResponse implements Releasa
     private final RefCounted counted = AbstractRefCounted.of(this::close);
     private final Page page;
     private final boolean finished;
-    /**
-     * We always use the remote exchange framwork even for local exchanges, but
-     * local exchanges shouldn't close the Page. Remote exchanges totally should
-     * as soon as they've serialized the block. This is a clever hack Nhat mentioned
-     * that can do that. But I don't like it. But it works and might unstick us.
-     */
-    private boolean serialized = false;
+    private boolean pageTaken;
 
     public ExchangeResponse(Page page, boolean finished) {
         this.page = page;
@@ -44,16 +38,19 @@ public final class ExchangeResponse extends TransportResponse implements Releasa
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        serialized = true;
         out.writeOptionalWriteable(page);
         out.writeBoolean(finished);
     }
 
     /**
-     * Returns a page responded by {@link RemoteSink}. This can be null and out of order.
+     * Take the ownership of the page responded by {@link RemoteSink}. This can be null and out of order.
      */
     @Nullable
-    public Page page() {
+    public Page takePage() {
+        if (pageTaken) {
+            throw new IllegalStateException("Page was taken already");
+        }
+        pageTaken = true;
         return page;
     }
 
@@ -100,7 +97,7 @@ public final class ExchangeResponse extends TransportResponse implements Releasa
 
     @Override
     public void close() {
-        if (serialized && page != null) {
+        if (pageTaken == false && page != null) {
             page.releaseBlocks();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeResponse.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeResponse.java
@@ -48,6 +48,7 @@ public final class ExchangeResponse extends TransportResponse implements Releasa
     @Nullable
     public Page takePage() {
         if (pageTaken) {
+            assert false : "Page was taken already";
             throw new IllegalStateException("Page was taken already");
         }
         pageTaken = true;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceHandler.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceHandler.java
@@ -157,7 +157,7 @@ public final class ExchangeSourceHandler extends AbstractRefCounted {
                 // finish other sinks if one of them failed or sources no longer need pages.
                 boolean toFinishSinks = buffer.noMoreInputs() || failure.get() != null;
                 remoteSink.fetchPageAsync(toFinishSinks, ActionListener.wrap(resp -> {
-                    Page page = resp.page();
+                    Page page = resp.takePage();
                     if (page != null) {
                         buffer.addPage(page);
                     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -345,7 +345,7 @@ public class ExchangeServiceTests extends ESTestCase {
         sinkExchanger.fetchPageAsync(true, future);
         ExchangeResponse resp = future.actionGet();
         assertTrue(resp.finished());
-        assertNull(resp.page());
+        assertNull(resp.takePage());
         assertTrue(sink.waitForWriting().isDone());
         assertTrue(sink.isFinished());
     }
@@ -394,8 +394,9 @@ public class ExchangeServiceTests extends ESTestCase {
                     @Override
                     public void sendResponse(TransportResponse response) throws IOException {
                         ExchangeResponse exchangeResponse = (ExchangeResponse) response;
-                        if (exchangeResponse.page() != null) {
-                            IntBlock block = exchangeResponse.page().getBlock(0);
+                        Page page = exchangeResponse.takePage();
+                        if (page != null) {
+                            IntBlock block = page.getBlock(0);
                             for (int i = 0; i < block.getPositionCount(); i++) {
                                 if (block.getInt(i) == disconnectOnSeqNo) {
                                     throw new IOException("page is too large");


### PR DESCRIPTION
This change removes the hack in ExchangeResponse. Now when an ExchangeSource receives a response, it takes ownership of the page instead of relying on serialization.

Initially, I tried to use the exchange sink directly for the local connection; however, it still required a hack in the deserialization process (see https://github.com/elastic/elasticsearch/commit/b577af538d62b4d9acc96585b2bdec0133109dca). I think this approach is clearer in terms of ownership.