### PR TITLE
Ignore empty Page in CannedOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
@@ -23,7 +23,7 @@ public class CannedSourceOperator extends SourceOperator {
             List<Page> pages = new ArrayList<>();
             while (source.isFinished() == false) {
                 Page in = source.getOutput();
-                if (in == null) {
+                if (in == null || in.getPositionCount() == 0) {
                     continue;
                 }
                 pages.add(in);


### PR DESCRIPTION
An empty page should never be passed to an operator because the driver may [release](https://github.com/elastic/elasticsearch/blob/0e219307f2d63bcbfc4357c75bf7c4b510801e21/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java#L187-L188) it between operators. The CannedSourceOperator, which is used in tests only, violates this rule, leading to downstream operators accessing an already-released page.

Closes #100060
Closes #100069