### PR TITLE
Collect and merge response headers in ESQL

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverRunner.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverRunner.java
@@ -9,17 +9,29 @@ package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.tasks.TaskCancelledException;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Run a set of drivers to completion.
  */
 public abstract class DriverRunner {
+    private final ThreadContext threadContext;
+
+    public DriverRunner(ThreadContext threadContext) {
+        this.threadContext = threadContext;
+    }
+
     /**
      * Start a driver.
      */
@@ -30,8 +42,11 @@ public abstract class DriverRunner {
      */
     public void runToCompletion(List<Driver> drivers, ActionListener<Void> listener) {
         AtomicReference<Exception> failure = new AtomicReference<>();
+        AtomicArray<Map<String, List<String>>> responseHeaders = new AtomicArray<>(drivers.size());
         CountDown counter = new CountDown(drivers.size());
-        for (Driver driver : drivers) {
+        for (int i = 0; i < drivers.size(); i++) {
+            Driver driver = drivers.get(i);
+            int driverIndex = i;
             ActionListener<Void> driverListener = new ActionListener<>() {
                 @Override
                 public void onResponse(Void unused) {
@@ -66,7 +81,9 @@ public abstract class DriverRunner {
                 }
 
                 private void done() {
+                    responseHeaders.setOnce(driverIndex, threadContext.getResponseHeaders());
                     if (counter.countDown()) {
+                        mergeResponseHeaders(responseHeaders);
                         for (Driver d : drivers) {
                             if (d.status().status() == DriverStatus.Status.QUEUED) {
                                 d.close();
@@ -85,6 +102,25 @@ public abstract class DriverRunner {
             };
 
             start(driver, driverListener);
+        }
+    }
+
+    private void mergeResponseHeaders(AtomicArray<Map<String, List<String>>> responseHeaders) {
+        final Map<String, Set<String>> merged = new HashMap<>();
+        for (int i = 0; i < responseHeaders.length(); i++) {
+            final Map<String, List<String>> resp = responseHeaders.get(i);
+            if (resp == null || resp.isEmpty()) {
+                continue;
+            }
+            for (Map.Entry<String, List<String>> e : resp.entrySet()) {
+                // Use LinkedHashSet to retain the order of the values
+                merged.computeIfAbsent(e.getKey(), k -> new LinkedHashSet<>(e.getValue().size())).addAll(e.getValue());
+            }
+        }
+        for (Map.Entry<String, Set<String>> e : merged.entrySet()) {
+            for (String v : e.getValue()) {
+                threadContext.addResponseHeader(e.getKey(), v);
+            }
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverTaskRunner.java
@@ -42,7 +42,7 @@ public class DriverTaskRunner {
     }
 
     public void executeDrivers(Task parentTask, List<Driver> drivers, Executor executor, ActionListener<Void> listener) {
-        var runner = new DriverRunner() {
+        var runner = new DriverRunner(transportService.getThreadPool().getThreadContext()) {
             @Override
             protected void start(Driver driver, ActionListener<Void> driverListener) {
                 transportService.sendChildRequest(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -160,7 +160,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         List<Page> results = new ArrayList<>();
 
         List<Driver> drivers = createDriversForInput(bigArrays, input, results, false /* no throwing ops */);
-        var runner = new DriverRunner() {
+        var runner = new DriverRunner(threadPool.getThreadContext()) {
             @Override
             protected void start(Driver driver, ActionListener<Void> listener) {
                 Driver.start(threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 10000), listener);
@@ -182,7 +182,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         List<Page> results = new ArrayList<>();
 
         List<Driver> drivers = createDriversForInput(bigArrays, input, results, true /* one throwing op */);
-        var runner = new DriverRunner() {
+        var runner = new DriverRunner(threadPool.getThreadContext()) {
             @Override
             protected void start(Driver driver, ActionListener<Void> listener) {
                 Driver.start(threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 1000), listener);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -193,7 +193,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
             getTestClass().getSimpleName(),
             new FixedExecutorBuilder(Settings.EMPTY, "esql", numThreads, 1024, "esql", EsExecutors.TaskTrackingConfig.DEFAULT)
         );
-        var driverRunner = new DriverRunner() {
+        var driverRunner = new DriverRunner(threadPool.getThreadContext()) {
             @Override
             protected void start(Driver driver, ActionListener<Void> driverListener) {
                 Driver.start(threadPool.executor("esql"), driver, between(1, 10000), driverListener);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -301,7 +301,7 @@ public class ExchangeServiceTests extends ESTestCase {
             drivers.add(d);
         }
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        new DriverRunner() {
+        new DriverRunner(threadPool.getThreadContext()) {
             @Override
             protected void start(Driver driver, ActionListener<Void> listener) {
                 Driver.start(threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 10000), listener);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/lookup/EnrichLookupIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/lookup/EnrichLookupIT.java
@@ -141,7 +141,7 @@ public class EnrichLookupIT extends AbstractEsqlIntegTestCase {
 
         DateFormatter dateFmt = DateFormatter.forPattern("yyyy-MM-dd");
 
-        var runner = new DriverRunner() {
+        var runner = new DriverRunner(transportService.getThreadPool().getThreadContext()) {
             final Executor executor = transportService.getThreadPool().executor(EsqlPlugin.ESQL_THREAD_POOL_NAME);
 
             @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -378,7 +378,7 @@ public class CsvTests extends ESTestCase {
                 Randomness.shuffle(drivers);
             }
             // Execute the driver
-            DriverRunner runner = new DriverRunner() {
+            DriverRunner runner = new DriverRunner(threadPool.getThreadContext()) {
                 @Override
                 protected void start(Driver driver, ActionListener<Void> driverListener) {
                     Driver.start(threadPool.executor(ESQL_THREAD_POOL_NAME), driver, between(1, 1000), driverListener);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -19,7 +19,9 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
@@ -87,10 +89,12 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -378,22 +382,52 @@ public class CsvTests extends ESTestCase {
                 Randomness.shuffle(drivers);
             }
             // Execute the driver
+            final Queue<Map<String, List<String>>> responseHeaders = ConcurrentCollections.newQueue();
             DriverRunner runner = new DriverRunner() {
                 @Override
                 protected void start(Driver driver, ActionListener<Void> driverListener) {
-                    Driver.start(threadPool.executor(ESQL_THREAD_POOL_NAME), driver, between(1, 1000), driverListener);
+                    Driver.start(
+                        threadPool.executor(ESQL_THREAD_POOL_NAME),
+                        driver,
+                        between(1, 1000),
+                        ActionListener.runBefore(
+                            driverListener,
+                            () -> responseHeaders.add(threadPool.getThreadContext().getResponseHeaders())
+                        )
+                    );
                 }
             };
             PlainActionFuture<ActualResults> future = new PlainActionFuture<>();
-            runner.runToCompletion(drivers, ActionListener.releaseAfter(future, () -> Releasables.close(drivers)).map(ignore -> {
-                var responseHeaders = threadPool.getThreadContext().getResponseHeaders();
-                return new ActualResults(columnNames, columnTypes, dataTypes, collectedPages, responseHeaders);
-            }));
+            runner.runToCompletion(
+                drivers,
+                ActionListener.releaseAfter(future, () -> Releasables.close(drivers))
+                    .map(
+                        ignore -> new ActualResults(
+                            columnNames,
+                            columnTypes,
+                            dataTypes,
+                            collectedPages,
+                            mergeResponseHeaders(responseHeaders)
+                        )
+                    )
+            );
             return future.actionGet(TimeValue.timeValueSeconds(30));
         } finally {
             Releasables.close(() -> Releasables.close(drivers), exchangeSource::decRef);
             assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
         }
+    }
+
+    private static Map<String, List<String>> mergeResponseHeaders(Collection<Map<String, List<String>>> responses) {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        for (Map<String, List<String>> r : responses) {
+            for (Map.Entry<String, List<String>> e : r.entrySet()) {
+                for (String v : e.getValue()) {
+                    threadContext.addResponseHeader(e.getKey(), v);
+                }
+            }
+        }
+        return threadContext.getResponseHeaders();
     }
 
     private Throwable reworkException(Throwable th) {


### PR DESCRIPTION
It seems that our infrastructure does not merge response headers across multiple asynchronous calls. I can reproduce this issue using the TransportService. Response headers are not merged properly in this scenario:

1. The caller initiates two asynchronous calls, c1 and c2, which can involve network requests.

2. c1 responded with a warning in the header responses. We merge these response headers with the original ThreadContext of the calling thread and update the ThreadContext of the current thread (leaving the calling thread untouched).

3. c2 responded with no warning in the header responses. Since the original ThreadContext of the calling thread did not get updated after c1, as it's immutable, we won't be able to merge response headers between c1 and c2.

4. The caller receives a response from the responding thread of c2 without any warning.

This PR manually collect and merge response headers in DriverRunner. I think we should generalize this pattern for Elasticsearch.