### PR TITLE
Add test that exhibits errors on match_only_text highlighting

### DIFF
--- a/docs/changelog/100066.yaml
+++ b/docs/changelog/100066.yaml
@@ -1,0 +1,5 @@
+pr: 100066
+summary: Add test that exhibits errors on `match_only_text` highlighting
+area: Highlighting
+type: bug
+issues: []

--- a/modules/mapper-extras/src/internalClusterTest/java/org/elasticsearch/index/mapper/MatchOnlyTextMapperIntegrationIT.java
+++ b/modules/mapper-extras/src/internalClusterTest/java/org/elasticsearch/index/mapper/MatchOnlyTextMapperIntegrationIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+
+public class MatchOnlyTextMapperIntegrationIT extends ESIntegTestCase {
+
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(MapperExtrasPlugin.class);
+    }
+
+    public void testHighlightingWithMatchOnlyTextFieldMatchPhrase() throws IOException {
+        XContentBuilder mappings = jsonBuilder();
+        mappings.startObject().startObject("properties").startObject("message").field("type", "match_only_text").endObject().endObject();
+        mappings.endObject();
+        assertAcked(prepareCreate("test").setMapping(mappings));
+        BulkRequestBuilder bulk = client().prepareBulk("test").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        for (int i = 0; i < 2000; i++) {
+            bulk.add(
+                client().prepareIndex()
+                    .setSource(
+                        XContentFactory.jsonBuilder()
+                            .startObject()
+                            .field(
+                                "message",
+                                "[.ds-.slm-history-5-2023.09.20-"
+                                    + randomInt()
+                                    + "][0] marking and sending shard failed due to [failed recovery]"
+                            )
+                            .endObject()
+                    )
+            );
+        }
+        BulkResponse bulkItemResponses = bulk.get();
+        assertNoFailures(bulkItemResponses);
+
+        SearchResponse searchResponse = client().prepareSearch("test")
+            .setQuery(QueryBuilders.matchPhraseQuery("message", "marking and sending shard"))
+            .setSize(500)
+            .highlighter(new HighlightBuilder().field("message"))
+            .get();
+        assertNoFailures(searchResponse);
+    }
+
+}


### PR DESCRIPTION
We recently had errors in some of our dashboards that we narrowed down to highlighting on a "match_only_text" field with a "match_phrae" query. This problem only seems to surface with several segments, so we need to index a larger number of documents and retrieve a larger document size in the request to have a high-enough likelyhood to fail.
The test added in the PR does this and often enough fails with either of these two failure types:

Variation 1, which is the one we originally encountered: 
```
java.lang.AssertionError: Unexpected ShardFailures: [shard [[ZtI-5CyWTRGpBRbHOMGB4Q][test][0]], reason [org.elasticsearch.transport.RemoteTransportException: [node_s1][127.0.0.1:13303][indices:data/read/search[phase/fetch/id]]
Caused by: org.elasticsearch.search.fetch.FetchPhaseExecutionException: Fetch Failed [Error running fetch phase for doc [14]]
	at org.elasticsearch.search.fetch.FetchPhaseDocsIterator.iterate(FetchPhaseDocsIterator.java:73)
	at org.elasticsearch.search.fetch.FetchPhase.buildSearchHits(FetchPhase.java:170)
	at org.elasticsearch.search.fetch.FetchPhase.execute(FetchPhase.java:79)
	at org.elasticsearch.search.SearchService.lambda$executeFetchPhase$9(SearchService.java:861)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:51)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:48)
	at org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:73)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(Thread.java:833)
Caused by: org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper: index_out_of_bounds_exception: Index 7 out of bounds for length 7
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.util.Objects.checkIndex(Objects.java:359)
	at org.apache.lucene.index.CodecReader$1.document(CodecReader.java:108)
	at org.elasticsearch.search.internal.FieldUsageTrackingDirectoryReader$FieldUsageTrackingLeafReader$2.document(FieldUsageTrackingDirectoryReader.java:150)
	at org.elasticsearch.index.fieldvisitor.StoredFieldLoader$ReaderStoredFieldLoader.advanceTo(StoredFieldLoader.java:182)
	at org.elasticsearch.search.lookup.StoredFieldSourceProvider$LeafStoredFieldSourceProvider.getSource(StoredFieldSourceProvider.java:75)
	at org.elasticsearch.search.lookup.StoredFieldSourceProvider.getSource(StoredFieldSourceProvider.java:38)
	at org.elasticsearch.search.lookup.SearchLookup.getSource(SearchLookup.java:144)
	at org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper$MatchOnlyTextFieldType.lambda$getValueFetcherProvider$2(MatchOnlyTextFieldMapper.java:213)
	at org.elasticsearch.index.mapper.extras.SourceConfirmedTextQuery$RuntimePhraseScorer.computeFreq(SourceConfirmedTextQuery.java:376)
	at org.elasticsearch.index.mapper.extras.SourceConfirmedTextQuery$RuntimePhraseScorer.freq(SourceConfirmedTextQuery.java:368)
	at org.elasticsearch.index.mapper.extras.SourceConfirmedTextQuery$RuntimePhraseScorer$1.matches(SourceConfirmedTextQuery.java:327)
	at org.apache.lucene.search.Weight.matches(Weight.java:90)
	at org.apache.lucene.search.uhighlight.FieldOffsetStrategy.createOffsetsEnumsWeightMatcher(FieldOffsetStrategy.java:147)
	at org.apache.lucene.search.uhighlight.FieldOffsetStrategy.createOffsetsEnumFromReader(FieldOffsetStrategy.java:74)
	at org.apache.lucene.search.uhighlight.MemoryIndexOffsetStrategy.getOffsetsEnum(MemoryIndexOffsetStrategy.java:119)
	at org.apache.lucene.search.uhighlight.FieldHighlighter.highlightFieldForDoc(FieldHighlighter.java:80)
	at org.elasticsearch.lucene.search.uhighlight.CustomFieldHighlighter.highlightFieldForDoc(CustomFieldHighlighter.java:63)
	at org.elasticsearch.lucene.search.uhighlight.CustomUnifiedHighlighter.highlightField(CustomUnifiedHighlighter.java:148)
	at org.elasticsearch.search.fetch.subphase.highlight.DefaultHighlighter.highlight(DefaultHighlighter.java:81)
	at org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase$1.process(HighlightPhase.java:69)
	at org.elasticsearch.search.fetch.FetchPhase$1.nextDoc(FetchPhase.java:164)
	at org.elasticsearch.search.fetch.FetchPhaseDocsIterator.iterate(FetchPhaseDocsIterator.java:70)
```

Variation 2:
```
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_s0][search][T#1],5,TGRP-MatchOnlyTextMapperIntegrationIT]
java.lang.AssertionError: StoredFieldsReader are only supposed to be consumed in the thread in which they have been acquired. But was acquired in Thread[elasticsearch[node_s0][search_worker][T#1],5,TGRP-MatchOnlyTextMapperIntegrationIT] and consumed in Thread[elasticsearch[node_s0][search][T#1],5,TGRP-MatchOnlyTextMapperIntegrationIT].
	at __randomizedtesting.SeedInfo.seed([15907A006BC32E2B]:0)
	at org.apache.lucene.tests.codecs.asserting.AssertingCodec.assertThread(AssertingCodec.java:44)
	at org.apache.lucene.tests.codecs.asserting.AssertingStoredFieldsFormat$AssertingStoredFieldsReader.document(AssertingStoredFieldsFormat.java:74)
	at org.elasticsearch.search.internal.FieldUsageTrackingDirectoryReader$FieldUsageTrackingLeafReader$FieldUsageTrackingStoredFieldsReader.document(FieldUsageTrackingDirectoryReader.java:274)
	at org.elasticsearch.index.fieldvisitor.StoredFieldLoader$ReaderStoredFieldLoader.advanceTo(StoredFieldLoader.java:182)
	at org.elasticsearch.search.lookup.StoredFieldSourceProvider$LeafStoredFieldSourceProvider.getSource(StoredFieldSourceProvider.java:75)
	at org.elasticsearch.search.lookup.StoredFieldSourceProvider.getSource(StoredFieldSourceProvider.java:38)
	at org.elasticsearch.search.lookup.SearchLookup.getSource(SearchLookup.java:144)
	at org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper$MatchOnlyTextFieldType.lambda$getValueFetcherProvider$2(MatchOnlyTextFieldMapper.java:213)
	at org.elasticsearch.index.mapper.extras.SourceConfirmedTextQuery$RuntimePhraseScorer.computeFreq(SourceConfirmedTextQuery.java:376)
	at org.elasticsearch.index.mapper.extras.SourceConfirmedTextQuery$RuntimePhraseScorer.freq(SourceConfirmedTextQuery.java:368)
	at org.elasticsearch.index.mapper.extras.SourceConfirmedTextQuery$RuntimePhraseScorer$1.matches(SourceConfirmedTextQuery.java:327)
	at org.apache.lucene.search.Weight.matches(Weight.java:90)
	at org.apache.lucene.search.uhighlight.FieldOffsetStrategy.createOffsetsEnumsWeightMatcher(FieldOffsetStrategy.java:147)
	at org.apache.lucene.search.uhighlight.FieldOffsetStrategy.createOffsetsEnumFromReader(FieldOffsetStrategy.java:74)
	at org.apache.lucene.search.uhighlight.MemoryIndexOffsetStrategy.getOffsetsEnum(MemoryIndexOffsetStrategy.java:119)
	at org.apache.lucene.search.uhighlight.FieldHighlighter.highlightFieldForDoc(FieldHighlighter.java:80)
	at org.elasticsearch.lucene.search.uhighlight.CustomFieldHighlighter.highlightFieldForDoc(CustomFieldHighlighter.java:63)
	at org.elasticsearch.lucene.search.uhighlight.CustomUnifiedHighlighter.highlightField(CustomUnifiedHighlighter.java:148)
	at org.elasticsearch.search.fetch.subphase.highlight.DefaultHighlighter.highlight(DefaultHighlighter.java:81)
	at org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase$1.process(HighlightPhase.java:69)
	at org.elasticsearch.search.fetch.FetchPhase$1.nextDoc(FetchPhase.java:164)
	at org.elasticsearch.search.fetch.FetchPhaseDocsIterator.iterate(FetchPhaseDocsIterator.java:70)
	at org.elasticsearch.search.fetch.FetchPhase.buildSearchHits(FetchPhase.java:170)
	at org.elasticsearch.search.fetch.FetchPhase.execute(FetchPhase.java:79)
	at org.elasticsearch.search.SearchService.executeFetchPhase(SearchService.java:709)
	at org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:680)
	at org.elasticsearch.search.SearchService.lambda$executeQueryPhase$2(SearchService.java:542)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:51)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:48)
	at org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:73)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

The first is related to highlighting, the later seems to exhibit problems with offloading work from the search thread to the recently introduced "search_worker" threads. 