### PR TITLE
[8.10] Show concrete error when enrich index not exist rather than NPE (#99604)

### DIFF
--- a/docs/changelog/99604.yaml
+++ b/docs/changelog/99604.yaml
@@ -1,0 +1,5 @@
+pr: 99604
+summary: Show concrete error when enrich index not exist rather than NPE
+area: Ingest Node
+type: enhancement
+issues: []

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
@@ -88,6 +89,9 @@ public final class EnrichCache {
     private String getEnrichIndexKey(SearchRequest searchRequest) {
         String alias = searchRequest.indices()[0];
         IndexAbstraction ia = metadata.getIndicesLookup().get(alias);
+        if (ia == null) {
+            throw new IndexNotFoundException("no generated enrich index [" + alias + "]");
+        }
         return ia.getIndices().get(0).getName();
     }
 


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Show concrete error when enrich index not exist rather than NPE (#99604)