### PR TITLE
[7.17] Add Suse 15.5 to docker ignore list (#100156)

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -8,6 +8,7 @@ centos-6
 debian-8
 debian-11
 opensuse-leap-15.1
+opensuse-leap-15.5
 ol-6.10
 ol-7.7
 sles-12.3 # older version used in Vagrant image
@@ -16,3 +17,4 @@ sles-15.1
 sles-15.2
 sles-15.3
 sles-15.4
+sles-15.5


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Add Suse 15.5 to docker ignore list (#100156)