### PR TITLE
ESQL: Clone blocks in CSV tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -291,11 +291,12 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
         }
         DocBlock docBlock = page.getBlock(0);
         IntVector docIndices = docBlock.asVector().docs();
-        Block loadedBlock = testData.getBlock(columnIndex);
-        int[] filteredPositions = new int[docIndices.getPositionCount()];
+        Block originalData = testData.getBlock(columnIndex);
+        Block.Builder builder = originalData.elementType().newBlockBuilder(docIndices.getPositionCount());
         for (int c = 0; c < docIndices.getPositionCount(); c++) {
-            filteredPositions[c] = docIndices.getInt(c);
+            int doc = docIndices.getInt(c);
+            builder.copyFrom(originalData, doc, doc + 1);
         }
-        return loadedBlock.filter(filteredPositions);
+        return builder.build();
     }
 }


### PR DESCRIPTION
Previously in our tests we loaded the data once and sent it to as many threads as we needed. The trouble with this is that we want to `close` the blocks after we've consumed them. If we do that then we can't share them! This sends unqiue blocks to each reader.
