### PR TITLE
[Profiling] Insert root node in empty flamegraph

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
@@ -119,6 +119,46 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return countExclusive;
     }
 
+    public List<Map<String, Integer>> getEdges() {
+        return edges;
+    }
+
+    public List<String> getFileIds() {
+        return fileIds;
+    }
+
+    public List<Integer> getFrameTypes() {
+        return frameTypes;
+    }
+
+    public List<Boolean> getInlineFrames() {
+        return inlineFrames;
+    }
+
+    public List<String> getFileNames() {
+        return fileNames;
+    }
+
+    public List<Integer> getAddressOrLines() {
+        return addressOrLines;
+    }
+
+    public List<String> getFunctionNames() {
+        return functionNames;
+    }
+
+    public List<Integer> getFunctionOffsets() {
+        return functionOffsets;
+    }
+
+    public List<String> getSourceFileNames() {
+        return sourceFileNames;
+    }
+
+    public List<Integer> getSourceLines() {
+        return sourceLines;
+    }
+
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
@@ -190,11 +190,9 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
             this.sourceLines = new ArrayList<>(capacity);
             this.countInclusive = new ArrayList<>(capacity);
             this.countExclusive = new ArrayList<>(capacity);
-            if (frames > 0) {
-                // root node
-                int nodeId = this.addNode("", 0, false, "", 0, "", 0, "", 0, 0, null);
-                this.setCurrentNode(nodeId);
-            }
+            // always insert root node
+            int nodeId = this.addNode("", 0, false, "", 0, "", 0, "", 0, 0, null);
+            this.setCurrentNode(nodeId);
             this.samplingRate = samplingRate;
         }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
@@ -56,6 +56,80 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
         assertEquals(List.of(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), response.getCountInclusive());
         assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 1), response.getCountExclusive());
+        assertEquals(
+            List.of(
+                Map.of("fr28zxcZ2UDasxYuu6dV-w12784352", 1),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w19334053", 2),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w19336161", 3),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w18795859", 4),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w18622708", 5),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w18619213", 6),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w12989721", 7),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w13658842", 8),
+                Map.of("fr28zxcZ2UDasxYuu6dV-w16339645", 9),
+                Map.of()
+            ),
+            response.getEdges()
+        );
+        assertEquals(
+            List.of(
+                "",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w"
+            ),
+            response.getFileIds()
+        );
+        assertEquals(List.of(0, 3, 3, 3, 3, 3, 3, 3, 3, 3), response.getFrameTypes());
+        assertEquals(List.of(false, false, false, false, false, false, false, false, false, false), response.getInlineFrames());
+        assertEquals(
+            List.of(
+                "",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd"
+            ),
+            response.getFileNames()
+        );
+        assertEquals(
+            List.of(0, 12784352, 19334053, 19336161, 18795859, 18622708, 18619213, 12989721, 13658842, 16339645),
+            response.getAddressOrLines()
+        );
+        assertEquals(List.of("", "", "", "", "", "", "", "", "", ""), response.getFunctionNames());
+        assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), response.getFunctionOffsets());
+        assertEquals(List.of("", "", "", "", "", "", "", "", "", ""), response.getSourceFileNames());
+        assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), response.getSourceLines());
+    }
 
+    public void testCreateEmptyFlamegraphWithRootNode() {
+        GetStackTracesResponse stacktraces = new GetStackTracesResponse(Map.of(), Map.of(), Map.of(), Map.of(), 0, 1.0d);
+        GetFlamegraphResponse response = TransportGetFlamegraphAction.buildFlamegraph(stacktraces);
+        assertNotNull(response);
+        assertEquals(1, response.getSize());
+        assertEquals(1.0d, response.getSamplingRate(), 0.001d);
+        assertEquals(List.of(0), response.getCountInclusive());
+        assertEquals(List.of(0), response.getCountExclusive());
+        assertEquals(List.of(Map.of()), response.getEdges());
+        assertEquals(List.of(""), response.getFileIds());
+        assertEquals(List.of(0), response.getFrameTypes());
+        assertEquals(List.of(false), response.getInlineFrames());
+        assertEquals(List.of(""), response.getFileNames());
+        assertEquals(List.of(0), response.getAddressOrLines());
+        assertEquals(List.of(""), response.getFunctionNames());
+        assertEquals(List.of(0), response.getFunctionOffsets());
+        assertEquals(List.of(""), response.getSourceFileNames());
+        assertEquals(List.of(0), response.getSourceLines());
     }
 }


### PR DESCRIPTION
With this commit we ensure that a root node is always present in the structure returned by the flamegraph API.