### PR TITLE
[8.7] Add breaking change docs for #92820 (#99849)

### DIFF
--- a/docs/reference/indices/resolve.asciidoc
+++ b/docs/reference/indices/resolve.asciidoc
@@ -68,8 +68,8 @@ for the target data stream, index, or index alias.
 +
 --
 (Required, string) Comma-separated name(s) or index pattern(s) of the
-indices, aliases, and data streams to resolve. Resources on
-<<remote-clusters,remote clusters>> can be specified using the
+indices, aliases, and data streams to resolve, using <<api-multi-index>>.
+Resources on <<remote-clusters,remote clusters>> can be specified using the
 `<cluster>:<name>` syntax.
 --
 
@@ -79,6 +79,18 @@ indices, aliases, and data streams to resolve. Resources on
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
++
+Defaults to `false`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
++
+Defaults to `true`.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
++
+Defaults to `false`.
 
 [[resolve-index-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/release-notes/8.7.0.asciidoc
+++ b/docs/reference/release-notes/8.7.0.asciidoc
@@ -16,6 +16,16 @@ include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 Ingest Node::
 * Making `JsonProcessor` stricter so that it does not silently drop data {es-pull}93179[#93179] (issue: {es-issue}92898[#92898])
 
+Indices APIs::
+* The <<indices-resolve-index-api>> API implementation was adjusted to use the
+same index resolution mechanism as other similar APIs, adding support for the
+`ignore_unavailable` and `allow_no_indices` flags and the `_all` meta-index. If
+there are no matching indices then earlier versions of this API would return an
+empty result with the `200 OK` HTTP response code, but from 8.7.0 onwards by
+default it returns an `IndexNotFoundException` with the `404 Not Found` HTTP
+response code. To recover the old behaviour, add the query parameter
+`?ignore_unavailable=true` ({es-pull}92820[#92820]).
+
 [[bug-8.7.0]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Add breaking change docs for #92820 (#99849)