### PR TITLE
Optimize field name matching in field caps API

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -29,7 +29,6 @@ import org.elasticsearch.tasks.CancellableTask;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -49,7 +48,7 @@ class FieldCapabilitiesFetcher {
     FieldCapabilitiesIndexResponse fetch(
         CancellableTask task,
         ShardId shardId,
-        String[] fieldPatterns,
+        Predicate<String> fieldNameFilter,
         String[] filters,
         String[] fieldTypes,
         QueryBuilder indexFilter,
@@ -63,7 +62,7 @@ class FieldCapabilitiesFetcher {
             return doFetch(
                 task,
                 shardId,
-                fieldPatterns,
+                fieldNameFilter,
                 filters,
                 fieldTypes,
                 indexFilter,
@@ -78,7 +77,7 @@ class FieldCapabilitiesFetcher {
     private FieldCapabilitiesIndexResponse doFetch(
         CancellableTask task,
         ShardId shardId,
-        String[] fieldPatterns,
+        Predicate<String> fieldNameFilter,
         String[] filters,
         String[] fieldTypes,
         QueryBuilder indexFilter,
@@ -112,7 +111,7 @@ class FieldCapabilitiesFetcher {
         Predicate<String> fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
         final Map<String, IndexFieldCapabilities> responseMap = retrieveFieldCaps(
             searchExecutionContext,
-            fieldPatterns,
+            fieldNameFilter,
             filters,
             fieldTypes,
             fieldPredicate
@@ -125,23 +124,20 @@ class FieldCapabilitiesFetcher {
 
     static Map<String, IndexFieldCapabilities> retrieveFieldCaps(
         SearchExecutionContext context,
-        String[] fieldPatterns,
+        Predicate<String> fieldNameFilter,
         String[] filters,
         String[] types,
         Predicate<String> indexFieldfilter
     ) {
-
-        Set<String> fieldNames = new HashSet<>();
-        for (String pattern : fieldPatterns) {
-            fieldNames.addAll(context.getMatchingFieldNames(pattern));
-        }
-
         boolean includeParentObjects = checkIncludeParents(filters);
 
         Predicate<MappedFieldType> filter = buildFilter(indexFieldfilter, filters, types, context);
         boolean isTimeSeriesIndex = context.getIndexSettings().getTimestampBounds() != null;
         Map<String, IndexFieldCapabilities> responseMap = new HashMap<>();
-        for (String field : fieldNames) {
+        for (String field : context.getAllFieldNames()) {
+            if (fieldNameFilter.test(field) == false) {
+                continue;
+            }
             MappedFieldType ft = context.getFieldType(field);
             if (filter.test(ft)) {
                 IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
@@ -56,6 +57,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.search.TransportSearchHelper.checkCCSVersionCompatibility;
@@ -488,6 +490,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                     .stream()
                     .collect(Collectors.groupingBy(ShardId::getIndexName));
                 final FieldCapabilitiesFetcher fetcher = new FieldCapabilitiesFetcher(indicesService);
+                final Predicate<String> fieldNameFilter = Regex.simpleMatcher(request.fields());
                 for (List<ShardId> shardIds : groupedShardIds.values()) {
                     final Map<ShardId, Exception> failures = new HashMap<>();
                     final Set<ShardId> unmatched = new HashSet<>();
@@ -496,7 +499,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                             final FieldCapabilitiesIndexResponse response = fetcher.fetch(
                                 (CancellableTask) task,
                                 shardId,
-                                request.fields(),
+                                fieldNameFilter,
                                 request.filters(),
                                 request.allowedTypes(),
                                 request.indexFilter(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -162,7 +162,7 @@ final class FieldTypeLookup {
      */
     Set<String> getMatchingFieldNames(String pattern) {
         if (Regex.isMatchAllPattern(pattern)) {
-            return Collections.unmodifiableSet(fullNameToFieldType.keySet());
+            return fullNameToFieldType.keySet();
         }
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -9,6 +9,7 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.CountDown;
@@ -321,5 +322,16 @@ public class QueryRewriteContext {
             }
         }
         return matches;
+    }
+
+    /**
+     * Same as {@link #getMatchingFieldNames(String)} with pattern {@code *} but returns an {@link Iterable} instead of a set.
+     */
+    public Iterable<String> getAllFieldNames() {
+        var allFromMapping = mappingLookup.getMatchingFieldNames("*");
+        // runtime mappings and non-runtime fields don't overlap, so we can simply concatenate the iterables here
+        return runtimeMappings.isEmpty()
+            ? allFromMapping
+            : () -> Iterators.concat(allFromMapping.iterator(), runtimeMappings.keySet().iterator());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFilterTests.java
@@ -38,7 +38,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
 
         Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
             sec,
-            new String[] { "*" },
+            s -> true,
             new String[] { "-nested" },
             Strings.EMPTY_ARRAY,
             f -> true
@@ -64,7 +64,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
         {
             Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
                 sec,
-                new String[] { "*" },
+                s -> true,
                 new String[] { "+metadata" },
                 Strings.EMPTY_ARRAY,
                 f -> true
@@ -75,7 +75,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
         {
             Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
                 sec,
-                new String[] { "*" },
+                s -> true,
                 new String[] { "-metadata" },
                 Strings.EMPTY_ARRAY,
                 f -> true
@@ -106,7 +106,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
 
         Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
             sec,
-            new String[] { "*" },
+            s -> true,
             new String[] { "-multifield" },
             Strings.EMPTY_ARRAY,
             f -> true
@@ -135,7 +135,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
 
         Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
             sec,
-            new String[] { "*" },
+            s -> true,
             new String[] { "-parent" },
             Strings.EMPTY_ARRAY,
             f -> true
@@ -161,7 +161,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
         {
             Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
                 sec,
-                new String[] { "*" },
+                s -> true,
                 Strings.EMPTY_ARRAY,
                 Strings.EMPTY_ARRAY,
                 securityFilter
@@ -175,7 +175,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
         {
             Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
                 sec,
-                new String[] { "*" },
+                s -> true,
                 new String[] { "-metadata" },
                 Strings.EMPTY_ARRAY,
                 securityFilter
@@ -201,7 +201,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
 
         Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
             sec,
-            new String[] { "*" },
+            s -> true,
             Strings.EMPTY_ARRAY,
             new String[] { "text", "keyword" },
             f -> true


### PR DESCRIPTION
When using field caps name patterns, a large share (as in 50%+) of the CPU runtime can go into matching field names because all fields are iterated for ever pattern provided.
We can significantly improve this case by pre-compiling the predicate which seems to speedup both the case without matching any field names and the slow case of multiple patterns.


relevant slow stack-trace that is improved by at least he number of patterns by this PR as well as by removing a lot of allocations.

```
 100.0% [cpu=96.4%, other=3.6%] (500ms out of 500ms) cpu usage by thread 'elasticsearch[instance-0000000084][search_coordination][T#1]'
     2/10 snapshots sharing following 114 elements
       java.base@20.0.2/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1921)
       java.base@20.0.2/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
       java.base@20.0.2/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
       java.base@20.0.2/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
       java.base@20.0.2/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
       java.base@20.0.2/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
       app/org.elasticsearch.server@8.10.0/org.elasticsearch.index.mapper.FieldTypeLookup.getMatchingFieldNames(FieldTypeLookup.java:174)
       app/org.elasticsearch.server@8.10.0/org.elasticsearch.index.mapper.MappingLookup.getMatchingFieldNames(MappingLookup.java:381)
       app/org.elasticsearch.server@8.10.0/org.elasticsearch.index.query.QueryRewriteContext.getMatchingFieldNames(QueryRewriteContext.java:308)
```