### PR TITLE
Make open/close index API public

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestCloseIndexAction extends BaseRestHandler {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestCloseIndexAction.class);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestOpenIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestOpenIndexAction.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestOpenIndexAction extends BaseRestHandler {
 
     @Override


### PR DESCRIPTION
Certain index settings can only be updated when an index is closed, which makes close/open index API necessary.