### PR TITLE
Remove temporary TransportAction constructors

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -44,19 +44,6 @@ public abstract class HandledTransportAction<Request extends ActionRequest, Resp
         this(actionName, true, transportService, actionFilters, requestReader, executor);
     }
 
-    /**
-     * Temporary for serverless compatibility. TODO remove.
-     */
-    protected HandledTransportAction(
-        String actionName,
-        TransportService transportService,
-        ActionFilters actionFilters,
-        Writeable.Reader<Request> requestReader,
-        String executor
-    ) {
-        this(actionName, true, transportService, actionFilters, requestReader, transportService.getThreadPool().executor(executor));
-    }
-
     protected HandledTransportAction(
         String actionName,
         boolean canTripCircuitBreaker,

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
@@ -44,29 +44,6 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
     protected final String transportUnpromotableAction;
     protected final Executor executor;
 
-    /**
-     * Temporary for serverless compatibility. TODO remove.
-     */
-    protected TransportBroadcastUnpromotableAction(
-        String actionName,
-        ClusterService clusterService,
-        TransportService transportService,
-        ShardStateAction shardStateAction,
-        ActionFilters actionFilters,
-        Writeable.Reader<Request> requestReader,
-        String executor
-    ) {
-        this(
-            actionName,
-            clusterService,
-            transportService,
-            shardStateAction,
-            actionFilters,
-            requestReader,
-            transportService.getThreadPool().executor(executor)
-        );
-    }
-
     protected TransportBroadcastUnpromotableAction(
         String actionName,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -67,33 +67,6 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
     protected final Executor executor;
 
-    /**
-     * Temporary for serverless compatibility. TODO remove.
-     */
-    protected TransportMasterNodeAction(
-        String actionName,
-        TransportService transportService,
-        ClusterService clusterService,
-        ThreadPool threadPool,
-        ActionFilters actionFilters,
-        Writeable.Reader<Request> request,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        Writeable.Reader<Response> response,
-        String executor
-    ) {
-        this(
-            actionName,
-            transportService,
-            clusterService,
-            threadPool,
-            actionFilters,
-            request,
-            indexNameExpressionResolver,
-            response,
-            threadPool.executor(executor)
-        );
-    }
-
     protected TransportMasterNodeAction(
         String actionName,
         TransportService transportService,

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -57,22 +57,6 @@ public abstract class TransportNodesAction<
     private final Executor finalExecutor;
 
     /**
-     * Temporary for serverless compatibility. TODO remove.
-     */
-    protected TransportNodesAction(
-        String actionName,
-        ThreadPool threadPool,
-        ClusterService clusterService,
-        TransportService transportService,
-        ActionFilters actionFilters,
-        Writeable.Reader<NodesRequest> request,
-        Writeable.Reader<NodeRequest> nodeRequest,
-        String executor
-    ) {
-        this(actionName, threadPool, clusterService, transportService, actionFilters, request, nodeRequest, threadPool.executor(executor));
-    }
-
-    /**
      * @param actionName        action name
      * @param threadPool        thread-pool
      * @param clusterService    cluster service


### PR DESCRIPTION
Temporary constructors were added for serverless compatibility
until serverless could be updated to use new constructors.

Closes #97879
