### PR TITLE
Simplify FieldCaps Transport Messages Code

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -17,65 +17,54 @@ import org.elasticsearch.index.mapper.TimeSeriesParams;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Describes the capabilities of a field in a single index.
+ * @param name           The name of the field.
+ * @param type           The type associated with the field.
+ * @param isSearchable   Whether this field is indexed for search.
+ * @param isAggregatable Whether this field can be aggregated on.
+ * @param meta           Metadata about the field.
  */
-public class IndexFieldCapabilities implements Writeable {
+
+public record IndexFieldCapabilities(
+    String name,
+    String type,
+    boolean isMetadatafield,
+    boolean isSearchable,
+    boolean isAggregatable,
+    boolean isDimension,
+    TimeSeriesParams.MetricType metricType,
+    Map<String, String> meta
+) implements Writeable {
 
     private static final StringLiteralDeduplicator typeStringDeduplicator = new StringLiteralDeduplicator();
 
-    private final String name;
-    private final String type;
-    private final boolean isMetadatafield;
-    private final boolean isSearchable;
-    private final boolean isAggregatable;
-    private final boolean isDimension;
-    private final TimeSeriesParams.MetricType metricType;
-    private final Map<String, String> meta;
-
-    /**
-     * @param name The name of the field.
-     * @param type The type associated with the field.
-     * @param isSearchable Whether this field is indexed for search.
-     * @param isAggregatable Whether this field can be aggregated on.
-     * @param meta Metadata about the field.
-     */
-    IndexFieldCapabilities(
-        String name,
-        String type,
-        boolean isMetadatafield,
-        boolean isSearchable,
-        boolean isAggregatable,
-        boolean isDimension,
-        TimeSeriesParams.MetricType metricType,
-        Map<String, String> meta
-    ) {
-        this.name = name;
-        this.type = type;
-        this.isMetadatafield = isMetadatafield;
-        this.isSearchable = isSearchable;
-        this.isAggregatable = isAggregatable;
-        this.isDimension = isDimension;
-        this.metricType = metricType;
-        this.meta = meta;
-    }
-
-    IndexFieldCapabilities(StreamInput in) throws IOException {
-        this.name = in.readString();
-        this.type = typeStringDeduplicator.deduplicate(in.readString());
-        this.isMetadatafield = in.readBoolean();
-        this.isSearchable = in.readBoolean();
-        this.isAggregatable = in.readBoolean();
+    public static IndexFieldCapabilities readFrom(StreamInput in) throws IOException {
+        String name = in.readString();
+        String type = typeStringDeduplicator.deduplicate(in.readString());
+        boolean isMetadatafield = in.readBoolean();
+        boolean isSearchable = in.readBoolean();
+        boolean isAggregatable = in.readBoolean();
+        boolean isDimension;
+        TimeSeriesParams.MetricType metricType;
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
-            this.isDimension = in.readBoolean();
-            this.metricType = in.readOptionalEnum(TimeSeriesParams.MetricType.class);
+            isDimension = in.readBoolean();
+            metricType = in.readOptionalEnum(TimeSeriesParams.MetricType.class);
         } else {
-            this.isDimension = false;
-            this.metricType = null;
+            isDimension = false;
+            metricType = null;
         }
-        this.meta = in.readMap(StreamInput::readString);
+        return new IndexFieldCapabilities(
+            name,
+            type,
+            isMetadatafield,
+            isSearchable,
+            isAggregatable,
+            isDimension,
+            metricType,
+            in.readMap(StreamInput::readString)
+        );
     }
 
     @Override
@@ -92,55 +81,4 @@ public class IndexFieldCapabilities implements Writeable {
         out.writeMap(meta, StreamOutput::writeString);
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public boolean isMetadatafield() {
-        return isMetadatafield;
-    }
-
-    public boolean isAggregatable() {
-        return isAggregatable;
-    }
-
-    public boolean isSearchable() {
-        return isSearchable;
-    }
-
-    public boolean isDimension() {
-        return isDimension;
-    }
-
-    public TimeSeriesParams.MetricType getMetricType() {
-        return metricType;
-    }
-
-    public Map<String, String> meta() {
-        return meta;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        IndexFieldCapabilities that = (IndexFieldCapabilities) o;
-        return isMetadatafield == that.isMetadatafield
-            && isSearchable == that.isSearchable
-            && isAggregatable == that.isAggregatable
-            && isDimension == that.isDimension
-            && Objects.equals(metricType, that.metricType)
-            && Objects.equals(name, that.name)
-            && Objects.equals(type, that.type)
-            && Objects.equals(meta, that.meta);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, type, isMetadatafield, isSearchable, isAggregatable, isDimension, metricType, meta);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/ResponseRewriter.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/ResponseRewriter.java
@@ -54,11 +54,11 @@ final class ResponseRewriter {
         Set<String> nestedObjects = null;
         if (allowedTypes.length > 0) {
             Set<String> at = Set.of(allowedTypes);
-            test = test.and(ifc -> at.contains(ifc.getType()));
+            test = test.and(ifc -> at.contains(ifc.type()));
         }
         for (String filter : filters) {
             if ("-parent".equals(filter)) {
-                test = test.and(fc -> fc.getType().equals("nested") == false && fc.getType().equals("object") == false);
+                test = test.and(fc -> fc.type().equals("nested") == false && fc.type().equals("object") == false);
             }
             if ("-metadata".equals(filter)) {
                 test = test.and(fc -> fc.isMetadatafield() == false);
@@ -71,7 +71,7 @@ final class ResponseRewriter {
                     nestedObjects = findTypes("nested", input);
                 }
                 Set<String> no = nestedObjects;
-                test = test.and(fc -> isNestedField(fc.getName(), no) == false);
+                test = test.and(fc -> isNestedField(fc.name(), no) == false);
             }
             if ("-multifield".equals(filter)) {
                 // immediate parent is not an object field
@@ -79,7 +79,7 @@ final class ResponseRewriter {
                     objects = findTypes("object", input);
                 }
                 Set<String> o = objects;
-                test = test.and(fc -> isNotMultifield(fc.getName(), o));
+                test = test.and(fc -> isNotMultifield(fc.name(), o));
             }
         }
         Predicate<IndexFieldCapabilities> finalTest = test;
@@ -94,7 +94,7 @@ final class ResponseRewriter {
     private static Set<String> findTypes(String type, Map<String, IndexFieldCapabilities> fieldCaps) {
         return fieldCaps.entrySet()
             .stream()
-            .filter(entry -> type.equals(entry.getValue().getType()))
+            .filter(entry -> type.equals(entry.getValue().type()))
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -418,7 +418,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             final IndexFieldCapabilities fieldCap = entry.getValue();
             Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(field, f -> new HashMap<>());
             FieldCapabilities.Builder builder = typeMap.computeIfAbsent(
-                fieldCap.getType(),
+                fieldCap.type(),
                 key -> new FieldCapabilities.Builder(field, key)
             );
             builder.add(
@@ -427,7 +427,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 fieldCap.isSearchable(),
                 fieldCap.isAggregatable(),
                 fieldCap.isDimension(),
-                fieldCap.getMetricType(),
+                fieldCap.metricType(),
                 fieldCap.meta()
             );
         }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -417,10 +417,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             final String field = entry.getKey();
             final IndexFieldCapabilities fieldCap = entry.getValue();
             Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(field, f -> new HashMap<>());
-            FieldCapabilities.Builder builder = typeMap.computeIfAbsent(
-                fieldCap.type(),
-                key -> new FieldCapabilities.Builder(field, key)
-            );
+            FieldCapabilities.Builder builder = typeMap.computeIfAbsent(fieldCap.type(), key -> new FieldCapabilities.Builder(field, key));
             builder.add(
                 indices,
                 fieldCap.isMetadatafield(),

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -161,8 +161,8 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
                 // Exclude metric types which was introduced in 8.0
                 assertThat(outCap.keySet(), equalTo(inCap.keySet()));
                 for (String field : outCap.keySet()) {
-                    assertThat(outCap.get(field).getName(), equalTo(inCap.get(field).getName()));
-                    assertThat(outCap.get(field).getType(), equalTo(inCap.get(field).getType()));
+                    assertThat(outCap.get(field).name(), equalTo(inCap.get(field).name()));
+                    assertThat(outCap.get(field).type(), equalTo(inCap.get(field).type()));
                     assertThat(outCap.get(field).isSearchable(), equalTo(inCap.get(field).isSearchable()));
                     assertThat(outCap.get(field).isAggregatable(), equalTo(inCap.get(field).isAggregatable()));
                     assertThat(outCap.get(field).meta(), equalTo(inCap.get(field).meta()));

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -235,8 +235,8 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
                 // Exclude metric types which was introduced in 8.0
                 assertThat(outCap.keySet(), equalTo(inCap.keySet()));
                 for (String field : outCap.keySet()) {
-                    assertThat(outCap.get(field).getName(), equalTo(inCap.get(field).getName()));
-                    assertThat(outCap.get(field).getType(), equalTo(inCap.get(field).getType()));
+                    assertThat(outCap.get(field).name(), equalTo(inCap.get(field).name()));
+                    assertThat(outCap.get(field).type(), equalTo(inCap.get(field).type()));
                     assertThat(outCap.get(field).isSearchable(), equalTo(inCap.get(field).isSearchable()));
                     assertThat(outCap.get(field).isAggregatable(), equalTo(inCap.get(field).isAggregatable()));
                     assertThat(outCap.get(field).meta(), equalTo(inCap.get(field).meta()));


### PR DESCRIPTION
This removes the intermediate GroupBy record and a few list allocations to reduce the memory and runtime overhead of large responses when there isn't as much deduplication.

This should help visibly with the not-as-much-deduplication case already, but more importantly it sets up a massive improvement in a follow-up that I'd open right after this is merged!
We can assume that the `IndexFieldCapabilities` instances (now a record to make this obvious) will be duplicated across entries massively. So we can deduplicate them when writing through a lookup table, massively shrinking the size of these responses and making operations on the coordinating node much faster as well.