### PR TITLE
Speedup IndexNameExpressionResolver#checkSystemIndexAccess

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -59,6 +59,8 @@ import java.util.stream.Stream;
 public class IndexNameExpressionResolver {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(IndexNameExpressionResolver.class);
 
+    private static final Predicate<String> ALWAYS_TRUE = s -> true;
+
     public static final String EXCLUDED_DATA_STREAMS_KEY = "es.excluded_ds";
     public static final Version SYSTEM_INDEX_ENFORCEMENT_VERSION = Version.V_8_0_0;
     public static final IndexVersion SYSTEM_INDEX_ENFORCEMENT_INDEX_VERSION = IndexVersion.V_8_0_0;
@@ -100,7 +102,7 @@ public class IndexNameExpressionResolver {
             false,
             request.includeDataStreams(),
             SystemIndexAccessLevel.BACKWARDS_COMPATIBLE_ONLY,
-            name -> true,
+            ALWAYS_TRUE,
             this.getNetNewSystemIndexPredicate()
         );
         return concreteIndexNames(context, request.indices());
@@ -395,33 +397,45 @@ public class IndexNameExpressionResolver {
     }
 
     private void checkSystemIndexAccess(Context context, Set<Index> concreteIndices) {
-        final Metadata metadata = context.getState().metadata();
-        final Predicate<String> systemIndexAccessPredicate = context.getSystemIndexAccessPredicate().negate();
-        final List<IndexMetadata> systemIndicesThatShouldNotBeAccessed = concreteIndices.stream()
-            .map(metadata::index)
-            .filter(IndexMetadata::isSystem)
-            .filter(idxMetadata -> systemIndexAccessPredicate.test(idxMetadata.getIndex().getName()))
-            .toList();
-
-        if (systemIndicesThatShouldNotBeAccessed.isEmpty()) {
+        final Predicate<String> systemIndexAccessPredicate = context.getSystemIndexAccessPredicate();
+        if (systemIndexAccessPredicate == ALWAYS_TRUE) {
             return;
         }
+        doCheckSystemIndexAccess(context, concreteIndices, systemIndexAccessPredicate);
+    }
 
+    private void doCheckSystemIndexAccess(Context context, Set<Index> concreteIndices, Predicate<String> systemIndexAccessPredicate) {
+        final Metadata metadata = context.getState().metadata();
         final List<String> resolvedSystemIndices = new ArrayList<>();
         final List<String> resolvedNetNewSystemIndices = new ArrayList<>();
         final Set<String> resolvedSystemDataStreams = new HashSet<>();
         final SortedMap<String, IndexAbstraction> indicesLookup = metadata.getIndicesLookup();
-        for (IndexMetadata idxMetadata : systemIndicesThatShouldNotBeAccessed) {
-            IndexAbstraction abstraction = indicesLookup.get(idxMetadata.getIndex().getName());
-            if (abstraction.getParentDataStream() != null) {
-                resolvedSystemDataStreams.add(abstraction.getParentDataStream().getName());
-            } else if (systemIndices.isNetNewSystemIndex(idxMetadata.getIndex().getName())) {
-                resolvedNetNewSystemIndices.add(idxMetadata.getIndex().getName());
-            } else {
-                resolvedSystemIndices.add(idxMetadata.getIndex().getName());
+        boolean matchedIndex = false;
+        for (Index concreteIndex : concreteIndices) {
+            IndexMetadata idxMetadata = metadata.index(concreteIndex);
+            String name = concreteIndex.getName();
+            if (idxMetadata.isSystem() && systemIndexAccessPredicate.test(name) == false) {
+                matchedIndex = true;
+                IndexAbstraction indexAbstraction = indicesLookup.get(name);
+                if (indexAbstraction.getParentDataStream() != null) {
+                    resolvedSystemDataStreams.add(indexAbstraction.getParentDataStream().getName());
+                } else if (systemIndices.isNetNewSystemIndex(name)) {
+                    resolvedNetNewSystemIndices.add(name);
+                } else {
+                    resolvedSystemIndices.add(name);
+                }
             }
         }
+        if (matchedIndex) {
+            handleMatchedSystemIndices(resolvedSystemIndices, resolvedSystemDataStreams, resolvedNetNewSystemIndices);
+        }
+    }
 
+    private void handleMatchedSystemIndices(
+        List<String> resolvedSystemIndices,
+        Set<String> resolvedSystemDataStreams,
+        List<String> resolvedNetNewSystemIndices
+    ) {
         if (resolvedSystemIndices.isEmpty() == false) {
             Collections.sort(resolvedSystemIndices);
             deprecationLogger.warn(
@@ -938,7 +952,7 @@ public class IndexNameExpressionResolver {
         } else if (systemIndexAccessLevel == SystemIndexAccessLevel.BACKWARDS_COMPATIBLE_ONLY) {
             systemIndexAccessLevelPredicate = getNetNewSystemIndexPredicate();
         } else if (systemIndexAccessLevel == SystemIndexAccessLevel.ALL) {
-            systemIndexAccessLevelPredicate = s -> true;
+            systemIndexAccessLevelPredicate = ALWAYS_TRUE;
         } else {
             // everything other than allowed should be included in the deprecation message
             systemIndexAccessLevelPredicate = systemIndices.getProductSystemIndexNamePredicate(threadContext);
@@ -968,7 +982,7 @@ public class IndexNameExpressionResolver {
         private final Predicate<String> netNewSystemIndexPredicate;
 
         Context(ClusterState state, IndicesOptions options, SystemIndexAccessLevel systemIndexAccessLevel) {
-            this(state, options, systemIndexAccessLevel, s -> true, s -> false);
+            this(state, options, systemIndexAccessLevel, ALWAYS_TRUE, s -> false);
         }
 
         Context(


### PR DESCRIPTION
Often we're dealing with the always true predicate here in which case we can skip most of the logic. Also the existing logic can be made somewhat faster by shrinking it into a single loop. I realise that the identity check on the predicate isn't all that great but it's good enough I think and we do the same elsewhere.

... found while benchmarking large field_caps requests.