### PR TITLE
Inline SnapshotRetentionConfiguration#getSnapshotDeletionPredicate

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
@@ -53,16 +53,16 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
             null
         );
         SnapshotInfo oldInfo = makeInfo(0);
-        assertThat(conf.getSnapshotDeletionPredicate(Collections.singletonList(oldInfo)).test(oldInfo), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, Collections.singletonList(oldInfo)), equalTo(true));
 
         SnapshotInfo newInfo = makeInfo(1);
-        assertThat(conf.getSnapshotDeletionPredicate(Collections.singletonList(newInfo)).test(newInfo), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, Collections.singletonList(newInfo)), equalTo(false));
 
         List<SnapshotInfo> infos = new ArrayList<>();
         infos.add(newInfo);
         infos.add(oldInfo);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(newInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, infos), equalTo(true));
     }
 
     public void testExpiredWithMinimum() {
@@ -78,12 +78,12 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         List<SnapshotInfo> infos = new ArrayList<>();
         infos.add(newInfo);
         infos.add(oldInfo);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(newInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, infos), equalTo(false));
 
         conf = new SnapshotRetentionConfiguration(() -> TimeValue.timeValueDays(1).millis() + 1, TimeValue.timeValueDays(1), 1, null);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(newInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, infos), equalTo(true));
     }
 
     public void testMaximum() {
@@ -99,15 +99,15 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s9 = makeInfo(9);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, s2, s3, s4, s5, s6, s7, s8, s9);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s5), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s6), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s7), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s8), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s9), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s3, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s4, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s5, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s6, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s7, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s8, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s9, infos), equalTo(false));
     }
 
     public void testMaximumWithExpireAfter() {
@@ -122,9 +122,9 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo new1 = makeInfo(2);
 
         List<SnapshotInfo> infos = Arrays.asList(old1, old2, new1);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(old1), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(old2), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(new1), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(old1, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(old2, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(new1, infos), equalTo(false));
     }
 
     public void testMaximumWithFailedOrPartial() {
@@ -135,10 +135,10 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s4 = makeInfo(4);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, s2, s3, s4);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s3, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s4, infos), equalTo(false));
     }
 
     public void testFailuresDeletedIfExpired() {
@@ -157,16 +157,16 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
             null
         );
         SnapshotInfo oldInfo = makeFailureOrPartial(0, failure);
-        assertThat(conf.getSnapshotDeletionPredicate(Collections.singletonList(oldInfo)).test(oldInfo), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, Collections.singletonList(oldInfo)), equalTo(true));
 
         SnapshotInfo newInfo = makeFailureOrPartial(1, failure);
-        assertThat(conf.getSnapshotDeletionPredicate(Collections.singletonList(newInfo)).test(newInfo), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, Collections.singletonList(newInfo)), equalTo(false));
 
         List<SnapshotInfo> infos = new ArrayList<>();
         infos.add(newInfo);
         infos.add(oldInfo);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(newInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, infos), equalTo(true));
     }
 
     public void testFailuresDeletedIfNoExpiryAndMoreRecentSuccessExists() {
@@ -185,10 +185,10 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s4 = makeInfo(4);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, s2, s3, s4);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s3, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(s4, infos), equalTo(false));
     }
 
     public void testFailuresKeptIfNoExpiryAndNoMoreRecentSuccess() {
@@ -208,10 +208,10 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s4 = makeFailureOrPartial(4, failure);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, s2, s3, s4);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s3, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s4, infos), equalTo(false));
     }
 
     public void testFailuresNotCountedTowardsMaximum() {
@@ -231,11 +231,11 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s5 = makeInfo(5);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, s2, s3, s4, s5);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s5), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s3, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s4, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s5, infos), equalTo(false));
     }
 
     public void testFailuresNotCountedTowardsMinimum() {
@@ -261,14 +261,14 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         infos.add(newInfo);
         infos.add(failureInfo);
         infos.add(oldInfo);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(newInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(failureInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(failureInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, infos), equalTo(false));
 
         conf = new SnapshotRetentionConfiguration(() -> TimeValue.timeValueDays(1).millis() + 2, TimeValue.timeValueDays(1), 1, null);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(newInfo), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(failureInfo), equalTo(true));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(newInfo, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(failureInfo, infos), equalTo(true));
+        assertThat(conf.isSnapshotEligibleForDeletion(oldInfo, infos), equalTo(true));
     }
 
     public void testMostRecentSuccessfulTimestampIsUsed() {
@@ -280,10 +280,10 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s4 = makeFailureOrPartial(4, failureBeforePartial == false);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, s2, s3, s4);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s3, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s4, infos), equalTo(false));
     }
 
     public void testFewerSuccessesThanMinWithPartial() {
@@ -293,9 +293,9 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         SnapshotInfo s2 = makeInfo(3);
 
         List<SnapshotInfo> infos = Arrays.asList(s1, sP, s2);
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(sP), equalTo(false));
-        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s1, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(sP, infos), equalTo(false));
+        assertThat(conf.isSnapshotEligibleForDeletion(s2, infos), equalTo(false));
     }
 
     private SnapshotInfo makeInfo(long startTime) {

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -208,7 +208,8 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
         final String repository = policy.getRepository();
         // Retrieve the predicate based on the retention policy, passing in snapshots pertaining only to *this* policy and repository
-        boolean eligible = retention.getSnapshotDeletionPredicate(
+        boolean eligible = retention.isSnapshotEligibleForDeletion(
+            snapshot,
             allSnapshots.get(repository)
                 .stream()
                 .filter(
@@ -218,7 +219,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                         .orElse(false)
                 )
                 .toList()
-        ).test(snapshot);
+        );
         logger.debug(
             "[{}] testing snapshot [{}] deletion eligibility: {}",
             repository,


### PR DESCRIPTION
We only ever test each instance of this predicate once, immediately
after creating it, so we may as well just convert it into a regular
method that returns `boolean` instead.

More preliminary work before fixing #99953