### PR TITLE
[7.17] Show concrete error when enrich index not exist rather than NPE (#99604)

### DIFF
--- a/docs/changelog/99604.yaml
+++ b/docs/changelog/99604.yaml
@@ -1,0 +1,5 @@
+pr: 99604
+summary: Show concrete error when enrich index not exist rather than NPE
+area: Ingest Node
+type: enhancement
+issues: []

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 
@@ -88,6 +89,9 @@ public final class EnrichCache {
     private String getEnrichIndexKey(SearchRequest searchRequest) {
         String alias = searchRequest.indices()[0];
         IndexAbstraction ia = metadata.getIndicesLookup().get(alias);
+        if (ia == null) {
+            throw new IndexNotFoundException("no generated enrich index [" + alias + "]");
+        }
         return ia.getIndices().get(0).getName();
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichCacheTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichCacheTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.enrich.MatchProcessorTests.mapOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -184,6 +186,24 @@ public class EnrichCacheTests extends ESTestCase {
         original.put("embedded_object", new byte[] { 1, 2, 3 });
         result = EnrichCache.deepCopy(original, false);
         assertArrayEquals(new byte[] { 1, 2, 3 }, (byte[]) result.get("embedded_object"));
+    }
+
+    public void testEnrichIndexNotExist() {
+        // Emulate cluster metadata:
+        Metadata metadata = Metadata.builder().build();
+
+        // Emulated search request on a non-exist enrich index that an enrich processor could generate
+        SearchRequest searchRequest = new SearchRequest(EnrichPolicy.getBaseName("policy-enrich-index-not-generated")).source(
+            new SearchSourceBuilder().query(new MatchQueryBuilder("test", "query"))
+        );
+        // Emulated search response (content doesn't matter, since it isn't used, it just a cache entry)
+        List<Map<?, ?>> searchResponse = Collections.singletonList(Collections.singletonMap("test", "entry"));
+
+        EnrichCache enrichCache = new EnrichCache(1);
+        enrichCache.setMetadata(metadata);
+
+        IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> enrichCache.put(searchRequest, searchResponse));
+        assertThat(e.getMessage(), containsString("no generated enrich index [.enrich-policy-enrich-index-not-generated]"));
     }
 
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Show concrete error when enrich index not exist rather than NPE (#99604)](https://github.com/elastic/elasticsearch/pull/99604)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)