### PR TITLE
Moved APM service version from Version to Build.version()

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.server.cli;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.Version;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.Strings;

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -44,7 +44,7 @@ class APMJvmOptions {
     // tag::noformat
     private static final Map<String, String> STATIC_CONFIG = Map.of(
         // Identifies the version of Elasticsearch in the captured trace data.
-        "service_version", Version.CURRENT.toString(),
+        "service_version", Build.current().version(),
 
         // Configures a log file to write to. `_AGENT_HOME_` is a placeholder used
         // by the agent. Don't disable writing to a log file, as the agent will then

--- a/docs/changelog/100084.yaml
+++ b/docs/changelog/100084.yaml
@@ -1,0 +1,5 @@
+pr: 100084
+summary: Moved APM service version from Version to Build.version()
+area: Infra/Core
+type: enhancement
+issues: []

--- a/docs/changelog/100084.yaml
+++ b/docs/changelog/100084.yaml
@@ -1,5 +1,0 @@
-pr: 100084
-summary: Moved APM service version from Version to Build.version()
-area: Infra/Core
-type: enhancement
-issues: []

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
@@ -24,7 +24,7 @@ import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
-import org.elasticsearch.Version;
+import org.elasticsearch.Build;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.lucene.RegExp;
 import org.elasticsearch.common.settings.Settings;
@@ -149,7 +149,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
 
         return AccessController.doPrivileged((PrivilegedAction<APMServices>) () -> {
             var openTelemetry = GlobalOpenTelemetry.get();
-            var tracer = openTelemetry.getTracer("elasticsearch", Version.CURRENT.toString());
+            var tracer = openTelemetry.getTracer("elasticsearch", Build.current().version());
             return new APMServices(tracer, openTelemetry);
         });
     }


### PR DESCRIPTION
Change is minimal. Tested on both stateful and stateless, works as intended:

Stateful/on-prem:
![image](https://github.com/elastic/elasticsearch/assets/2022952/0a10bbd7-07f8-4440-a897-0a56f8abf2ae)

Serverless:
![image](https://github.com/elastic/elasticsearch/assets/2022952/9e2e6b1d-f0ca-4929-aeab-59b6df268925)

Needs some additional changes on serverless to make it fully functional on that side (already submitted a sister PR)