### PR TITLE
ESQL: Fix limit default size setting key

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -77,7 +77,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
     );
 
     public static final Setting<Integer> QUERY_RESULT_TRUNCATION_DEFAULT_SIZE = Setting.intSetting(
-        "esql.query.result_truncation_max_size",
+        "esql.query.result_truncation_default_size",
         500,
         1,
         10000,


### PR DESCRIPTION
Fix c&p error:
`s/esql.query.result_truncation_max_size/esql.query.result_truncation_default_size/`
