### PR TITLE
[TEST] Test that aggregate_metric_double is unsupported in ESQL

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/40_tsdb.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/40_tsdb.yml
@@ -109,3 +109,35 @@ filter on counter:
       esql.query:
         body:
           query: 'from test | where k8s.pod.network.tx == 1434577921'
+
+---
+stats on aggregate_metric_double:
+  - do:
+      indices.create:
+        index: test2
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ dim ]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              dim:
+                type: keyword
+                time_series_dimension: true
+              agg_metric:
+                type: aggregate_metric_double
+                metrics:
+                  - max
+                default_metric: max
+
+  - do:
+      catch: /Cannot use field \[agg_metric\] with unsupported type \[aggregate_metric_double\]/
+      esql.query:
+        body:
+          query: 'FROM test2 | STATS max(agg_metric) BY dim '

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/40_tsdb.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/40_tsdb.yml
@@ -60,6 +60,39 @@ setup:
           - '{"index": {}}'
           - '{"@timestamp": "2021-04-28T18:51:03.142Z", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434595272, "rx": 530605511}}}}'
 
+  - do:
+      indices.create:
+        index: test2
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ dim ]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              dim:
+                type: keyword
+                time_series_dimension: true
+              agg_metric:
+                type: aggregate_metric_double
+                metrics:
+                  - max
+                default_metric: max
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim": "A", "agg_metric": {"max": 10}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:24.467Z", "dim": "B", "agg_metric": {"max": 20}}'
+
 ---
 load everything:
   - do:
@@ -111,31 +144,22 @@ filter on counter:
           query: 'from test | where k8s.pod.network.tx == 1434577921'
 
 ---
-stats on aggregate_metric_double:
+from doc with aggregate_metric_double:
   - do:
-      indices.create:
-        index: test2
+      esql.query:
         body:
-          settings:
-            index:
-              mode: time_series
-              routing_path: [ dim ]
-              time_series:
-                start_time: 2021-04-28T00:00:00Z
-                end_time: 2021-04-29T00:00:00Z
-          mappings:
-            properties:
-              "@timestamp":
-                type: date
-              dim:
-                type: keyword
-                time_series_dimension: true
-              agg_metric:
-                type: aggregate_metric_double
-                metrics:
-                  - max
-                default_metric: max
+          query: 'from test2'
 
+  - match: {columns.0.name: "@timestamp"}
+  - match: {columns.0.type: "date"}
+  - match: {columns.1.name: "agg_metric"}
+  - match: {columns.1.type: "unsupported"}
+  - match: {columns.2.name: "dim"}
+  - match: {columns.2.type: "keyword"}
+  - length: {values: 0}
+
+---
+stats on aggregate_metric_double:
   - do:
       catch: /Cannot use field \[agg_metric\] with unsupported type \[aggregate_metric_double\]/
       esql.query:


### PR DESCRIPTION
Add a YAML test that verifies that type `aggregate_metric_double` is not supported in ES|QL. This type is used in downsampled indexes, to summarize metrics values over bucketing intervals. None of this is currently supported in ES|QL.
