### PR TITLE
Chunk intermediate output of grouping aggregation

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
@@ -142,9 +142,11 @@ public class AggregatorBenchmark {
             default -> throw new IllegalArgumentException("unsupported grouping [" + grouping + "]");
         };
         DriverContext driverContext = driverContext();
+        int maxPageSize = 16 * 1024;
         return new HashAggregationOperator(
             List.of(supplier(op, dataType, groups.size()).groupingAggregatorFactory(AggregatorMode.SINGLE)),
-            () -> BlockHash.build(groups, BIG_ARRAYS, 16 * 1024, false),
+            () -> BlockHash.build(groups, BIG_ARRAYS, maxPageSize, false),
+            maxPageSize,
             driverContext
         );
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregator.java
@@ -68,11 +68,15 @@ public class GroupingAggregator implements Releasable {
      *                 the results. Always ascending.
      */
     public void evaluate(Block[] blocks, int offset, IntVector selected) {
-        if (mode.isOutputPartial()) {
+        if (isOutputPartial()) {
             aggregatorFunction.evaluateIntermediate(blocks, offset, selected);
         } else {
             aggregatorFunction.evaluateFinal(blocks, offset, selected);
         }
+    }
+
+    public boolean isOutputPartial() {
+        return mode.isOutputPartial();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -46,6 +46,11 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
     public abstract Block[] getKeys();
 
     /**
+     * The number of keys in this {@link BlockHash}
+     */
+    public abstract long size();
+
+    /**
      * The grouping ids that are not empty. We use this because some block hashes reserve
      * space for grouping ids and then don't end up using them. For example,
      * {@link BooleanBlockHash} does this by always assigning {@code false} to {@code 0}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -73,6 +73,17 @@ final class BooleanBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        int size = 0;
+        for (boolean b : everSeen) {
+            if (b) {
+                size++;
+            }
+        }
+        return size;
+    }
+
+    @Override
     public IntVector nonEmpty() {
         IntVector.Builder builder = IntVector.newVectorBuilder(everSeen.length);
         for (int i = 0; i < everSeen.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -107,6 +107,11 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        return bytesRefHash.size() + (seenNull ? 1 : 0);
+    }
+
+    @Override
     public IntVector nonEmpty() {
         return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(bytesRefHash.size() + 1));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
@@ -179,6 +179,11 @@ final class BytesRefLongBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        return finalHash.size();
+    }
+
+    @Override
     public BitArray seenGroupIds(BigArrays bigArrays) {
         return new SeenGroupIds.Range(0, Math.toIntExact(finalHash.size())).seenGroupIds(bigArrays);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -96,6 +96,11 @@ final class DoubleBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        return longHash.size() + (seenNull ? 1 : 0);
+    }
+
+    @Override
     public IntVector nonEmpty() {
         return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(longHash.size() + 1));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -89,6 +89,11 @@ final class IntBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        return longHash.size() + (seenNull ? 1 : 0);
+    }
+
+    @Override
     public IntVector nonEmpty() {
         return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(longHash.size() + 1));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -96,6 +96,11 @@ final class LongBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        return longHash.size() + (seenNull ? 1 : 0);
+    }
+
+    @Override
     public IntVector nonEmpty() {
         return IntVector.range(seenNull ? 0 : 1, Math.toIntExact(longHash.size() + 1));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongLongBlockHash.java
@@ -194,6 +194,11 @@ final class LongLongBlockHash extends BlockHash {
     }
 
     @Override
+    public long size() {
+        return hash.size();
+    }
+
+    @Override
     public IntVector nonEmpty() {
         return IntVector.range(0, Math.toIntExact(hash.size()));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -238,6 +238,11 @@ final class PackedValuesBlockHash extends BlockHash {
         return keyBlocks;
     }
 
+    @Override
+    public long size() {
+        return bytesRefHash.size();
+    }
+
     private void readKeys(BatchEncoder.Decoder[] decoders, Block.Builder[] builders, BytesRef[] nulls, BytesRef[] values, int count) {
         for (int g = 0; g < builders.length; g++) {
             int nullByte = g / 8;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -254,6 +254,7 @@ public class OperatorTests extends MapperServiceTestCase {
                                 randomPageSize(),
                                 false
                             ),
+                            randomPageSize(),
                             driverContext
                         )
                     ),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -214,9 +214,10 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
             List<GroupingAggregator.Factory> aggregators,
             Supplier<BlockHash> blockHash,
             String columnName,
+            int maxPageSize,
             DriverContext driverContext
         ) {
-            super(aggregators, blockHash, driverContext);
+            super(aggregators, blockHash, maxPageSize, driverContext);
             this.columnName = columnName;
         }
 
@@ -264,6 +265,7 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
                     false
                 ),
                 columnName,
+                pageSize,
                 driverContext
             );
         }


### PR DESCRIPTION
This change enables the HashAggregationOperator (i.e., grouping aggregation) to emit output pages that conform to the maxPageSize parameter. However, we can only apply this change to the intermediate output, not the final output. This change has several implications:

- It reduces the maximum memory consumption during partial grouping aggregation.
- It minimizes idle time in the final grouping aggregation by continuously fetching smaller pages, thereby reducing query latency.

However, it's important to note the following potential downsides:

- It may increase the intra-transfer data between nodes, as we might need to serialize keys multiple times.
- It could introduce additional work for the final grouping aggregation, potentially reducing system throughput.

Despite these potential disadvantages, I believe that chunking the output is necessary. This change is also a prerequisite for enabling disk spilling during the final grouping aggregation.