### PR TITLE
[Profiling] Allow to customize the ILM policy

### DIFF
--- a/docs/changelog/99909.yaml
+++ b/docs/changelog/99909.yaml
@@ -1,0 +1,5 @@
+pr: 99909
+summary: "[Profiling] Allow to customize the ILM policy"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-events.json
@@ -7,8 +7,10 @@
   },
   "composed_of": [
     "profiling-events",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
     "description": "Index template for profiling-events"

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-executables.json
@@ -5,8 +5,10 @@
   "composed_of": [
     "profiling-executables",
     "profiling-ilm",
-    "profiling-hot-tier"
+    "profiling-hot-tier",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
     "description": "Index template for .profiling-executables"

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-hosts.json
@@ -5,8 +5,10 @@
   "data_stream": {},
   "composed_of": [
     "profiling-hosts",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
     "description": "Template for profiling-hosts"

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-metrics.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-metrics.json
@@ -5,8 +5,10 @@
   "data_stream": {},
   "composed_of": [
     "profiling-metrics",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
     "description": "Template for profiling-metrics"

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stackframes.json
@@ -5,8 +5,10 @@
   "composed_of": [
     "profiling-stackframes",
     "profiling-ilm",
-    "profiling-hot-tier"
+    "profiling-hot-tier",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
     "description": "Index template for .profiling-stackframes"

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stacktraces.json
@@ -5,8 +5,10 @@
   "composed_of": [
     "profiling-stacktraces",
     "profiling-ilm",
-    "profiling-hot-tier"
+    "profiling-hot-tier",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
     "description": "Index template for .profiling-stacktraces"

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-global.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-global.json
@@ -5,8 +5,10 @@
   "composed_of": [
     "profiling-symbols",
     "profiling-ilm",
-    "profiling-hot-tier"
+    "profiling-hot-tier",
+    "profiling-ilm@custom"
   ],
+  "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "template": {
     "settings": {
       "index": {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -41,7 +41,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // history (please add a comment why you increased the version here)
     // version 1: initial
     // version 2: Added 'profiling.host.machine' keyword mapping to profiling-hosts
-    public static final int INDEX_TEMPLATE_VERSION = 2;
+    // version 3: Add optional component template profiling-ilm@custom to all ILM-managed index templates
+    public static final int INDEX_TEMPLATE_VERSION = 3;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 1;

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -41,7 +41,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // history (please add a comment why you increased the version here)
     // version 1: initial
     // version 2: Added 'profiling.host.machine' keyword mapping to profiling-hosts
-    // version 3: Add optional component template profiling-ilm@custom to all ILM-managed index templates
+    // version 3: Add optional component template 'profiling-ilm@custom' to all ILM-managed index templates
     public static final int INDEX_TEMPLATE_VERSION = 3;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index


### PR DESCRIPTION
With this commit we reference the component template `profiling-ilm@custom` in all composable index templates that define indices / data streams managed by ILM. This allows users to override the built-in ILM policy and define e.g. a shorter retention period.