### PR TITLE
Improve time-series error and documentation

### DIFF
--- a/docs/changelog/100018.yaml
+++ b/docs/changelog/100018.yaml
@@ -1,0 +1,5 @@
+pr: 100018
+summary: Improve time-series error and documentation
+area: "TSDB, Aggregations"
+type: enhancement
+issues: []

--- a/docs/changelog/100018.yaml
+++ b/docs/changelog/100018.yaml
@@ -1,5 +1,5 @@
 pr: 100018
 summary: Improve time-series error and documentation
-area: "TSDB, Aggregations"
+area: "TSDB"
 type: enhancement
 issues: []

--- a/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/time-series-aggregation.asciidoc
@@ -67,8 +67,6 @@ PUT /my-time-series-index-0/_bulk
 --------------------------------------------------
 // NOTCONSOLE
 
-//////////////////////////
-
 To perform a time series aggregation, specify "time_series" as the aggregation type. When the boolean "keyed"
 is true, each bucket is given a unique key.
 
@@ -84,8 +82,6 @@ GET /_search
 }
 --------------------------------------------------
 // NOTCONSOLE
-
-//////////////////////////
 
 This will return all results in the time series, however a more typical query will use sub aggregations to reduce the
 date returned to something more relevant.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationExecutionContext.java
@@ -54,7 +54,7 @@ public class AggregationExecutionContext {
 
     public int getTsidOrd() {
         if (tsidOrdProvider == null) {
-            throw new AggregationExecutionException(
+            throw new IllegalArgumentException(
                 "Aggregation on a time-series field is misconfigured, likely due to lack of wrapping "
                     + "a metric aggregation within a `time-series` aggregation"
             );

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationExecutionContext.java
@@ -54,8 +54,10 @@ public class AggregationExecutionContext {
 
     public int getTsidOrd() {
         if (tsidOrdProvider == null) {
-            throw new AggregationExecutionException("Aggregation on a time-series field is misconfigured, likely due to lack of wrapping " +
-                "a metric aggregation within a `time-series` aggregation");
+            throw new AggregationExecutionException(
+                "Aggregation on a time-series field is misconfigured, likely due to lack of wrapping "
+                    + "a metric aggregation within a `time-series` aggregation"
+            );
         }
         return tsidOrdProvider.getAsInt();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationExecutionContext.java
@@ -53,6 +53,10 @@ public class AggregationExecutionContext {
     }
 
     public int getTsidOrd() {
+        if (tsidOrdProvider == null) {
+            throw new AggregationExecutionException("Aggregation on a time-series field is misconfigured, likely due to lack of wrapping " +
+                "a metric aggregation within a `time-series` aggregation");
+        }
         return tsidOrdProvider.getAsInt();
     }
 }


### PR DESCRIPTION
Running a metric aggregation on a time-series metric errors out today with the following cryptic message:

```
Cannot invoke "java.util.function.IntSupplier.getAsInt()" because "this.tsidOrdProvider" is null
```

This is due to the lack of a wrapping time-series agg. Documentation for the latter is missing an example:

<img width="893" alt="Screenshot 2023-09-28 at 3 14 45 PM" src="https://github.com/elastic/elasticsearch/assets/131142368/5875b45c-1f5a-47d3-8182-24c710fd9320">

This PR address both issues.

