### PR TITLE
[DOCS] Add security update to 8.9.2 release notes

### DIFF
--- a/docs/reference/release-notes/8.9.1.asciidoc
+++ b/docs/reference/release-notes/8.9.1.asciidoc
@@ -3,25 +3,6 @@
 
 Also see <<breaking-changes-8.9,Breaking changes in 8.9>>.
 
-[float]
-[[security-updates-8.9.1]]
-=== Security updates
-
-* {es} generally filters out sensitive information and credentials before
-logging to the audit log. It was found that this filtering was not applied when
-requests to {es} use certain deprecated `_xpack/security` URIs for APIs. The
-impact of this flaw is that sensitive information, such as passwords and tokens,
-might be printed in cleartext in {es} audit logs. Note that audit logging is
-disabled by default and needs to be explicitly enabled. Even when audit logging
-is enabled, request bodies that could contain sensitive information are not
-printed to the audit log unless explicitly configured.
-+
-The issue is resolved in {es} 8.9.2.
-+
-For more information, see our related
-https://discuss.elastic.co/t/elasticsearch-8-9-2-and-7-17-13-security-update/342479[security
-announcement].
-
 [[bug-8.9.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.9.1.asciidoc
+++ b/docs/reference/release-notes/8.9.1.asciidoc
@@ -3,6 +3,25 @@
 
 Also see <<breaking-changes-8.9,Breaking changes in 8.9>>.
 
+[float]
+[[security-updates-8.9.1]]
+=== Security updates
+
+* {es} generally filters out sensitive information and credentials before
+logging to the audit log. It was found that this filtering was not applied when
+requests to {es} use certain deprecated `_xpack/security` URIs for APIs. The
+impact of this flaw is that sensitive information, such as passwords and tokens,
+might be printed in cleartext in {es} audit logs. Note that audit logging is
+disabled by default and needs to be explicitly enabled. Even when audit logging
+is enabled, request bodies that could contain sensitive information are not
+printed to the audit log unless explicitly configured.
++
+The issue is resolved in {es} 8.9.2.
++
+For more information, see our related
+https://discuss.elastic.co/t/elasticsearch-8-9-2-and-7-17-13-security-update/342479[security
+announcement].
+
 [[bug-8.9.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.9.2.asciidoc
+++ b/docs/reference/release-notes/8.9.2.asciidoc
@@ -3,6 +3,25 @@
 
 Also see <<breaking-changes-8.9,Breaking changes in 8.9>>.
 
+[float]
+[[security-updates-8.9.2]]
+=== Security updates
+
+* {es} generally filters out sensitive information and credentials before
+logging to the audit log. It was found that this filtering was not applied when
+requests to {es} use certain deprecated `_xpack/security` URIs for APIs. The
+impact of this flaw is that sensitive information, such as passwords and tokens,
+might be printed in cleartext in {es} audit logs. Note that audit logging is
+disabled by default and needs to be explicitly enabled. Even when audit logging
+is enabled, request bodies that could contain sensitive information are not
+printed to the audit log unless explicitly configured.
++
+The issue is resolved in {es} 8.9.2.
++
+For more information, see our related
+https://discuss.elastic.co/t/elasticsearch-8-9-2-and-7-17-13-security-update/342479[security
+announcement].
+
 [[bug-8.9.2]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Adds an update for the [audit logs security announcement](https://discuss.elastic.co/t/elasticsearch-8-9-2-and-7-17-13-security-update/342479) to the 8.9.2 release notes. This was overlooked when the announcement was first made.

I plan to add a similar note to the 7.17.13 release notes.