### PR TITLE
Avoid arithmetic overflow in LuceneCountOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -121,7 +121,7 @@ public class LuceneCountOperator extends LuceneOperator {
                 Weight weight = scorer.weight();
                 var leafReaderContext = scorer.leafReaderContext();
                 // see org.apache.lucene.search.TotalHitCountCollector
-                int leafCount = weight == null ? -1 : weight.count(leafReaderContext);
+                int leafCount = weight.count(leafReaderContext);
                 if (leafCount != -1) {
                     // make sure to NOT multi count as the count _shortcut_ (which is segment wide)
                     // handle doc partitioning where the same leaf can be seen multiple times
@@ -132,10 +132,11 @@ public class LuceneCountOperator extends LuceneOperator {
                         var count = Math.min(leafCount, remainingDocs);
                         totalHits += count;
                         remainingDocs -= count;
-                        scorer.markAsDone();
                     }
+                    scorer.markAsDone();
                 } else {
                     // could not apply shortcut, trigger the search
+                    // TODO: avoid iterating all documents in multiple calls to make cancellation more responsive.
                     scorer.scoreNextRange(leafCollector, leafReaderContext.reader().getLiveDocs(), remainingDocs);
                 }
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -126,6 +126,9 @@ public abstract class LuceneOperator extends SourceOperator {
 
         void scoreNextRange(LeafCollector collector, Bits acceptDocs, int numDocs) throws IOException {
             assert isDone() == false : "scorer is exhausted";
+            // avoid overflow and limit the range
+            numDocs = Math.min(maxPosition - position, numDocs);
+            assert numDocs > 0 : "scorer was exhausted";
             position = bulkScorer.score(collector, acceptDocs, position, Math.min(maxPosition, position + numDocs));
         }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
@@ -151,7 +151,7 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
         }
         // We can't verify the limit if we have more than one pipeline
         if (dataPartitioning == DataPartitioning.SHARD || size <= limit || taskConcurrency == 1) {
-            assertThat(totalCount, equalTo(size));
+            assertThat(totalCount, equalTo((long)size));
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.compute.lucene;
 
-import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -36,10 +36,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -58,6 +59,7 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
     }
 
     private LuceneCountOperator.Factory simple(BigArrays bigArrays, DataPartitioning dataPartitioning, int numDocs, int limit) {
+        boolean enableShortcut = randomBoolean();
         int commitEvery = Math.max(1, numDocs / 10);
         try (
             RandomIndexWriter writer = new RandomIndexWriter(
@@ -67,9 +69,14 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
             )
         ) {
             for (int d = 0; d < numDocs; d++) {
-                List<IndexableField> doc = new ArrayList<>();
-                doc.add(new SortedNumericDocValuesField("s", d));
+                var doc = new Document();
+                doc.add(new LongPoint("s", d));
                 writer.addDocument(doc);
+                if (enableShortcut == false && randomBoolean()) {
+                    doc = new Document();
+                    doc.add(new LongPoint("s", randomLongBetween(numDocs * 5L, numDocs * 10L)));
+                    writer.addDocument(doc);
+                }
                 if (d % commitEvery == 0) {
                     writer.commit();
                 }
@@ -83,8 +90,13 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
         SearchExecutionContext ectx = mock(SearchExecutionContext.class);
         when(ctx.getSearchExecutionContext()).thenReturn(ectx);
         when(ectx.getIndexReader()).thenReturn(reader);
-        Function<SearchContext, Query> queryFunction = c -> new MatchAllDocsQuery();
-        return new LuceneCountOperator.Factory(List.of(ctx), queryFunction, dataPartitioning, 1, limit);
+        final Query query;
+        if (enableShortcut && randomBoolean()) {
+            query = new MatchAllDocsQuery();
+        } else {
+            query = LongPoint.newRangeQuery("s", 0, numDocs);
+        }
+        return new LuceneCountOperator.Factory(List.of(ctx), c -> query, dataPartitioning, between(1, 8), limit);
     }
 
     @Override
@@ -102,34 +114,45 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
 
     // TODO tests for the other data partitioning configurations
 
-    public void testShardDataPartitioning() {
+    public void testSimple() {
         int size = between(1_000, 20_000);
-        int limit = between(10, size);
+        int limit = randomBoolean() ? between(10, size) : Integer.MAX_VALUE;
         testCount(size, limit);
     }
 
     public void testEmpty() {
-        testCount(0, between(10, 10_000));
+        int limit = randomBoolean() ? between(10, 10000) : Integer.MAX_VALUE;
+        testCount(0, limit);
     }
 
     private void testCount(int size, int limit) {
-        DriverContext ctx = driverContext();
-        LuceneCountOperator.Factory factory = simple(nonBreakingBigArrays(), DataPartitioning.SHARD, size, limit);
-
-        List<Page> results = new ArrayList<>();
-        OperatorTestCase.runDriver(new Driver(ctx, factory.get(ctx), List.of(), new PageConsumerOperator(results::add), () -> {}));
-        OperatorTestCase.assertDriverContext(ctx);
-
-        assertThat(results, hasSize(1));
-        Page page = results.get(0);
-
-        assertThat(page.getPositionCount(), is(1));
-        assertThat(page.getBlockCount(), is(2));
-        LongBlock lb = page.getBlock(0);
-        assertThat(lb.getPositionCount(), is(1));
-        assertThat(lb.getLong(0), is((long) Math.min(size, limit)));
-        BooleanBlock bb = page.getBlock(1);
-        assertThat(bb.getBoolean(1), is(true));
+        DataPartitioning dataPartitioning = randomFrom(DataPartitioning.values());
+        LuceneCountOperator.Factory factory = simple(nonBreakingBigArrays(), dataPartitioning, size, limit);
+        List<Page> results = new CopyOnWriteArrayList<>();
+        List<Driver> drivers = new ArrayList<>();
+        int taskConcurrency = between(1, 8);
+        for (int i = 0; i < taskConcurrency; i++) {
+            DriverContext ctx = driverContext();
+            drivers.add(new Driver(ctx, factory.get(ctx), List.of(), new PageConsumerOperator(results::add), () -> {}));
+        }
+        OperatorTestCase.runDriver(drivers);
+        assertThat(results.size(), lessThanOrEqualTo(taskConcurrency));
+        long totalCount = 0;
+        for (Page page : results) {
+            assertThat(page.getPositionCount(), is(1));
+            assertThat(page.getBlockCount(), is(2));
+            LongBlock lb = page.getBlock(0);
+            assertThat(lb.getPositionCount(), is(1));
+            long count = lb.getLong(0);
+            assertThat(count, lessThanOrEqualTo((long) limit));
+            totalCount += count;
+            BooleanBlock bb = page.getBlock(1);
+            assertTrue(bb.getBoolean(0));
+        }
+        // We can't verify the limit if we have more than one pipeline
+        if (dataPartitioning == DataPartitioning.SHARD || size <= limit || taskConcurrency == 1) {
+            assertThat(totalCount, equalTo(size));
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneCountOperatorTests.java
@@ -151,7 +151,7 @@ public class LuceneCountOperatorTests extends AnyOperatorTestCase {
         }
         // We can't verify the limit if we have more than one pipeline
         if (dataPartitioning == DataPartitioning.SHARD || size <= limit || taskConcurrency == 1) {
-            assertThat(totalCount, equalTo((long)size));
+            assertThat(totalCount, equalTo((long) size));
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -442,42 +442,45 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testUngroupedCountAll() {
-        EsqlQueryResponse results = run("from test | stats count(*)");
-        logger.info(results);
-        Assert.assertEquals(1, results.columns().size());
-        Assert.assertEquals(1, getValuesList(results).size());
-        assertEquals("count(*)", results.columns().get(0).name());
-        assertEquals("long", results.columns().get(0).type());
-        var values = getValuesList(results).get(0);
-        assertEquals(1, values.size());
-        assertEquals(40, (long) values.get(0));
+        try (EsqlQueryResponse results = run("from test | stats count(*)")) {
+            logger.info(results);
+            Assert.assertEquals(1, results.columns().size());
+            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals("count(*)", results.columns().get(0).name());
+            assertEquals("long", results.columns().get(0).type());
+            var values = getValuesList(results).get(0);
+            assertEquals(1, values.size());
+            assertEquals(40, (long) values.get(0));
+        }
     }
 
     public void testUngroupedCountAllWithFilter() {
-        EsqlQueryResponse results = run("from test | where data > 1 | stats count(*)");
-        logger.info(results);
-        Assert.assertEquals(1, results.columns().size());
-        Assert.assertEquals(1, getValuesList(results).size());
-        assertEquals("count(*)", results.columns().get(0).name());
-        assertEquals("long", results.columns().get(0).type());
-        var values = getValuesList(results).get(0);
-        assertEquals(1, values.size());
-        assertEquals(20, (long) values.get(0));
+        try (EsqlQueryResponse results = run("from test | where data > 1 | stats count(*)")) {
+            logger.info(results);
+            Assert.assertEquals(1, results.columns().size());
+            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals("count(*)", results.columns().get(0).name());
+            assertEquals("long", results.columns().get(0).type());
+            var values = getValuesList(results).get(0);
+            assertEquals(1, values.size());
+            assertEquals(20, (long) values.get(0));
+        }
     }
 
     public void testGroupedCountAllWithFilter() {
-        EsqlQueryResponse results = run("from test | where data > 1 | stats count(*) by data | sort data");
-        logger.info(results);
-        Assert.assertEquals(2, results.columns().size());
-        Assert.assertEquals(1, getValuesList(results).size());
-        assertEquals("count(*)", results.columns().get(0).name());
-        assertEquals("long", results.columns().get(0).type());
-        assertEquals("data", results.columns().get(1).name());
-        assertEquals("long", results.columns().get(1).type());
-        var values = getValuesList(results).get(0);
-        assertEquals(2, values.size());
-        assertEquals(20, (long) values.get(0));
-        assertEquals(2L, (long) values.get(1));
+        try (EsqlQueryResponse results = run("from test | where data > 1 | stats count(*) by data | sort data")) {
+            logger.info(results);
+            Assert.assertEquals(2, results.columns().size());
+            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals("count(*)", results.columns().get(0).name());
+            assertEquals("long", results.columns().get(0).type());
+            assertEquals("data", results.columns().get(1).name());
+            assertEquals("long", results.columns().get(1).type());
+            var values = getValuesList(results).get(0);
+            assertEquals(2, values.size());
+            assertEquals(20, (long) values.get(0));
+            assertEquals(2L, (long) values.get(1));
+        }
     }
 
     public void testFromStatsEvalWithPragma() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Build;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -67,7 +66,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100127")
 public class EsqlActionIT extends AbstractEsqlIntegTestCase {
 
     long epoch = System.currentTimeMillis();
@@ -467,7 +465,6 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         assertEquals(20, (long) values.get(0));
     }
 
-    @AwaitsFix(bugUrl = "tracking down a 64b(long) memory leak")
     public void testGroupedCountAllWithFilter() {
         EsqlQueryResponse results = run("from test | where data > 1 | stats count(*) by data | sort data");
         logger.info(results);


### PR DESCRIPTION
The LuceneCountOperator has two issues that can prevent the operator from finishing (or leading to an infinite loop in the Driver):

1. It doesn't finish the scorer when we can shortcut and a partial leaf is not the first one
2. It requests Integer.MAX_VALUE documents when performing manual counting, which leads to arithmetic overflow for a partial leaf which is not the first one (i.e, position > 0)

Closes #100127