### PR TITLE
ESQL: Make sure the request breaker is empty

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/single-node/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 
 dependencies {
   javaRestTestImplementation project(xpackModule('esql:qa:testFixtures'))
+  yamlRestTestImplementation project(xpackModule('esql:qa:server'))
 }
 
 restResources {

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlIT.java
@@ -11,6 +11,9 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
+import org.junit.After;
+import org.junit.Before;
 
 public class EsqlClientYamlIT extends ESClientYamlSuiteTestCase {
 
@@ -21,5 +24,11 @@ public class EsqlClientYamlIT extends ESClientYamlSuiteTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return createParameters();
+    }
+
+    @Before
+    @After
+    public void assertRequestBreakerEmpty() throws Exception {
+        EsqlSpecTestCase.assertRequestBreakerEmpty();
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
+import org.junit.Before;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -555,5 +556,11 @@ public class RestEsqlTestCase extends ESRestTestCase {
     @Override
     protected boolean preserveClusterUponCompletion() {
         return true;
+    }
+
+    @Before
+    @After
+    public void assertRequestBreakerEmpty() throws Exception {
+        EsqlSpecTestCase.assertRequestBreakerEmpty();
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -205,7 +205,8 @@ emp_no:integer | languages:integer | gender:keyword | first_name:keyword | abc:i
 10100 | 4 | F | Hironobu | 3
 ;
 
-projectFromWithStatsAfterLimit
+# awaitsfix https://github.com/elastic/elasticsearch/issues/99826
+projectFromWithStatsAfterLimit-Ignore
 from employees | sort emp_no | keep gender, avg_worked_seconds, first_name, last_name | limit 10 | stats m = max(avg_worked_seconds) by gender;
 
    m:long | gender:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata-ignoreCsvTests.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata-ignoreCsvTests.csv-spec
@@ -95,7 +95,8 @@ emp_no:integer |_version:long |_index:keyword
 10002          |1             |employees
 ;
 
-withMvFunction
+# awaitsfix https://github.com/elastic/elasticsearch/issues/99826
+withMvFunction-Ignore
 from employees [metadata _version] | eval i = mv_avg(_version) + 2 | stats min = min(emp_no) by i;
 
 min:integer |i:double


### PR DESCRIPTION
ESQL uses the request breaker to track memory and it's super important that it clear the breaker after every execution, including errors.
