### PR TITLE
Make MappedFieldType#meta type "more consistent"

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -178,7 +178,7 @@ class FieldCapabilitiesFetcher {
                             false,
                             false,
                             null,
-                            Collections.emptyMap()
+                            Map.of()
                         );
                         responseMap.put(parentField, fieldCap);
                     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -203,14 +203,6 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
         return responseMap;
     }
 
-    /**
-     *
-     * Get the field capabilities for the provided {@code field}
-     */
-    public IndexFieldCapabilities getField(String field) {
-        return responseMap.get(field);
-    }
-
     TransportVersion getOriginVersion() {
         return originVersion;
     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -63,7 +63,7 @@ public record IndexFieldCapabilities(
             isAggregatable,
             isDimension,
             metricType,
-            in.readMap(StreamInput::readString)
+            in.readImmutableMap(StreamInput::readString)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -36,7 +36,6 @@ import org.elasticsearch.xcontent.support.AbstractXContentParser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -1108,7 +1107,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return new Parameter<>(
                 "meta",
                 true,
-                Collections::emptyMap,
+                Map::of,
                 (n, c, o) -> TypeParsers.parseMeta(n, o),
                 m -> m.fieldType().meta(),
                 XContentBuilder::stringStringMap,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -79,7 +79,9 @@ public abstract class MappedFieldType {
         this.isStored = isStored;
         this.docValues = hasDocValues;
         this.textSearchInfo = Objects.requireNonNull(textSearchInfo);
-        this.meta = Objects.requireNonNull(meta);
+        // meta should be sorted but for the one item or empty case we can fall back to immutable maps to save some memory since order is
+        // irrelevant
+        this.meta = meta.size() <= 1 ? Map.copyOf(meta) : meta;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -38,6 +38,9 @@ public class TypeParsers {
         }
         @SuppressWarnings("unchecked")
         Map<String, ?> meta = (Map<String, ?>) metaObject;
+        if (meta.isEmpty()) {
+            return Map.of();
+        }
         if (meta.size() > 5) {
             throw new MapperParsingException("[meta] can't have more than 5 entries, but got " + meta.size() + " on field [" + name + "]");
         }
@@ -68,6 +71,12 @@ public class TypeParsers {
                         + "]"
                 );
             }
+        }
+        var entrySet = meta.entrySet();
+        if (entrySet.size() == 1) {
+            // no need to sort for a single entry
+            var entry = entrySet.iterator().next();
+            return Map.of(entry.getKey(), (String) entry.getValue());
         }
         Map<String, String> sortedMeta = new TreeMap<>();
         for (Map.Entry<String, ?> entry : meta.entrySet()) {


### PR DESCRIPTION
We use various types for this field depending on the code path taken. This leads to a rather high cost for serializing the meta map in field caps (from the virtual call overhead as well as the fact that we have an unmodifiable wrapped `TreeMap` here quiet often).
=> this PR makes a bit of an effort to use a consistent type as much as possible to get more predictable performance and save some heap here and there.
