### PR TITLE
[8.9][DOCS] Adds new line before paragraph title on delayed data page. (#99902)

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -22,6 +22,7 @@ the value of `query_delay'. If it doesn't help, investigate the ingest latency a
 cause. You can do this by comparing event and ingest timestamps. High latency 
 is often caused by bursts of ingested documents, misconfiguration of the ingest 
 pipeline, or misalignment of system clocks.
+
 == Why worry about delayed data?
 
 If data are delayed randomly (and consequently are missing from analysis), the


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [8.10][DOCS] Adds new line before paragraph title on delayed data page. (#99902)