### PR TITLE
Remove StreamInput.readArraySize

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -585,7 +585,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                     BytesRef qbSource = binaryDocValues.binaryValue();
                     try (
                         InputStream in = new ByteArrayInputStream(qbSource.bytes, qbSource.offset, qbSource.length);
-                        StreamInput input = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(in, qbSource.length), registry)
+                        StreamInput input = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(in), registry)
                     ) {
                         // Query builder's content is stored via BinaryFieldMapper, which has a custom encoding
                         // to encode multiple binary values into a single binary doc values field.

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -158,7 +158,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
             @Override
             public ReleasableBytesReference readReleasableBytesReference() throws IOException {
-                final int len = readArraySize();
+                final int len = readVInt();
                 return retainAndSkip(len);
             }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -10,7 +10,6 @@ package org.elasticsearch.common.io.stream;
 
 import org.apache.lucene.util.BytesRef;
 
-import java.io.EOFException;
 import java.io.IOException;
 
 /**
@@ -75,14 +74,6 @@ public class ByteArrayStreamInput extends StreamInput {
     @Override
     public int available() {
         return limit - pos;
-    }
-
-    @Override
-    protected void ensureCanReadBytes(int length) throws EOFException {
-        final int available = limit - pos;
-        if (length > available) {
-            throwEOF(length, available);
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -227,14 +227,6 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    protected void ensureCanReadBytes(int length) throws EOFException {
-        final int available = buffer.remaining();
-        if (length > available) {
-            throwEOF(length, available);
-        }
-    }
-
-    @Override
     public void mark(int readlimit) {
         buffer.mark();
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -11,7 +11,6 @@ package org.elasticsearch.common.io.stream;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 
-import java.io.EOFException;
 import java.io.IOException;
 
 /**
@@ -106,11 +105,6 @@ public abstract class FilterStreamInput extends StreamInput {
         delegate.setTransportVersion(version);
         // also set the version on this stream directly, so that any uses of this.version are still correct
         super.setTransportVersion(version);
-    }
-
-    @Override
-    protected void ensureCanReadBytes(int length) throws EOFException {
-        delegate.ensureCanReadBytes(length);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
@@ -18,28 +18,13 @@ import java.util.Objects;
 public class InputStreamStreamInput extends StreamInput {
 
     private final InputStream is;
-    private final long sizeLimit;
 
     /**
      * Creates a new InputStreamStreamInput with unlimited size
      * @param is the input stream to wrap
      */
     public InputStreamStreamInput(InputStream is) {
-        this(is, Long.MAX_VALUE);
-    }
-
-    /**
-     * Creates a new InputStreamStreamInput with a size limit
-     * @param is the input stream to wrap
-     * @param sizeLimit a hard limit of the number of bytes in the given input stream. This is used for internal input validation
-     */
-    public InputStreamStreamInput(InputStream is, long sizeLimit) {
         this.is = is;
-        if (sizeLimit < 0) {
-            throw new IllegalArgumentException("size limit must be positive");
-        }
-        this.sizeLimit = sizeLimit;
-
     }
 
     @Override
@@ -103,10 +88,4 @@ public class InputStreamStreamInput extends StreamInput {
         return is.skip(n);
     }
 
-    @Override
-    protected void ensureCanReadBytes(int length) throws EOFException {
-        if (length > sizeLimit) {
-            throw new EOFException("tried to read: " + length + " bytes but this stream is limited to: " + sizeLimit);
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
@@ -34,7 +34,7 @@ public class NamedWriteableAwareStreamInput extends FilterStreamInput {
 
     @Override
     public <T extends NamedWriteable> List<T> readNamedWriteableCollectionAsList(Class<T> categoryClass) throws IOException {
-        int count = readArraySize();
+        int count = readVInt();
         if (count == 0) {
             return Collections.emptyList();
         }

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogHeader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogHeader.java
@@ -112,7 +112,7 @@ final class TranslogHeader {
         try {
             // This input is intentionally not closed because closing it will close the FileChannel.
             final BufferedChecksumStreamInput in = new BufferedChecksumStreamInput(
-                new InputStreamStreamInput(java.nio.channels.Channels.newInputStream(channel), channel.size()),
+                new InputStreamStreamInput(java.nio.channels.Channels.newInputStream(channel)),
                 path.toString()
             );
             final int version = readHeaderVersion(path, channel, in);

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
@@ -607,20 +606,6 @@ public abstract class AbstractStreamTests extends ESTestCase {
         var list = new ArrayList<>(set);
         Collections.reverse(list);
         assertGenericRoundtrip(new LinkedHashSet<>(list));
-    }
-
-    public void testReadArraySize() throws IOException {
-        BytesStreamOutput stream = new BytesStreamOutput();
-        byte[] array = new byte[randomIntBetween(1, 10)];
-        for (int i = 0; i < array.length; i++) {
-            array[i] = randomByte();
-        }
-        stream.writeByteArray(array);
-        StreamInput streamInput = new InputStreamStreamInput(getStreamInput(stream.bytes()), array.length - 1);
-        expectThrows(EOFException.class, streamInput::readByteArray);
-        streamInput = new InputStreamStreamInput(getStreamInput(stream.bytes()), BytesReference.toBytes(stream.bytes()).length);
-
-        assertArrayEquals(array, streamInput.readByteArray());
     }
 
     public void testFilterStreamInputDelegatesAvailable() throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -763,7 +763,7 @@ public class BytesStreamsTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     assertEquals(i, ints[i]);
                 }
-                expectThrows(IllegalStateException.class, () -> streamInput.readIntArray());
+                expectThrows(OutOfMemoryError.class, streamInput::readIntArray);
             }
         }
     }
@@ -784,8 +784,7 @@ public class BytesStreamsTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     assertEquals(i, ints[i]);
                 }
-                EOFException eofException = expectThrows(EOFException.class, () -> streamInput.readIntArray());
-                assertEquals("tried to read: 100 bytes but only 40 remaining", eofException.getMessage());
+                expectThrows(EOFException.class, streamInput::readIntArray);
             }
         }
     }
@@ -806,8 +805,7 @@ public class BytesStreamsTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     assertEquals(i, ints[i]);
                 }
-                NegativeArraySizeException exception = expectThrows(NegativeArraySizeException.class, () -> streamInput.readIntArray());
-                assertEquals("array size must be positive but was: -2147483648", exception.getMessage());
+                expectThrows(NegativeArraySizeException.class, streamInput::readIntArray);
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -859,7 +859,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     assertEquals(i, ints[i]);
                 }
-                expectThrows(IllegalStateException.class, () -> streamInput.readIntArray());
+                expectThrows(OutOfMemoryError.class, streamInput::readIntArray);
             }
         }
     }
@@ -880,8 +880,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     assertEquals(i, ints[i]);
                 }
-                EOFException eofException = expectThrows(EOFException.class, () -> streamInput.readIntArray());
-                assertEquals("tried to read: 100 bytes but only 40 remaining", eofException.getMessage());
+                expectThrows(EOFException.class, streamInput::readIntArray);
             }
         }
     }
@@ -902,8 +901,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     assertEquals(i, ints[i]);
                 }
-                NegativeArraySizeException exception = expectThrows(NegativeArraySizeException.class, () -> streamInput.readIntArray());
-                assertEquals("array size must be positive but was: -2147483648", exception.getMessage());
+                expectThrows(NegativeArraySizeException.class, streamInput::readIntArray);
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -130,7 +130,7 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
 
         // try to read more than the stream contains
         si.reset();
-        expectThrows(IndexOutOfBoundsException.class, () -> si.readBytes(targetBuf, 0, length * 2));
+        expectThrows(EOFException.class, () -> si.readBytes(new byte[length * 2], 0, length * 2));
     }
 
     public void testStreamInputMarkAndReset() throws IOException {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -58,7 +58,6 @@ import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.type.DefaultDataTypeRegistry;
 import org.elasticsearch.xpack.ql.type.EsField;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -257,11 +256,6 @@ public class CircuitBreakerTests extends ESTestCase {
                     @Override
                     public int available() throws IOException {
                         return 0;
-                    }
-
-                    @Override
-                    protected void ensureCanReadBytes(int length) throws EOFException {
-
                     }
 
                     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
@@ -153,7 +153,7 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput {
     }
 
     public AttributeSet readAttributeSet(Writeable.Reader<Attribute> reader) throws IOException {
-        int count = readArraySize();
+        int count = readVInt();
         if (count == 0) {
             return new AttributeSet();
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -628,7 +628,7 @@ public final class TokenService {
      */
     void decodeToken(String token, boolean validateUserToken, ActionListener<UserToken> listener) {
         final byte[] bytes = token.getBytes(StandardCharsets.UTF_8);
-        try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)), bytes.length)) {
+        try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)))) {
             final TransportVersion version = TransportVersion.readVersion(in);
             in.setTransportVersion(version);
             if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {
@@ -1099,7 +1099,7 @@ public final class TokenService {
             findTokenFromRefreshToken(refreshToken, securityMainIndex, backoff, listener);
         } else {
             final byte[] bytes = refreshToken.getBytes(StandardCharsets.UTF_8);
-            try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)), bytes.length)) {
+            try (StreamInput in = new InputStreamStreamInput(Base64.getDecoder().wrap(new ByteArrayInputStream(bytes)))) {
                 final TransportVersion version = TransportVersion.readVersion(in);
                 in.setTransportVersion(version);
                 if (version.onOrAfter(VERSION_GET_TOKEN_DOC_FOR_REFRESH)) {


### PR DESCRIPTION
I noticed that the readArraySize method is quite expensive when benchmarking field caps related things. The reason is that the ensureCapacity call is not getting inlined well mostly. Since that call doesn't work for all stream implementations, was broken for the limited length `InputStreamStreamInput` (it only checked an individual read against the size limit regardless of the current stream offset) I think we can just remove this safety measure and use `readVInt`. Moreover, we were already using readVInt and readArraySize somewhat interchangably and it's a stretch to claim that readArraySize actually protects nodes in the real world IMO.

-> this PR removes readArraySize and replaces it with readVInt throughout, speeding up (among other things) reading the string array in a field caps request by about 15% in my benchmarking.

Had to make a couple of minor adjustments to the exceptions thrown and tests here and there but all of that stuff was not super consistent across implementations to begin with an IMO is rather more than less consistent now.
