### PR TITLE
Switch fleet's built-in ILM policies to use .actions.rollover.max_primary_shard_size

### DIFF
--- a/docs/changelog/99984.yaml
+++ b/docs/changelog/99984.yaml
@@ -1,0 +1,6 @@
+pr: 99984
+summary: Switch fleet's built-in ILM policies to use .actions.rollover.max_primary_shard_size
+area: ILM+SLM
+type: enhancement
+issues:
+ - 99983

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-actions-results-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-actions-results-ilm-policy.json
@@ -4,7 +4,7 @@
       "min_age": "0ms",
       "actions": {
         "rollover": {
-          "max_size": "300gb",
+          "max_primary_shard_size": "300gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-data-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-data-ilm-policy.json
@@ -4,7 +4,7 @@
       "min_age": "0ms",
       "actions": {
         "rollover": {
-          "max_size": "10gb",
+          "max_primary_shard_size": "10gb",
           "max_age": "7d"
         }
       }

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-meta-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-fromhost-meta-ilm-policy.json
@@ -4,7 +4,7 @@
       "min_age": "0ms",
       "actions": {
         "rollover": {
-          "max_size": "10gb",
+          "max_primary_shard_size": "10gb",
           "max_age": "30d"
         }
       }

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-data-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-data-ilm-policy.json
@@ -4,7 +4,7 @@
       "min_age": "0ms",
       "actions": {
         "rollover": {
-          "max_size": "10gb",
+          "max_primary_shard_size": "10gb",
           "max_age": "14d"
         }
       }

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-meta-ilm-policy.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-file-tohost-meta-ilm-policy.json
@@ -4,7 +4,7 @@
       "min_age": "0ms",
       "actions": {
         "rollover": {
-          "max_size": "10gb",
+          "max_primary_shard_size": "10gb",
           "max_age": "30d"
         }
       }


### PR DESCRIPTION
### Description

In the Kibana UI, when looking at ILM policies related to fleet, I see warnings:

**Maximum index size is deprecated and will be removed in a future version. Use maximum primary shard size instead.**. This comes from https://github.com/elastic/kibana/pull/96545

To avoid confusion for the end-user, I recommend that the same changes which were done in elasticsearch's default ILM policies be done for fleet:


Related to:
*  https://github.com/elastic/elasticsearch/issues/63026
* https://github.com/elastic/elasticsearch/pull/69995 by @joegallo
* https://github.com/elastic/beats/pull/25000
* https://github.com/elastic/kibana/pull/96545

Fixes #99983

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>
