### PR TITLE
Log TooManyBucketException and CircuitBreakerException

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -145,7 +145,7 @@ public class TransportVersions {
     public static final TransportVersion WAIT_FOR_CLUSTER_STATE_IN_RECOVERY_ADDED = def(8_502_00_0);
     public static final TransportVersion RECOVERY_COMMIT_TOO_NEW_EXCEPTION_ADDED = def(8_503_00_0);
     public static final TransportVersion NODE_INFO_COMPONENT_VERSIONS_ADDED = def(8_504_00_0);
-    public static final TransportVersion LOG_TOO_MANY_BUCKETS_ERROR = def(8_505_00_0);
+    public static final TransportVersion BUCKET_COUNT_ADDED_TO_TOO_MANY_BUCKETS_EXCEPTION = def(8_505_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -145,6 +145,7 @@ public class TransportVersions {
     public static final TransportVersion WAIT_FOR_CLUSTER_STATE_IN_RECOVERY_ADDED = def(8_502_00_0);
     public static final TransportVersion RECOVERY_COMMIT_TOO_NEW_EXCEPTION_ADDED = def(8_503_00_0);
     public static final TransportVersion NODE_INFO_COMPONENT_VERSIONS_ADDED = def(8_504_00_0);
+    public static final TransportVersion LOG_TOO_MANY_BUCKETS_ERROR = def(8_505_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationReduceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationReduceContext.java
@@ -219,7 +219,8 @@ public abstract sealed class AggregationReduceContext permits AggregationReduceC
                 multiBucketConsumer.accept(size);
             } catch (MultiBucketConsumerService.TooManyBucketsException e) {
                 logger.error(
-                    "Too many buckets for aggregation [%s] (max [%d], count [%d])".formatted(
+                    String.format(
+                        "Too many buckets for aggregation [%s] (max [%d], count [%d])",
                         aggregationName,
                         e.getMaxBuckets(),
                         e.getBucketsCount()
@@ -228,7 +229,8 @@ public abstract sealed class AggregationReduceContext permits AggregationReduceC
                 throw e;
             } catch (CircuitBreakingException e) {
                 logger.error(
-                    "Too much memory required for aggregation [%s] (max [%d] bytes, estimated [%d] bytes)".formatted(
+                    String.format(
+                        "Too much memory required for aggregation [%s] (max [%d] bytes, estimated [%d] bytes)",
                         aggregationName,
                         e.getByteLimit(),
                         e.getBytesWanted()

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationReduceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationReduceContext.java
@@ -17,6 +17,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.tasks.TaskCancelledException;
 
+import java.util.Locale;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
@@ -220,6 +221,7 @@ public abstract sealed class AggregationReduceContext permits AggregationReduceC
             } catch (MultiBucketConsumerService.TooManyBucketsException e) {
                 logger.error(
                     String.format(
+                        Locale.ROOT,
                         "Too many buckets for aggregation [%s] (max [%d], count [%d])",
                         aggregationName,
                         e.getMaxBuckets(),
@@ -230,6 +232,7 @@ public abstract sealed class AggregationReduceContext permits AggregationReduceC
             } catch (CircuitBreakingException e) {
                 logger.error(
                     String.format(
+                        Locale.ROOT,
                         "Too much memory required for aggregation [%s] (max [%d] bytes, estimated [%d] bytes)",
                         aggregationName,
                         e.getByteLimit(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationReduceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationReduceContext.java
@@ -17,7 +17,6 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.tasks.TaskCancelledException;
 
-import java.util.Locale;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
@@ -220,24 +219,18 @@ public abstract sealed class AggregationReduceContext permits AggregationReduceC
                 multiBucketConsumer.accept(size);
             } catch (MultiBucketConsumerService.TooManyBucketsException e) {
                 logger.error(
-                    String.format(
-                        Locale.ROOT,
-                        "Too many buckets for aggregation [%s] (max [%d], count [%d])",
-                        aggregationName,
-                        e.getMaxBuckets(),
-                        e.getBucketsCount()
-                    )
+                    "Too many buckets for aggregation [{}] (max [{}], count [{}])",
+                    aggregationName,
+                    e.getMaxBuckets(),
+                    e.getBucketCount()
                 );
                 throw e;
             } catch (CircuitBreakingException e) {
                 logger.error(
-                    String.format(
-                        Locale.ROOT,
-                        "Too much memory required for aggregation [%s] (max [%d] bytes, estimated [%d] bytes)",
-                        aggregationName,
-                        e.getByteLimit(),
-                        e.getBytesWanted()
-                    )
+                    "Too much memory required for aggregation [{}] (max [{}] bytes, estimated [{}] bytes)",
+                    aggregationName,
+                    e.getByteLimit(),
+                    e.getBytesWanted()
                 );
                 throw e;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -64,14 +64,18 @@ public class MultiBucketConsumerService {
         public TooManyBucketsException(StreamInput in) throws IOException {
             super(in);
             maxBuckets = in.readInt();
-            bucketsCount = in.getTransportVersion().onOrAfter(TransportVersions.LOG_TOO_MANY_BUCKETS_ERROR) ? in.readVInt() : -1;
+            if (in.getTransportVersion().onOrAfter(TransportVersions.BUCKET_COUNT_ADDED_TO_TOO_MANY_BUCKETS_EXCEPTION)) bucketsCount = in
+                .readVInt();
+            else bucketsCount = -1;
         }
 
         @Override
         protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
             super.writeTo(out, nestedExceptionsWriter);
             out.writeInt(maxBuckets);
-            out.writeVInt(out.getTransportVersion().onOrAfter(TransportVersions.LOG_TOO_MANY_BUCKETS_ERROR) ? bucketsCount : -1);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.BUCKET_COUNT_ADDED_TO_TOO_MANY_BUCKETS_EXCEPTION)) {
+                out.writeVInt(bucketsCount);
+            }
         }
 
         public int getMaxBuckets() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -53,20 +53,20 @@ public class MultiBucketConsumerService {
 
     public static class TooManyBucketsException extends AggregationExecutionException {
         private final int maxBuckets;
-        private final int bucketsCount;
+        private final int bucketCount;
 
-        public TooManyBucketsException(String message, int maxBuckets, int bucketsCount) {
+        public TooManyBucketsException(String message, int maxBuckets, int bucketCount) {
             super(message);
             this.maxBuckets = maxBuckets;
-            this.bucketsCount = bucketsCount;
+            this.bucketCount = bucketCount;
         }
 
         public TooManyBucketsException(StreamInput in) throws IOException {
             super(in);
             maxBuckets = in.readInt();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.BUCKET_COUNT_ADDED_TO_TOO_MANY_BUCKETS_EXCEPTION)) bucketsCount = in
+            if (in.getTransportVersion().onOrAfter(TransportVersions.BUCKET_COUNT_ADDED_TO_TOO_MANY_BUCKETS_EXCEPTION)) bucketCount = in
                 .readVInt();
-            else bucketsCount = -1;
+            else bucketCount = -1;
         }
 
         @Override
@@ -74,7 +74,7 @@ public class MultiBucketConsumerService {
             super.writeTo(out, nestedExceptionsWriter);
             out.writeInt(maxBuckets);
             if (out.getTransportVersion().onOrAfter(TransportVersions.BUCKET_COUNT_ADDED_TO_TOO_MANY_BUCKETS_EXCEPTION)) {
-                out.writeVInt(bucketsCount);
+                out.writeVInt(bucketCount);
             }
         }
 
@@ -82,8 +82,8 @@ public class MultiBucketConsumerService {
             return maxBuckets;
         }
 
-        public int getBucketsCount() {
-            return bucketsCount;
+        public int getBucketCount() {
+            return bucketCount;
         }
 
         @Override
@@ -94,8 +94,8 @@ public class MultiBucketConsumerService {
         @Override
         protected void metadataToXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field("max_buckets", maxBuckets);
-            if (bucketsCount >= 0) {
-                builder.field("buckets_count", bucketsCount);
+            if (bucketCount >= 0) {
+                builder.field("buckets_count", bucketCount);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
@@ -49,7 +49,7 @@ class CompositeAggregationFactory extends AggregatorFactory {
             return new CompositeAggregator(name, factories, context, parent, metadata, size, sources, afterKey);
         } catch (MultiBucketConsumerService.TooManyBucketsException e) {
             logger.error(
-                "Too many buckets for aggregation [%s] (max [%d], count [%d])".formatted(name, e.getMaxBuckets(), e.getBucketsCount())
+                String.format("Too many buckets for aggregation [%s] (max [%d], count [%d])", name, e.getMaxBuckets(), e.getBucketsCount())
             );
             throw e;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
 
 class CompositeAggregationFactory extends AggregatorFactory {
@@ -49,7 +50,13 @@ class CompositeAggregationFactory extends AggregatorFactory {
             return new CompositeAggregator(name, factories, context, parent, metadata, size, sources, afterKey);
         } catch (MultiBucketConsumerService.TooManyBucketsException e) {
             logger.error(
-                String.format("Too many buckets for aggregation [%s] (max [%d], count [%d])", name, e.getMaxBuckets(), e.getBucketsCount())
+                String.format(
+                    Locale.ROOT,
+                    "Too many buckets for aggregation [%s] (max [%d], count [%d])",
+                    name,
+                    e.getMaxBuckets(),
+                    e.getBucketsCount()
+                )
             );
             throw e;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
-import java.util.Locale;
 import java.util.Map;
 
 class CompositeAggregationFactory extends AggregatorFactory {
@@ -49,15 +48,7 @@ class CompositeAggregationFactory extends AggregatorFactory {
         try {
             return new CompositeAggregator(name, factories, context, parent, metadata, size, sources, afterKey);
         } catch (MultiBucketConsumerService.TooManyBucketsException e) {
-            logger.error(
-                String.format(
-                    Locale.ROOT,
-                    "Too many buckets for aggregation [%s] (max [%d], count [%d])",
-                    name,
-                    e.getMaxBuckets(),
-                    e.getBucketsCount()
-                )
-            );
+            logger.error("Too many buckets for aggregation [{}] (max [{}], count [{}])", name, e.getMaxBuckets(), e.getBucketCount());
             throw e;
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -116,7 +116,8 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
                     + "]. This limit can be set by changing the ["
                     + MAX_BUCKET_SETTING.getKey()
                     + "] cluster level setting.",
-                bucketLimit
+                bucketLimit,
+                size
             );
         }
         this.sourceConfigs = sourceConfigs;

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -384,7 +384,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         );
         assertEquals("Too many buckets", ex.getMessage());
         assertEquals(max, ex.getMaxBuckets());
-        assertEquals(count, ex.getBucketsCount());
+        assertEquals(count, ex.getBucketCount());
     }
 
     public void testTimestampParsingException() throws IOException {

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -376,12 +376,15 @@ public class ExceptionSerializationTests extends ESTestCase {
 
     public void testTooManyBucketsException() throws IOException {
         TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
+        int max = randomIntBetween(10, 20);
+        int count = randomIntBetween(100, 200);
         MultiBucketConsumerService.TooManyBucketsException ex = serialize(
-            new MultiBucketConsumerService.TooManyBucketsException("Too many buckets", 100),
+            new MultiBucketConsumerService.TooManyBucketsException("Too many buckets", max, count),
             version
         );
         assertEquals("Too many buckets", ex.getMessage());
-        assertEquals(100, ex.getMaxBuckets());
+        assertEquals(max, ex.getMaxBuckets());
+        assertEquals(count, ex.getBucketsCount());
     }
 
     public void testTimestampParsingException() throws IOException {


### PR DESCRIPTION
Here we log `TooManyBucketsException` and `CircuitBreakerException` including
* the maximum number of buckets
* the actual number of buckets
* the name of the aggregation

This is done to ease investigation of issues easier is some scenarios.
