### PR TITLE
[Test] Explicitly set number_of_shards to 1 for tests that rely on the default

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/cardinality_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/cardinality_metric.yml
@@ -3,6 +3,8 @@ setup:
       indices.create:
           index: test_1
           body:
+            settings:
+              number_of_shards: 1
             mappings:
               properties:
                 int_field:
@@ -45,6 +47,8 @@ setup:
       indices.create:
         index: test_2
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               other_field:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/doc_count_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/doc_count_field.yml
@@ -3,6 +3,8 @@ setup:
       indices.create:
         index: test_1
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               str:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -9,6 +9,8 @@
       indices.create:
         index: test_index
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             dynamic_templates:
               - location:
@@ -181,6 +183,8 @@
       indices.create:
         index: test_index
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             dynamic_templates:
               - location:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/40_keyword_ignore.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/40_keyword_ignore.yml
@@ -4,6 +4,8 @@ setup:
       indices.create:
           index: test-index
           body:
+            settings:
+              number_of_shards: 1
             mappings:
               "properties":
                 "k1":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/210_rescore_explain.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/210_rescore_explain.yml
@@ -1,6 +1,13 @@
 ---
 "Score should match explanation in rescore":
   - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
       bulk:
         refresh: true
         body:
@@ -18,16 +25,16 @@
         body:
           explain: true
           query:
-            match_all: {}
+            match_all: { }
           rescore:
             window_size: 2
             query:
               rescore_query:
-                match_all: {}
+                match_all: { }
               query_weight: 5
               rescore_query_weight: 10
 
-  - match: {hits.max_score: 15}
+  - match: { hits.max_score: 15 }
   - match: { hits.hits.0._score: 15 }
   - match: { hits.hits.0._explanation.value: 15 }
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/310_match_bool_prefix.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/310_match_bool_prefix.yml
@@ -7,6 +7,8 @@ setup:
       indices.create:
         index:  test
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               my_field1:

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -136,7 +137,13 @@ public class DataLoader {
     }
 
     private static void createTestIndex(RestHighLevelClient client, String indexName, String mapping) throws IOException {
-        ESRestTestCase.createIndex(client.getLowLevelClient(), indexName, null, mapping, null);
+        ESRestTestCase.createIndex(
+            client.getLowLevelClient(),
+            indexName,
+            Settings.builder().put("number_of_shards", 1).build(),
+            mapping,
+            null
+        );
     }
 
     /**

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/versionfield/20_scripts.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/versionfield/20_scripts.yml
@@ -12,6 +12,8 @@ setup:
         indices.create:
           index: test_index
           body:
+              settings:
+                number_of_shards: 1
               mappings:
                 properties:
                   version:


### PR DESCRIPTION
Some tests rely on the natural index order for test assertions. This works when the index has a single primary shard but fails otherwise. This PR adjusts the relevant tests so that they explicitly configure the number of shards to 1.

Relates: ES-6540
