### PR TITLE
Release empty page in CannedSourceOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
@@ -23,7 +23,11 @@ public class CannedSourceOperator extends SourceOperator {
             List<Page> pages = new ArrayList<>();
             while (source.isFinished() == false) {
                 Page in = source.getOutput();
-                if (in == null || in.getPositionCount() == 0) {
+                if (in == null) {
+                    continue;
+                }
+                if (in.getPositionCount() == 0) {
+                    in.releaseBlocks();
                     continue;
                 }
                 pages.add(in);


### PR DESCRIPTION
TopNOperatorTests are failing because we don't release an empty Page in CannedSourceOperator, which is used in tests only.


Closes #100116