### PR TITLE
ESQL: Ensure pages contain no duplicate blocks

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -74,6 +74,7 @@ public final class Page implements Writeable {
                 throw new IllegalArgumentException("can't build page out of released blocks but [" + b + "] was released");
             }
         }
+        assert hasNoEqualBlocks() : "contains two equal blocks";
     }
 
     public Page(StreamInput in) throws IOException {
@@ -85,6 +86,19 @@ public final class Page implements Writeable {
         }
         this.positionCount = positionCount;
         this.blocks = blocks;
+        assert hasNoEqualBlocks() : "contains two equal blocks";
+    }
+
+    private boolean hasNoEqualBlocks() {
+        for (int i = 0; i < blocks.length - 1; i++) {
+            for (int j = i + 1; j < blocks.length; j++) {
+                if (blocks[i] == blocks[j]) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private static int determinePositionCount(Block... blocks) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -84,6 +84,11 @@ public class BasicPageTests extends SerializationTestCase {
         );
     }
 
+    public void testZeAssertion() {
+        var block = IntBlock.newConstantBlockWith(1, 1);
+        expectThrows(AssertionError.class, () -> new Page(1, new Block[] { block, block }));
+    }
+
     public void testEqualityAndHashCode() throws IOException {
         final EqualsHashCodeTestUtils.CopyFunction<Page> copyPageFunction = page -> {
             Block[] blocks = new Block[page.getBlockCount()];


### PR DESCRIPTION
Workaround to ensure all blocks are correctly accounted for in circuit breakers.