### PR TITLE
More-SnapshotDetails-based SnapshotRetentionConfiguration

### DIFF
--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -210,7 +210,8 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
         final String repository = policy.getRepository();
         // Retrieve the predicate based on the retention policy, passing in snapshots pertaining only to *this* policy and repository
         boolean eligible = retention.isSnapshotEligibleForDeletion(
-            snapshot,
+            snapshot.snapshotId(),
+            RepositoryData.SnapshotDetails.fromSnapshotInfo(snapshot),
             allSnapshots.get(repository)
                 .stream()
                 .filter(


### PR DESCRIPTION
A follow-on from #100058 to make `SnapshotRetentionConfiguration` even
more `SnapshotDetails`-based.