### PR TITLE
Remove Version#minimumCompatibilityVersion in QA FullClusterRestartIT

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1869,7 +1869,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         assumeTrue("the old transport.compress setting existed before 7.14", getOldClusterVersion().before(Version.V_7_14_0));
         assumeTrue(
             "Early versions of 6.x do not have cluster.remote* prefixed settings",
-            getOldClusterVersion().onOrAfter(Version.V_7_14_0.minimumCompatibilityVersion())
+            getOldClusterVersion().onOrAfter(Version.fromString("6.8.0"))
         );
         if (isRunningAgainstOldCluster()) {
             final Request putSettingsRequest = new Request("PUT", "/_cluster/settings");


### PR DESCRIPTION
This is one of the few uses of `Version#minimumCompatibilityVersion` that isn't covered by other planned work. Since the minimum compatibility version for `7.14.0` is always going to be `6.8.0`, we can just hardcode the value.