### PR TITLE
Allowing data streams java rest tests to run in a test framework that provides its own credentials

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/DataStreamUpgradeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/DataStreamUpgradeRestIT.java
@@ -39,11 +39,16 @@ public class DataStreamUpgradeRestIT extends DisabledSecurityDataStreamTestCase 
 
     @Override
     protected Settings restClientSettings() {
-        Settings.Builder builder = Settings.builder();
-        if (System.getProperty("tests.rest.client_path_prefix") != null) {
-            builder.put(CLIENT_PATH_PREFIX, System.getProperty("tests.rest.client_path_prefix"));
+        // If this test is running in a test frameowrk that handles its own authorization, we don't want to overwrite it.
+        if (super.restClientSettings().keySet().contains(ThreadContext.PREFIX + ".Authorization")) {
+            return super.restClientSettings();
+        } else {
+            Settings.Builder builder = Settings.builder();
+            if (System.getProperty("tests.rest.client_path_prefix") != null) {
+                builder.put(CLIENT_PATH_PREFIX, System.getProperty("tests.rest.client_path_prefix"));
+            }
+            return builder.put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE).build();
         }
-        return builder.put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE).build();
     }
 
     public void testCompatibleMappingUpgrade() throws Exception {

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecyclePermissionsRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecyclePermissionsRestIT.java
@@ -17,21 +17,15 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -40,16 +34,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class DataStreamLifecyclePermissionsRestIT extends ESRestTestCase {
 
     private static final String PASSWORD = "secret-test-password";
-    private static Path caPath;
-
-    @BeforeClass
-    public static void init() throws URISyntaxException, FileNotFoundException {
-        URL resource = DataStreamLifecyclePermissionsRestIT.class.getResource("/ssl/ca.crt");
-        if (resource == null) {
-            throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
-        }
-        caPath = PathUtils.get(resource.toURI());
-    }
 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
@@ -57,22 +41,8 @@ public class DataStreamLifecyclePermissionsRestIT extends ESRestTestCase {
         .setting("xpack.watcher.enabled", "false")
         .setting("xpack.ml.enabled", "false")
         .setting("xpack.security.enabled", "true")
-        .setting("xpack.license.self_generated.type", "trial")
-        .setting("xpack.security.http.ssl.enabled", "true")
-        .setting("xpack.security.http.ssl.certificate", "node.crt")
-        .setting("xpack.security.http.ssl.key", "node.key")
-        .setting("xpack.security.http.ssl.certificate_authorities", "ca.crt")
-        .setting("xpack.security.transport.ssl.enabled", "true")
-        .setting("xpack.security.transport.ssl.certificate", "node.crt")
-        .setting("xpack.security.transport.ssl.key", "node.key")
-        .setting("xpack.security.transport.ssl.certificate_authorities", "ca.crt")
-        .setting("xpack.security.transport.ssl.verification_mode", "certificate")
-        .keystore("xpack.security.transport.ssl.secure_key_passphrase", "node-password")
-        .keystore("xpack.security.http.ssl.secure_key_passphrase", "node-password")
-        .keystore("bootstrap.password", PASSWORD)
-        .configFile("node.key", Resource.fromClasspath("ssl/node.key"))
-        .configFile("node.crt", Resource.fromClasspath("ssl/node.crt"))
-        .configFile("ca.crt", Resource.fromClasspath("ssl/ca.crt"))
+        .setting("xpack.security.transport.ssl.enabled", "false")
+        .setting("xpack.security.http.ssl.enabled", "false")
         .user("test_admin", PASSWORD, "superuser", false)
         .user("test_data_stream_lifecycle", PASSWORD, "manage_data_stream_lifecycle", false)
         .user("test_non_privileged", PASSWORD, "not_privileged", false)
@@ -86,27 +56,45 @@ public class DataStreamLifecyclePermissionsRestIT extends ESRestTestCase {
 
     @Override
     protected Settings restClientSettings() {
-        // Note: This user is assigned the role "manage_data_stream_lifecycle". That role is defined in roles.yml.
-        String token = basicAuthHeaderValue("test_data_stream_lifecycle", new SecureString(PASSWORD.toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
+        // If this test is running in a test frameowrk that handles its own authorization, we don't want to overwrite it.
+        if (super.restClientSettings().keySet().contains(ThreadContext.PREFIX + ".Authorization")) {
+            return super.restClientSettings();
+        } else {
+            // Note: This user is assigned the role "manage_data_stream_lifecycle". That role is defined in roles.yml.
+            String token = basicAuthHeaderValue("test_data_stream_lifecycle", new SecureString(PASSWORD.toCharArray()));
+            return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+        }
     }
 
     @Override
     protected Settings restAdminSettings() {
-        String token = basicAuthHeaderValue("test_admin", new SecureString(PASSWORD.toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
+        /*
+         * Here we can't just check whether there is an authorization setting because super.restAdminSettings() calls restClientSettings(),
+         * and that will have an authorization setting regardless. So we have to check whether it's been set to have the
+         * test_data_stream_lifecycle user (which is what this class's restClientSettings() does if there is no other authorization already
+         * set).
+         */
+        Settings superSettings = super.restAdminSettings();
+        String authKey = ThreadContext.PREFIX + ".Authorization";
+        String nonAdminToken = basicAuthHeaderValue("test_data_stream_lifecycle", new SecureString(PASSWORD.toCharArray()));
+        if (superSettings.keySet().contains(authKey) && superSettings.get(authKey).equals(nonAdminToken) == false) {
+            return superSettings;
+        } else {
+            String token = basicAuthHeaderValue("test_admin", new SecureString(PASSWORD.toCharArray()));
+            return Settings.builder().put(authKey, token).build();
+        }
+    }
+
+    private Settings restPrivilegedClientSettings() {
+        // Note: This user is assigned the role "not_privileged". That role is defined in roles.yml.
+        String token = basicAuthHeaderValue("test_data_stream_lifecycle", new SecureString(PASSWORD.toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
     private Settings restUnprivilegedClientSettings() {
         // Note: This user is assigned the role "not_privileged". That role is defined in roles.yml.
         String token = basicAuthHeaderValue("test_non_privileged", new SecureString(PASSWORD.toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
-    }
-
-    @Override
-    protected String getProtocol() {
-        // Because http.ssl.enabled = true
-        return "https";
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
     @SuppressWarnings("unchecked")
@@ -150,7 +138,12 @@ public class DataStreamLifecyclePermissionsRestIT extends ESRestTestCase {
                 makeRequest(nonDataStreamLifecycleManagerClient, putLifecycleRequest, false);
             }
         }
-        {
+        try (
+            RestClient dataStreamLifecycleManagerClient = buildClient(
+                restPrivilegedClientSettings(),
+                getClusterHosts().toArray(new HttpHost[0])
+            )
+        ) {
             // Now test that the user who has the manage_data_stream_lifecycle privilege on data-stream-lifecycle-* data streams cannot
             // manage other data streams:
             String otherDataStreamName = "other-data-stream-lifecycle-test";
@@ -160,10 +153,14 @@ public class DataStreamLifecyclePermissionsRestIT extends ESRestTestCase {
             String otherIndex = (String) ((List<Map<String, Object>>) otherNodes.get(0).get("indices")).get(0).get("index_name");
             Request putOtherLifecycleRequest = new Request("PUT", "_data_stream/" + otherDataStreamName + "/_lifecycle");
             putOtherLifecycleRequest.setJsonEntity("{}");
-            makeRequest(client(), new Request("GET", "/" + otherIndex + "/_lifecycle/explain"), false);
-            makeRequest(client(), new Request("GET", "_data_stream/" + otherDataStreamName + "/_lifecycle"), false);
-            makeRequest(client(), new Request("DELETE", "_data_stream/" + otherDataStreamName + "/_lifecycle"), false);
-            makeRequest(client(), putOtherLifecycleRequest, false);
+            makeRequest(dataStreamLifecycleManagerClient, new Request("GET", "/" + otherIndex + "/_lifecycle/explain"), false);
+            makeRequest(dataStreamLifecycleManagerClient, new Request("GET", "_data_stream/" + otherDataStreamName + "/_lifecycle"), false);
+            makeRequest(
+                dataStreamLifecycleManagerClient,
+                new Request("DELETE", "_data_stream/" + otherDataStreamName + "/_lifecycle"),
+                false
+            );
+            makeRequest(dataStreamLifecycleManagerClient, putOtherLifecycleRequest, false);
         }
     }
 


### PR DESCRIPTION
In some test runtime environments, the authorization setting is set by the framework. We don't want to overwrite this in the test. Similar to #100113.