### PR TITLE
[7.17] [buildkite] Use local SSDs for platform-support tests (#100098)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -26,8 +26,9 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          diskSizeGb: 350
-          machineType: n1-standard-32
+          localSsds: 1
+          localSsdInterface: nvme
+          machineType: custom-32-98304
         env: {}
   - group: platform-support-windows
     steps:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[buildkite] Use local SSDs for platform-support tests (#100098)](https://github.com/elastic/elasticsearch/pull/100098)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)