### PR TITLE
[ML] Reducing use of DiscoveryNode.getVersion

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TrainedModelValidator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TrainedModelValidator.java
@@ -59,7 +59,7 @@ final class TrainedModelValidator {
         if (MlConfigVersion.getMinMlConfigVersion(state.nodes()).before(minimumVersion)) {
             throw new ActionRequestValidationException().addValidationError(
                 format(
-                    "The model [%s] requires that all nodes are at least version [%s]",
+                    "The model [%s] requires that all nodes have ML config version [%s] or higher",
                     resolvedModelPackageConfig.getPackagedModelId(),
                     resolvedModelPackageConfig.getMinimumVersion()
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -807,7 +807,7 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
                     + id
                     + "] on node ["
                     + JobNodeSelector.nodeNameAndVersion(node)
-                    + "], because the data frame analytics requires a node of version ["
+                    + "], because the data frame analytics requires a node with ML config version ["
                     + TaskParams.VERSION_INTRODUCED
                     + "] or higher";
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.autoscaling.NativeMemoryCapacity;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
@@ -346,7 +347,7 @@ public class JobNodeSelector {
     public static String nodeNameAndVersion(DiscoveryNode node) {
         String nodeNameOrID = nodeNameOrId(node);
         StringBuilder builder = new StringBuilder("{").append(nodeNameOrID).append('}');
-        builder.append('{').append("version=").append(node.getVersion()).append('}');
+        builder.append('{').append("ML config version=").append(MlConfigVersion.fromNode(node)).append('}');
         return builder.toString();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -179,7 +179,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                 + jobId
                 + "] on node ["
                 + JobNodeSelector.nodeNameAndVersion(node)
-                + "], because the job's model snapshot requires a node of version ["
+                + "], because the job's model snapshot requires a node with ML config version ["
                 + job.getModelSnapshotMinVersion()
                 + "] or higher";
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,12 +80,25 @@ public class JobNodeSelectorTests extends ESTestCase {
         when(memoryTracker.getJobMemoryRequirement(anyString(), anyString())).thenReturn(JOB_MEMORY_REQUIREMENT.getBytes());
     }
 
-    public void testNodeNameAndVersion() {
+    public void testNodeNameAndVersionForRecentNode() {
         TransportAddress ta = new TransportAddress(InetAddress.getLoopbackAddress(), 9300);
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put("unrelated", "attribute");
+        Map<String, String> attributes = Map.of(MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR, "10.0.0", "unrelated", "attribute");
         DiscoveryNode node = DiscoveryNodeUtils.create("_node_name1", "_node_id1", ta, attributes, ROLES_WITHOUT_ML);
-        assertEquals("{_node_name1}{version=" + node.getVersion() + "}", JobNodeSelector.nodeNameAndVersion(node));
+        assertEquals("{_node_name1}{ML config version=10.0.0}", JobNodeSelector.nodeNameAndVersion(node));
+    }
+
+    public void testNodeNameAndVersionForOldNode() {
+        TransportAddress ta = new TransportAddress(InetAddress.getLoopbackAddress(), 9300);
+        Map<String, String> attributes = Map.of("unrelated", "attribute");
+        DiscoveryNode node = new DiscoveryNode(
+            "_node_name2",
+            "_node_id2",
+            ta,
+            attributes,
+            ROLES_WITH_ML,
+            VersionInformation.inferVersions(Version.fromString("8.7.0"))
+        );
+        assertEquals("{_node_name2}{ML config version=8.7.0}", JobNodeSelector.nodeNameAndVersion(node));
     }
 
     public void testNodeNameAndMlAttributes() {
@@ -869,12 +881,12 @@ public class JobNodeSelectorTests extends ESTestCase {
         assertThat(
             result.getExplanation(),
             equalTo(
-                "Not opening job [incompatible_type_job] on node [{_node_name1}{version="
-                    + Version.CURRENT
+                "Not opening job [incompatible_type_job] on node [{_node_name1}{ML config version="
+                    + MlConfigVersion.CURRENT
                     + "}], "
                     + "because this node does not support jobs of type [incompatible_type]|"
-                    + "Not opening job [incompatible_type_job] on node [{_node_name2}{version="
-                    + Version.CURRENT
+                    + "Not opening job [incompatible_type_job] on node [{_node_name2}{ML config version="
+                    + MlConfigVersion.CURRENT
                     + "}], "
                     + "because this node does not support jobs of type [incompatible_type]"
             )
@@ -946,7 +958,10 @@ public class JobNodeSelectorTests extends ESTestCase {
             node -> nodeFilter(node, job)
         );
         PersistentTasksCustomMetadata.Assignment result = jobNodeSelector.selectNode(10, 2, 30, MAX_JOB_BYTES, false);
-        assertThat(result.getExplanation(), containsString("job's model snapshot requires a node of version [7.3.0] or higher"));
+        assertThat(
+            result.getExplanation(),
+            containsString("job's model snapshot requires a node with ML config version [7.3.0] or higher")
+        );
         assertNull(result.getExecutorNode());
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -96,7 +96,7 @@ public class JobNodeSelectorTests extends ESTestCase {
             ta,
             attributes,
             ROLES_WITH_ML,
-            VersionInformation.inferVersions(Version.fromString("8.7.0"))
+            VersionInformation.inferVersions(Version.V_8_7_0)
         );
         assertEquals("{_node_name2}{ML config version=8.7.0}", JobNodeSelector.nodeNameAndVersion(node));
     }


### PR DESCRIPTION
Remove as much usage as possible of DiscoveryNode.getVersion. Generally for these cases we should be using MlConfigVersion.