### PR TITLE
[ML] Removing uses of Version.major from ML code

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
@@ -6,7 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.packageloader;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.Build;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.bootstrap.BootstrapCheck;
@@ -44,10 +44,11 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
     // re-using thread pool setup by the ml plugin
     public static final String UTILITY_THREAD_POOL_NAME = "ml_utility";
 
+    // This link will be invalid for serverless, but serverless will never be
+    // air-gapped, so this message should never be needed.
     private static final String MODEL_REPOSITORY_DOCUMENTATION_LINK = format(
-        "https://www.elastic.co/guide/en/machine-learning/%d.%d/ml-nlp-elser.html#air-gapped-install",
-        Version.CURRENT.major,
-        Version.CURRENT.minor
+        "https://www.elastic.co/guide/en/machine-learning/%s/ml-nlp-elser.html#air-gapped-install",
+        Build.current().version().replaceFirst("^(\\d+\\.\\d+).*", "$1")
     );
 
     public MachineLearningPackageLoader() {}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.junit.BeforeClass;
 
@@ -123,8 +124,11 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         Response getSnapshotsResponse = getModelSnapshots(JOB_ID);
         List<Map<String, Object>> snapshots = (List<Map<String, Object>>) entityAsMap(getSnapshotsResponse).get("model_snapshots");
         assertThat(snapshots, hasSize(2));
-        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
-        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
+        MlConfigVersion snapshotConfigVersion = MlConfigVersion.fromString(snapshots.get(0).get("min_version").toString());
+        assertTrue(
+            "Expected " + snapshotConfigVersion + " not greater than " + MlConfigVersion.CURRENT,
+            snapshotConfigVersion.onOrBefore(MlConfigVersion.CURRENT)
+        );
 
         Map<String, Object> snapshotToUpgrade = snapshots.stream()
             .filter(s -> s.get("snapshot_id").equals(currentSnapshotId) == false)
@@ -232,8 +236,11 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         var modelSnapshots = entityAsMap(getModelSnapshots(JOB_ID));
         var snapshots = (List<Map<String, Object>>) modelSnapshots.get("model_snapshots");
         assertThat(snapshots, hasSize(2));
-        assertThat(Integer.parseInt(snapshots.get(0).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
-        assertThat(Integer.parseInt(snapshots.get(1).get("min_version").toString(), 0, 1, 10), equalTo((int) UPGRADE_FROM_VERSION.major));
+        MlConfigVersion snapshotConfigVersion = MlConfigVersion.fromString(snapshots.get(0).get("min_version").toString());
+        assertTrue(
+            "Expected " + snapshotConfigVersion + " not greater than " + MlConfigVersion.CURRENT,
+            snapshotConfigVersion.onOrBefore(MlConfigVersion.CURRENT)
+        );
     }
 
     private Response buildAndPutJob(String jobId, TimeValue bucketSpan) throws Exception {


### PR DESCRIPTION
We want to avoid using the member variables of the Version class wherever possible.

This PR removes accesses of Version.major.

This change also revealed that we were incorrectly asserting on model snapshot versions in our upgrade tests now that they are using MlConfigVersion.