### PR TITLE
Excluding ilm history from a data stream query in a yaml rest test

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -138,7 +138,7 @@ setup:
 
   - do:
       indices.get_data_stream:
-        name: ['*','-.ml*', '-.ds-ilm-history*']
+        name: ['*', '-ilm-history*']
         expand_wildcards: hidden
   - length: { data_streams: 2 }
   - match: { data_streams.0.name: .hidden-data-stream }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -138,7 +138,7 @@ setup:
 
   - do:
       indices.get_data_stream:
-        name: "*"
+        name: ['*','-.ml*', '-.ds-ilm-history*']
         expand_wildcards: hidden
   - length: { data_streams: 2 }
   - match: { data_streams.0.name: .hidden-data-stream }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/80_resolve_index_data_streams.yml
@@ -116,7 +116,7 @@ setup:
 
   - do:
       indices.resolve_index:
-        name: ['*','-.ml*', '-.ds-ilm-history*']
+        name: ['*','-.ml*', '-.ds-ilm-history*', '-ilm-history*']
         expand_wildcards: [all]
 
   - match: {indices.0.name: "/\\.ds-simple-data-stream1-(\\d{4}\\.\\d{2}\\.\\d{2}-)?000001/"}


### PR DESCRIPTION
In #99837 we stopped setting `indices.lifecycle.history_index_enabled` to false in the data streams yaml
rest tests. I missed a place where we do a wildcard datastream query that can include hidden indices. This
PR corrects that mistake. I searched all the .yml files and couldn't find any other places we do a wildcard
query that could match the ilm history index.
Closes #99913
Closes #99889