### PR TITLE
Muting failing test MixedClusterClientYamlTestSuiteIT test {p0=search.vectors/90_sparse_vector/Sparse vector in 7.x} 

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -144,9 +144,8 @@
 ---
 "Sparse vector in 7.x":
   - skip:
-      features: allowed_warnings
-      version: "8.0.0 - "
-      reason: "sparse_vector field type supported in 7.x"
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/100003"
   - do:
       allowed_warnings:
         - "The [sparse_vector] field type is deprecated and will be removed in 8.0."

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -144,6 +144,7 @@
 ---
 "Sparse vector in 7.x":
   - skip:
+      features: allowed_warnings
       version: "all"
       reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/100003"
   - do:


### PR DESCRIPTION
Relates to: https://github.com/elastic/elasticsearch/issues/100003

Mutes failing test temporarily to allow investigation & avoid noise