### PR TITLE
ESQL: Handle allocation errors inside topn

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -89,7 +89,7 @@ public enum Releasables {
      *  // the resources will be released when reaching here
      *  </pre>
      */
-    public static Releasable wrap(final Iterable<Releasable> releasables) {
+    public static Releasable wrap(final Iterable<? extends Releasable> releasables) {
         return new Releasable() {
             @Override
             public void close() {

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -160,7 +160,14 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
 
     @Override
     public long ramBytesUsed() {
-        return BASE_RAM_BYTES_USED + startOffsets.ramBytesUsed() + bytes.ramBytesUsed();
+        return BASE_RAM_BYTES_USED + bigArraysRamBytesUsed();
+    }
+
+    /**
+     * Memory used by the {@link BigArrays} portion of this {@link BytesRefArray}.
+     */
+    public long bigArraysRamBytesUsed() {
+        return startOffsets.ramBytesUsed() + bytes.ramBytesUsed();
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -678,6 +678,9 @@ public class MockBigArrays extends BigArrays {
             while (true) {
                 long old = used.get();
                 long total = old + bytes;
+                if (total < 0) {
+                    throw new AssertionError("total must be >= 0 but was [" + total + "]");
+                }
                 if (total > max.getBytes()) {
                     throw new CircuitBreakingException(ERROR_MESSAGE, bytes, max.getBytes(), Durability.TRANSIENT);
                 }
@@ -689,7 +692,10 @@ public class MockBigArrays extends BigArrays {
 
         @Override
         public void addWithoutBreaking(long bytes) {
-            used.addAndGet(bytes);
+            long total = used.addAndGet(bytes);
+            if (total < 0) {
+                throw new AssertionError("total must be >= 0 but was [" + total + "]");
+            }
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -75,6 +75,7 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
     public static long ramBytesEstimated(boolean[] values, int[] firstValueIndexes, BitSet nullsMask) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask) + RamUsageEstimator.shallowSizeOfInstance(MvOrdering.class);
+        // TODO mvordering is shared
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlockBuilder.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.apache.lucene.util.RamUsageEstimator;
+
 import java.util.Arrays;
 
 /**
@@ -20,7 +22,7 @@ final class BooleanBlockBuilder extends AbstractBlockBuilder implements BooleanB
     BooleanBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         super(blockFactory);
         int initialSize = Math.max(estimatedSize, 2);
-        adjustBreaker(initialSize);
+        adjustBreaker(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + initialSize * elementSize());
         values = new boolean[initialSize];
     }
 
@@ -192,8 +194,16 @@ final class BooleanBlockBuilder extends AbstractBlockBuilder implements BooleanB
                 block = new BooleanArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
             }
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
+        built();
         return block;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBuilder.java
@@ -49,6 +49,7 @@ final class BooleanVectorBuilder extends AbstractVectorBuilder implements Boolea
 
     @Override
     public BooleanVector build() {
+        finish();
         BooleanVector vector;
         if (valueCount == 1) {
             vector = new ConstantBooleanVector(values[0], 1, blockFactory);
@@ -58,8 +59,16 @@ final class BooleanVectorBuilder extends AbstractVectorBuilder implements Boolea
             }
             vector = new BooleanArrayVector(values, valueCount, blockFactory);
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, false);
+        built();
         return vector;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -77,6 +77,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
     public static long ramBytesEstimated(BytesRefArray values, int[] firstValueIndexes, BitSet nullsMask) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask) + RamUsageEstimator.shallowSizeOfInstance(MvOrdering.class);
+        // TODO mvordering is shared
     }
 
     @Override
@@ -111,7 +112,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
 
     @Override
     public void close() {
-        blockFactory.adjustBreaker(-(ramBytesUsed() - values.ramBytesUsed()), true);
+        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -85,7 +85,7 @@ public final class BytesRefArrayVector extends AbstractVector implements BytesRe
 
     @Override
     public void close() {
-        blockFactory.adjustBreaker(-BASE_RAM_BYTES_USED, true);
+        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
@@ -193,8 +193,18 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
     public BytesRefBlock build() {
         finish();
         BytesRefBlock block;
+        assert estimatedBytes == 0 || firstValueIndexes != null;
         if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
             block = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory).asBlock();
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
             Releasables.closeExpectNoException(values);
         } else {
             if (isDense() && singleValued()) {
@@ -202,17 +212,17 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
             } else {
                 block = new BytesRefArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
             }
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes - values.bigArraysRamBytesUsed(), false);
         }
-        /*
-         * Update the breaker with the actual bytes used.
-         * We pass false below even though we've used the bytes. That's weird,
-         * but if we break here we will throw away the used memory, letting
-         * it be deallocated. The exception will bubble up and the builder will
-         * still technically be open, meaning the calling code should close it
-         * which will return all used memory to the breaker.
-         */
-        blockFactory.adjustBreaker(block.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
-        assert estimatedBytes == 0;
+        values = null;
         built();
         return block;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
@@ -197,7 +197,6 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
             block = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory).asBlock();
             Releasables.closeExpectNoException(values);
         } else {
-            estimatedBytes += values.ramBytesUsed();
             if (isDense() && singleValued()) {
                 block = new BytesRefArrayVector(values, positionCount, blockFactory).asBlock();
             } else {
@@ -212,7 +211,8 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
          * still technically be open, meaning the calling code should close it
          * which will return all used memory to the breaker.
          */
-        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
+        blockFactory.adjustBreaker(block.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
+        assert estimatedBytes == 0;
         built();
         return block;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
@@ -60,9 +60,9 @@ final class BytesRefVectorBuilder extends AbstractVectorBuilder implements Bytes
             vector = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory);
             Releasables.closeExpectNoException(values);
         } else {
-            estimatedBytes = values.ramBytesUsed();
             vector = new BytesRefArrayVector(values, valueCount, blockFactory);
         }
+        assert estimatedBytes == 0;
         /*
          * Update the breaker with the actual bytes used.
          * We pass false below even though we've used the bytes. That's weird,
@@ -71,7 +71,8 @@ final class BytesRefVectorBuilder extends AbstractVectorBuilder implements Bytes
          * still technically be open, meaning the calling code should close it
          * which will return all used memory to the breaker.
          */
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, false);
+        blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
+        values = null;
         built();
         return vector;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
@@ -56,22 +56,31 @@ final class BytesRefVectorBuilder extends AbstractVectorBuilder implements Bytes
     public BytesRefVector build() {
         finish();
         BytesRefVector vector;
+        assert estimatedBytes == 0;
         if (valueCount == 1) {
             vector = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory);
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(vector.ramBytesUsed(), false);
             Releasables.closeExpectNoException(values);
         } else {
             vector = new BytesRefArrayVector(values, valueCount, blockFactory);
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
         }
-        assert estimatedBytes == 0;
-        /*
-         * Update the breaker with the actual bytes used.
-         * We pass false below even though we've used the bytes. That's weird,
-         * but if we break here we will throw away the used memory, letting
-         * it be deallocated. The exception will bubble up and the builder will
-         * still technically be open, meaning the calling code should close it
-         * which will return all used memory to the breaker.
-         */
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
         values = null;
         built();
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -75,6 +75,7 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
     public static long ramBytesEstimated(double[] values, int[] firstValueIndexes, BitSet nullsMask) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask) + RamUsageEstimator.shallowSizeOfInstance(MvOrdering.class);
+        // TODO mvordering is shared
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -75,6 +75,7 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
     public static long ramBytesEstimated(int[] values, int[] firstValueIndexes, BitSet nullsMask) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask) + RamUsageEstimator.shallowSizeOfInstance(MvOrdering.class);
+        // TODO mvordering is shared
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlockBuilder.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.apache.lucene.util.RamUsageEstimator;
+
 import java.util.Arrays;
 
 /**
@@ -20,7 +22,7 @@ final class IntBlockBuilder extends AbstractBlockBuilder implements IntBlock.Bui
     IntBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         super(blockFactory);
         int initialSize = Math.max(estimatedSize, 2);
-        adjustBreaker(initialSize);
+        adjustBreaker(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + initialSize * elementSize());
         values = new int[initialSize];
     }
 
@@ -192,8 +194,16 @@ final class IntBlockBuilder extends AbstractBlockBuilder implements IntBlock.Bui
                 block = new IntArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
             }
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
+        built();
         return block;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBuilder.java
@@ -49,6 +49,7 @@ final class IntVectorBuilder extends AbstractVectorBuilder implements IntVector.
 
     @Override
     public IntVector build() {
+        finish();
         IntVector vector;
         if (valueCount == 1) {
             vector = new ConstantIntVector(values[0], 1, blockFactory);
@@ -58,8 +59,16 @@ final class IntVectorBuilder extends AbstractVectorBuilder implements IntVector.
             }
             vector = new IntArrayVector(values, valueCount, blockFactory);
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, false);
+        built();
         return vector;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -75,6 +75,7 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
     public static long ramBytesEstimated(long[] values, int[] firstValueIndexes, BitSet nullsMask) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask) + RamUsageEstimator.shallowSizeOfInstance(MvOrdering.class);
+        // TODO mvordering is shared
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlockBuilder.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.apache.lucene.util.RamUsageEstimator;
+
 import java.util.Arrays;
 
 /**
@@ -20,7 +22,7 @@ final class LongBlockBuilder extends AbstractBlockBuilder implements LongBlock.B
     LongBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         super(blockFactory);
         int initialSize = Math.max(estimatedSize, 2);
-        adjustBreaker(initialSize);
+        adjustBreaker(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + initialSize * elementSize());
         values = new long[initialSize];
     }
 
@@ -192,8 +194,16 @@ final class LongBlockBuilder extends AbstractBlockBuilder implements LongBlock.B
                 block = new LongArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
             }
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
+        built();
         return block;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBuilder.java
@@ -49,6 +49,7 @@ final class LongVectorBuilder extends AbstractVectorBuilder implements LongVecto
 
     @Override
     public LongVector build() {
+        finish();
         LongVector vector;
         if (valueCount == 1) {
             vector = new ConstantLongVector(values[0], 1, blockFactory);
@@ -58,8 +59,16 @@ final class LongVectorBuilder extends AbstractVectorBuilder implements LongVecto
             }
             vector = new LongArrayVector(values, valueCount, blockFactory);
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, false);
+        built();
         return vector;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForBoolean.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForBoolean.java
@@ -64,4 +64,9 @@ class ResultBuilderForBoolean implements ResultBuilder {
     public String toString() {
         return "ResultBuilderForBoolean[inKey=" + inKey + "]";
     }
+
+    @Override
+    public void close() {
+        builder.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForBytesRef.java
@@ -68,4 +68,9 @@ class ResultBuilderForBytesRef implements ResultBuilder {
     public String toString() {
         return "ResultBuilderForBytesRef[inKey=" + inKey + "]";
     }
+
+    @Override
+    public void close() {
+        builder.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForDouble.java
@@ -64,4 +64,9 @@ class ResultBuilderForDouble implements ResultBuilder {
     public String toString() {
         return "ResultBuilderForDouble[inKey=" + inKey + "]";
     }
+
+    @Override
+    public void close() {
+        builder.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForInt.java
@@ -64,4 +64,9 @@ class ResultBuilderForInt implements ResultBuilder {
     public String toString() {
         return "ResultBuilderForInt[inKey=" + inKey + "]";
     }
+
+    @Override
+    public void close() {
+        builder.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForLong.java
@@ -64,4 +64,9 @@ class ResultBuilderForLong implements ResultBuilder {
     public String toString() {
         return "ResultBuilderForLong[inKey=" + inKey + "]";
     }
+
+    @Override
+    public void close() {
+        builder.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBuilder.java
@@ -7,8 +7,13 @@
 
 package org.elasticsearch.compute.data;
 
-abstract class AbstractVectorBuilder {
+abstract class AbstractVectorBuilder implements Vector.Builder {
     protected int valueCount;
+
+    /**
+     * Has this builder been closed already?
+     */
+    private boolean closed = false;
 
     protected final BlockFactory blockFactory;
 
@@ -46,4 +51,38 @@ abstract class AbstractVectorBuilder {
         blockFactory.adjustBreaker(deltaBytes, false);
         estimatedBytes += deltaBytes;
     }
+
+    /**
+     * Called during implementations of {@link Block.Builder#build} as a first step
+     * to check if the block is still open and to finish the last position.
+     */
+    protected final void finish() {
+        if (closed) {
+            throw new IllegalStateException("already closed");
+        }
+    }
+
+    /**
+     * Called during implementations of {@link Block.Builder#build} as a last step
+     * to mark the Builder as closed and make sure that further closes don't double
+     * free memory.
+     */
+    protected final void built() {
+        closed = true;
+        estimatedBytes = 0;
+    }
+
+    @Override
+    public final void close() {
+        if (closed == false) {
+            closed = true;
+            adjustBreaker(-estimatedBytes);
+            extraClose();
+        }
+    }
+
+    /**
+     * Called when first {@link #close() closed}.
+     */
+    protected void extraClose() {}
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -130,7 +130,11 @@ public interface Block extends Accountable, NamedWriteable, Releasable {
         return blockFactory.newConstantNullBlock(positions);
     }
 
-    interface Builder {
+    /**
+     * Builds {@link Block}s. Typically, you use one of it's direct supinterfaces like {@link IntBlock.Builder}.
+     * This is {@link Releasable} and should be released after building the block or if building the block fails.
+     */
+    interface Builder extends Releasable {
 
         /**
          * Appends a null value to the block.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -289,7 +289,7 @@ public class BlockFactory {
         MvOrdering mvOrdering
     ) {
         var b = new BytesRefArrayBlock(values, positionCount, firstValueIndexes, nulls, mvOrdering, this);
-        adjustBreaker(b.ramBytesUsed() - values.ramBytesUsed(), true);
+        adjustBreaker(b.ramBytesUsed() - values.bigArraysRamBytesUsed(), true);
         return b;
     }
 
@@ -299,7 +299,7 @@ public class BlockFactory {
 
     public BytesRefVector newBytesRefArrayVector(BytesRefArray values, int positionCount) {
         var b = new BytesRefArrayVector(values, positionCount, this);
-        adjustBreaker(b.ramBytesUsed() - values.ramBytesUsed(), true);
+        adjustBreaker(b.ramBytesUsed() - values.bigArraysRamBytesUsed(), true);
         return b;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -132,6 +132,11 @@ public final class ConstantNullBlock extends AbstractBlock {
     static class Builder implements Block.Builder {
         private int positionCount;
 
+        /**
+         * Has this builder been closed already?
+         */
+        private boolean closed = false;
+
         @Override
         public Builder appendNull() {
             positionCount++;
@@ -170,7 +175,16 @@ public final class ConstantNullBlock extends AbstractBlock {
 
         @Override
         public Block build() {
+            if (closed) {
+                throw new IllegalStateException("already closed");
+            }
+            close();
             return new ConstantNullBlock(positionCount);
+        }
+
+        @Override
+        public void close() {
+            closed = true;
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -146,7 +146,7 @@ public class DocBlock extends AbstractVectorBlock implements Block {
 
         @Override
         public DocBlock build() {
-            // Pass null for singleSegmentNonDecreasing so we 1calculate it when we first need it.
+            // Pass null for singleSegmentNonDecreasing so we calculate it when we first need it.
             return new DocVector(shards.build(), segments.build(), docs.build(), null).asBlock();
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -78,8 +78,8 @@ public class DocBlock extends AbstractVectorBlock implements Block {
     /**
      * A builder the for {@link DocBlock}.
      */
-    public static Builder newBlockBuilder(int estimatedSize) {
-        return new Builder(estimatedSize);
+    public static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
+        return new Builder(estimatedSize, blockFactory);
     }
 
     public static class Builder implements Block.Builder {
@@ -87,10 +87,10 @@ public class DocBlock extends AbstractVectorBlock implements Block {
         private final IntVector.Builder segments;
         private final IntVector.Builder docs;
 
-        private Builder(int estimatedSize) {
-            shards = IntVector.newVectorBuilder(estimatedSize);
-            segments = IntVector.newVectorBuilder(estimatedSize);
-            docs = IntVector.newVectorBuilder(estimatedSize);
+        private Builder(int estimatedSize, BlockFactory blockFactory) {
+            shards = IntVector.newVectorBuilder(estimatedSize, blockFactory);
+            segments = IntVector.newVectorBuilder(estimatedSize, blockFactory);
+            docs = IntVector.newVectorBuilder(estimatedSize, blockFactory);
         }
 
         public Builder appendShard(int shard) {
@@ -146,8 +146,13 @@ public class DocBlock extends AbstractVectorBlock implements Block {
 
         @Override
         public DocBlock build() {
-            // Pass null for singleSegmentNonDecreasing so we calculate it when we first need it.
+            // Pass null for singleSegmentNonDecreasing so we 1calculate it when we first need it.
             return new DocVector(shards.build(), segments.build(), docs.build(), null).asBlock();
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(shards, segments, docs);
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
@@ -9,8 +9,6 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 
-import java.util.function.IntFunction;
-
 /**
  * The type of elements in {@link Block} and {@link Vector}
  */
@@ -22,7 +20,7 @@ public enum ElementType {
     /**
      * Blocks containing only null values.
      */
-    NULL(estimatedSize -> new ConstantNullBlock.Builder()),
+    NULL((estimatedSize, blockFactory) -> new ConstantNullBlock.Builder()),
 
     BYTES_REF(BytesRefBlock::newBlockBuilder),
 
@@ -34,19 +32,32 @@ public enum ElementType {
     /**
      * Intermediate blocks which don't support retrieving elements.
      */
-    UNKNOWN(estimatedSize -> { throw new UnsupportedOperationException("can't build null blocks"); });
+    UNKNOWN((estimatedSize, blockFactory) -> { throw new UnsupportedOperationException("can't build null blocks"); });
 
-    private final IntFunction<Block.Builder> builder;
+    interface BuilderSupplier {
+        Block.Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory);
+    }
 
-    ElementType(IntFunction<Block.Builder> builder) {
+    private final BuilderSupplier builder;
+
+    ElementType(BuilderSupplier builder) {
         this.builder = builder;
     }
 
     /**
      * Create a new {@link Block.Builder} for blocks of this type.
+     * @deprecated use {@link #newBlockBuilder(int, BlockFactory)}
      */
-    public Block.Builder newBlockBuilder(int estimatedSize) {  // TODO add BlockFactory
-        return builder.apply(estimatedSize);
+    @Deprecated
+    public Block.Builder newBlockBuilder(int estimatedSize) {
+        return builder.newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
+    }
+
+    /**
+     * Create a new {@link Block.Builder} for blocks of this type.
+     */
+    public Block.Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
+        return builder.newBlockBuilder(estimatedSize, blockFactory);
     }
 
     public static ElementType fromJava(Class<?> type) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -50,7 +50,11 @@ public interface Vector extends Accountable, Releasable {
     /** The block factory associated with this vector. */
     BlockFactory blockFactory();
 
-    interface Builder {
+    /**
+     * Builds {@link Vector}s. Typically, you use one of it's direct supinterfaces like {@link IntVector.Builder}.
+     * This is {@link Releasable} and should be released after building the vector or if building the vector fails.
+     */
+    interface Builder extends Releasable {
         /**
          * Builds the block. This method can be called multiple times.
          */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -93,6 +93,7 @@ $endif$
     public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int[] firstValueIndexes, BitSet nullsMask) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask) + RamUsageEstimator.shallowSizeOfInstance(MvOrdering.class);
+        // TODO mvordering is shared
     }
 
     @Override
@@ -133,7 +134,7 @@ $endif$
     @Override
     public void close() {
     $if(BytesRef)$
-        blockFactory.adjustBreaker(-(ramBytesUsed() - values.ramBytesUsed()), true);
+        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     $else$
         blockFactory.adjustBreaker(-ramBytesUsed(), true);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -110,7 +110,7 @@ $endif$
 $if(BytesRef)$
     @Override
     public void close() {
-        blockFactory.adjustBreaker(-BASE_RAM_BYTES_USED, true);
+        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     }
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -253,7 +253,6 @@ $if(BytesRef)$
             block = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory).asBlock();
             Releasables.closeExpectNoException(values);
         } else {
-            estimatedBytes += values.ramBytesUsed();
 $else$
             block = new Constant$Type$Vector(values[0], 1, blockFactory).asBlock();
         } else {
@@ -275,7 +274,12 @@ $endif$
          * still technically be open, meaning the calling code should close it
          * which will return all used memory to the breaker.
          */
+$if(BytesRef)$
+        blockFactory.adjustBreaker(block.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
+        assert estimatedBytes == 0;
+$else$
         blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
+$endif$
         built();
         return block;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -14,6 +14,8 @@ import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
 $else$
+import org.apache.lucene.util.RamUsageEstimator;
+
 import java.util.Arrays;
 $endif$
 
@@ -41,7 +43,7 @@ $else$
     $Type$BlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         super(blockFactory);
         int initialSize = Math.max(estimatedSize, 2);
-        adjustBreaker(initialSize);
+        adjustBreaker(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + initialSize * elementSize());
         values = new $type$[initialSize];
     }
 $endif$
@@ -265,8 +267,23 @@ $endif$
                 block = new $Type$ArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
             }
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
+        built();
         return block;
     }
+$if(BytesRef)$
+
+    @Override
+    public void extraClose() {
+        Releasables.closeExpectNoException(values);
+    }
+$endif$
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -248,18 +248,44 @@ $endif$
     public $Type$Block build() {
         finish();
         $Type$Block block;
-        if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
 $if(BytesRef)$
+        assert estimatedBytes == 0 || firstValueIndexes != null;
+        if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
             block = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory).asBlock();
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
             Releasables.closeExpectNoException(values);
         } else {
+            if (isDense() && singleValued()) {
+                block = new $Type$ArrayVector(values, positionCount, blockFactory).asBlock();
+            } else {
+                block = new $Type$ArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
+            }
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes - values.bigArraysRamBytesUsed(), false);
+        }
+        values = null;
 $else$
+        if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
             block = new Constant$Type$Vector(values[0], 1, blockFactory).asBlock();
         } else {
             if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
                 values = Arrays.copyOf(values, valueCount);
             }
-$endif$
             if (isDense() && singleValued()) {
                 block = new $Type$ArrayVector(values, positionCount, blockFactory).asBlock();
             } else {
@@ -274,10 +300,6 @@ $endif$
          * still technically be open, meaning the calling code should close it
          * which will return all used memory to the breaker.
          */
-$if(BytesRef)$
-        blockFactory.adjustBreaker(block.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
-        assert estimatedBytes == 0;
-$else$
         blockFactory.adjustBreaker(block.ramBytesUsed() - estimatedBytes, false);
 $endif$
         built();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
@@ -85,19 +85,31 @@ $endif$
     public $Type$Vector build() {
         finish();
         $Type$Vector vector;
-        if (valueCount == 1) {
 $if(BytesRef)$
+        if (valueCount == 1) {
             vector = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory);
             Releasables.closeExpectNoException(values);
         } else {
-            estimatedBytes = values.ramBytesUsed();
+            vector = new $Type$ArrayVector(values, valueCount, blockFactory);
+        }
+        assert estimatedBytes == 0;
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
+        values = null;
 $else$
+        if (valueCount == 1) {
             vector = new Constant$Type$Vector(values[0], 1, blockFactory);
         } else {
             if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
                 values = Arrays.copyOf(values, valueCount);
             }
-$endif$
             vector = new $Type$ArrayVector(values, valueCount, blockFactory);
         }
         /*
@@ -109,6 +121,7 @@ $endif$
          * which will return all used memory to the breaker.
          */
         blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, false);
+$endif$
         built();
         return vector;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
@@ -86,22 +86,31 @@ $endif$
         finish();
         $Type$Vector vector;
 $if(BytesRef)$
+        assert estimatedBytes == 0;
         if (valueCount == 1) {
             vector = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory);
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(vector.ramBytesUsed(), false);
             Releasables.closeExpectNoException(values);
         } else {
             vector = new $Type$ArrayVector(values, valueCount, blockFactory);
+            /*
+             * Update the breaker with the actual bytes used.
+             * We pass false below even though we've used the bytes. That's weird,
+             * but if we break here we will throw away the used memory, letting
+             * it be deallocated. The exception will bubble up and the builder will
+             * still technically be open, meaning the calling code should close it
+             * which will return all used memory to the breaker.
+             */
+            blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
         }
-        assert estimatedBytes == 0;
-        /*
-         * Update the breaker with the actual bytes used.
-         * We pass false below even though we've used the bytes. That's weird,
-         * but if we break here we will throw away the used memory, letting
-         * it be deallocated. The exception will bubble up and the builder will
-         * still technically be open, meaning the calling code should close it
-         * which will return all used memory to the breaker.
-         */
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
         values = null;
 $else$
         if (valueCount == 1) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
@@ -83,6 +83,7 @@ $endif$
 
     @Override
     public $Type$Vector build() {
+        finish();
         $Type$Vector vector;
         if (valueCount == 1) {
 $if(BytesRef)$
@@ -99,8 +100,23 @@ $else$
 $endif$
             vector = new $Type$ArrayVector(values, valueCount, blockFactory);
         }
-        // update the breaker with the actual bytes used.
-        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, true);
+        /*
+         * Update the breaker with the actual bytes used.
+         * We pass false below even though we've used the bytes. That's weird,
+         * but if we break here we will throw away the used memory, letting
+         * it be deallocated. The exception will bubble up and the builder will
+         * still technically be open, meaning the calling code should close it
+         * which will return all used memory to the breaker.
+         */
+        blockFactory.adjustBreaker(vector.ramBytesUsed() - estimatedBytes, false);
+        built();
         return vector;
     }
+$if(BytesRef)$
+
+    @Override
+    public void extraClose() {
+        Releasables.closeExpectNoException(values);
+    }
+$endif$
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -181,7 +181,13 @@ public class Driver implements Releasable, Describable {
 
             if (op.isFinished() == false && nextOp.needsInput()) {
                 Page page = op.getOutput();
-                if (page != null && page.getPositionCount() != 0) {
+                if (page == null) {
+                    // No result, just move to the next iteration
+                } else if (page.getPositionCount() == 0) {
+                    // Empty result, release any memory it holds immediately and move to the next iteration
+                    page.releaseBlocks();
+                } else {
+                    // Non-empty result from the previous operation, move it to the next operation
                     nextOp.addInput(page);
                     movedPage = true;
                 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilder.java
@@ -11,11 +11,12 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.core.Releasable;
 
 /**
  * Builds {@link Block}s from keys and values encoded into {@link BytesRef}s.
  */
-interface ResultBuilder {
+interface ResultBuilder extends Releasable {
     /**
      * Called for each sort key before {@link #decodeValue} to consume the sort key and
      * store the value of the key for {@link #decodeValue} can use it to reconstruct

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilderForDoc.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilderForDoc.java
@@ -20,6 +20,7 @@ class ResultBuilderForDoc implements ResultBuilder {
     private int position;
 
     ResultBuilderForDoc(BlockFactory blockFactory, int positions) {
+        // TODO use fixed length builders
         this.blockFactory = blockFactory;
         this.shards = new int[positions];
         this.segments = new int[positions];
@@ -52,5 +53,10 @@ class ResultBuilderForDoc implements ResultBuilder {
     @Override
     public String toString() {
         return "ValueExtractorForDoc";
+    }
+
+    @Override
+    public void close() {
+        // TODO memory accounting
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilderForNull.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilderForNull.java
@@ -42,4 +42,9 @@ public class ResultBuilderForNull implements ResultBuilder {
     public String toString() {
         return "ValueExtractorForNull";
     }
+
+    @Override
+    public void close() {
+        // Nothing to close
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PriorityQueue;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
@@ -241,6 +242,7 @@ public class TopNOperator implements Operator, Accountable {
     private final List<TopNEncoder> encoders;
     private final List<SortOrder> sortOrders;
 
+    private Row spare;
     private Iterator<Page> output;
 
     public TopNOperator(
@@ -313,21 +315,20 @@ public class TopNOperator implements Operator, Accountable {
          * and must be closed. That happens either because it's overflow from the
          * inputQueue or because we hit an allocation failure while building it.
          */
-        Row row = null;
         try {
             for (int i = 0; i < page.getPositionCount(); i++) {
-                if (row == null) {
-                    row = new Row(breaker);
+                if (spare == null) {
+                    spare = new Row(breaker);
                 } else {
-                    row.keys.clear();
-                    row.orderByCompositeKeyAscending.clear();
-                    row.values.clear();
+                    spare.keys.clear();
+                    spare.orderByCompositeKeyAscending.clear();
+                    spare.values.clear();
                 }
-                rowFiller.row(i, row);
-                row = inputQueue.insertWithOverflow(row);
+                rowFiller.row(i, spare);
+                spare = inputQueue.insertWithOverflow(spare);
             }
         } finally {
-            Releasables.close(row, () -> page.releaseBlocks());
+            Releasables.close(() -> page.releaseBlocks());
         }
     }
 
@@ -339,18 +340,24 @@ public class TopNOperator implements Operator, Accountable {
     }
 
     private Iterator<Page> toPages() {
+        if (spare != null) {
+            // Remove the spare, we're never going to use it again.
+            spare.close();
+            spare = null;
+        }
         if (inputQueue.size() == 0) {
             return Collections.emptyIterator();
         }
         List<Row> list = new ArrayList<>(inputQueue.size());
+        List<Page> result = new ArrayList<>();
+        ResultBuilder[] builders = null;
+        boolean success = false;
         try {
             while (inputQueue.size() > 0) {
                 list.add(inputQueue.pop());
             }
             Collections.reverse(list);
 
-            List<Page> result = new ArrayList<>();
-            ResultBuilder[] builders = null;
             int p = 0;
             int size = 0;
             for (int i = 0; i < list.size(); i++) {
@@ -399,14 +406,22 @@ public class TopNOperator implements Operator, Accountable {
                 p++;
                 if (p == size) {
                     result.add(new Page(Arrays.stream(builders).map(ResultBuilder::build).toArray(Block[]::new)));
+                    Releasables.closeExpectNoException(builders);
                     builders = null;
                 }
-
             }
             assert builders == null;
+            success = true;
             return result.iterator();
         } finally {
-            Releasables.closeExpectNoException(() -> Releasables.close(list));
+            if (success == false) {
+                List<Releasable> close = new ArrayList<>(list);
+                for (Page p : result) {
+                    close.add(p::releaseBlocks);
+                }
+                Collections.addAll(close, builders);
+                Releasables.closeExpectNoException(Releasables.wrap(close));
+            }
         }
     }
 
@@ -435,10 +450,15 @@ public class TopNOperator implements Operator, Accountable {
     @Override
     public void close() {
         /*
-         * If everything went well we'll have drained inputQueue to this'll
-         * be a noop. But if inputQueue
+         * If we close before calling finish then spare and inputQueue will be live rows
+         * that need closing. If we close after calling finish then the output iterator
+         * will contain pages of results that have yet to be returned.
          */
-        Releasables.closeExpectNoException(() -> Releasables.close(inputQueue));
+        Releasables.closeExpectNoException(
+            spare,
+            inputQueue == null ? null : Releasables.wrap(inputQueue),
+            output == null ? null : Releasables.wrap(() -> Iterators.map(output, p -> p::releaseBlocks))
+        );
     }
 
     private static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TopNOperator.class) + RamUsageEstimator

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ResultBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ResultBuilder.java.st
@@ -82,4 +82,9 @@ $endif$
     public String toString() {
         return "ResultBuilderFor$Type$[inKey=" + inKey + "]";
     }
+
+    @Override
+    public void close() {
+        builder.close();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderTests.java
@@ -7,47 +7,42 @@
 
 package org.elasticsearch.compute.data;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class BlockBuilderTests extends ESTestCase {
-
-    public void testAllNullsInt() {
-        for (int numEntries : List.of(1, randomIntBetween(1, 100))) {
-            testAllNullsImpl(IntBlock.newBlockBuilder(0), numEntries);
-            testAllNullsImpl(IntBlock.newBlockBuilder(100), numEntries);
-            testAllNullsImpl(IntBlock.newBlockBuilder(1000), numEntries);
-            testAllNullsImpl(IntBlock.newBlockBuilder(randomIntBetween(0, 100)), numEntries);
+    @ParametersFactory
+    public static List<Object[]> params() {
+        List<Object[]> params = new ArrayList<>();
+        for (ElementType elementType : ElementType.values()) {
+            if (elementType == ElementType.UNKNOWN || elementType == ElementType.NULL || elementType == ElementType.DOC) {
+                continue;
+            }
+            params.add(new Object[] { elementType });
         }
+        return params;
     }
 
-    public void testAllNullsLong() {
-        for (int numEntries : List.of(1, randomIntBetween(1, 100))) {
-            testAllNullsImpl(LongBlock.newBlockBuilder(0), numEntries);
-            testAllNullsImpl(LongBlock.newBlockBuilder(100), numEntries);
-            testAllNullsImpl(LongBlock.newBlockBuilder(1000), numEntries);
-            testAllNullsImpl(LongBlock.newBlockBuilder(randomIntBetween(0, 100)), numEntries);
-        }
+    private final ElementType elementType;
+
+    public BlockBuilderTests(ElementType elementType) {
+        this.elementType = elementType;
     }
 
-    public void testAllNullsDouble() {
+    public void testAllNulls() {
         for (int numEntries : List.of(1, randomIntBetween(1, 100))) {
-            testAllNullsImpl(DoubleBlock.newBlockBuilder(0), numEntries);
-            testAllNullsImpl(DoubleBlock.newBlockBuilder(100), numEntries);
-            testAllNullsImpl(DoubleBlock.newBlockBuilder(1000), numEntries);
-            testAllNullsImpl(DoubleBlock.newBlockBuilder(randomIntBetween(0, 100)), numEntries);
-        }
-    }
-
-    public void testAllNullsBytesRef() {
-        for (int numEntries : List.of(1, randomIntBetween(1, 100))) {
-            testAllNullsImpl(BytesRefBlock.newBlockBuilder(0), numEntries);
-            testAllNullsImpl(BytesRefBlock.newBlockBuilder(100), numEntries);
-            testAllNullsImpl(BytesRefBlock.newBlockBuilder(1000), numEntries);
-            testAllNullsImpl(BytesRefBlock.newBlockBuilder(randomIntBetween(0, 100)), numEntries);
+            testAllNullsImpl(elementType.newBlockBuilder(0), numEntries);
+            testAllNullsImpl(elementType.newBlockBuilder(100), numEntries);
+            testAllNullsImpl(elementType.newBlockBuilder(1000), numEntries);
+            testAllNullsImpl(elementType.newBlockBuilder(randomIntBetween(0, 100)), numEntries);
         }
     }
 
@@ -64,5 +59,37 @@ public class BlockBuilderTests extends ESTestCase {
 
     static int randomPosition(int positionCount) {
         return positionCount == 1 ? 0 : randomIntBetween(0, positionCount - 1);
+    }
+
+    public void testCloseWithoutBuilding() {
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        elementType.newBlockBuilder(10, blockFactory).close();
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    public void testSingleBuild() {
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        try (Block.Builder builder = elementType.newBlockBuilder(10, blockFactory)) {
+            BasicBlockTests.RandomBlock random = BasicBlockTests.randomBlock(elementType, 10, false, 1, 1, 0, 0);
+            builder.copyFrom(random.block(), 0, random.block().getPositionCount());
+            try (Block built = builder.build()) {
+                assertThat(built, equalTo(random.block()));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    public void testDoubleBuild() {
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        try (Block.Builder builder = elementType.newBlockBuilder(10, blockFactory)) {
+            BasicBlockTests.RandomBlock random = BasicBlockTests.randomBlock(elementType, 10, false, 1, 1, 0, 0);
+            builder.copyFrom(random.block(), 0, random.block().getPositionCount());
+            try (Block built = builder.build()) {
+                assertThat(built, equalTo(random.block()));
+            }
+            Exception e = expectThrows(IllegalStateException.class, builder::build);
+            assertThat(e.getMessage(), equalTo("already closed"));
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -48,11 +48,29 @@ public class BlockFactoryTests extends ESTestCase {
 
     @ParametersFactory
     public static List<Object[]> params() {
-        List<Supplier<BlockFactory>> l = List.of(() -> {
-            CircuitBreaker breaker = new MockBigArrays.LimitedBreaker("esql-test-breaker", ByteSizeValue.ofGb(1));
-            BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, mockBreakerService(breaker));
-            return BlockFactory.getInstance(breaker, bigArrays);
-        }, BlockFactory::getGlobalInstance);
+        List<Supplier<BlockFactory>> l = List.of(new Supplier<>() {
+            @Override
+            public BlockFactory get() {
+                CircuitBreaker breaker = new MockBigArrays.LimitedBreaker("esql-test-breaker", ByteSizeValue.ofGb(1));
+                BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, mockBreakerService(breaker));
+                return BlockFactory.getInstance(breaker, bigArrays);
+            }
+
+            @Override
+            public String toString() {
+                return "1gb";
+            }
+        }, new Supplier<>() {
+            @Override
+            public BlockFactory get() {
+                return BlockFactory.getGlobalInstance();
+            }
+
+            @Override
+            public String toString() {
+                return "global";
+            }
+        });
         return l.stream().map(s -> new Object[] { s }).toList();
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 // more specific to the factory implementation itself (and not necessarily tested elsewhere).
 public class BlockFactoryTests extends ESTestCase {
     public static BlockFactory blockFactory(ByteSizeValue size) {
-        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, size);
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, size).withCircuitBreaking();
         return new BlockFactory(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST), bigArrays);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -37,6 +37,10 @@ import static org.mockito.Mockito.when;
 // BlockFactory is used and effectively tested in many other places, but this class contains tests
 // more specific to the factory implementation itself (and not necessarily tested elsewhere).
 public class BlockFactoryTests extends ESTestCase {
+    public static BlockFactory blockFactory(ByteSizeValue size) {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, size);
+        return new BlockFactory(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST), bigArrays);
+    }
 
     final CircuitBreaker breaker;
     final BigArrays bigArrays;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -95,32 +96,36 @@ public class DocVectorTests extends ESTestCase {
     }
 
     private void assertShardSegmentDocMap(int[][] data, int[][] expected) {
-        DocBlock.Builder builder = DocBlock.newBlockBuilder(data.length);
-        for (int r = 0; r < data.length; r++) {
-            builder.appendShard(data[r][0]);
-            builder.appendSegment(data[r][1]);
-            builder.appendDoc(data[r][2]);
-        }
-        DocVector docVector = builder.build().asVector();
-        int[] forwards = docVector.shardSegmentDocMapForwards();
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        try (DocBlock.Builder builder = DocBlock.newBlockBuilder(data.length, blockFactory)) {
+            for (int r = 0; r < data.length; r++) {
+                builder.appendShard(data[r][0]);
+                builder.appendSegment(data[r][1]);
+                builder.appendDoc(data[r][2]);
+            }
+            try (DocVector docVector = builder.build().asVector()) {
+                int[] forwards = docVector.shardSegmentDocMapForwards();
 
-        int[][] result = new int[docVector.getPositionCount()][];
-        for (int p = 0; p < result.length; p++) {
-            result[p] = new int[] {
-                docVector.shards().getInt(forwards[p]),
-                docVector.segments().getInt(forwards[p]),
-                docVector.docs().getInt(forwards[p]) };
-        }
-        assertThat(result, equalTo(expected));
+                int[][] result = new int[docVector.getPositionCount()][];
+                for (int p = 0; p < result.length; p++) {
+                    result[p] = new int[] {
+                        docVector.shards().getInt(forwards[p]),
+                        docVector.segments().getInt(forwards[p]),
+                        docVector.docs().getInt(forwards[p]) };
+                }
+                assertThat(result, equalTo(expected));
 
-        int[] backwards = docVector.shardSegmentDocMapBackwards();
-        for (int p = 0; p < result.length; p++) {
-            result[p] = new int[] {
-                docVector.shards().getInt(backwards[forwards[p]]),
-                docVector.segments().getInt(backwards[forwards[p]]),
-                docVector.docs().getInt(backwards[forwards[p]]) };
-        }
+                int[] backwards = docVector.shardSegmentDocMapBackwards();
+                for (int p = 0; p < result.length; p++) {
+                    result[p] = new int[] {
+                        docVector.shards().getInt(backwards[forwards[p]]),
+                        docVector.segments().getInt(backwards[forwards[p]]),
+                        docVector.docs().getInt(backwards[forwards[p]]) };
+                }
 
-        assertThat(result, equalTo(data));
+                assertThat(result, equalTo(data));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
@@ -139,6 +139,11 @@ public abstract class TestBlockBuilder implements Block.Builder {
         public IntBlock build() {
             return builder.build();
         }
+
+        @Override
+        public void close() {
+            builder.close();
+        }
     }
 
     private static class TestLongBlockBuilder extends TestBlockBuilder {
@@ -194,6 +199,11 @@ public abstract class TestBlockBuilder implements Block.Builder {
         @Override
         public LongBlock build() {
             return builder.build();
+        }
+
+        @Override
+        public void close() {
+            builder.close();
         }
     }
 
@@ -251,6 +261,11 @@ public abstract class TestBlockBuilder implements Block.Builder {
         public DoubleBlock build() {
             return builder.build();
         }
+
+        @Override
+        public void close() {
+            builder.close();
+        }
     }
 
     private static class TestBytesRefBlockBuilder extends TestBlockBuilder {
@@ -306,6 +321,11 @@ public abstract class TestBlockBuilder implements Block.Builder {
         @Override
         public BytesRefBlock build() {
             return builder.build();
+        }
+
+        @Override
+        public void close() {
+            builder.close();
         }
     }
 
@@ -365,6 +385,11 @@ public abstract class TestBlockBuilder implements Block.Builder {
         @Override
         public BooleanBlock build() {
             return builder.build();
+        }
+
+        @Override
+        public void close() {
+            builder.close();
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class VectorBuilderTests extends ESTestCase {
+    @ParametersFactory
+    public static List<Object[]> params() {
+        List<Object[]> params = new ArrayList<>();
+        for (ElementType elementType : ElementType.values()) {
+            if (elementType == ElementType.UNKNOWN || elementType == ElementType.NULL || elementType == ElementType.DOC) {
+                continue;
+            }
+            params.add(new Object[] { elementType });
+        }
+        return params;
+    }
+
+    private final ElementType elementType;
+
+    public VectorBuilderTests(ElementType elementType) {
+        this.elementType = elementType;
+    }
+
+    public void testCloseWithoutBuilding() {
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        vectorBuilder(10, blockFactory).close();
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    public void testSingleBuild() {
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        try (Vector.Builder builder = vectorBuilder(10, blockFactory)) {
+            BasicBlockTests.RandomBlock random = BasicBlockTests.randomBlock(elementType, 10, false, 1, 1, 0, 0);
+            fill(builder, random.block().asVector());
+            try (Vector built = builder.build()) {
+                assertThat(built, equalTo(random.block().asVector()));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    public void testDoubleBuild() {
+        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        try (Vector.Builder builder = vectorBuilder(10, blockFactory)) {
+            BasicBlockTests.RandomBlock random = BasicBlockTests.randomBlock(elementType, 10, false, 1, 1, 0, 0);
+            fill(builder, random.block().asVector());
+            try (Vector built = builder.build()) {
+                assertThat(built, equalTo(random.block().asVector()));
+            }
+            Exception e = expectThrows(IllegalStateException.class, builder::build);
+            assertThat(e.getMessage(), equalTo("already closed"));
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    private Vector.Builder vectorBuilder(int estimatedSize, BlockFactory blockFactory) {
+        return switch (elementType) {
+            case NULL, DOC, UNKNOWN -> throw new UnsupportedOperationException();
+            case BOOLEAN -> BooleanVector.newVectorBuilder(estimatedSize, blockFactory);
+            case BYTES_REF -> BytesRefVector.newVectorBuilder(estimatedSize, blockFactory);
+            case DOUBLE -> DoubleVector.newVectorBuilder(estimatedSize, blockFactory);
+            case INT -> IntVector.newVectorBuilder(estimatedSize, blockFactory);
+            case LONG -> LongVector.newVectorBuilder(estimatedSize, blockFactory);
+        };
+    }
+
+    private void fill(Vector.Builder builder, Vector from) {
+        switch (elementType) {
+            case NULL, DOC, UNKNOWN -> throw new UnsupportedOperationException();
+            case BOOLEAN -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((BooleanVector.Builder) builder).appendBoolean(((BooleanVector) from).getBoolean(p));
+                }
+            }
+            case BYTES_REF -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((BytesRefVector.Builder) builder).appendBytesRef(((BytesRefVector) from).getBytesRef(p, new BytesRef()));
+                }
+            }
+            case DOUBLE -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((DoubleVector.Builder) builder).appendDouble(((DoubleVector) from).getDouble(p));
+                }
+            }
+            case INT -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((IntVector.Builder) builder).appendInt(((IntVector) from).getInt(p));
+                }
+            }
+            case LONG -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((LongVector.Builder) builder).appendLong(((LongVector) from).getLong(p));
+                }
+            }
+        }
+        ;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
@@ -9,10 +9,6 @@ package org.elasticsearch.compute.data;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
-import com.carrotsearch.randomizedtesting.annotations.Seed;
-
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -28,7 +24,6 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@Seed("7E594D56CF8843C5:4B7F19DE1F496E74")
 public class VectorBuilderTests extends ESTestCase {
     @ParametersFactory
     public static List<Object[]> params() {
@@ -54,10 +49,22 @@ public class VectorBuilderTests extends ESTestCase {
         assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
     }
 
-    public void testSingleBuild() {
+    public void testBuildSmall() {
+        testBuild(between(1, 100));
+    }
+
+    public void testBuildHuge() {
+        testBuild(between(1_000, 50_000));
+    }
+
+    public void testBuildSingle() {
+        testBuild(1);
+    }
+
+    private void testBuild(int size) {
         BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
-        try (Vector.Builder builder = vectorBuilder(10, blockFactory)) {
-            BasicBlockTests.RandomBlock random = BasicBlockTests.randomBlock(elementType, 10, false, 1, 1, 0, 0);
+        try (Vector.Builder builder = vectorBuilder(randomBoolean() ? size : 1, blockFactory)) {
+            BasicBlockTests.RandomBlock random = BasicBlockTests.randomBlock(elementType, size, false, 1, 1, 0, 0);
             fill(builder, random.block().asVector());
             try (Vector built = builder.build()) {
                 assertThat(built, equalTo(random.block().asVector()));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
@@ -96,5 +96,9 @@ public class CannedSourceOperator extends SourceOperator {
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        while (page.hasNext()) {
+            page.next().releaseBlocks();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -186,7 +186,7 @@ public class TopNOperatorTests extends OperatorTestCase {
          * 775 causes us to blow up while collecting values and 780 doesn't
          * trip the breaker. So 775 is the max on this range.
          */
-        return ByteSizeValue.ofBytes(775);
+        return ByteSizeValue.ofBytes(between(1, 775));
     }
 
     public void testRamBytesUsed() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -38,7 +38,9 @@ import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.operator.TupleBlockSourceOperator;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.xpack.versionfield.Version;
+import org.junit.After;
 
 import java.lang.reflect.Field;
 import java.net.InetAddress;
@@ -184,7 +186,7 @@ public class TopNOperatorTests extends OperatorTestCase {
          * 775 causes us to blow up while collecting values and 780 doesn't
          * trip the breaker. So 775 is the max on this range.
          */
-        return ByteSizeValue.ofBytes(between(1, 775));
+        return ByteSizeValue.ofBytes(775);
     }
 
     public void testRamBytesUsed() {
@@ -210,23 +212,26 @@ public class TopNOperatorTests extends OperatorTestCase {
         // We under-count by a few bytes because of the lists. In that end that's fine, but we need to account for it here.
         long underCount = 200;
         DriverContext context = driverContext();
-        TopNOperator op = new TopNOperator.TopNOperatorFactory(
-            topCount,
-            List.of(LONG),
-            List.of(DEFAULT_UNSORTABLE),
-            List.of(new TopNOperator.SortOrder(0, true, false)),
-            pageSize
-        ).get(context);
-        long actualEmpty = RamUsageTester.ramUsed(op, acc);
-        assertThat(op.ramBytesUsed(), both(greaterThan(actualEmpty - underCount)).and(lessThan(actualEmpty)));
-        // But when we fill it then we're quite close
-        for (Page p : CannedSourceOperator.collectPages(simpleInput(context.blockFactory(), topCount))) {
-            op.addInput(p);
-        }
-        long actualFull = RamUsageTester.ramUsed(op, acc);
-        assertThat(op.ramBytesUsed(), both(greaterThan(actualFull - underCount)).and(lessThan(actualFull)));
+        try (
+            TopNOperator op = new TopNOperator.TopNOperatorFactory(
+                topCount,
+                List.of(LONG),
+                List.of(DEFAULT_UNSORTABLE),
+                List.of(new TopNOperator.SortOrder(0, true, false)),
+                pageSize
+            ).get(context)
+        ) {
+            long actualEmpty = RamUsageTester.ramUsed(op, acc);
+            assertThat(op.ramBytesUsed(), both(greaterThan(actualEmpty - underCount)).and(lessThan(actualEmpty)));
+            // But when we fill it then we're quite close
+            for (Page p : CannedSourceOperator.collectPages(simpleInput(context.blockFactory(), topCount))) {
+                op.addInput(p);
+            }
+            long actualFull = RamUsageTester.ramUsed(op, acc);
+            assertThat(op.ramBytesUsed(), both(greaterThan(actualFull - underCount)).and(lessThan(actualFull)));
 
-        // TODO empty it again and check.
+            // TODO empty it again and check.
+        }
     }
 
     public void testRandomTopN() {
@@ -637,6 +642,7 @@ public class TopNOperatorTests extends OperatorTestCase {
                     for (int i = 0; i < block1.getPositionCount(); i++) {
                         outputValues.add(tuple(block1.isNull(i) ? null : block1.getLong(i), block2.isNull(i) ? null : block2.getLong(i)));
                     }
+                    page.releaseBlocks();
                 }),
                 () -> {}
             )
@@ -1284,6 +1290,50 @@ public class TopNOperatorTests extends OperatorTestCase {
         assertThat((Integer) actual.get(1).get(1), equalTo(100));
     }
 
+    public void testErrorBeforeFullyDraining() {
+        int maxPageSize = between(1, 100);
+        int topCount = maxPageSize * 4;
+        int docCount = topCount * 10;
+        List<List<Object>> actual = new ArrayList<>();
+        DriverContext driverContext = driverContext();
+        try (
+            Driver driver = new Driver(
+                driverContext,
+                new SequenceLongBlockSourceOperator(driverContext.blockFactory(), LongStream.range(0, docCount)),
+                List.of(
+                    new TopNOperator(
+                        driverContext.blockFactory(),
+                        nonBreakingBigArrays().breakerService().getBreaker("request"),
+                        topCount,
+                        List.of(LONG),
+                        List.of(DEFAULT_UNSORTABLE),
+                        List.of(new TopNOperator.SortOrder(0, true, randomBoolean())),
+                        maxPageSize
+                    )
+                ),
+                new PageConsumerOperator(p -> {
+                    assertThat(p.getPositionCount(), equalTo(maxPageSize));
+                    if (actual.isEmpty()) {
+                        readInto(actual, p);
+                    } else {
+                        p.releaseBlocks();
+                        throw new RuntimeException("boo");
+                    }
+                }),
+                () -> {}
+            )
+        ) {
+            Exception e = expectThrows(RuntimeException.class, () -> runDriver(driver));
+            assertThat(e.getMessage(), equalTo("boo"));
+        }
+
+        ListMatcher values = matchesList();
+        for (int i = 0; i < maxPageSize; i++) {
+            values = values.item((long) i);
+        }
+        assertMap(actual, matchesList().item(values));
+    }
+
     public void testCloseWithoutCompleting() {
         CircuitBreaker breaker = new MockBigArrays.LimitedBreaker(CircuitBreaker.REQUEST, ByteSizeValue.ofGb(1));
         try (
@@ -1299,13 +1349,23 @@ public class TopNOperatorTests extends OperatorTestCase {
         ) {
             op.addInput(new Page(new IntArrayVector(new int[] { 1 }, 1).asBlock()));
         }
-        assertThat(breaker.getUsed(), equalTo(0L));
     }
+
+    private final List<CircuitBreaker> breakers = new ArrayList<>();
 
     @Override
     protected DriverContext driverContext() { // TODO remove this when the parent uses a breaking block factory
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1)).withCircuitBreaking();
-        return new DriverContext(bigArrays, new BlockFactory(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST), bigArrays));
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        breakers.add(breaker);
+        return new DriverContext(bigArrays, new BlockFactory(breaker, bigArrays));
+    }
+
+    @After
+    public void allBreakersEmpty() {
+        for (CircuitBreaker breaker : breakers) {
+            assertThat(breaker.getUsed(), equalTo(0L));
+        }
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata-ignoreCsvTests.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata-ignoreCsvTests.csv-spec
@@ -7,7 +7,8 @@ emp_no:integer |_index:keyword |_version:long
 10002          |employees      |1
 ;
 
-aliasWithSameName
+# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
+aliasWithSameName-Ignore
 from employees [metadata _index, _version] | sort emp_no | limit 2 | eval _index = _index, _version = _version | keep emp_no, _index, _version;
 
 emp_no:integer |_index:keyword |_version:long


### PR DESCRIPTION
This properly handles allocation errors inside of topn by making `Block.Builder` and `Vector.Builder` `Releasable`. The "new way" to deal with block factories is like this:
```
try (var b = IntBlock.builder(3, blockFactory) {
  b.append(1);
  b.append(2);
  b.append(3);
  return b.build();
}
```

If anything goes wrong the block factory's `close` method will be called by the `try` block and all of the circuit breaking that it reserves will be released.

For this all to work well `Block.Builder`s have to be one-shot. In other words, you can only call `.build` on them one time. That shifts the accounting from the builder into the block. It is an error to call `build` twice.
