### PR TITLE
Rework beats artifacts resolution in docker build

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -46,7 +46,7 @@ if (useDra == false) {
         ivy {
           name = 'beats'
           if (useLocalArtifacts) {
-            url "file://${getLayout().getBuildDirectory().getAsFile().get()}/artifacts/"
+            url getLayout().getBuildDirectory().dir("artifacts").get().asFile
             patternLayout {
               artifact '/[organisation]/[module]-[revision]-[classifier].[ext]'
             }

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -65,12 +65,9 @@ if (useDra == false) {
           metadataSources { artifact() }
         }
       }
-
       filter {
         includeGroup("beats")
       }
-
-
     }
   }
 }
@@ -105,9 +102,9 @@ String tiniArch = Architecture.current() == Architecture.AARCH64 ? 'arm64' : 'am
 
 dependencies {
   aarch64DockerSource project(":distribution:archives:linux-aarch64-tar")
-  aarch64DockerSourceTar project(path: ":distribution:archives:linux-aarch64-tar", configuration: "default")
+  aarch64DockerSourceTar project(path: ":distribution:archives:linux-aarch64-tar", configuration:"default")
   dockerSource project(":distribution:archives:linux-tar")
-  dockerSourceTar project(path: ":distribution:archives:linux-tar", configuration: "default")
+  dockerSourceTar project(path: ":distribution:archives:linux-tar", configuration:"default")
   log4jConfig project(path: ":distribution", configuration: 'log4jConfig')
   tini "krallin:tini:0.19.0:${tiniArch}"
   allPlugins project(path: ':plugins', configuration: 'allPlugins')
@@ -118,7 +115,7 @@ dependencies {
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->
-  def (major, minor) = VersionProperties.elasticsearch.split("\\.")
+  def (major,minor) = VersionProperties.elasticsearch.split("\\.")
 
   // We tag our Docker images with various pieces of information, including a timestamp
   // for when the image was built. However, this makes it impossible completely cache
@@ -341,9 +338,9 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
     into "${project.buildDir}/docker-context/${archiveName}"
 
     // Since we replaced the remote URL in the Dockerfile, copy in the required file
-    if (base == DockerBase.IRON_BANK) {
+    if(base == DockerBase.IRON_BANK) {
       from(architecture == Architecture.AARCH64 ? configurations.aarch64DockerSourceTar : configurations.dockerSourceTar)
-      from(configurations.tini) {
+      from (configurations.tini) {
         rename { _ -> 'tini' }
       }
     } else {
@@ -452,11 +449,9 @@ void addBuildEssDockerImageTask(Architecture architecture) {
       }
 
       from(projectDir.resolve("src/docker/Dockerfile.cloud-ess")) {
-        expand(
-          [
-            base_image: "elasticsearch${DockerBase.CLOUD.suffix}:${architecture.classifier}"
-          ]
-        )
+        expand([
+          base_image: "elasticsearch${DockerBase.CLOUD.suffix}:${architecture.classifier}"
+        ])
         filter SquashNewlinesFilter
         rename ~/Dockerfile\.cloud-ess$/, 'Dockerfile'
       }
@@ -497,10 +492,7 @@ for (final Architecture architecture : Architecture.values()) {
 }
 
 boolean isArchitectureSupported(Architecture architecture) {
-  Provider<DockerSupportService> serviceProvider = GradleUtils.getBuildService(
-    project.gradle.sharedServices,
-    DockerSupportPlugin.DOCKER_SUPPORT_SERVICE_NAME
-  )
+  Provider<DockerSupportService> serviceProvider = GradleUtils.getBuildService(project.gradle.sharedServices, DockerSupportPlugin.DOCKER_SUPPORT_SERVICE_NAME)
   return serviceProvider.get().dockerAvailability.supportedArchitectures().contains(architecture)
 }
 

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -38,30 +38,39 @@ repositories {
   }
 }
 
-if(useDra == false) {
+if (useDra == false) {
   repositories {
-    // Cloud builds bundle some beats
-    ivy {
-      name = 'beats'
-      if (useLocalArtifacts) {
-        url "file://${buildDir}/artifacts/"
-        patternLayout {
-          artifact '/[organisation]/[module]-[revision]-[classifier].[ext]'
-        }
-      } else {
-        url "https://artifacts-snapshot.elastic.co/"
-        patternLayout {
-          if (VersionProperties.isElasticsearchSnapshot()) {
-            artifact '/[organization]/[revision]/downloads/[organization]/[module]/[module]-[revision]-[classifier].[ext]'
+    exclusiveContent {
+      // Cloud builds bundle some beats
+      forRepository {
+        ivy {
+          name = 'beats'
+          if (useLocalArtifacts) {
+            url "file://${getLayout().getBuildDirectory().getAsFile().get()}/artifacts/"
+            patternLayout {
+              artifact '/[organisation]/[module]-[revision]-[classifier].[ext]'
+            }
           } else {
-            // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
-            // Release builds are always done with a local repo.
-            artifact '/[organization]/[revision]-SNAPSHOT/downloads/[organization]/[module]/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
+            url "https://artifacts-snapshot.elastic.co/"
+            patternLayout {
+              if (VersionProperties.isElasticsearchSnapshot()) {
+                artifact '/[organization]/[revision]/downloads/[organization]/[module]/[module]-[revision]-[classifier].[ext]'
+              } else {
+                // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
+                // Release builds are always done with a local repo.
+                artifact '/[organization]/[revision]-SNAPSHOT/downloads/[organization]/[module]/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
+              }
+            }
           }
+          metadataSources { artifact() }
         }
       }
-      metadataSources { artifact() }
-      content { includeGroup 'beats' }
+
+      filter {
+        includeGroup("beats")
+      }
+
+
     }
   }
 }
@@ -96,9 +105,9 @@ String tiniArch = Architecture.current() == Architecture.AARCH64 ? 'arm64' : 'am
 
 dependencies {
   aarch64DockerSource project(":distribution:archives:linux-aarch64-tar")
-  aarch64DockerSourceTar project(path: ":distribution:archives:linux-aarch64-tar", configuration:"default")
+  aarch64DockerSourceTar project(path: ":distribution:archives:linux-aarch64-tar", configuration: "default")
   dockerSource project(":distribution:archives:linux-tar")
-  dockerSourceTar project(path: ":distribution:archives:linux-tar", configuration:"default")
+  dockerSourceTar project(path: ":distribution:archives:linux-tar", configuration: "default")
   log4jConfig project(path: ":distribution", configuration: 'log4jConfig')
   tini "krallin:tini:0.19.0:${tiniArch}"
   allPlugins project(path: ':plugins', configuration: 'allPlugins')
@@ -109,7 +118,7 @@ dependencies {
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->
-  def (major,minor) = VersionProperties.elasticsearch.split("\\.")
+  def (major, minor) = VersionProperties.elasticsearch.split("\\.")
 
   // We tag our Docker images with various pieces of information, including a timestamp
   // for when the image was built. However, this makes it impossible completely cache
@@ -332,9 +341,9 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
     into "${project.buildDir}/docker-context/${archiveName}"
 
     // Since we replaced the remote URL in the Dockerfile, copy in the required file
-    if(base == DockerBase.IRON_BANK) {
+    if (base == DockerBase.IRON_BANK) {
       from(architecture == Architecture.AARCH64 ? configurations.aarch64DockerSourceTar : configurations.dockerSourceTar)
-      from (configurations.tini) {
+      from(configurations.tini) {
         rename { _ -> 'tini' }
       }
     } else {
@@ -443,9 +452,11 @@ void addBuildEssDockerImageTask(Architecture architecture) {
       }
 
       from(projectDir.resolve("src/docker/Dockerfile.cloud-ess")) {
-        expand([
-          base_image: "elasticsearch${DockerBase.CLOUD.suffix}:${architecture.classifier}"
-        ])
+        expand(
+          [
+            base_image: "elasticsearch${DockerBase.CLOUD.suffix}:${architecture.classifier}"
+          ]
+        )
         filter SquashNewlinesFilter
         rename ~/Dockerfile\.cloud-ess$/, 'Dockerfile'
       }
@@ -486,7 +497,10 @@ for (final Architecture architecture : Architecture.values()) {
 }
 
 boolean isArchitectureSupported(Architecture architecture) {
-  Provider<DockerSupportService> serviceProvider = GradleUtils.getBuildService(project.gradle.sharedServices, DockerSupportPlugin.DOCKER_SUPPORT_SERVICE_NAME)
+  Provider<DockerSupportService> serviceProvider = GradleUtils.getBuildService(
+    project.gradle.sharedServices,
+    DockerSupportPlugin.DOCKER_SUPPORT_SERVICE_NAME
+  )
   return serviceProvider.get().dockerAvailability.supportedArchitectures().contains(architecture)
 }
 


### PR DESCRIPTION
It seems gradle behaviour has changed in 8.3 or let's say resolution logic is broken as it reports misguiding error messages as reported in https://github.com/elastic/elasticsearch/issues/100152 
This workaround fixes the exclusive group filtering by ensuring only the beats repo is tried for beats artifacts.
I couldn't reproduce the resolution issue as we see in https://github.com/elastic/elasticsearch/issues/100152 locally.
Will follow up with the gradle team on the issue.
