### PR TITLE
Log TooManyBucketsException

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -91,6 +93,7 @@ public class MultiBucketConsumerService {
      * {@link Aggregator#buildAggregations} and {@link InternalAggregation#reduce}.
      */
     public static class MultiBucketConsumer implements IntConsumer {
+        private final Logger logger = LogManager.getLogger(MultiBucketConsumer.class);
         private final int limit;
         private final CircuitBreaker breaker;
 
@@ -108,6 +111,7 @@ public class MultiBucketConsumerService {
             if (value != 0) {
                 count += value;
                 if (count > limit) {
+                    logger.warn("Too many buckets (max [{}], count [{}])", limit, count);
                     throw new TooManyBucketsException(
                         "Trying to create too many buckets. Must be less than or equal to: ["
                             + limit

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -36,6 +36,8 @@ import org.elasticsearch.common.Rounding;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.lucene.queries.SearchAfterSortedDocQuery;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -68,6 +70,7 @@ import static org.elasticsearch.search.aggregations.MultiBucketConsumerService.M
 
 public final class CompositeAggregator extends BucketsAggregator implements SizedBucketAggregator {
 
+    private final Logger logger = LogManager.getLogger(CompositeAggregator.class);
     private final int size;
     private final List<String> sourceNames;
     private final int[] reverseMuls;
@@ -107,6 +110,7 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
         // check that the provided size is not greater than the search.max_buckets setting
         int bucketLimit = aggCtx.maxBuckets();
         if (size > bucketLimit) {
+            logger.warn("Too many buckets (max [{}], count [{}])", bucketLimit, size);
             throw new MultiBucketConsumerService.TooManyBucketsException(
                 "Trying to create too many buckets. Must be less than or equal"
                     + " to: ["


### PR DESCRIPTION
Here we just log `TooManyBucketException` to make investigating issues easier.
