### PR TITLE
[Transform] Remove usages of Version from transforms

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettingsTests.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.core.transform.transforms;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.transform.AbstractSerializingTransformTestCase;
+import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -31,7 +31,7 @@ public class TransformDestIndexSettingsTests extends AbstractSerializingTransfor
 
         if (randomBoolean()) {
             mappings = Maps.newMapWithExpectedSize(size);
-            mappings.put("_meta", singletonMap("_transform", singletonMap("version", Version.CURRENT.toString())));
+            mappings.put("_meta", singletonMap("_transform", singletonMap("version", TransformConfigVersion.CURRENT.toString())));
             for (int i = 0; i < size; i++) {
                 mappings.put(randomAlphaOfLength(10), singletonMap("type", randomAlphaOfLength(10)));
             }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.transform.integration;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
 import org.elasticsearch.xpack.core.transform.transforms.DestAlias;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.junit.Before;
@@ -53,7 +53,7 @@ public class TransformDestIndexIT extends TransformRestTestCase {
 
         Map<?, ?> mappingAsMap = entityAsMap(mappingResponse);
         assertEquals(
-            Version.CURRENT.toString(),
+            TransformConfigVersion.CURRENT.toString(),
             XContentMapValues.extractValue("pivot_reviews.mappings._meta._transform.version.created", mappingAsMap)
         );
         assertTrue(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.transform.persistence;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
@@ -28,6 +27,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.DestAlias;
@@ -265,14 +265,14 @@ public final class TransformIndex {
     }
 
     /*
-     * Return meta data that stores some useful information about the transform index, stored as "_meta":
+     * Return metadata that stores some useful information about the transform index, stored as "_meta":
      *
      * {
      *   "created_by" : "transform",
      *   "_transform" : {
      *     "transform" : "id",
      *     "version" : {
-     *       "created" : "8.0.0"
+     *       "created" : "10.0.0"
      *     },
      *     "creation_date_in_millis" : 1584025695202
      *   }
@@ -285,7 +285,10 @@ public final class TransformIndex {
 
         Map<String, Object> transformMetadata = new HashMap<>();
         transformMetadata.put(TransformField.CREATION_DATE_MILLIS, clock.millis());
-        transformMetadata.put(TransformField.VERSION.getPreferredName(), Map.of(TransformField.CREATED, Version.CURRENT.toString()));
+        transformMetadata.put(
+            TransformField.VERSION.getPreferredName(),
+            Map.of(TransformField.CREATED, TransformConfigVersion.CURRENT.toString())
+        );
         transformMetadata.put(TransformField.TRANSFORM, id);
 
         metadata.put(TransformField.META_FIELDNAME, transformMetadata);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.transform.persistence;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -69,6 +68,22 @@ public final class TransformInternalIndex {
      * version 7 (7.13):add mapping for config::pivot, config::latest, config::retention_policy and config::sync
      */
 
+    /**
+     * The new system index mappings version used in preference to <code>version</code>
+     * since 8.10. A value of 1 for this constant corresponds to version 7 in the table
+     * of changes above. Increment this constant by one at the same time as adding a new
+     * entry to the table of changes above.
+     */
+    public static final int TRANSFORM_INDEX_MAPPINGS_VERSION = 1;
+    /**
+     * No longer used for determining the age of mappings, but system index descriptor
+     * code requires <em>something</em> be set. We use a value that can be parsed by
+     * old nodes in mixed-version clusters, just in case any old code exists that
+     * tries to parse <code>version</code> from index metadata, and that will indicate
+     * to these old nodes that the mappings are newer than they are.
+     */
+    private static final String LEGACY_VERSION_FIELD_VALUE = "8.11.0";
+
     // constants for mappings
     public static final String DYNAMIC = "dynamic";
     public static final String PROPERTIES = "properties";
@@ -87,7 +102,6 @@ public final class TransformInternalIndex {
     public static final String KEYWORD = "keyword";
     public static final String BOOLEAN = "boolean";
     public static final String FLATTENED = "flattened";
-    public static final int TRANSFORM_INDEX_MAPPINGS_VERSION = 1;
 
     public static SystemIndexDescriptor getSystemIndexDescriptor(Settings transformInternalIndexAdditionalSettings) throws IOException {
         return SystemIndexDescriptor.builder()
@@ -359,7 +373,7 @@ public final class TransformInternalIndex {
      */
     private static XContentBuilder addMetaInformation(XContentBuilder builder) throws IOException {
         return builder.startObject("_meta")
-            .field("version", Version.CURRENT)
+            .field("version", LEGACY_VERSION_FIELD_VALUE)
             .field(SystemIndexDescriptor.VERSION_META_KEY, TRANSFORM_INDEX_MAPPINGS_VERSION)
             .endObject();
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.transform.transforms;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -323,7 +322,6 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
                             DiscoveryNodeRole.TRANSFORM_ROLE
                         )
                     )
-                    .version(Version.V_7_7_0)
                     .attributes(
                         Map.of(TransformConfigVersion.TRANSFORM_CONFIG_VERSION_NODE_ATTR, TransformConfigVersion.V_7_7_0.toString())
                     )


### PR DESCRIPTION
Transforms code outside of TransformConfigVersion no longer uses the Version class.