### PR TITLE
Introduce local-only action utils

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -677,7 +677,7 @@ public class ActionModule extends AbstractModule {
         actions.register(ListTasksAction.INSTANCE, TransportListTasksAction.class);
         actions.register(GetTaskAction.INSTANCE, TransportGetTaskAction.class);
         actions.register(CancelTasksAction.INSTANCE, TransportCancelTasksAction.class);
-        actions.register(GetHealthAction.INSTANCE, GetHealthAction.TransportAction.class);
+        actions.register(GetHealthAction.INSTANCE, GetHealthAction.LocalAction.class);
         actions.register(PrevalidateNodeRemovalAction.INSTANCE, TransportPrevalidateNodeRemovalAction.class);
         actions.register(HealthApiStatsAction.INSTANCE, HealthApiStatsTransportAction.class);
 

--- a/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 
@@ -123,5 +124,15 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
                 delegate.onFailure(inner);
             }
         }
+    }
+
+    /**
+     * A method to use as a placeholder in implementations of {@link TransportAction} which only ever run on the local node, and therefore
+     * do not need to serialize or deserialize any messages. See also {@link Writeable.Reader#localOnly()}.
+     */
+    // TODO remove this when https://github.com/elastic/elasticsearch/issues/100111 is resolved
+    public static <T> T localOnly() {
+        assert false : "local-only action";
+        throw new UnsupportedOperationException("local-only action");
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/Writeable.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.common.io.stream;
 
+import org.elasticsearch.action.support.TransportAction;
+
 import java.io.IOException;
 
 /**
@@ -74,6 +76,13 @@ public interface Writeable {
          */
         V read(StreamInput in) throws IOException;
 
+        /**
+         * A {@link Reader} which must never be called, for use in local-only transport actions. See also {@link TransportAction#localOnly}.
+         */
+        // TODO remove this when https://github.com/elastic/elasticsearch/issues/100111 is resolved
+        static <V> Reader<V> localOnly() {
+            return in -> TransportAction.localOnly();
+        }
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
@@ -14,13 +14,14 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.health.stats.HealthApiStats;
@@ -45,7 +46,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
     public static final String NAME = "cluster:monitor/health_api";
 
     private GetHealthAction() {
-        super(NAME, GetHealthAction.Response::new);
+        super(NAME, Writeable.Reader.localOnly());
     }
 
     public static class Response extends ActionResponse implements ChunkedToXContent {
@@ -54,10 +55,6 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
         @Nullable
         private final HealthStatus status;
         private final List<HealthIndicatorResult> indicators;
-
-        public Response(StreamInput in) {
-            throw new AssertionError("GetHealthAction should not be sent over the wire.");
-        }
 
         public Response(final ClusterName clusterName, final List<HealthIndicatorResult> indicators, boolean showTopLevelStatus) {
             this.indicators = indicators;
@@ -90,7 +87,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            throw new AssertionError("GetHealthAction should not be sent over the wire.");
+            TransportAction.localOnly();
         }
 
         @Override
@@ -173,9 +170,14 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
             return new CancellableTask(id, type, action, "", parentTaskId, headers);
         }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            TransportAction.localOnly();
+        }
     }
 
-    public static class TransportAction extends org.elasticsearch.action.support.TransportAction<Request, Response> {
+    public static class LocalAction extends TransportAction<Request, Response> {
 
         private final ClusterService clusterService;
         private final HealthService healthService;
@@ -183,7 +185,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
         private final HealthApiStats healthApiStats;
 
         @Inject
-        public TransportAction(
+        public LocalAction(
             ActionFilters actionFilters,
             TransportService transportService,
             ClusterService clusterService,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -23,7 +24,7 @@ public class DeleteInternalCcrRepositoryAction extends ActionType<ActionResponse
     public static final String NAME = "internal:admin/ccr/internal_repository/delete";
 
     private DeleteInternalCcrRepositoryAction() {
-        super(NAME, in -> ActionResponse.Empty.INSTANCE);
+        super(NAME, Writeable.Reader.localOnly());
     }
 
     public static class TransportDeleteInternalRepositoryAction extends TransportAction<

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/DeleteInternalCcrRepositoryRequest.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr.action.repositories;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -29,7 +30,7 @@ public class DeleteInternalCcrRepositoryRequest extends ActionRequest {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("DeleteInternalRepositoryRequest cannot be serialized for sending across the wire.");
+        TransportAction.localOnly();
     }
 
     public String getName() {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -23,7 +24,7 @@ public class PutInternalCcrRepositoryAction extends ActionType<ActionResponse.Em
     public static final String NAME = "internal:admin/ccr/internal_repository/put";
 
     private PutInternalCcrRepositoryAction() {
-        super(NAME, in -> ActionResponse.Empty.INSTANCE);
+        super(NAME, Writeable.Reader.localOnly());
     }
 
     public static class TransportPutInternalRepositoryAction extends TransportAction<

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutInternalCcrRepositoryRequest.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr.action.repositories;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class PutInternalCcrRepositoryRequest extends ActionRequest {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("PutInternalRepositoryRequest cannot be serialized for sending across the wire.");
+        TransportAction.localOnly();
     }
 
     public String getName() {

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -369,7 +369,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return List.of(
-            new ActionHandler<>(GetGlobalCheckpointsAction.INSTANCE, GetGlobalCheckpointsAction.TransportAction.class),
+            new ActionHandler<>(GetGlobalCheckpointsAction.INSTANCE, GetGlobalCheckpointsAction.LocalAction.class),
             new ActionHandler<>(GetGlobalCheckpointsShardAction.INSTANCE, GetGlobalCheckpointsShardAction.TransportAction.class),
             new ActionHandler<>(GetSecretAction.INSTANCE, TransportGetSecretAction.class),
             new ActionHandler<>(PostSecretAction.INSTANCE, TransportPostSecretAction.class),

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
@@ -26,8 +27,8 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.TimeValue;
@@ -54,7 +55,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
     public static final String NAME = "indices:monitor/fleet/global_checkpoints";
 
     private GetGlobalCheckpointsAction() {
-        super(NAME, GetGlobalCheckpointsAction.Response::new);
+        super(NAME, Writeable.Reader.localOnly());
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {
@@ -67,10 +68,6 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
             this.globalCheckpoints = globalCheckpoints;
         }
 
-        public Response(StreamInput in) {
-            throw new AssertionError("GetGlobalCheckpointsAction should not be sent over the wire.");
-        }
-
         public long[] globalCheckpoints() {
             return globalCheckpoints;
         }
@@ -80,8 +77,8 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            throw new AssertionError("GetGlobalCheckpointsAction should not be sent over the wire.");
+        public void writeTo(StreamOutput out) {
+            TransportAction.localOnly();
         }
 
         @Override
@@ -151,9 +148,14 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
         public IndicesOptions indicesOptions() {
             return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
         }
+
+        @Override
+        public void writeTo(StreamOutput out) {
+            TransportAction.localOnly();
+        }
     }
 
-    public static class TransportAction extends org.elasticsearch.action.support.TransportAction<Request, Response> {
+    public static class LocalAction extends TransportAction<Request, Response> {
 
         private final ClusterService clusterService;
         private final NodeClient client;
@@ -161,7 +163,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
         private final ThreadPool threadPool;
 
         @Inject
-        public TransportAction(
+        public LocalAction(
             final ActionFilters actionFilters,
             final TransportService transportService,
             final ClusterService clusterService,


### PR DESCRIPTION
Introduces some never-called `localOnly()` placeholders to clearly mark
the dead code in actions that never run on remote nodes.

Relates #100111