### PR TITLE
Decouple trial license resets from product version

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.license.internal.MutableLicenseService;
+import org.elasticsearch.license.internal.TrialLicenseEra;
 import org.elasticsearch.license.internal.XPackLicenseStatus;
 import org.elasticsearch.protocol.xpack.license.LicensesStatus;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
@@ -249,12 +250,12 @@ public class ClusterStateLicenseService extends AbstractLifecycleComponent
                     }
                     Metadata currentMetadata = currentState.metadata();
                     LicensesMetadata licensesMetadata = currentMetadata.custom(LicensesMetadata.TYPE);
-                    Version trialVersion = null;
+                    TrialLicenseEra trialEra = null;
                     if (licensesMetadata != null) {
-                        trialVersion = licensesMetadata.getMostRecentTrialVersion();
+                        trialEra = licensesMetadata.getMostRecentTrialEra();
                     }
                     Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
-                    mdBuilder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(newLicense, trialVersion));
+                    mdBuilder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(newLicense, trialEra));
                     return ClusterState.builder(currentState).metadata(mdBuilder).build();
                 }
             });

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.license;
 
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -15,6 +14,7 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.license.internal.TrialLicenseEra;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;
@@ -78,8 +78,8 @@ public class StartBasicClusterTask implements ClusterStateTaskListener {
                     return currentLicensesMetadata;
                 }
             }
-            Version trialVersion = currentLicensesMetadata != null ? currentLicensesMetadata.getMostRecentTrialVersion() : null;
-            updatedLicensesMetadata = new LicensesMetadata(selfGeneratedLicense, trialVersion);
+            TrialLicenseEra trialEra = currentLicensesMetadata != null ? currentLicensesMetadata.getMostRecentTrialEra() : null;
+            updatedLicensesMetadata = new LicensesMetadata(selfGeneratedLicense, trialEra);
         } else {
             updatedLicensesMetadata = currentLicensesMetadata;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.license;
 
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -15,6 +14,7 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.license.internal.TrialLicenseEra;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;
@@ -88,7 +88,7 @@ public class StartTrialClusterTask implements ClusterStateTaskListener {
                 specBuilder.maxNodes(LicenseSettings.SELF_GENERATED_LICENSE_MAX_NODES);
             }
             License selfGeneratedLicense = SelfGeneratedLicense.create(specBuilder, discoveryNodes);
-            LicensesMetadata newLicensesMetadata = new LicensesMetadata(selfGeneratedLicense, Version.CURRENT);
+            LicensesMetadata newLicensesMetadata = new LicensesMetadata(selfGeneratedLicense, TrialLicenseEra.CURRENT);
             taskContext.success(() -> listener.onResponse(new PostStartTrialResponse(PostStartTrialResponse.Status.UPGRADED_TO_TRIAL)));
             return newLicensesMetadata;
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
@@ -9,13 +9,13 @@ package org.elasticsearch.license;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Supplier;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.license.internal.TrialLicenseEra;
 import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;
@@ -87,8 +87,8 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
             .type(type)
             .expiryDate(expiryDate);
         License selfGeneratedLicense = SelfGeneratedLicense.create(specBuilder, currentState.nodes());
-        Version trialVersion = currentLicenseMetadata.getMostRecentTrialVersion();
-        LicensesMetadata newLicenseMetadata = new LicensesMetadata(selfGeneratedLicense, trialVersion);
+        TrialLicenseEra trialEra = currentLicenseMetadata.getMostRecentTrialEra();
+        LicensesMetadata newLicenseMetadata = new LicensesMetadata(selfGeneratedLicense, trialEra);
         mdBuilder.putCustom(LicensesMetadata.TYPE, newLicenseMetadata);
         logger.info(
             "Updating existing license to the new version.\n\nOld license:\n {}\n\n New license:\n{}",
@@ -129,7 +129,7 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
             .type(License.LicenseType.BASIC)
             .expiryDate(LicenseSettings.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS);
         License selfGeneratedLicense = SelfGeneratedLicense.create(specBuilder, currentLicense.version());
-        Version trialVersion = currentLicenseMetadata.getMostRecentTrialVersion();
+        TrialLicenseEra trialVersion = currentLicenseMetadata.getMostRecentTrialEra();
         return new LicensesMetadata(selfGeneratedLicense, trialVersion);
     }
 
@@ -152,7 +152,7 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
         License selfGeneratedLicense = SelfGeneratedLicense.create(specBuilder, currentState.nodes());
         LicensesMetadata licensesMetadata;
         if (License.LicenseType.TRIAL.equals(type)) {
-            licensesMetadata = new LicensesMetadata(selfGeneratedLicense, Version.CURRENT);
+            licensesMetadata = new LicensesMetadata(selfGeneratedLicense, TrialLicenseEra.CURRENT);
         } else {
             licensesMetadata = new LicensesMetadata(selfGeneratedLicense, null);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/internal/TrialLicenseEra.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/internal/TrialLicenseEra.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license.internal;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Sometimes we release a version with a bunch of cool new features, and we want people to be able to start a new trial license in a cluster
+ * that's already used a trial and let it expire. This class controls when we do that. The serialization of this class is designed to
+ * maintain compatibility with old-school Elasticsearch versions.
+ */
+public class TrialLicenseEra implements ToXContentFragment, Writeable {
+
+    // Increment this when we want users to be able to start a new trial
+    public static final TrialLicenseEra CURRENT = new TrialLicenseEra(8);
+
+    private final int era;
+
+    public TrialLicenseEra(int era) {
+        this.era = era;
+    }
+
+    public TrialLicenseEra(StreamInput in) throws IOException {
+        this.era = (in.readVInt() - 99) / 1000000;
+    }
+
+    public static TrialLicenseEra fromString(String from) {
+        String[] parts = from.split("[.-]");
+        if (parts.length == 0) {
+            throw new IllegalArgumentException("illegal trial era format: [" + from + "]");
+        }
+        try {
+            final int era = Integer.parseInt(parts[0]);
+            return new TrialLicenseEra(era);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("unable to parse trial era: [" + from + "]", e);
+        }
+    }
+
+    int asInt() {
+        return era;
+    }
+
+    public boolean ableToStartNewTrialSince(TrialLicenseEra since) {
+        return since.asInt() < era;
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(era);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(asVersionString()); // suffix added for BWC
+    }
+
+    // pkg-private for testing
+    String asVersionString() {
+        return this + ".0.0";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TrialLicenseEra that = (TrialLicenseEra) o;
+        return era == that.era;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(era);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt((era * 1000000) + 99); // matches Version serialization
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesMetadataSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesMetadataSerializationTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.license.internal.TrialLicenseEra;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
@@ -44,12 +45,12 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         builder.endObject();
         LicensesMetadata licensesMetadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));
         assertThat(licensesMetadataFromXContent.getLicense(), equalTo(license));
-        assertNull(licensesMetadataFromXContent.getMostRecentTrialVersion());
+        assertNull(licensesMetadataFromXContent.getMostRecentTrialEra());
     }
 
     public void testXContentSerializationOneSignedLicenseWithUsedTrial() throws Exception {
         License license = TestUtils.generateSignedLicense(TimeValue.timeValueHours(2));
-        LicensesMetadata licensesMetadata = new LicensesMetadata(license, Version.CURRENT);
+        LicensesMetadata licensesMetadata = new LicensesMetadata(license, TrialLicenseEra.CURRENT);
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject("licenses");
@@ -58,12 +59,12 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         builder.endObject();
         LicensesMetadata licensesMetadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));
         assertThat(licensesMetadataFromXContent.getLicense(), equalTo(license));
-        assertEquals(licensesMetadataFromXContent.getMostRecentTrialVersion(), Version.CURRENT);
+        assertEquals(licensesMetadataFromXContent.getMostRecentTrialEra(), TrialLicenseEra.CURRENT);
     }
 
     public void testLicenseMetadataParsingDoesNotSwallowOtherMetadata() throws Exception {
         License license = TestUtils.generateSignedLicense(TimeValue.timeValueHours(2));
-        LicensesMetadata licensesMetadata = new LicensesMetadata(license, Version.CURRENT);
+        LicensesMetadata licensesMetadata = new LicensesMetadata(license, TrialLicenseEra.CURRENT);
         RepositoryMetadata repositoryMetadata = new RepositoryMetadata("repo", "fs", Settings.EMPTY);
         RepositoriesMetadata repositoriesMetadata = new RepositoriesMetadata(Collections.singletonList(repositoryMetadata));
         final Metadata.Builder metadataBuilder = Metadata.builder();
@@ -97,7 +98,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
             .type(randomBoolean() ? "trial" : "basic")
             .expiryDate(issueDate + TimeValue.timeValueHours(2).getMillis());
         final License trialLicense = SelfGeneratedLicense.create(specBuilder, License.VERSION_CURRENT);
-        LicensesMetadata licensesMetadata = new LicensesMetadata(trialLicense, Version.CURRENT);
+        LicensesMetadata licensesMetadata = new LicensesMetadata(trialLicense, TrialLicenseEra.CURRENT);
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject("licenses");
@@ -106,7 +107,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         builder.endObject();
         LicensesMetadata licensesMetadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));
         assertThat(licensesMetadataFromXContent.getLicense(), equalTo(trialLicense));
-        assertEquals(licensesMetadataFromXContent.getMostRecentTrialVersion(), Version.CURRENT);
+        assertEquals(licensesMetadataFromXContent.getMostRecentTrialEra(), TrialLicenseEra.CURRENT);
     }
 
     public void testLicenseTombstoneFromXContext() throws Exception {
@@ -130,7 +131,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         builder.endObject();
         LicensesMetadata metadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));
         assertThat(metadataFromXContent.getLicense(), equalTo(LicensesMetadata.LICENSE_TOMBSTONE));
-        assertEquals(metadataFromXContent.getMostRecentTrialVersion(), Version.CURRENT);
+        assertEquals(metadataFromXContent.getMostRecentTrialEra(), TrialLicenseEra.CURRENT);
     }
 
     private static LicensesMetadata getLicensesMetadataFromXContent(XContentParser parser) throws Exception {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/internal/TrialLicenseEraTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/internal/TrialLicenseEraTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license.internal;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TrialLicenseEraTests extends ESTestCase {
+
+    public void testCanParseAllVersions() {
+        for (var version : Version.getDeclaredVersions(Version.class)) {
+            TrialLicenseEra era = TrialLicenseEra.fromString(version.toString());
+            assertThat((byte) era.asInt(), equalTo(version.major));
+        }
+    }
+
+    public void testVersionWireCompatibility() throws IOException {
+        for (var version : Version.getDeclaredVersions(Version.class)) {
+            versionToEraSerialization(version);
+        }
+
+        for (int i = 2; i <= 1_000; i++) { // 1000 chosen arbitrarily; we really just want to make sure there's room to grow
+            eraToVersionSerialization(new TrialLicenseEra(i));
+        }
+    }
+
+    // This simulates a node of a version that supports transport eras receiving a message which is still using old-school Versions
+    private TrialLicenseEra versionToEraSerialization(Version version) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setTransportVersion(TransportVersion.current());
+            Version.writeVersion(version, output);
+            try (
+                StreamInput in = new NamedWriteableAwareStreamInput(
+                    output.bytes().streamInput(),
+                    new NamedWriteableRegistry(Collections.emptyList())
+                )
+            ) {
+                in.setTransportVersion(TransportVersion.current());
+                TrialLicenseEra readEra = new TrialLicenseEra(in);
+                assertEquals(readEra.asInt(), version.major);
+                return readEra;
+            }
+        }
+    }
+
+    // This simulates (imperfectly) a node of a version that does not support transport eras receiving a message which uses trial version
+    // eras
+    private Version eraToVersionSerialization(TrialLicenseEra era) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setTransportVersion(TransportVersion.current());
+            era.writeTo(output);
+            try (
+                StreamInput in = new NamedWriteableAwareStreamInput(
+                    output.bytes().streamInput(),
+                    new NamedWriteableRegistry(Collections.emptyList())
+                )
+            ) {
+                in.setTransportVersion(TransportVersion.current());
+                Version readVersion = Version.readVersion(in);
+                assertEquals(readVersion.major, era.asInt());
+                return readVersion;
+            }
+        }
+    }
+
+    public void testRoundTripParsing() {
+        var randomEra = new TrialLicenseEra(randomNonNegativeInt());
+        assertThat(TrialLicenseEra.fromString(randomEra.toString()), equalTo(randomEra));
+    }
+
+    public void testVersionCanParseAllEras() {
+        for (int i = 2; i <= TrialLicenseEra.CURRENT.asInt(); i++) {
+            Version.fromString(new TrialLicenseEra(i).asVersionString());
+        }
+    }
+
+    public void testNewTrialAllowed() {
+        var randomEra = new TrialLicenseEra(randomNonNegativeInt());
+        var subsequentEra = new TrialLicenseEra(randomEra.asInt() + randomIntBetween(0, Integer.MAX_VALUE - randomEra.asInt()));
+        assertFalse(randomEra.ableToStartNewTrialSince(randomEra));
+        assertTrue(subsequentEra.ableToStartNewTrialSince(randomEra));
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheckTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.license.ClusterStateLicenseService;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicensesMetadata;
 import org.elasticsearch.license.TestUtils;
+import org.elasticsearch.license.internal.TrialLicenseEra;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -38,7 +39,7 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         ClusterStateLicenseService licenseService = mock(ClusterStateLicenseService.class);
-        Metadata metadata = createLicensesMetadata(previousVersion, randomFrom("basic", "trial"));
+        Metadata metadata = createLicensesMetadata(TrialLicenseEra.fromString(previousVersion.toString()), randomFrom("basic", "trial"));
         License license = mock(License.class);
         when(licenseService.getLicense(metadata)).thenReturn(license);
         when(license.operationMode()).thenReturn(randomFrom(License.OperationMode.BASIC, License.OperationMode.TRIAL));
@@ -70,7 +71,7 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         ClusterStateLicenseService licenseService = mock(ClusterStateLicenseService.class);
-        Metadata metadata = createLicensesMetadata(previousVersion, randomFrom("gold", "platinum"));
+        Metadata metadata = createLicensesMetadata(TrialLicenseEra.fromString(previousVersion.toString()), randomFrom("gold", "platinum"));
         License license = mock(License.class);
         when(licenseService.getLicense(metadata)).thenReturn(license);
         when(license.operationMode()).thenReturn(randomFrom(License.OperationMode.GOLD, License.OperationMode.PLATINUM));
@@ -91,7 +92,7 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
         BootstrapCheck.BootstrapCheckResult result = new SecurityImplicitBehaviorBootstrapCheck(nodeMetadata, licenseService).check(
             createTestContext(
                 Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build(),
-                createLicensesMetadata(previousVersion, randomFrom("basic", "trial"))
+                createLicensesMetadata(TrialLicenseEra.fromString(previousVersion.toString()), randomFrom("basic", "trial"))
             )
         );
         assertThat(result.isSuccess(), is(true));
@@ -103,7 +104,10 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         ClusterStateLicenseService licenseService = mock(ClusterStateLicenseService.class);
         BootstrapCheck.BootstrapCheckResult result = new SecurityImplicitBehaviorBootstrapCheck(nodeMetadata, licenseService).check(
-            createTestContext(Settings.EMPTY, createLicensesMetadata(previousVersion, randomFrom("basic", "trial")))
+            createTestContext(
+                Settings.EMPTY,
+                createLicensesMetadata(TrialLicenseEra.fromString(previousVersion.toString()), randomFrom("basic", "trial"))
+            )
         );
         assertThat(result.isSuccess(), is(true));
     }
@@ -116,14 +120,14 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
         BootstrapCheck.BootstrapCheckResult result = new SecurityImplicitBehaviorBootstrapCheck(nodeMetadata, licenseService).check(
             createTestContext(
                 Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build(),
-                createLicensesMetadata(previousVersion, randomFrom("basic", "trial"))
+                createLicensesMetadata(TrialLicenseEra.fromString(previousVersion.toString()), randomFrom("basic", "trial"))
             )
         );
         assertThat(result.isSuccess(), is(true));
     }
 
-    private Metadata createLicensesMetadata(Version version, String licenseMode) throws Exception {
+    private Metadata createLicensesMetadata(TrialLicenseEra era, String licenseMode) throws Exception {
         License license = TestUtils.generateSignedLicense(licenseMode, TimeValue.timeValueHours(2));
-        return Metadata.builder().putCustom(LicensesMetadata.TYPE, new LicensesMetadata(license, version)).build();
+        return Metadata.builder().putCustom(LicensesMetadata.TYPE, new LicensesMetadata(license, era)).build();
     }
 }


### PR DESCRIPTION
Prior to this commit, a new trial license was allowed for a cluster for each major version. This was a reasonable strategy when we were releasing major versions on a highly regular cadence, but since those releases have slowed, we may wish to offer new trial licenses that are not tied to a major version release.

This commit introduces the concept of a Trial Licence Era, which is independent from the Elasticsearch version. In order to avoid complications with serialization, the TrialLicenseEra class is serialized in a way that is wire-compatible with the general Version class, and maintains the existing behavior for trials started in released versions. Thorough unit tests are included to verify that TrialLicenseEra and Version are compatible in both streamed and XContent representations.