### PR TITLE
SnapshotDetails-based SnapshotRetentionConfiguration

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -1150,6 +1150,23 @@ public final class RepositoryData {
             return Objects.hash(snapshotState, version, startTimeMillis, endTimeMillis, slmPolicy);
         }
 
+        public static SnapshotDetails fromSnapshotInfo(SnapshotInfo snapshotInfo) {
+            return new SnapshotDetails(
+                snapshotInfo.state(),
+                snapshotInfo.version(),
+                snapshotInfo.startTime(),
+                snapshotInfo.endTime(),
+                slmPolicy(snapshotInfo.userMetadata())
+            );
+        }
+
+        private static String slmPolicy(Map<String, Object> userMetadata) {
+            if (userMetadata != null && userMetadata.get(SnapshotsService.POLICY_ID_METADATA_FIELD) instanceof String policyId) {
+                return policyId;
+            } else {
+                return "";
+            }
+        }
     }
 
 }

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.scheduler.SchedulerEngine;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
@@ -218,7 +219,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                         .map(pId -> pId.equals(policyId))
                         .orElse(false)
                 )
-                .toList()
+                .collect(Collectors.toMap(SnapshotInfo::snapshotId, RepositoryData.SnapshotDetails::fromSnapshotInfo))
         );
         logger.debug(
             "[{}] testing snapshot [{}] deletion eligibility: {}",


### PR DESCRIPTION
Today `SnapshotRetentionConfiguration` requires a full set of
`SnapshotInfo` objects to do its retention computations, but these can
be fairly large and expensive to obtain in a large repository. Moreover
it doesn't need the whole `SnapshotInfo`, everything it needs is in
`SnapshotDetails` which is in the root `RepositoryData` blob and usually
held in-memory on the master node.

This commit reworks `SnapshotRetentionConfiguration` to do its
computations based on `SnapshotDetails`.