### PR TITLE
[Transform] fix BWC error when upgrading from 7.x

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.client.internal.Client;
@@ -138,7 +139,11 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                 ),
                 // at this point the transport already spend some time budget in `doExecute`, it is hard to tell what is left:
                 // recording the time spend would be complex and crosses machine boundaries, that's why we use a heuristic here
-                TimeValue.timeValueMillis((long) (request.getTimeout().millis() * CHECKPOINT_INFO_TIMEOUT_SHARE))
+                TimeValue.timeValueMillis(
+                    (long) ((request.getTimeout() != null
+                        ? request.getTimeout().millis()
+                        : AcknowledgedRequest.DEFAULT_ACK_TIMEOUT.millis()) * CHECKPOINT_INFO_TIMEOUT_SHARE)
+                )
             );
         } else {
             listener.onResponse(new Response(Collections.emptyList()));


### PR DESCRIPTION
fix a regression introduced in #99914: the timeout variable can be `null` if upgraded from 7

relates #99914
fixes #99945

Note: This fix is already part of the backport of the original PR #99940, no backport needed for _this_ PR.