### PR TITLE
[7.17] [DOCS] Add security update to 7.17.13 release notes (#99949)

### DIFF
--- a/docs/reference/release-notes/7.17.13.asciidoc
+++ b/docs/reference/release-notes/7.17.13.asciidoc
@@ -3,6 +3,25 @@
 
 Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 
+[float]
+[[security-updates-7.17.13]]
+=== Security updates
+
+* {es} generally filters out sensitive information and credentials before
+logging to the audit log. It was found that this filtering was not applied when
+requests to {es} use certain deprecated `_xpack/security` URIs for APIs. The
+impact of this flaw is that sensitive information, such as passwords and tokens,
+might be printed in cleartext in {es} audit logs. Note that audit logging is
+disabled by default and needs to be explicitly enabled. Even when audit logging
+is enabled, request bodies that could contain sensitive information are not
+printed to the audit log unless explicitly configured.
++
+The issue is resolved in {es} 7.17.13.
++
+For more information, see our related
+https://discuss.elastic.co/t/elasticsearch-8-9-2-and-7-17-13-security-update/342479[security
+announcement].
+
 [[enhancement-7.17.13]]
 [float]
 === Enhancements


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[DOCS] Add security update to 8.9.2 release notes (#99949)](https://github.com/elastic/elasticsearch/pull/99949)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)