### PR TITLE
Clarify Wait for snapshot action in documentation 

### DIFF
--- a/docs/reference/ilm/actions/ilm-wait-for-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-wait-for-snapshot.asciidoc
@@ -5,7 +5,8 @@
 Phases allowed: delete.
 
 Waits for the specified {slm-init} policy to be executed before removing the index.
-This ensures that a snapshot of the deleted index is available.
+This only checks that an SLM policy has had a successful execution at some point after the wait action has started.
+It does not ensure that a snapshot of the index is available before deletion.
 
 [[ilm-wait-for-snapshot-options]]
 ==== Options


### PR DESCRIPTION
The current description of wait for snapshot can be misleading/ambiguous.

Ref: https://github.com/elastic/elasticsearch/issues/57809

Please back port accordingly.
