### PR TITLE
FilterBlobContainer should delegate writeBlob(String, BytesReference,boolean)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/support/FilterBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/support/FilterBlobContainer.java
@@ -80,6 +80,11 @@ public abstract class FilterBlobContainer implements BlobContainer {
     }
 
     @Override
+    public void writeBlob(String blobName, BytesReference bytes, boolean failIfAlreadyExists) throws IOException {
+        delegate.writeBlob(blobName, bytes, failIfAlreadyExists);
+    }
+
+    @Override
     public DeleteResult delete() throws IOException {
         return delegate.delete();
     }


### PR DESCRIPTION
FilterBlobContainer does not correctly delegate the `writeBlob(String, BytesReference, boolean)` method as it idefaults to another method in the BlobContainer interface.