### PR TITLE
Revert "[Transform] improve transform log/audit correctness when stopped"

### DIFF
--- a/docs/changelog/99917.yaml
+++ b/docs/changelog/99917.yaml
@@ -1,5 +1,0 @@
-pr: 99917
-summary: Improve transform log/audit correctness when stopped
-area: Transform
-type: enhancement
-issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -395,7 +395,6 @@ class ClientTransformIndexer extends TransformIndexer {
 
     @Override
     protected void onStop() {
-        logger.debug(() -> format("[%s] transform initiating stop", transformConfig.getId()));
         closePointInTime();
         super.onStop();
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -564,10 +564,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     @Override
     protected void afterFinishOrFailure() {
-        finishIndexerThreadShutdown(() -> {
-            auditor.info(transformConfig.getId(), "Transform has stopped.");
-            logger.info("[{}] transform has stopped.", transformConfig.getId());
-        });
+        finishIndexerThreadShutdown();
     }
 
     @Override
@@ -647,6 +644,12 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         } catch (Exception e) {
             logger.error(() -> "[" + getJobId() + "] transform encountered an unexpected internal exception: ", e);
         }
+    }
+
+    @Override
+    protected void onStop() {
+        auditor.info(transformConfig.getId(), "Transform has stopped.");
+        logger.info("[{}] transform has stopped.", transformConfig.getId());
     }
 
     @Override
@@ -1200,7 +1203,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         }
     }
 
-    private void finishIndexerThreadShutdown(Runnable next) {
+    private void finishIndexerThreadShutdown() {
         synchronized (context) {
             indexerThreadShuttingDown = false;
             if (saveStateRequestedDuringIndexerThreadShutdown) {
@@ -1209,9 +1212,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 if (context.shouldStopAtCheckpoint() && nextCheckpoint == null) {
                     stop();
                 }
-                doSaveState(getState(), getPosition(), next);
-            } else {
-                next.run();
+                doSaveState(getState(), getPosition(), () -> {});
             }
         }
     }


### PR DESCRIPTION
Unfortunately, PR https://github.com/elastic/elasticsearch/pull/99917 has caused some unexpected log spam.
It's better to revert it in order to make log/audit messages less confusing.

Reverts elastic/elasticsearch#99917