### PR TITLE
Removed special override for platform specific trained models

### DIFF
--- a/docs/changelog/100067.yaml
+++ b/docs/changelog/100067.yaml
@@ -1,0 +1,5 @@
+pr: 100067
+summary: Removed special override for platform specific trained models
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/changelog/100067.yaml
+++ b/docs/changelog/100067.yaml
@@ -1,5 +1,0 @@
-pr: 100067
-summary: Removed special override for platform specific trained models
-area: Machine Learning
-type: enhancement
-issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/MlPlatformArchitecturesUtil.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/MlPlatformArchitecturesUtil.java
@@ -76,11 +76,8 @@ public class MlPlatformArchitecturesUtil {
         String modelID = configToReturn.getModelId();
         String modelPlatformArchitecture = configToReturn.getPlatformArchitecture();
 
-        String modifiedPlatformArchitecture = (modelPlatformArchitecture == null && modelID.contains("linux-x86_64"))
-            ? "linux-x86_64"
-            : null;
         ActionListener<Set<String>> architecturesListener = ActionListener.wrap((architectures) -> {
-            verifyMlNodesAndModelArchitectures(architectures, modifiedPlatformArchitecture, modelID);
+            verifyMlNodesAndModelArchitectures(architectures, modelPlatformArchitecture, modelID);
             successOrFailureListener.onResponse(configToReturn);
         }, successOrFailureListener::onFailure);
 


### PR DESCRIPTION
This change should be merged once the new platform specific elser model has the platform_architecture field set.

This change removes the special override introduced in this commit:
https://github.com/elastic/elasticsearch/pull/99584/commits/8742d16b20be6562a838ab0438980f551872ef9d#diff-0cca845513802964492dbbc803c1080526509dedd3dfd39d27a5b5426d6133f7R76-R78