### PR TITLE
[DOCS] Create URLs for docs migrating from Enterprise Search

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1932,3 +1932,68 @@ Refer to <<remote-clusters>>.
 === Configure roles and users for remote clusters
 
 Refer to <<remote-clusters>>.
+
+[role="exclude",id="ingest-pipeline-search"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="ingest-pipeline-search-inference"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="nlp-example"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="behavioral-analytics-overview"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="behavioral-analytics-start"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="behavioral-analytics-api"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="behavioral-analytics-event"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="behavioral-analytics-event-reference"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="behavioral-analytics-cors"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="search-application-overview"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="search-application-api"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="search-application-client"]
+=== Foo
+
+coming::[8.11.0]
+
+[role="exclude",id="search-application-security"]
+=== Foo
+
+coming::[8.11.0]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1934,12 +1934,12 @@ Refer to <<remote-clusters>>.
 Refer to <<remote-clusters>>.
 
 [role="exclude",id="ingest-pipeline-search"]
-=== Foo
+=== Ingest pipelines for Search indices
 
 coming::[8.11.0]
 
 [role="exclude",id="ingest-pipeline-search-inference"]
-=== Foo
+=== Inference processing for search indices
 
 coming::[8.11.0]
 
@@ -1949,56 +1949,56 @@ coming::[8.11.0]
 coming::[8.11.0]
 
 [role="exclude",id="nlp-example"]
-=== Foo
+=== Tutorial: Natural language processing (NLP)
 
 coming::[8.11.0]
 
 [role="exclude",id="behavioral-analytics-overview"]
-=== Foo
+=== Elastic Behavioral Analytics
 
 coming::[8.11.0]
 
 [role="exclude",id="behavioral-analytics-start"]
-=== Foo
+=== Get started with Behavioral Analytics
 
 coming::[8.11.0]
 
 [role="exclude",id="behavioral-analytics-api"]
-=== Foo
+=== Behavioral Analytics APIs
 
 coming::[8.11.0]
 
 [role="exclude",id="behavioral-analytics-event"]
-=== Foo
+=== View Behavioral Analytics Events
 
 coming::[8.11.0]
 
 [role="exclude",id="behavioral-analytics-event-reference"]
-=== Foo
+=== Behavioral Analytics events reference
 
 coming::[8.11.0]
 
 [role="exclude",id="behavioral-analytics-cors"]
-=== Foo
+=== Set up CORS for Behavioral Analytics
 
 coming::[8.11.0]
 
 [role="exclude",id="search-application-overview"]
-=== Foo
+=== Elastic Search Applications
 
 coming::[8.11.0]
 
 [role="exclude",id="search-application-api"]
-=== Foo
+=== Search Applications search API and templates
 
 coming::[8.11.0]
 
 [role="exclude",id="search-application-client"]
-=== Foo
+=== Search Applications client
 
 coming::[8.11.0]
 
 [role="exclude",id="search-application-security"]
-=== Foo
+=== Search Applications security
 
 coming::[8.11.0]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1943,6 +1943,11 @@ coming::[8.11.0]
 
 coming::[8.11.0]
 
+[id="ingest-pipeline-search-inference-update-mapping"]
+==== Update mapping
+
+coming::[8.11.0]
+
 [role="exclude",id="nlp-example"]
 === Foo
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1939,7 +1939,7 @@ Refer to <<remote-clusters>>.
 coming::[8.11.0]
 
 [role="exclude",id="ingest-pipeline-search-inference"]
-=== Inference processing for search indices
+=== Inference processing for Search indices
 
 coming::[8.11.0]
 


### PR DESCRIPTION
Several docs are going to migrate from Enterprise Search to Elasticsearch.

Create the new URLs without yet placing the pages into the Elasticsearch navigation. This will allow us to handle redirects for Kibana, docs, and the web without waiting for additional content design decisions.

The new URLs will be:

- https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-pipeline-search.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-pipeline-search-inference.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest-pipeline-search-inference.html#ingest-pipeline-search-inference-update-mapping
- https://www.elastic.co/guide/en/elasticsearch/reference/master/nlp-example.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/behavioral-analytics-overview.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/behavioral-analytics-start.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/behavioral-analytics-api.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/behavioral-analytics-event.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/behavioral-analytics-event-reference.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/behavioral-analytics-cors.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-overview.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-api.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-client.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-security.html