### PR TITLE
Rename tracing settings to telemetry

### DIFF
--- a/TRACING.md
+++ b/TRACING.md
@@ -23,18 +23,18 @@ You must supply configuration and credentials for the APM server (see below).
 In your `elasticsearch.yml` add the following configuration:
 
 ```
-tracing.apm.enabled: true
-tracing.apm.agent.server_url: https://<your-apm-server>:443
+telemetry.tracing.enabled: true
+telemetry.agent.server_url: https://<your-apm-server>:443
 ```
 
-When using a secret token to authenticate with the APM server, you must add it to the Elasticsearch keystore under `tracing.apm.secret_token`. For example, execute:
+When using a secret token to authenticate with the APM server, you must add it to the Elasticsearch keystore under `telemetry.secret_token`. For example, execute:
 
-    bin/elasticsearch-keystore add tracing.apm.secret_token
+    bin/elasticsearch-keystore add telemetry.secret_token
 
-then enter the token when prompted. If you are using API keys, change the keystore key name to `tracing.apm.api_key`.
+then enter the token when prompted. If you are using API keys, change the keystore key name to `telemetry.api_key`.
 
-All APM settings live under `tracing.apm`. All settings related to the Java agent
-go under `tracing.apm.agent`. Anything you set under there will be propagated to
+All APM settings live under `telemetry`. All settings related to the Java agent
+go under `telemetry.agent`. Anything you set under there will be propagated to
 the agent.
 
 For agent settings that can be changed dynamically, you can use the cluster
@@ -43,7 +43,7 @@ settings REST API. For example, to change the sampling rate:
     curl -XPUT \
       -H "Content-type: application/json" \
       -u "$USERNAME:$PASSWORD" \
-      -d '{ "persistent": { "tracing.apm.agent.transaction_sample_rate": "0.75" } }' \
+      -d '{ "persistent": { "telemetry.agent.transaction_sample_rate": "0.75" } }' \
       https://localhost:9200/_cluster/settings
 
 

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -182,8 +182,8 @@ class APMJvmOptions {
     private static void extractSecureSettings(SecureSettings secrets, Map<String, String> propertiesMap) {
         final Set<String> settingNames = secrets.getSettingNames();
         for (String key : List.of("api_key", "secret_token")) {
-            if (settingNames.contains("tracing.apm." + key)) {
-                try (SecureString token = secrets.getString("tracing.apm." + key)) {
+            if (settingNames.contains("telemetry." + key)) {
+                try (SecureString token = secrets.getString("telemetry." + key)) {
                     propertiesMap.put(key, token.toString());
                 }
             }
@@ -213,11 +213,11 @@ class APMJvmOptions {
     static Map<String, String> extractApmSettings(Settings settings) throws UserException {
         final Map<String, String> propertiesMap = new HashMap<>();
 
-        final Settings agentSettings = settings.getByPrefix("tracing.apm.agent.");
+        final Settings agentSettings = settings.getByPrefix("telemetry.agent.");
         agentSettings.keySet().forEach(key -> propertiesMap.put(key, String.valueOf(agentSettings.get(key))));
 
         // special handling of global labels, the agent expects them in format: key1=value1,key2=value2
-        final Settings globalLabelsSettings = settings.getByPrefix("tracing.apm.agent.global_labels.");
+        final Settings globalLabelsSettings = settings.getByPrefix("telemetry.agent.global_labels.");
         final StringJoiner globalLabels = new StringJoiner(",");
 
         for (var globalLabel : globalLabelsSettings.keySet()) {
@@ -242,7 +242,7 @@ class APMJvmOptions {
             if (propertiesMap.containsKey(key)) {
                 throw new UserException(
                     ExitCodes.CONFIG,
-                    "Do not set a value for [tracing.apm.agent." + key + "], as this is configured automatically by Elasticsearch"
+                    "Do not set a value for [telemetry.agent." + key + "], as this is configured automatically by Elasticsearch"
                 );
             }
         }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
@@ -75,12 +75,12 @@ public class APMJvmOptionsTests extends ESTestCase {
 
     public void testExtractSettings() throws UserException {
         Settings settings = Settings.builder()
-            .put("tracing.apm.enabled", true)
-            .put("tracing.apm.agent.server_url", "https://myurl:443")
-            .put("tracing.apm.agent.service_node_name", "instance-0000000001")
-            .put("tracing.apm.agent.global_labels.deployment_id", "123")
-            .put("tracing.apm.agent.global_labels.deployment_name", "APM Tracing")
-            .put("tracing.apm.agent.global_labels.organization_id", "456")
+            .put("telemetry.tracing.enabled", true)
+            .put("telemetry.agent.server_url", "https://myurl:443")
+            .put("telemetry.agent.service_node_name", "instance-0000000001")
+            .put("telemetry.agent.global_labels.deployment_id", "123")
+            .put("telemetry.agent.global_labels.deployment_name", "APM Tracing")
+            .put("telemetry.agent.global_labels.organization_id", "456")
             .build();
 
         var extracted = APMJvmOptions.extractApmSettings(settings);
@@ -101,12 +101,12 @@ public class APMJvmOptionsTests extends ESTestCase {
         assertThat(labels, containsInAnyOrder("deployment_name=APM Tracing", "organization_id=456", "deployment_id=123"));
 
         settings = Settings.builder()
-            .put("tracing.apm.enabled", true)
-            .put("tracing.apm.agent.server_url", "https://myurl:443")
-            .put("tracing.apm.agent.service_node_name", "instance-0000000001")
-            .put("tracing.apm.agent.global_labels.deployment_id", "")
-            .put("tracing.apm.agent.global_labels.deployment_name", "APM=Tracing")
-            .put("tracing.apm.agent.global_labels.organization_id", ",456")
+            .put("telemetry.tracing.enabled", true)
+            .put("telemetry.agent.server_url", "https://myurl:443")
+            .put("telemetry.agent.service_node_name", "instance-0000000001")
+            .put("telemetry.agent.global_labels.deployment_id", "")
+            .put("telemetry.agent.global_labels.deployment_name", "APM=Tracing")
+            .put("telemetry.agent.global_labels.organization_id", ",456")
             .build();
 
         extracted = APMJvmOptions.extractApmSettings(settings);

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -44,8 +44,8 @@ import java.util.function.Supplier;
  * programmatically attach the agent, the Security Manager permissions required for this
  * make this approach difficult to the point of impossibility.
  * <p>
- * All settings are found under the <code>tracing.apm.</code> prefix. Any setting under
- * the <code>tracing.apm.agent.</code> prefix will be forwarded on to the APM Java agent
+ * All settings are found under the <code>telemetry.</code> prefix. Any setting under
+ * the <code>telemetry.agent.</code> prefix will be forwarded on to the APM Java agent
  * by setting appropriate system properties. Some settings can only be set once, and must be
  * set when the agent starts. We therefore also create and configure a config file in
  * the {@code APMJvmOptions} class, which we then delete when Elasticsearch starts, so that

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -103,13 +103,13 @@ public class APM extends Plugin implements NetworkPlugin, TelemetryPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return List.of(
-            APMAgentSettings.APM_ENABLED_SETTING,
-            APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING,
-            APMAgentSettings.APM_TRACING_NAMES_EXCLUDE_SETTING,
-            APMAgentSettings.APM_TRACING_SANITIZE_FIELD_NAMES,
-            APMAgentSettings.APM_AGENT_SETTINGS,
-            APMAgentSettings.APM_SECRET_TOKEN_SETTING,
-            APMAgentSettings.APM_API_KEY_SETTING
+            APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING,
+            APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING,
+            APMAgentSettings.TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING,
+            APMAgentSettings.TELEMETRY_TRACING_SANITIZE_FIELD_NAMES,
+            APMAgentSettings.TELEMETRY_AGENT_SETTINGS,
+            APMAgentSettings.TELEMETRY_SECRET_TOKEN_SETTING,
+            APMAgentSettings.TELEMETRY_API_KEY_SETTING
         );
     }
 }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -98,7 +98,7 @@ public class APMAgentSettings {
         });
     }
 
-    private static final String APM_SETTING_PREFIX = "tracing.apm.";
+    private static final String TELEMETRY_SETTING_PREFIX = "telemetry.";
 
     /**
      * A list of APM agent config keys that should never be configured by the user.
@@ -106,12 +106,12 @@ public class APMAgentSettings {
     private static final List<String> PROHIBITED_AGENT_KEYS = List.of(
         // ES generates a config file and sets this value
         "config_file",
-        // ES controls this via `tracing.apm.enabled`
+        // ES controls this via `telemetry.tracing.enabled`
         "recording"
     );
 
     public static final Setting.AffixSetting<String> APM_AGENT_SETTINGS = Setting.prefixKeySetting(
-        APM_SETTING_PREFIX + "agent.",
+        TELEMETRY_SETTING_PREFIX + "agent.",
         (qualifiedKey) -> {
             final String[] parts = qualifiedKey.split("\\.");
             final String key = parts[parts.length - 1];
@@ -126,19 +126,19 @@ public class APMAgentSettings {
     );
 
     public static final Setting<List<String>> APM_TRACING_NAMES_INCLUDE_SETTING = Setting.stringListSetting(
-        APM_SETTING_PREFIX + "names.include",
+        TELEMETRY_SETTING_PREFIX + "names.include",
         OperatorDynamic,
         NodeScope
     );
 
     public static final Setting<List<String>> APM_TRACING_NAMES_EXCLUDE_SETTING = Setting.stringListSetting(
-        APM_SETTING_PREFIX + "names.exclude",
+        TELEMETRY_SETTING_PREFIX + "names.exclude",
         OperatorDynamic,
         NodeScope
     );
 
     public static final Setting<List<String>> APM_TRACING_SANITIZE_FIELD_NAMES = Setting.stringListSetting(
-        APM_SETTING_PREFIX + "sanitize_field_names",
+        TELEMETRY_SETTING_PREFIX + "sanitize_field_names",
         List.of(
             "password",
             "passwd",
@@ -158,16 +158,16 @@ public class APMAgentSettings {
     );
 
     public static final Setting<Boolean> APM_ENABLED_SETTING = Setting.boolSetting(
-        APM_SETTING_PREFIX + "enabled",
+        TELEMETRY_SETTING_PREFIX + "tracing.enabled",
         false,
         OperatorDynamic,
         NodeScope
     );
 
     public static final Setting<SecureString> APM_SECRET_TOKEN_SETTING = SecureSetting.secureString(
-        APM_SETTING_PREFIX + "secret_token",
+        TELEMETRY_SETTING_PREFIX + "secret_token",
         null
     );
 
-    public static final Setting<SecureString> APM_API_KEY_SETTING = SecureSetting.secureString(APM_SETTING_PREFIX + "api_key", null);
+    public static final Setting<SecureString> APM_API_KEY_SETTING = SecureSetting.secureString(TELEMETRY_SETTING_PREFIX + "api_key", null);
 }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -99,6 +99,7 @@ public class APMAgentSettings {
     }
 
     private static final String TELEMETRY_SETTING_PREFIX = "telemetry.";
+    private static final String TRACING_SETTING_PREFIX = TELEMETRY_SETTING_PREFIX + "tracing.";
 
     /**
      * A list of APM agent config keys that should never be configured by the user.
@@ -126,19 +127,19 @@ public class APMAgentSettings {
     );
 
     public static final Setting<List<String>> APM_TRACING_NAMES_INCLUDE_SETTING = Setting.stringListSetting(
-        TELEMETRY_SETTING_PREFIX + "names.include",
+        TRACING_SETTING_PREFIX + "names.include",
         OperatorDynamic,
         NodeScope
     );
 
     public static final Setting<List<String>> APM_TRACING_NAMES_EXCLUDE_SETTING = Setting.stringListSetting(
-        TELEMETRY_SETTING_PREFIX + "names.exclude",
+        TRACING_SETTING_PREFIX + "names.exclude",
         OperatorDynamic,
         NodeScope
     );
 
     public static final Setting<List<String>> APM_TRACING_SANITIZE_FIELD_NAMES = Setting.stringListSetting(
-        TELEMETRY_SETTING_PREFIX + "sanitize_field_names",
+        TRACING_SETTING_PREFIX + "sanitize_field_names",
         List.of(
             "password",
             "passwd",
@@ -158,7 +159,7 @@ public class APMAgentSettings {
     );
 
     public static final Setting<Boolean> APM_ENABLED_SETTING = Setting.boolSetting(
-        TELEMETRY_SETTING_PREFIX + "tracing.enabled",
+        TRACING_SETTING_PREFIX + "enabled",
         false,
         OperatorDynamic,
         NodeScope

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
@@ -43,10 +43,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.APM_ENABLED_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.APM_TRACING_NAMES_EXCLUDE_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING;
-import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.APM_TRACING_SANITIZE_FIELD_NAMES;
+import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING;
+import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING;
+import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING;
+import static org.elasticsearch.telemetry.apm.internal.APMAgentSettings.TELEMETRY_TRACING_SANITIZE_FIELD_NAMES;
 
 /**
  * This is an implementation of the {@link org.elasticsearch.telemetry.tracing.Tracer} interface, which uses
@@ -89,13 +89,13 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     record APMServices(Tracer tracer, OpenTelemetry openTelemetry) {}
 
     public APMTracer(Settings settings) {
-        this.includeNames = APM_TRACING_NAMES_INCLUDE_SETTING.get(settings);
-        this.excludeNames = APM_TRACING_NAMES_EXCLUDE_SETTING.get(settings);
-        this.labelFilters = APM_TRACING_SANITIZE_FIELD_NAMES.get(settings);
+        this.includeNames = TELEMETRY_TRACING_NAMES_INCLUDE_SETTING.get(settings);
+        this.excludeNames = TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING.get(settings);
+        this.labelFilters = TELEMETRY_TRACING_SANITIZE_FIELD_NAMES.get(settings);
 
         this.filterAutomaton = buildAutomaton(includeNames, excludeNames);
         this.labelFilterAutomaton = buildAutomaton(labelFilters, List.of());
-        this.enabled = APM_ENABLED_SETTING.get(settings);
+        this.enabled = TELEMETRY_TRACING_ENABLED_SETTING.get(settings);
     }
 
     public void setEnabled(boolean enabled) {

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
@@ -22,7 +22,7 @@ public class APMAgentSettingsTests extends ESTestCase {
      */
     public void test_whenTracerEnabled_setsRecordingProperty() {
         APMAgentSettings apmAgentSettings = spy(new APMAgentSettings());
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
         apmAgentSettings.syncAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("recording", "true");
@@ -33,7 +33,7 @@ public class APMAgentSettingsTests extends ESTestCase {
      */
     public void test_whenTracerDisabled_setsRecordingProperty() {
         APMAgentSettings apmAgentSettings = spy(new APMAgentSettings());
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), false).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), false).build();
         apmAgentSettings.syncAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("recording", "false");
@@ -45,7 +45,7 @@ public class APMAgentSettingsTests extends ESTestCase {
      */
     public void test_whenTracerCreated_defaultSettingsApplied() {
         APMAgentSettings apmAgentSettings = spy(new APMAgentSettings());
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
         apmAgentSettings.syncAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("transaction_sample_rate", "0.2");
@@ -58,8 +58,8 @@ public class APMAgentSettingsTests extends ESTestCase {
     public void test_whenTracerCreated_clusterSettingsOverrideDefaults() {
         APMAgentSettings apmAgentSettings = spy(new APMAgentSettings());
         Settings settings = Settings.builder()
-            .put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true)
-            .put(APMAgentSettings.APM_AGENT_SETTINGS.getKey() + "transaction_sample_rate", "0.75")
+            .put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
+            .put(APMAgentSettings.TELEMETRY_AGENT_SETTINGS.getKey() + "transaction_sample_rate", "0.75")
             .build();
         apmAgentSettings.syncAgentSystemProperties(settings);
 
@@ -77,8 +77,8 @@ public class APMAgentSettingsTests extends ESTestCase {
     public void test_whenTracerCreated_clusterSettingsAlsoApplied() {
         APMAgentSettings apmAgentSettings = spy(new APMAgentSettings());
         Settings settings = Settings.builder()
-            .put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true)
-            .put(APMAgentSettings.APM_AGENT_SETTINGS.getKey() + "span_compression_enabled", "true")
+            .put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
+            .put(APMAgentSettings.TELEMETRY_AGENT_SETTINGS.getKey() + "span_compression_enabled", "true")
             .build();
         apmAgentSettings.syncAgentSystemProperties(settings);
 

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracerTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracerTests.java
@@ -52,7 +52,7 @@ public class APMTracerTests extends ESTestCase {
      * Check that the tracer doesn't create spans when tracing is disabled.
      */
     public void test_onTraceStarted_withTracingDisabled_doesNotStartTrace() {
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), false).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), false).build();
         APMTracer apmTracer = buildTracer(settings);
 
         apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
@@ -65,8 +65,8 @@ public class APMTracerTests extends ESTestCase {
      */
     public void test_onTraceStarted_withSpanNameOmitted_doesNotStartTrace() {
         Settings settings = Settings.builder()
-            .put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true)
-            .putList(APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING.getKey(), List.of("filtered*"))
+            .put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
+            .putList(APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING.getKey(), List.of("filtered*"))
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
@@ -79,7 +79,7 @@ public class APMTracerTests extends ESTestCase {
      * Check that when a trace is started, the tracer starts a span and records it.
      */
     public void test_onTraceStarted_startsTrace() {
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
         APMTracer apmTracer = buildTracer(settings);
 
         apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
@@ -92,7 +92,7 @@ public class APMTracerTests extends ESTestCase {
      * Checks that when a trace is started with a specific start time, the tracer starts a span and records it.
      */
     public void test_onTraceStartedWithStartTime_startsTrace() {
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
         APMTracer apmTracer = buildTracer(settings);
 
         ThreadContext threadContext = new ThreadContext(settings);
@@ -110,7 +110,7 @@ public class APMTracerTests extends ESTestCase {
      * Check that when a trace is stopped, the tracer ends the span and removes the record of it.
      */
     public void test_onTraceStopped_stopsTrace() {
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
         APMTracer apmTracer = buildTracer(settings);
 
         apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
@@ -127,7 +127,7 @@ public class APMTracerTests extends ESTestCase {
      * check that the local context object is added, however.
      */
     public void test_whenTraceStarted_threadContextIsPopulated() {
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
         APMTracer apmTracer = buildTracer(settings);
 
         ThreadContext threadContext = new ThreadContext(settings);
@@ -147,8 +147,8 @@ public class APMTracerTests extends ESTestCase {
             "name-b*"
         );
         Settings settings = Settings.builder()
-            .put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true)
-            .putList(APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING.getKey(), includePatterns)
+            .put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
+            .putList(APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING.getKey(), includePatterns)
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
@@ -169,9 +169,9 @@ public class APMTracerTests extends ESTestCase {
         final List<String> includePatterns = List.of("name-a*");
         final List<String> excludePatterns = List.of("name-a*");
         Settings settings = Settings.builder()
-            .put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true)
-            .putList(APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING.getKey(), includePatterns)
-            .putList(APMAgentSettings.APM_TRACING_NAMES_EXCLUDE_SETTING.getKey(), excludePatterns)
+            .put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
+            .putList(APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING.getKey(), includePatterns)
+            .putList(APMAgentSettings.TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING.getKey(), excludePatterns)
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
@@ -192,8 +192,8 @@ public class APMTracerTests extends ESTestCase {
             "name-b*"
         );
         Settings settings = Settings.builder()
-            .put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), true)
-            .putList(APMAgentSettings.APM_TRACING_NAMES_EXCLUDE_SETTING.getKey(), excludePatterns)
+            .put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true)
+            .putList(APMAgentSettings.TELEMETRY_TRACING_NAMES_EXCLUDE_SETTING.getKey(), excludePatterns)
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
@@ -210,7 +210,7 @@ public class APMTracerTests extends ESTestCase {
      * Check that sensitive attributes are not added verbatim to a span, but instead the value is redacted.
      */
     public void test_whenAddingAttributes_thenSensitiveValuesAreRedacted() {
-        Settings settings = Settings.builder().put(APMAgentSettings.APM_ENABLED_SETTING.getKey(), false).build();
+        Settings settings = Settings.builder().put(APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.getKey(), false).build();
         APMTracer apmTracer = buildTracer(settings);
         CharacterRunAutomaton labelFilterAutomaton = apmTracer.getLabelFilterAutomaton();
 

--- a/qa/apm/docker-compose.yml
+++ b/qa/apm/docker-compose.yml
@@ -56,13 +56,13 @@ services:
       - xpack.security.authc.token.enabled=true
       - xpack.security.enabled=true
       # APM specific settings. We don't configure `secret_key` because Kibana is configured with a blank key
-      - tracing.apm.enabled=true
-      - tracing.apm.agent.server_url=http://apmserver:8200
+      - telemetry.tracing.enabled=true
+      - telemetry.agent.server_url=http://apmserver:8200
       # Send traces to APM server aggressively
-      - tracing.apm.agent.metrics_interval=1s
+      - telemetry.agent.metrics_interval=1s
       # Record everything
-      - tracing.apm.agent.transaction_sample_rate=1
-      - tracing.apm.agent.log_level=debug
+      - telemetry.agent.transaction_sample_rate=1
+      - telemetry.agent.log_level=debug
     healthcheck:
       interval: 20s
       retries: 10


### PR DESCRIPTION
This allows us to turn on metrics without also turning on tracing.

`tracing.apm.enabled` -> `telemetry.tracing.enabled`
`tracing.apm.names.include` -> `telemetry.tracing.names.include`
`tracing.apm.names.exclude` -> `telemetry.tracing.names.exclude`
`tracing.apm.sanitize_field_names` -> `telemetry.tracing.sanitize_field_names`
`tracing.apm.agent.*` -> `telemetry.agent.*`
`tracing.apm.secret_token` -> `telemetry.secret_token`
`tracing.apm.api_key` -> `telemetry.api_key`