### PR TITLE
Fix flaky test

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/ModelSecretsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/ModelSecretsTests.java
@@ -32,7 +32,7 @@ public class ModelSecretsTests extends AbstractWireSerializingTestCase<ModelSecr
     }
 
     private static SecretSettings randomSecretSettings() {
-        return new FakeSecretSettings(randomAlphaOfLengthBetween(1, 10));
+        return new FakeSecretSettings(randomAlphaOfLengthBetween(8, 10));
     }
 
     @Override


### PR DESCRIPTION
Quick one: ModelSecretsTests testEqualsAndHashcode is too flaky: a random (fake) api-key of 1 has a too high chance of colliding (see https://gradle-enterprise.elastic.co/s/hrlw444sgiia6/tests/task/:x-pack:plugin:inference:test/details/org.elasticsearch.xpack.inference.ModelSecretsTests/testEqualsAndHashcode?top-execution=1 for a failure); besides, such a short key is irrealistic.