### PR TITLE
Remove method Netty4HttpPipeliningHandlerTests#shutdownExecutorService

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -70,16 +70,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     @After
     public void tearDown() throws Exception {
         waitingRequests.keySet().forEach(this::finishRequest);
-        shutdownExecutorService();
-        super.tearDown();
-    }
-
-    private CountDownLatch finishRequest(String url) {
-        waitingRequests.get(url).countDown();
-        return finishingRequests.get(url);
-    }
-
-    private void shutdownExecutorService() throws InterruptedException {
+        // shutdown the Executor Service
         if (handlerService.isShutdown() == false) {
             handlerService.shutdown();
             handlerService.awaitTermination(10, TimeUnit.SECONDS);
@@ -88,6 +79,12 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
             eventLoopService.shutdown();
             eventLoopService.awaitTermination(10, TimeUnit.SECONDS);
         }
+        super.tearDown();
+    }
+
+    private CountDownLatch finishRequest(String url) {
+        waitingRequests.get(url).countDown();
+        return finishingRequests.get(url);
     }
 
     public void testThatPipeliningWorksWithFastSerializedRequests() throws InterruptedException {


### PR DESCRIPTION
In the next Lucene version it has been introduced a static method on LuceneTestCase called shutdownExecutorService. This static method will clash with the method in Netty4HttpPipeliningHandlerTests and it is making the lucene_snapshot  branch unhappy. As the method is only called from the tearDown method, lets move the code there.