### PR TITLE
ESQL: Force-merge all CSV test indices at once

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -40,6 +40,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.common.Strings.delimitedListToStringArray;
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
@@ -135,6 +136,7 @@ public class CsvTestsDataLoader {
         for (var dataSet : CSV_DATASET_MAP.values()) {
             load(client, dataSet.indexName, "/" + dataSet.mappingFileName, "/" + dataSet.dataFileName, logger);
         }
+        forceMerge(client, CSV_DATASET_MAP.keySet(), logger);
         for (var policy : ENRICH_POLICIES) {
             loadEnrichPolicy(client, policy.policyName, policy.policyFileName, logger);
         }
@@ -216,9 +218,9 @@ public class CsvTestsDataLoader {
                                 );
                             } else {
                                 name = entries[i].substring(0, split).trim();
-                                if (name.indexOf(".") < 0) {
+                                if (name.contains(".") == false) {
                                     typeName = entries[i].substring(split + 1).trim();
-                                    if (typeName.length() == 0) {
+                                    if (typeName.isEmpty()) {
                                         throw new IllegalArgumentException(
                                             "A type is always expected in the schema definition; found " + entries[i]
                                         );
@@ -300,7 +302,7 @@ public class CsvTestsDataLoader {
         }
 
         request.setJsonEntity(builder.toString());
-        request.addParameter("refresh", "wait_for");
+        request.addParameter("refresh", "false"); // will be _forcemerge'd next
         Response response = client.performRequest(request);
         if (response.getStatusLine().getStatusCode() == 200) {
             HttpEntity entity = response.getEntity();
@@ -309,20 +311,25 @@ public class CsvTestsDataLoader {
                 Map<String, Object> result = XContentHelper.convertToMap(xContentType.xContent(), content, false);
                 Object errors = result.get("errors");
                 if (Boolean.FALSE.equals(errors)) {
-                    logger.info("Data loading OK");
-                    request = new Request("POST", "/" + indexName + "/_forcemerge?max_num_segments=1");
-                    response = client.performRequest(request);
-                    if (response.getStatusLine().getStatusCode() != 200) {
-                        logger.warn("Force-merge to 1 segment failed: " + response.getStatusLine());
-                    } else {
-                        logger.info("Forced-merge to 1 segment");
-                    }
+                    logger.info("Data loading of [{}] OK", indexName);
                 } else {
-                    logger.error("Data loading FAILED");
+                    throw new IOException("Data loading of [" + indexName + "] failed with errors: " + errors);
                 }
             }
         } else {
-            logger.error("Error loading data: " + response.getStatusLine());
+            throw new IOException("Data loading of [" + indexName + "] failed with status: " + response.getStatusLine());
+        }
+    }
+
+    private static void forceMerge(RestClient client, Set<String> indices, Logger logger) throws IOException {
+        String pattern = String.join(",", indices);
+
+        Request request = new Request("POST", "/" + pattern + "/_forcemerge?max_num_segments=1");
+        Response response = client.performRequest(request);
+        if (response.getStatusLine().getStatusCode() != 200) {
+            logger.warn("Force-merging [{}] to 1 segment failed: {}", pattern, response.getStatusLine());
+        } else {
+            logger.info("[{}] forced-merged to 1 segment", pattern);
         }
     }
 


### PR DESCRIPTION
This disables waiting for each test index to become search-available and force-merges all of them in one go, making the data loading slightly faster.
