### PR TITLE
[8.10] Add "manage" permission for fleet managed threat intel indices (#99231)

### DIFF
--- a/docs/changelog/99231.yaml
+++ b/docs/changelog/99231.yaml
@@ -1,0 +1,5 @@
+pr: 99231
+summary: Add manage permission for fleet managed threat intel indices
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -281,13 +281,12 @@ class KibanaOwnedReservedRoleDescriptors {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs-ti_*_latest.*")
                     .privileges(
-                        // Require "create_index", "delete_index", "read", "index", "delete", IndicesAliasesAction.NAME, and
-                        // UpdateSettingsAction.NAME for transform
                         "create_index",
                         "delete_index",
                         "read",
                         "index",
                         "delete",
+                        "manage",
                         IndicesAliasesAction.NAME,
                         UpdateSettingsAction.NAME
                     )


### PR DESCRIPTION
Backports the following commits to 8.10:

- https://github.com/elastic/elasticsearch/pull/99231