### PR TITLE
[ML] Decouple ML template versioning from product version

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/NotificationsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/NotificationsIndex.java
@@ -17,7 +17,7 @@ public final class NotificationsIndex {
 
     private static final String RESOURCE_PATH = "/ml/";
     private static final String MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";
-    private static final int NOTIFICATIONS_INDEX_MAPPINGS_VERSION = 1;
+    public static final int NOTIFICATIONS_INDEX_MAPPINGS_VERSION = 1;
 
     private NotificationsIndex() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/TemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/TemplateUtils.java
@@ -117,14 +117,15 @@ public class TemplateUtils {
      * Checks if a versioned template exists, and if it exists checks if the version is greater than or equal to the current version.
      * @param templateName Name of the index template
      * @param state Cluster state
+     * @param currentVersion The current version to check against
      */
-    public static boolean checkTemplateExistsAndVersionIsGTECurrentVersion(String templateName, ClusterState state) {
+    public static boolean checkTemplateExistsAndVersionIsGTECurrentVersion(String templateName, ClusterState state, long currentVersion) {
         ComposableIndexTemplate templateMetadata = state.metadata().templatesV2().get(templateName);
         if (templateMetadata == null) {
             return false;
         }
 
-        return templateMetadata.version() != null && templateMetadata.version() >= Version.CURRENT.id;
+        return templateMetadata.version() != null && templateMetadata.version() >= currentVersion;
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.common.notifications;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkAction;
@@ -22,7 +21,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -68,6 +66,8 @@ public class AbstractAuditorTests extends ESTestCase {
     private static final String TEST_NODE_NAME = "node_1";
     private static final String TEST_ORIGIN = "test_origin";
     private static final String TEST_INDEX = "test_index";
+
+    private static final int TEST_TEMPLATE_VERSION = 23456789;
 
     private Client client;
     private ArgumentCaptor<IndexRequest> indexRequestCaptor;
@@ -231,11 +231,8 @@ public class AbstractAuditorTests extends ESTestCase {
         Metadata metadata = mock(Metadata.class);
         when(metadata.getTemplates()).thenReturn(templates);
         when(metadata.templatesV2()).thenReturn(templatesV2);
-        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
-        when(nodes.getMinNodeVersion()).thenReturn(Version.CURRENT);
         ClusterState state = mock(ClusterState.class);
         when(state.getMetadata()).thenReturn(metadata);
-        when(state.nodes()).thenReturn(nodes);
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(state);
 
@@ -274,11 +271,8 @@ public class AbstractAuditorTests extends ESTestCase {
 
         Metadata metadata = mock(Metadata.class);
         when(metadata.getTemplates()).thenReturn(Map.of());
-        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
-        when(nodes.getMinNodeVersion()).thenReturn(Version.CURRENT);
         ClusterState state = mock(ClusterState.class);
         when(state.getMetadata()).thenReturn(metadata);
-        when(state.nodes()).thenReturn(nodes);
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(state);
 
@@ -294,11 +288,11 @@ public class AbstractAuditorTests extends ESTestCase {
                 new IndexTemplateConfig(
                     TEST_INDEX,
                     "/ml/notifications_index_template.json",
-                    Version.CURRENT.id,
+                    TEST_TEMPLATE_VERSION,
                     "xpack.ml.version",
                     Map.of(
                         "xpack.ml.version.id",
-                        String.valueOf(Version.CURRENT.id),
+                        String.valueOf(TEST_TEMPLATE_VERSION),
                         "xpack.ml.notifications.mappings",
                         NotificationsIndex.mapping()
                     )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.utils;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -33,10 +32,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
@@ -51,8 +47,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.stubbing.Answer;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -80,6 +74,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
     private static final String TEST_INDEX_ALIAS = "test-alias";
     private static final String LEGACY_INDEX_WITHOUT_SUFFIX = TEST_INDEX_PREFIX;
     private static final String FIRST_CONCRETE_INDEX = "test-000001";
+
+    private static final int TEST_TEMPLATE_VERSION = 12345678;
 
     private ThreadPool threadPool;
     private IndicesAdminClient indicesAdminClient;
@@ -143,9 +139,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
         verifyNoMoreInteractions(indicesAdminClient, listener);
     }
 
-    public void testInstallIndexTemplateIfRequired_GivenLegacyTemplateExistsAndModernCluster() throws UnknownHostException {
+    public void testInstallIndexTemplateIfRequired_GivenLegacyTemplateExistsAndModernCluster() {
         ClusterState clusterState = createClusterState(
-            Version.CURRENT,
             Collections.emptyMap(),
             Collections.singletonMap(
                 NotificationsIndex.NOTIFICATIONS_INDEX,
@@ -160,11 +155,11 @@ public class MlIndexAndAliasTests extends ESTestCase {
         IndexTemplateConfig notificationsTemplate = new IndexTemplateConfig(
             NotificationsIndex.NOTIFICATIONS_INDEX,
             "/ml/notifications_index_template.json",
-            Version.CURRENT.id,
+            TEST_TEMPLATE_VERSION,
             "xpack.ml.version",
             Map.of(
                 "xpack.ml.version.id",
-                String.valueOf(Version.CURRENT.id),
+                String.valueOf(TEST_TEMPLATE_VERSION),
                 "xpack.ml.notifications.mappings",
                 NotificationsIndex.mapping()
             )
@@ -182,9 +177,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
         inOrder.verify(listener).onResponse(true);
     }
 
-    public void testInstallIndexTemplateIfRequired_GivenComposableTemplateExists() throws UnknownHostException {
+    public void testInstallIndexTemplateIfRequired_GivenComposableTemplateExists() {
         ClusterState clusterState = createClusterState(
-            Version.CURRENT,
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.singletonMap(
@@ -199,11 +193,11 @@ public class MlIndexAndAliasTests extends ESTestCase {
         IndexTemplateConfig notificationsTemplate = new IndexTemplateConfig(
             NotificationsIndex.NOTIFICATIONS_INDEX,
             "/ml/notifications_index_template.json",
-            Version.CURRENT.id,
+            TEST_TEMPLATE_VERSION,
             "xpack.ml.version",
             Map.of(
                 "xpack.ml.version.id",
-                String.valueOf(Version.CURRENT.id),
+                String.valueOf(TEST_TEMPLATE_VERSION),
                 "xpack.ml.notifications.mappings",
                 NotificationsIndex.mapping()
             )
@@ -220,17 +214,17 @@ public class MlIndexAndAliasTests extends ESTestCase {
         verifyNoMoreInteractions(client);
     }
 
-    public void testInstallIndexTemplateIfRequired() throws UnknownHostException {
+    public void testInstallIndexTemplateIfRequired() {
         ClusterState clusterState = createClusterState(Collections.emptyMap());
 
         IndexTemplateConfig notificationsTemplate = new IndexTemplateConfig(
             NotificationsIndex.NOTIFICATIONS_INDEX,
             "/ml/notifications_index_template.json",
-            Version.CURRENT.id,
+            TEST_TEMPLATE_VERSION,
             "xpack.ml.version",
             Map.of(
                 "xpack.ml.version.id",
-                String.valueOf(Version.CURRENT.id),
+                String.valueOf(TEST_TEMPLATE_VERSION),
                 "xpack.ml.notifications.mappings",
                 NotificationsIndex.mapping()
             )
@@ -248,7 +242,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
         inOrder.verify(listener).onResponse(true);
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_CleanState() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_CleanState() {
         ClusterState clusterState = createClusterState(Collections.emptyMap());
         createIndexAndAliasIfNecessary(clusterState);
 
@@ -262,27 +256,26 @@ public class MlIndexAndAliasTests extends ESTestCase {
         assertThat(createRequest.aliases(), equalTo(Collections.singleton(new Alias(TEST_INDEX_ALIAS).isHidden(true))));
     }
 
-    private void assertNoClientInteractionsWhenWriteAliasAlreadyExists(String indexName) throws UnknownHostException {
+    private void assertNoClientInteractionsWhenWriteAliasAlreadyExists(String indexName) {
         ClusterState clusterState = createClusterState(Collections.singletonMap(indexName, createIndexMetadataWithAlias(indexName)));
         createIndexAndAliasIfNecessary(clusterState);
 
         verify(listener).onResponse(false);
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtInitialStateIndex() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtInitialStateIndex() {
         assertNoClientInteractionsWhenWriteAliasAlreadyExists(FIRST_CONCRETE_INDEX);
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtSubsequentStateIndex()
-        throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtSubsequentStateIndex() {
         assertNoClientInteractionsWhenWriteAliasAlreadyExists("test-000007");
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtDummyIndex() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtDummyIndex() {
         assertNoClientInteractionsWhenWriteAliasAlreadyExists("dummy-index");
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtLegacyStateIndex() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasAlreadyExistsAndPointsAtLegacyStateIndex() {
         ClusterState clusterState = createClusterState(
             Collections.singletonMap(LEGACY_INDEX_WITHOUT_SUFFIX, createIndexMetadataWithAlias(LEGACY_INDEX_WITHOUT_SUFFIX))
         );
@@ -309,8 +302,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
         );
     }
 
-    private void assertMlStateWriteAliasAddedToMostRecentMlStateIndex(List<String> existingIndexNames, String expectedWriteIndexName)
-        throws UnknownHostException {
+    private void assertMlStateWriteAliasAddedToMostRecentMlStateIndex(List<String> existingIndexNames, String expectedWriteIndexName) {
         ClusterState clusterState = createClusterState(
             existingIndexNames.stream().collect(toMap(Function.identity(), MlIndexAndAliasTests::createIndexMetadata))
         );
@@ -328,23 +320,22 @@ public class MlIndexAndAliasTests extends ESTestCase {
         );
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButInitialStateIndexExists() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButInitialStateIndexExists() {
         assertMlStateWriteAliasAddedToMostRecentMlStateIndex(Arrays.asList(FIRST_CONCRETE_INDEX), FIRST_CONCRETE_INDEX);
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButSubsequentStateIndicesExist() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButSubsequentStateIndicesExist() {
         assertMlStateWriteAliasAddedToMostRecentMlStateIndex(Arrays.asList("test-000003", "test-000040", "test-000500"), "test-000500");
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButBothLegacyAndNewIndicesExist()
-        throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButBothLegacyAndNewIndicesExist() {
         assertMlStateWriteAliasAddedToMostRecentMlStateIndex(
             Arrays.asList(LEGACY_INDEX_WITHOUT_SUFFIX, "test-000003", "test-000040", "test-000500"),
             "test-000500"
         );
     }
 
-    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButLegacyStateIndexExists() throws UnknownHostException {
+    public void testCreateStateIndexAndAliasIfNecessary_WriteAliasDoesNotExistButLegacyStateIndexExists() {
         ClusterState clusterState = createClusterState(
             Collections.singletonMap(LEGACY_INDEX_WITHOUT_SUFFIX, createIndexMetadata(LEGACY_INDEX_WITHOUT_SUFFIX))
         );
@@ -392,25 +383,16 @@ public class MlIndexAndAliasTests extends ESTestCase {
         };
     }
 
-    private static ClusterState createClusterState(Map<String, IndexMetadata> indices) throws UnknownHostException {
-        return createClusterState(Version.CURRENT, indices, Collections.emptyMap(), Collections.emptyMap());
+    private static ClusterState createClusterState(Map<String, IndexMetadata> indices) {
+        return createClusterState(indices, Collections.emptyMap(), Collections.emptyMap());
     }
 
     private static ClusterState createClusterState(
-        Version minNodeVersion,
         Map<String, IndexMetadata> indices,
         Map<String, IndexTemplateMetadata> legacyTemplates,
         Map<String, ComposableIndexTemplate> composableTemplates
-    ) throws UnknownHostException {
-        InetAddress inetAddress1 = InetAddress.getByAddress(new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
-        InetAddress inetAddress2 = InetAddress.getByAddress(new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 2 });
+    ) {
         return ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(
-                DiscoveryNodes.builder()
-                    .add(DiscoveryNodeUtils.create("foo", new TransportAddress(inetAddress1, 9201)))
-                    .add(DiscoveryNodeUtils.create("bar", new TransportAddress(inetAddress2, 9202), minNodeVersion))
-                    .build()
-            )
             .metadata(Metadata.builder().indices(indices).templates(legacyTemplates).indexTemplates(composableTemplates).build())
             .build();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1752,7 +1752,12 @@ public class MachineLearning extends Plugin
         // installs it if necessary
         List<String> templateNames = List.of(STATE_INDEX_PREFIX, AnomalyDetectorsIndex.jobResultsIndexPrefix());
         for (String templateName : templateNames) {
-            allPresent = allPresent && TemplateUtils.checkTemplateExistsAndVersionIsGTECurrentVersion(templateName, clusterState);
+            allPresent = allPresent
+                && TemplateUtils.checkTemplateExistsAndVersionIsGTECurrentVersion(
+                    templateName,
+                    clusterState,
+                    MlIndexTemplateRegistry.ML_INDEX_TEMPLATE_VERSION
+                );
         }
 
         return allPresent;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -29,6 +28,23 @@ import java.util.Map;
 
 public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
 
+    /**
+     * The template version starts from 10000000 because up until 8.11.0 we
+     * used version IDs for template versioning, so the first detached
+     * version number needs to be higher than the version ID of 8.11.0.
+     * We add on the mappings version of each of the templates that has
+     * mappings. This will cause _all_ templates to get installed when the
+     * mappings for any single template change. However, this is better
+     * than the risk of potentially updating mappings without updating the
+     * template versions and hence not reinstalling the templates. Note that
+     * the state index has no mappings - its template basically just says
+     * this - hence there's no mappings version for the state index. Please
+     * add a comment with a reason each time the base number is incremented.
+     * 10000001: TODO - reason
+     */
+    public static final int ML_INDEX_TEMPLATE_VERSION = 10000000 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
+        + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION;
+
     private static final String ROOT_RESOURCE_PATH = "/ml/";
     private static final String ANOMALY_DETECTION_PATH = ROOT_RESOURCE_PATH + "anomalydetection/";
     private static final String VERSION_PATTERN = "xpack.ml.version";
@@ -42,7 +58,7 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
 
     private IndexTemplateConfig stateTemplate() {
         Map<String, String> variables = new HashMap<>();
-        variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
+        variables.put(VERSION_ID_PATTERN, String.valueOf(ML_INDEX_TEMPLATE_VERSION));
         // In serverless a different version of "state_index_template.json" is shipped that won't substitute the ILM policy variable
         variables.put(INDEX_LIFECYCLE_NAME, ML_SIZE_BASED_ILM_POLICY_NAME);
         variables.put(INDEX_LIFECYCLE_ROLLOVER_ALIAS, AnomalyDetectorsIndex.jobStateIndexWriteAlias());
@@ -50,7 +66,7 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
         return new IndexTemplateConfig(
             AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
             ANOMALY_DETECTION_PATH + "state_index_template.json",
-            Version.CURRENT.id,
+            ML_INDEX_TEMPLATE_VERSION,
             VERSION_PATTERN,
             variables
         );
@@ -58,13 +74,13 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
 
     private static IndexTemplateConfig anomalyDetectionResultsTemplate() {
         Map<String, String> variables = new HashMap<>();
-        variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
+        variables.put(VERSION_ID_PATTERN, String.valueOf(ML_INDEX_TEMPLATE_VERSION));
         variables.put("xpack.ml.anomalydetection.results.mappings", AnomalyDetectorsIndex.resultsMapping());
 
         return new IndexTemplateConfig(
             AnomalyDetectorsIndex.jobResultsIndexPrefix(),
             ANOMALY_DETECTION_PATH + "results_index_template.json",
-            Version.CURRENT.id,
+            ML_INDEX_TEMPLATE_VERSION,
             VERSION_PATTERN,
             variables
         );
@@ -72,13 +88,13 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
 
     private static IndexTemplateConfig notificationsTemplate() {
         Map<String, String> variables = new HashMap<>();
-        variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
+        variables.put(VERSION_ID_PATTERN, String.valueOf(ML_INDEX_TEMPLATE_VERSION));
         variables.put("xpack.ml.notifications.mappings", NotificationsIndex.mapping());
 
         return new IndexTemplateConfig(
             NotificationsIndex.NOTIFICATIONS_INDEX,
             ROOT_RESOURCE_PATH + "notifications_index_template.json",
-            Version.CURRENT.id,
+            ML_INDEX_TEMPLATE_VERSION,
             VERSION_PATTERN,
             variables
         );
@@ -86,7 +102,7 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
 
     private IndexTemplateConfig statsTemplate() {
         Map<String, String> variables = new HashMap<>();
-        variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
+        variables.put(VERSION_ID_PATTERN, String.valueOf(ML_INDEX_TEMPLATE_VERSION));
         variables.put("xpack.ml.stats.mappings", MlStatsIndex.mapping());
         // In serverless a different version of "stats_index_template.json" is shipped that won't substitute the ILM policy variable
         variables.put(INDEX_LIFECYCLE_NAME, ML_SIZE_BASED_ILM_POLICY_NAME);
@@ -95,7 +111,7 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
         return new IndexTemplateConfig(
             MlStatsIndex.TEMPLATE_NAME,
             ROOT_RESOURCE_PATH + "stats_index_template.json",
-            Version.CURRENT.id,
+            ML_INDEX_TEMPLATE_VERSION,
             VERSION_PATTERN,
             variables
         );

--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.test.rest;
 
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -18,12 +17,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.ESTestCase.assertBusy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.fail;
 
 public final class XPackRestTestHelper {
@@ -31,8 +27,7 @@ public final class XPackRestTestHelper {
     private XPackRestTestHelper() {}
 
     /**
-     * For each template name wait for the template to be created and
-     * for the template version to be equal to the master node version.
+     * For each template name wait for the template to be created.
      *
      * @param client             The rest client
      * @param expectedTemplates  Names of the templates to wait for
@@ -41,23 +36,6 @@ public final class XPackRestTestHelper {
     @SuppressWarnings("unchecked")
     public static void waitForTemplates(RestClient client, List<String> expectedTemplates, boolean clusterUnderstandsComposableTemplates)
         throws Exception {
-        AtomicReference<Version> masterNodeVersion = new AtomicReference<>();
-
-        assertBusy(() -> {
-            Request request = new Request("GET", "/_cat/nodes");
-            request.addParameter("h", "master,version");
-            request.addParameter("error_trace", "true");
-            String response = EntityUtils.toString(client.performRequest(request).getEntity());
-
-            for (String line : response.split("\n")) {
-                if (line.startsWith("*")) {
-                    masterNodeVersion.set(Version.fromString(line.substring(2).trim()));
-                    return;
-                }
-            }
-            fail("No master elected");
-        });
-
         // TODO: legacy support can be removed once all X-Pack plugins use only composable
         // templates in the oldest version we test upgrades from
         assertBusy(() -> {
@@ -102,18 +80,6 @@ public final class XPackRestTestHelper {
                         + legacyTemplates
                 );
             }
-
-            expectedTemplates.forEach(template -> {
-                Map<?, ?> templateDefinition = (Map<?, ?>) response.get(template);
-                if (templateDefinition == null) {
-                    templateDefinition = (Map<?, ?>) legacyResponse.get(template);
-                }
-                assertThat(
-                    "Template [" + template + "] has unexpected version",
-                    Version.fromId((Integer) templateDefinition.get("version")),
-                    equalTo(masterNodeVersion.get())
-                );
-            });
         });
     }
 


### PR DESCRIPTION
The ML index templates used to be versioned using the product version. This won't work in serverless, so needs to be changed.

Most plugins have a separate version constant for their index templates that started at 1 and is incremented manually when any template changes. For ML, we've got used to _not_ having to worry about index template versions, only mappings versions. To try to continue this approach as far as possible, the new strategy for ML index template versions is:

- Start with 10000000. This is because 8.11.0's ID is 8110099, and whatever new scheme we use must generate numbers bigger than this.
- Add on the mappings version constants for all index mappings for which we use index templates. This means that incrementing the mappings version is still sufficient to cause the templates to be reinstalled. It's only necessary to increment the base template version if something changes in a template that's _not_ in the mappings, such as priority. This should be very rare. So the risk of forgetting to update the template versions when updating mappings is removed.