### PR TITLE
[Test] Ensure correct initial datasetSize estimation

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -815,7 +815,7 @@ public class StoreTests extends ESTestCase {
         // directory that returns total written bytes as the data set size
         final var directory = new ByteSizeDirectory(StoreTests.newDirectory(random())) {
 
-            final AtomicLong dataSetBytes = new AtomicLong(0L);
+            final AtomicLong dataSetBytes = new AtomicLong(estimateSizeInBytes(getDelegate()));
 
             @Override
             public long estimateSizeInBytes() throws IOException {


### PR DESCRIPTION
This PR accounts for the extra file created by ExtraFS for initial dataset size estimation.

Resolves: #99762
