### PR TITLE
Refactor NodesInfoRequest to extract NodeInfoMetrics to a top-level class from it

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoMetrics.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoMetrics.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.info;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class is a container that encapsulates the necessary information needed to indicate which node information is requested.
+ */
+public class NodesInfoMetrics implements Writeable {
+    private Set<String> requestedMetrics = Metric.allMetrics();
+
+    public NodesInfoMetrics() {}
+
+    public NodesInfoMetrics(StreamInput in) throws IOException {
+        requestedMetrics.clear();
+        requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
+    }
+
+    public Set<String> requestedMetrics() {
+        return requestedMetrics;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeStringArray(requestedMetrics.toArray(new String[0]));
+    }
+
+    /**
+     * An enumeration of the "core" sections of metrics that may be requested
+     * from the nodes information endpoint. Eventually this list will be
+     * pluggable.
+     */
+    public enum Metric {
+        SETTINGS("settings"),
+        OS("os"),
+        PROCESS("process"),
+        JVM("jvm"),
+        THREAD_POOL("thread_pool"),
+        TRANSPORT("transport"),
+        HTTP("http"),
+        REMOTE_CLUSTER_SERVER("remote_cluster_server"),
+        PLUGINS("plugins"),
+        INGEST("ingest"),
+        AGGREGATIONS("aggregations"),
+        INDICES("indices");
+
+        private final String metricName;
+
+        Metric(String name) {
+            this.metricName = name;
+        }
+
+        public String metricName() {
+            return this.metricName;
+        }
+
+        public static Set<String> allMetrics() {
+            return Arrays.stream(values()).map(Metric::metricName).collect(Collectors.toSet());
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -13,18 +13,16 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 /**
  * A request to get node (cluster) level information.
  */
 public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
-    private Set<String> requestedMetrics = Metric.allMetrics();
+    private NodesInfoMetrics nodesInfoMetrics;
 
     /**
      * Create a new NodeInfoRequest from a {@link StreamInput} object.
@@ -34,8 +32,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      */
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
-        requestedMetrics.clear();
-        requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
+        nodesInfoMetrics = new NodesInfoMetrics(in);
     }
 
     /**
@@ -45,6 +42,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     @SuppressWarnings("this-escape")
     public NodesInfoRequest(String... nodesIds) {
         super(nodesIds);
+        nodesInfoMetrics = new NodesInfoMetrics();
         all();
     }
 
@@ -52,7 +50,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Clears all info flags.
      */
     public NodesInfoRequest clear() {
-        requestedMetrics.clear();
+        nodesInfoMetrics.requestedMetrics().clear();
         return this;
     }
 
@@ -60,7 +58,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Sets to return all the data.
      */
     public NodesInfoRequest all() {
-        requestedMetrics.addAll(Metric.allMetrics());
+        nodesInfoMetrics.requestedMetrics().addAll(NodesInfoMetrics.Metric.allMetrics());
         return this;
     }
 
@@ -68,17 +66,17 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Get the names of requested metrics
      */
     public Set<String> requestedMetrics() {
-        return Set.copyOf(requestedMetrics);
+        return Set.copyOf(nodesInfoMetrics.requestedMetrics());
     }
 
     /**
      * Add metric
      */
     public NodesInfoRequest addMetric(String metric) {
-        if (Metric.allMetrics().contains(metric) == false) {
+        if (NodesInfoMetrics.Metric.allMetrics().contains(metric) == false) {
             throw new IllegalStateException("Used an illegal metric: " + metric);
         }
-        requestedMetrics.add(metric);
+        nodesInfoMetrics.requestedMetrics().add(metric);
         return this;
     }
 
@@ -87,12 +85,12 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      */
     public NodesInfoRequest addMetrics(String... metrics) {
         SortedSet<String> metricsSet = new TreeSet<>(Set.of(metrics));
-        if (Metric.allMetrics().containsAll(metricsSet) == false) {
-            metricsSet.removeAll(Metric.allMetrics());
+        if (NodesInfoMetrics.Metric.allMetrics().containsAll(metricsSet) == false) {
+            metricsSet.removeAll(NodesInfoMetrics.Metric.allMetrics());
             String plural = metricsSet.size() == 1 ? "" : "s";
             throw new IllegalStateException("Used illegal metric" + plural + ": " + metricsSet);
         }
-        requestedMetrics.addAll(metricsSet);
+        nodesInfoMetrics.requestedMetrics().addAll(metricsSet);
         return this;
     }
 
@@ -100,17 +98,17 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Remove metric
      */
     public NodesInfoRequest removeMetric(String metric) {
-        if (Metric.allMetrics().contains(metric) == false) {
+        if (NodesInfoMetrics.Metric.allMetrics().contains(metric) == false) {
             throw new IllegalStateException("Used an illegal metric: " + metric);
         }
-        requestedMetrics.remove(metric);
+        nodesInfoMetrics.requestedMetrics().remove(metric);
         return this;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringCollection(requestedMetrics);
+        nodesInfoMetrics.writeTo(out);
     }
 
     /**
@@ -118,7 +116,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @param metrics the metrics to include in the request
      * @return
      */
-    public static NodesInfoRequest requestWithMetrics(Metric... metrics) {
+    public static NodesInfoRequest requestWithMetrics(NodesInfoMetrics.Metric... metrics) {
         NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
         nodesInfoRequest.clear();
         for (var metric : metrics) {
@@ -127,37 +125,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
         return nodesInfoRequest;
     }
 
-    /**
-     * An enumeration of the "core" sections of metrics that may be requested
-     * from the nodes information endpoint. Eventually this list list will be
-     * pluggable.
-     */
-    public enum Metric {
-        SETTINGS("settings"),
-        OS("os"),
-        PROCESS("process"),
-        JVM("jvm"),
-        THREAD_POOL("thread_pool"),
-        TRANSPORT("transport"),
-        HTTP("http"),
-        REMOTE_CLUSTER_SERVER("remote_cluster_server"),
-        PLUGINS("plugins"),
-        INGEST("ingest"),
-        AGGREGATIONS("aggregations"),
-        INDICES("indices");
-
-        private final String metricName;
-
-        Metric(String name) {
-            this.metricName = name;
-        }
-
-        public String metricName() {
-            return this.metricName;
-        }
-
-        public static Set<String> allMetrics() {
-            return Arrays.stream(values()).map(Metric::metricName).collect(Collectors.toSet());
-        }
+    public NodesInfoMetrics getNodesInfoMetrics() {
+        return nodesInfoMetrics;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
@@ -38,7 +38,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node settings be returned.
      */
     public NodesInfoRequestBuilder setSettings(boolean settings) {
-        addOrRemoveMetric(settings, NodesInfoRequest.Metric.SETTINGS);
+        addOrRemoveMetric(settings, NodesInfoMetrics.Metric.SETTINGS);
         return this;
     }
 
@@ -46,7 +46,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node OS info be returned.
      */
     public NodesInfoRequestBuilder setOs(boolean os) {
-        addOrRemoveMetric(os, NodesInfoRequest.Metric.OS);
+        addOrRemoveMetric(os, NodesInfoMetrics.Metric.OS);
         return this;
     }
 
@@ -54,7 +54,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node OS process be returned.
      */
     public NodesInfoRequestBuilder setProcess(boolean process) {
-        addOrRemoveMetric(process, NodesInfoRequest.Metric.PROCESS);
+        addOrRemoveMetric(process, NodesInfoMetrics.Metric.PROCESS);
         return this;
     }
 
@@ -62,7 +62,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node JVM info be returned.
      */
     public NodesInfoRequestBuilder setJvm(boolean jvm) {
-        addOrRemoveMetric(jvm, NodesInfoRequest.Metric.JVM);
+        addOrRemoveMetric(jvm, NodesInfoMetrics.Metric.JVM);
         return this;
     }
 
@@ -70,7 +70,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node thread pool info be returned.
      */
     public NodesInfoRequestBuilder setThreadPool(boolean threadPool) {
-        addOrRemoveMetric(threadPool, NodesInfoRequest.Metric.THREAD_POOL);
+        addOrRemoveMetric(threadPool, NodesInfoMetrics.Metric.THREAD_POOL);
         return this;
     }
 
@@ -78,7 +78,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node Transport info be returned.
      */
     public NodesInfoRequestBuilder setTransport(boolean transport) {
-        addOrRemoveMetric(transport, NodesInfoRequest.Metric.TRANSPORT);
+        addOrRemoveMetric(transport, NodesInfoMetrics.Metric.TRANSPORT);
         return this;
     }
 
@@ -86,7 +86,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node HTTP info be returned.
      */
     public NodesInfoRequestBuilder setHttp(boolean http) {
-        addOrRemoveMetric(http, NodesInfoRequest.Metric.HTTP);
+        addOrRemoveMetric(http, NodesInfoMetrics.Metric.HTTP);
         return this;
     }
 
@@ -94,7 +94,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node plugins info be returned.
      */
     public NodesInfoRequestBuilder setPlugins(boolean plugins) {
-        addOrRemoveMetric(plugins, NodesInfoRequest.Metric.PLUGINS);
+        addOrRemoveMetric(plugins, NodesInfoMetrics.Metric.PLUGINS);
         return this;
     }
 
@@ -102,7 +102,7 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node ingest info be returned.
      */
     public NodesInfoRequestBuilder setIngest(boolean ingest) {
-        addOrRemoveMetric(ingest, NodesInfoRequest.Metric.INGEST);
+        addOrRemoveMetric(ingest, NodesInfoMetrics.Metric.INGEST);
         return this;
     }
 
@@ -110,11 +110,11 @@ public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesI
      * Should the node indices info be returned.
      */
     public NodesInfoRequestBuilder setIndices(boolean indices) {
-        addOrRemoveMetric(indices, NodesInfoRequest.Metric.INDICES);
+        addOrRemoveMetric(indices, NodesInfoMetrics.Metric.INDICES);
         return this;
     }
 
-    private void addOrRemoveMetric(boolean includeMetric, NodesInfoRequest.Metric metric) {
+    private void addOrRemoveMetric(boolean includeMetric, NodesInfoMetrics.Metric metric) {
         if (includeMetric) {
             request.addMetric(metric.metricName());
         } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -108,7 +109,7 @@ public class RemoteClusterNodesAction extends ActionType<RemoteClusterNodesActio
                 threadContext.markAsSystemContext();
                 if (request.remoteClusterServer) {
                     final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().clear()
-                        .addMetrics(NodesInfoRequest.Metric.REMOTE_CLUSTER_SERVER.metricName());
+                        .addMetrics(NodesInfoMetrics.Metric.REMOTE_CLUSTER_SERVER.metricName());
                     transportService.sendRequest(
                         transportService.getLocalNode(),
                         NodesInfoAction.NAME,

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -66,7 +67,7 @@ public class PutPipelineTransportAction extends AcknowledgedTransportMasterNodeA
         ingestService.putPipeline(request, listener, (nodeListener) -> {
             NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
             nodesInfoRequest.clear();
-            nodesInfoRequest.addMetric(NodesInfoRequest.Metric.INGEST.metricName());
+            nodesInfoRequest.addMetric(NodesInfoMetrics.Metric.INGEST.metricName());
             client.admin().cluster().nodesInfo(nodesInfoRequest, nodeListener);
         });
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesInfoAction.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.admin.cluster;
 
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
@@ -28,7 +29,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 @ServerlessScope(Scope.INTERNAL)
 public class RestNodesInfoAction extends BaseRestHandler {
-    static final Set<String> ALLOWED_METRICS = NodesInfoRequest.Metric.allMetrics();
+    static final Set<String> ALLOWED_METRICS = NodesInfoMetrics.Metric.allMetrics();
 
     private final SettingsFilter settingsFilter;
 

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.cat;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
@@ -60,7 +61,7 @@ public class RestNodeAttrsAction extends AbstractCatAction {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
-                nodesInfoRequest.clear().addMetric(NodesInfoRequest.Metric.PROCESS.metricName());
+                nodesInfoRequest.clear().addMetric(NodesInfoMetrics.Metric.PROCESS.metricName());
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestResponseListener<NodesInfoResponse>(channel) {
                     @Override
                     public RestResponse buildResponse(NodesInfoResponse nodesInfoResponse) throws Exception {

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.cat;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -90,10 +91,10 @@ public class RestNodesAction extends AbstractCatAction {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
                 nodesInfoRequest.clear()
                     .addMetrics(
-                        NodesInfoRequest.Metric.JVM.metricName(),
-                        NodesInfoRequest.Metric.OS.metricName(),
-                        NodesInfoRequest.Metric.PROCESS.metricName(),
-                        NodesInfoRequest.Metric.HTTP.metricName()
+                        NodesInfoMetrics.Metric.JVM.metricName(),
+                        NodesInfoMetrics.Metric.OS.metricName(),
+                        NodesInfoMetrics.Metric.PROCESS.metricName(),
+                        NodesInfoMetrics.Metric.HTTP.metricName()
                     );
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestActionListener<NodesInfoResponse>(channel) {
                     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.cat;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
@@ -61,7 +62,7 @@ public class RestPluginsAction extends AbstractCatAction {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) throws Exception {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
-                nodesInfoRequest.clear().addMetric(NodesInfoRequest.Metric.PLUGINS.metricName());
+                nodesInfoRequest.clear().addMetric(NodesInfoMetrics.Metric.PLUGINS.metricName());
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestResponseListener<NodesInfoResponse>(channel) {
                     @Override
                     public RestResponse buildResponse(final NodesInfoResponse nodesInfoResponse) throws Exception {

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.cat;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -77,7 +78,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
                 nodesInfoRequest.clear()
-                    .addMetrics(NodesInfoRequest.Metric.PROCESS.metricName(), NodesInfoRequest.Metric.THREAD_POOL.metricName());
+                    .addMetrics(NodesInfoMetrics.Metric.PROCESS.metricName(), NodesInfoMetrics.Metric.THREAD_POOL.metricName());
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestActionListener<NodesInfoResponse>(channel) {
                     @Override
                     public void processResponse(final NodesInfoResponse nodesInfoResponse) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -32,7 +32,7 @@ public class NodesInfoRequestTests extends ESTestCase {
      */
     public void testAddMetricsSet() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest(randomAlphaOfLength(8));
-        randomSubsetOf(NodesInfoRequest.Metric.allMetrics()).forEach(request::addMetric);
+        randomSubsetOf(NodesInfoMetrics.Metric.allMetrics()).forEach(request::addMetric);
         NodesInfoRequest deserializedRequest = roundTripRequest(request);
         assertThat(request.requestedMetrics(), equalTo(deserializedRequest.requestedMetrics()));
     }
@@ -42,7 +42,7 @@ public class NodesInfoRequestTests extends ESTestCase {
      */
     public void testAddSingleMetric() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest(randomAlphaOfLength(8));
-        request.addMetric(randomFrom(NodesInfoRequest.Metric.allMetrics()));
+        request.addMetric(randomFrom(NodesInfoMetrics.Metric.allMetrics()));
         NodesInfoRequest deserializedRequest = roundTripRequest(request);
         assertThat(request.requestedMetrics(), equalTo(deserializedRequest.requestedMetrics()));
     }
@@ -53,7 +53,7 @@ public class NodesInfoRequestTests extends ESTestCase {
     public void testRemoveSingleMetric() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest(randomAlphaOfLength(8));
         request.all();
-        String metric = randomFrom(NodesInfoRequest.Metric.allMetrics());
+        String metric = randomFrom(NodesInfoMetrics.Metric.allMetrics());
         request.removeMetric(metric);
 
         NodesInfoRequest deserializedRequest = roundTripRequest(request);
@@ -63,7 +63,7 @@ public class NodesInfoRequestTests extends ESTestCase {
 
     /**
      * Test that a newly constructed NodesInfoRequestObject requests all of the
-     * possible metrics defined in {@link NodesInfoRequest.Metric}.
+     * possible metrics defined in {@link NodesInfoMetrics.Metric}.
      */
     public void testNodesInfoRequestDefaults() {
         NodesInfoRequest defaultNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
@@ -80,7 +80,7 @@ public class NodesInfoRequestTests extends ESTestCase {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.all();
 
-        assertThat(request.requestedMetrics(), equalTo(NodesInfoRequest.Metric.allMetrics()));
+        assertThat(request.requestedMetrics(), equalTo(NodesInfoMetrics.Metric.allMetrics()));
     }
 
     /**
@@ -101,7 +101,7 @@ public class NodesInfoRequestTests extends ESTestCase {
         String unknownMetric2 = "unknown_metric2";
         Set<String> unknownMetrics = new HashSet<>();
         unknownMetrics.add(unknownMetric1);
-        unknownMetrics.addAll(randomSubsetOf(NodesInfoRequest.Metric.allMetrics()));
+        unknownMetrics.addAll(randomSubsetOf(NodesInfoMetrics.Metric.allMetrics()));
 
         NodesInfoRequest request = new NodesInfoRequest();
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -108,7 +109,7 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
 
         doAnswer(invocation -> {
             final NodesInfoRequest nodesInfoRequest = invocation.getArgument(2);
-            assertThat(nodesInfoRequest.requestedMetrics(), containsInAnyOrder(NodesInfoRequest.Metric.REMOTE_CLUSTER_SERVER.metricName()));
+            assertThat(nodesInfoRequest.requestedMetrics(), containsInAnyOrder(NodesInfoMetrics.Metric.REMOTE_CLUSTER_SERVER.metricName()));
             final ActionListenerResponseHandler<NodesInfoResponse> handler = invocation.getArgument(3);
             handler.handleResponse(nodesInfoResponse);
             return null;

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodeInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodeInfoService.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
@@ -138,7 +139,7 @@ public class AutoscalingNodeInfoService {
                                     .map(BaseNodeResponse::getNode)
                                     .map(DiscoveryNode::getId)
                                     .toArray(String[]::new)
-                            ).clear().addMetric(NodesInfoRequest.Metric.OS.metricName()).timeout(fetchTimeout),
+                            ).clear().addMetric(NodesInfoMetrics.Metric.OS.metricName()).timeout(fetchTimeout),
                             ActionListener.wrap(nodesInfoResponse -> {
                                 final Map<String, AutoscalingNodeInfo.Builder> builderBuilder = Maps.newHashMapWithExpectedSize(
                                     nodesStatsResponse.getNodes().size()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -142,7 +143,7 @@ public class TransportNodeEnrollmentAction extends HandledTransportAction<NodeEn
         }
 
         final List<String> nodeList = new ArrayList<>();
-        final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().addMetric(NodesInfoRequest.Metric.TRANSPORT.metricName());
+        final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().addMetric(NodesInfoMetrics.Metric.TRANSPORT.metricName());
         executeAsyncWithOrigin(client, SECURITY_ORIGIN, NodesInfoAction.INSTANCE, nodesInfoRequest, ActionListener.wrap(response -> {
             for (NodeInfo nodeInfo : response.getNodes()) {
                 nodeList.add(nodeInfo.getInfo(TransportInfo.class).getAddress().publishAddress().toString());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
@@ -65,7 +66,7 @@ public class InternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
     public void maybeCreateNodeEnrollmentToken(Consumer<String> consumer, Iterator<TimeValue> backoff) {
         // the enrollment token can only be used against the node that generated it
         final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().nodesIds("_local")
-            .addMetrics(NodesInfoRequest.Metric.HTTP.metricName(), NodesInfoRequest.Metric.TRANSPORT.metricName());
+            .addMetrics(NodesInfoMetrics.Metric.HTTP.metricName(), NodesInfoMetrics.Metric.TRANSPORT.metricName());
 
         client.execute(NodesInfoAction.INSTANCE, nodesInfoRequest, ActionListener.wrap(response -> {
             assert response.getNodes().size() == 1;
@@ -133,7 +134,7 @@ public class InternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
     public void createKibanaEnrollmentToken(Consumer<EnrollmentToken> consumer, Iterator<TimeValue> backoff) {
         // the enrollment token can only be used against the node that generated it
         final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().nodesIds("_local")
-            .addMetric(NodesInfoRequest.Metric.HTTP.metricName());
+            .addMetric(NodesInfoMetrics.Metric.HTTP.metricName());
         client.execute(NodesInfoAction.INSTANCE, nodesInfoRequest, ActionListener.wrap(response -> {
             assert response.getNodes().size() == 1;
             NodeInfo nodeInfo = response.getNodes().get(0);


### PR DESCRIPTION
This commit extracts `NodeInfoMetrics` to a top-level class from `NodesInfoRequest`. `NodeInfoMetrics` is a container that encapsulates the necessary information needed to indicate which node information is requested.

Relates #99938 