### PR TITLE
Add RandomAccessInput#length to SeekTrackingDirectoryWrapper

### DIFF
--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekTrackingDirectoryWrapper.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekTrackingDirectoryWrapper.java
@@ -144,6 +144,11 @@ public class SeekTrackingDirectoryWrapper implements IndexModule.DirectoryWrappe
                 // return default impl
                 return new RandomAccessInput() {
                     @Override
+                    public long length() {
+                        return slice.length();
+                    }
+
+                    @Override
                     public byte readByte(long pos) throws IOException {
                         slice.seek(pos);
                         return slice.readByte();


### PR DESCRIPTION
Fix compiling error after adding a new method to RandomAccessInput interface.