### PR TITLE
[8.10] ILM introduce the `check-ts-end-time-passed` step (#100179)

### DIFF
--- a/docs/changelog/100179.yaml
+++ b/docs/changelog/100179.yaml
@@ -1,0 +1,6 @@
+pr: 100179
+summary: ILM introduce the `check-ts-end-time-passed` step
+area: ILM+SLM
+type: bug
+issues:
+ - 99696

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReadOnlyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReadOnlyAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -58,10 +59,20 @@ public class ReadOnlyAction implements LifecycleAction {
     @Override
     public List<Step> toSteps(Client client, String phase, StepKey nextStepKey) {
         StepKey checkNotWriteIndex = new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME);
+        StepKey waitTimeSeriesEndTimePassesKey = new StepKey(phase, NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME);
         StepKey readOnlyKey = new StepKey(phase, NAME, NAME);
-        CheckNotDataStreamWriteIndexStep checkNotWriteIndexStep = new CheckNotDataStreamWriteIndexStep(checkNotWriteIndex, readOnlyKey);
+        CheckNotDataStreamWriteIndexStep checkNotWriteIndexStep = new CheckNotDataStreamWriteIndexStep(
+            checkNotWriteIndex,
+            waitTimeSeriesEndTimePassesKey
+        );
+        WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
+            waitTimeSeriesEndTimePassesKey,
+            readOnlyKey,
+            Instant::now,
+            client
+        );
         ReadOnlyStep readOnlyStep = new ReadOnlyStep(readOnlyKey, nextStepKey, client);
-        return Arrays.asList(checkNotWriteIndexStep, readOnlyStep);
+        return Arrays.asList(checkNotWriteIndexStep, waitUntilTimeSeriesEndTimeStep, readOnlyStep);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
@@ -23,8 +23,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.xcontent.ToXContentObject;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -271,18 +270,5 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
         }
         WaitForRolloverReadyStep other = (WaitForRolloverReadyStep) obj;
         return super.equals(obj) && Objects.equals(conditions, other.conditions);
-    }
-
-    // We currently have no information to provide for this AsyncWaitStep, so this is an empty object
-    private static final class EmptyInfo implements ToXContentObject {
-
-        static final EmptyInfo INSTANCE = new EmptyInfo();
-
-        private EmptyInfo() {}
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) {
-            return builder;
-        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
+import org.elasticsearch.xpack.core.ilm.step.info.SingleMessageFieldInfo;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+/**
+ * This {@link Step} waits until the {@link org.elasticsearch.index.IndexSettings#TIME_SERIES_END_TIME} passes for time series indices.
+ * For regular indices this step doesn't wait at all and the condition is evaluated to true immediately.
+ *
+ * Note that this step doens't execute an async/transport action and is able to evaluate its condition based on the local information
+ * available however, we want this step to be executed periodically using the `AsyncWaitStep` infrastructure.
+ * The condition will be evaluated every {@link LifecycleSettings#LIFECYCLE_POLL_INTERVAL}.
+ */
+public class WaitUntilTimeSeriesEndTimePassesStep extends AsyncWaitStep {
+
+    public static final String NAME = "check-ts-end-time-passed";
+    private final Supplier<Instant> nowSupplier;
+
+    public WaitUntilTimeSeriesEndTimePassesStep(StepKey key, StepKey nextStepKey, Supplier<Instant> nowSupplier, Client client) {
+        super(key, nextStepKey, client);
+        this.nowSupplier = nowSupplier;
+    }
+
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+
+    @Override
+    public void evaluateCondition(Metadata metadata, Index index, Listener listener, TimeValue masterTimeout) {
+        IndexMetadata indexMetadata = metadata.index(index);
+        assert indexMetadata != null
+            : "the index metadata for index [" + index.getName() + "] must exist in the cluster state for step " + "[" + NAME + "]";
+
+        if (IndexSettings.MODE.get(indexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
+            // this index is not a time series index so no need to wait
+            listener.onResponse(true, EmptyInfo.INSTANCE);
+            return;
+        }
+        Instant configuredEndTime = IndexSettings.TIME_SERIES_END_TIME.get(indexMetadata.getSettings());
+        assert configuredEndTime != null : "a time series index must have an end time configured but [" + index.getName() + "] does not";
+        if (nowSupplier.get().isBefore(configuredEndTime)) {
+            listener.onResponse(
+                false,
+                new SingleMessageFieldInfo(
+                    String.format(
+                        Locale.ROOT,
+                        "The [%s] setting for index [%s] is [%s]. Waiting until the index's time series end time lapses before"
+                            + " proceeding with action [%s] as the index can still accept writes.",
+                        IndexSettings.TIME_SERIES_END_TIME.getKey(),
+                        index.getName(),
+                        configuredEndTime.toEpochMilli(),
+                        getKey().action()
+                    )
+                )
+            );
+            return;
+        }
+
+        listener.onResponse(true, EmptyInfo.INSTANCE);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/step/info/EmptyInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/step/info/EmptyInfo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ilm.step.info;
+
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+/**
+ * An empty XContent object to indicate an ILM step is not providing any information.
+ */
+public final class EmptyInfo implements ToXContentObject {
+
+    public static final EmptyInfo INSTANCE = new EmptyInfo();
+
+    private EmptyInfo() {}
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) {
+        return builder;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
@@ -65,7 +65,7 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
         );
         List<Step> steps = action.toSteps(null, phase, nextStepKey);
         assertNotNull(steps);
-        assertEquals(14, steps.size());
+        assertEquals(15, steps.size());
 
         assertTrue(steps.get(0) instanceof BranchingStep);
         assertThat(steps.get(0).getKey().name(), equalTo(CONDITIONAL_TIME_SERIES_CHECK_KEY));
@@ -79,53 +79,57 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
 
         assertTrue(steps.get(2) instanceof WaitForNoFollowersStep);
         assertThat(steps.get(2).getKey().name(), equalTo(WaitForNoFollowersStep.NAME));
-        assertThat(steps.get(2).getNextStepKey().name(), equalTo(ReadOnlyStep.NAME));
+        assertThat(steps.get(2).getNextStepKey().name(), equalTo(WaitUntilTimeSeriesEndTimePassesStep.NAME));
 
-        assertTrue(steps.get(3) instanceof ReadOnlyStep);
-        assertThat(steps.get(3).getKey().name(), equalTo(ReadOnlyStep.NAME));
-        assertThat(steps.get(3).getNextStepKey().name(), equalTo(DownsamplePrepareLifeCycleStateStep.NAME));
+        assertTrue(steps.get(3) instanceof WaitUntilTimeSeriesEndTimePassesStep);
+        assertThat(steps.get(3).getKey().name(), equalTo(WaitUntilTimeSeriesEndTimePassesStep.NAME));
+        assertThat(steps.get(3).getNextStepKey().name(), equalTo(ReadOnlyStep.NAME));
 
-        assertTrue(steps.get(4) instanceof NoopStep);
-        assertThat(steps.get(4).getKey().name(), equalTo(CleanupTargetIndexStep.NAME));
-        assertThat(steps.get(4).getNextStepKey().name(), equalTo(DownsampleStep.NAME));
+        assertTrue(steps.get(4) instanceof ReadOnlyStep);
+        assertThat(steps.get(4).getKey().name(), equalTo(ReadOnlyStep.NAME));
+        assertThat(steps.get(4).getNextStepKey().name(), equalTo(DownsamplePrepareLifeCycleStateStep.NAME));
 
-        assertTrue(steps.get(5) instanceof DownsamplePrepareLifeCycleStateStep);
-        assertThat(steps.get(5).getKey().name(), equalTo(DownsamplePrepareLifeCycleStateStep.NAME));
+        assertTrue(steps.get(5) instanceof NoopStep);
+        assertThat(steps.get(5).getKey().name(), equalTo(CleanupTargetIndexStep.NAME));
         assertThat(steps.get(5).getNextStepKey().name(), equalTo(DownsampleStep.NAME));
 
-        assertTrue(steps.get(6) instanceof DownsampleStep);
-        assertThat(steps.get(6).getKey().name(), equalTo(DownsampleStep.NAME));
-        assertThat(steps.get(6).getNextStepKey().name(), equalTo(WaitForIndexColorStep.NAME));
+        assertTrue(steps.get(6) instanceof DownsamplePrepareLifeCycleStateStep);
+        assertThat(steps.get(6).getKey().name(), equalTo(DownsamplePrepareLifeCycleStateStep.NAME));
+        assertThat(steps.get(6).getNextStepKey().name(), equalTo(DownsampleStep.NAME));
 
-        assertTrue(steps.get(7) instanceof ClusterStateWaitUntilThresholdStep);
-        assertThat(steps.get(7).getKey().name(), equalTo(WaitForIndexColorStep.NAME));
-        assertThat(steps.get(7).getNextStepKey().name(), equalTo(CopyExecutionStateStep.NAME));
+        assertTrue(steps.get(7) instanceof DownsampleStep);
+        assertThat(steps.get(7).getKey().name(), equalTo(DownsampleStep.NAME));
+        assertThat(steps.get(7).getNextStepKey().name(), equalTo(WaitForIndexColorStep.NAME));
 
-        assertTrue(steps.get(8) instanceof CopyExecutionStateStep);
-        assertThat(steps.get(8).getKey().name(), equalTo(CopyExecutionStateStep.NAME));
-        assertThat(steps.get(8).getNextStepKey().name(), equalTo(CopySettingsStep.NAME));
+        assertTrue(steps.get(8) instanceof ClusterStateWaitUntilThresholdStep);
+        assertThat(steps.get(8).getKey().name(), equalTo(WaitForIndexColorStep.NAME));
+        assertThat(steps.get(8).getNextStepKey().name(), equalTo(CopyExecutionStateStep.NAME));
 
-        assertTrue(steps.get(9) instanceof CopySettingsStep);
-        assertThat(steps.get(9).getKey().name(), equalTo(CopySettingsStep.NAME));
-        assertThat(steps.get(9).getNextStepKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
+        assertTrue(steps.get(9) instanceof CopyExecutionStateStep);
+        assertThat(steps.get(9).getKey().name(), equalTo(CopyExecutionStateStep.NAME));
+        assertThat(steps.get(9).getNextStepKey().name(), equalTo(CopySettingsStep.NAME));
 
-        assertTrue(steps.get(10) instanceof BranchingStep);
-        assertThat(steps.get(10).getKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
-        expectThrows(IllegalStateException.class, () -> steps.get(10).getNextStepKey());
-        assertThat(((BranchingStep) steps.get(10)).getNextStepKeyOnFalse().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
-        assertThat(((BranchingStep) steps.get(10)).getNextStepKeyOnTrue().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
+        assertTrue(steps.get(10) instanceof CopySettingsStep);
+        assertThat(steps.get(10).getKey().name(), equalTo(CopySettingsStep.NAME));
+        assertThat(steps.get(10).getNextStepKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
 
-        assertTrue(steps.get(11) instanceof ReplaceDataStreamBackingIndexStep);
-        assertThat(steps.get(11).getKey().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
-        assertThat(steps.get(11).getNextStepKey().name(), equalTo(DeleteStep.NAME));
+        assertTrue(steps.get(11) instanceof BranchingStep);
+        assertThat(steps.get(11).getKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
+        expectThrows(IllegalStateException.class, () -> steps.get(11).getNextStepKey());
+        assertThat(((BranchingStep) steps.get(11)).getNextStepKeyOnFalse().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertThat(((BranchingStep) steps.get(11)).getNextStepKeyOnTrue().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
 
-        assertTrue(steps.get(12) instanceof DeleteStep);
-        assertThat(steps.get(12).getKey().name(), equalTo(DeleteStep.NAME));
-        assertThat(steps.get(12).getNextStepKey(), equalTo(nextStepKey));
+        assertTrue(steps.get(12) instanceof ReplaceDataStreamBackingIndexStep);
+        assertThat(steps.get(12).getKey().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
+        assertThat(steps.get(12).getNextStepKey().name(), equalTo(DeleteStep.NAME));
 
-        assertTrue(steps.get(13) instanceof SwapAliasesAndDeleteSourceIndexStep);
-        assertThat(steps.get(13).getKey().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertTrue(steps.get(13) instanceof DeleteStep);
+        assertThat(steps.get(13).getKey().name(), equalTo(DeleteStep.NAME));
         assertThat(steps.get(13).getNextStepKey(), equalTo(nextStepKey));
+
+        assertTrue(steps.get(14) instanceof SwapAliasesAndDeleteSourceIndexStep);
+        assertThat(steps.get(14).getKey().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertThat(steps.get(14).getNextStepKey(), equalTo(nextStepKey));
     }
 
     public void testEqualsAndHashCode() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -272,6 +272,7 @@ public class PhaseCacheManagementTests extends ESTestCase {
                 new Step.StepKey("phase", "allocate", AllocationRoutedStep.NAME),
                 new Step.StepKey("phase", "forcemerge", ForceMergeAction.CONDITIONAL_SKIP_FORCE_MERGE_STEP),
                 new Step.StepKey("phase", "forcemerge", CheckNotDataStreamWriteIndexStep.NAME),
+                new Step.StepKey("phase", "forcemerge", WaitUntilTimeSeriesEndTimePassesStep.NAME),
                 // This read-only key is now a noop step but we preserved it for backwards compatibility
                 new Step.StepKey("phase", "forcemerge", ReadOnlyAction.NAME),
                 new Step.StepKey("phase", "forcemerge", ForceMergeAction.NAME),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReadOnlyActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReadOnlyActionTests.java
@@ -46,17 +46,22 @@ public class ReadOnlyActionTests extends AbstractActionTestCase<ReadOnlyAction> 
         );
         List<Step> steps = action.toSteps(null, phase, nextStepKey);
         assertNotNull(steps);
-        assertEquals(2, steps.size());
+        assertEquals(3, steps.size());
         StepKey expectedFirstStepKey = new StepKey(phase, ReadOnlyAction.NAME, CheckNotDataStreamWriteIndexStep.NAME);
-        StepKey expectedSecondStepKey = new StepKey(phase, ReadOnlyAction.NAME, ReadOnlyAction.NAME);
+        StepKey expectedSecondStepKey = new StepKey(phase, ReadOnlyAction.NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME);
+        StepKey expectedThirdStepKey = new StepKey(phase, ReadOnlyAction.NAME, ReadOnlyAction.NAME);
         CheckNotDataStreamWriteIndexStep firstStep = (CheckNotDataStreamWriteIndexStep) steps.get(0);
-        ReadOnlyStep secondStep = (ReadOnlyStep) steps.get(1);
+        WaitUntilTimeSeriesEndTimePassesStep secondStep = (WaitUntilTimeSeriesEndTimePassesStep) steps.get(1);
+        ReadOnlyStep thirdStep = (ReadOnlyStep) steps.get(2);
 
         assertThat(firstStep.getKey(), equalTo(expectedFirstStepKey));
         assertThat(firstStep.getNextStepKey(), equalTo(expectedSecondStepKey));
 
         assertThat(secondStep.getKey(), equalTo(expectedSecondStepKey));
-        assertThat(secondStep.getNextStepKey(), equalTo(nextStepKey));
+        assertThat(secondStep.getNextStepKey(), equalTo(expectedThirdStepKey));
+
+        assertThat(thirdStep.getKey(), equalTo(expectedThirdStepKey));
+        assertThat(thirdStep.getNextStepKey(), equalTo(nextStepKey));
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -28,7 +28,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         StepKey nextStepKey = new StepKey(phase, randomAlphaOfLengthBetween(1, 5), randomAlphaOfLengthBetween(1, 5));
 
         List<Step> steps = action.toSteps(null, phase, nextStepKey, null);
-        assertThat(steps.size(), is(action.isForceMergeIndex() ? 18 : 16));
+        assertThat(steps.size(), is(action.isForceMergeIndex() ? 19 : 17));
 
         List<StepKey> expectedSteps = action.isForceMergeIndex()
             ? expectedStepKeysWithForceMerge(phase)
@@ -54,13 +54,13 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         if (action.isForceMergeIndex()) {
             assertThat(steps.get(16).getKey(), is(expectedSteps.get(16)));
             assertThat(steps.get(17).getKey(), is(expectedSteps.get(17)));
-            CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(8);
-            assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(7)));
-            validateWaitForDataTierStep(phase, steps, 9, 10);
+            CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(9);
+            assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(8)));
+            validateWaitForDataTierStep(phase, steps, 10, 11);
         } else {
-            CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(6);
-            assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(5)));
-            validateWaitForDataTierStep(phase, steps, 7, 8);
+            CreateSnapshotStep createSnapshotStep = (CreateSnapshotStep) steps.get(7);
+            assertThat(createSnapshotStep.getNextKeyOnIncomplete(), is(expectedSteps.get(6)));
+            validateWaitForDataTierStep(phase, steps, 8, 9);
         }
     }
 
@@ -102,6 +102,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
             new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
             new StepKey(phase, NAME, WaitForNoFollowersStep.NAME),
+            new StepKey(phase, NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME),
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_GENERATE_AND_CLEAN),
             new StepKey(phase, NAME, ForceMergeStep.NAME),
             new StepKey(phase, NAME, SegmentCountStep.NAME),
@@ -125,6 +126,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_ACTION_STEP),
             new StepKey(phase, NAME, CheckNotDataStreamWriteIndexStep.NAME),
             new StepKey(phase, NAME, WaitForNoFollowersStep.NAME),
+            new StepKey(phase, NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME),
             new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_SKIP_GENERATE_AND_CLEAN),
             new StepKey(phase, NAME, GenerateSnapshotNameStep.NAME),
             new StepKey(phase, NAME, CleanupSnapshotStep.NAME),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
@@ -262,24 +262,25 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
             randomAlphaOfLengthBetween(1, 10)
         );
         List<Step> steps = action.toSteps(client, phase, nextStepKey);
-        assertThat(steps.size(), equalTo(17));
+        assertThat(steps.size(), equalTo(18));
         StepKey expectedFirstKey = new StepKey(phase, ShrinkAction.NAME, ShrinkAction.CONDITIONAL_SKIP_SHRINK_STEP);
         StepKey expectedSecondKey = new StepKey(phase, ShrinkAction.NAME, CheckNotDataStreamWriteIndexStep.NAME);
         StepKey expectedThirdKey = new StepKey(phase, ShrinkAction.NAME, WaitForNoFollowersStep.NAME);
-        StepKey expectedFourthKey = new StepKey(phase, ShrinkAction.NAME, ReadOnlyAction.NAME);
-        StepKey expectedFifthKey = new StepKey(phase, ShrinkAction.NAME, CheckTargetShardsCountStep.NAME);
-        StepKey expectedSixthKey = new StepKey(phase, ShrinkAction.NAME, CleanupShrinkIndexStep.NAME);
-        StepKey expectedSeventhKey = new StepKey(phase, ShrinkAction.NAME, GenerateUniqueIndexNameStep.NAME);
-        StepKey expectedEighthKey = new StepKey(phase, ShrinkAction.NAME, SetSingleNodeAllocateStep.NAME);
-        StepKey expectedNinthKey = new StepKey(phase, ShrinkAction.NAME, CheckShrinkReadyStep.NAME);
-        StepKey expectedTenthKey = new StepKey(phase, ShrinkAction.NAME, ShrinkStep.NAME);
-        StepKey expectedEleventhKey = new StepKey(phase, ShrinkAction.NAME, ShrunkShardsAllocatedStep.NAME);
-        StepKey expectedTwelveKey = new StepKey(phase, ShrinkAction.NAME, CopyExecutionStateStep.NAME);
-        StepKey expectedThirteenKey = new StepKey(phase, ShrinkAction.NAME, ShrinkAction.CONDITIONAL_DATASTREAM_CHECK_KEY);
-        StepKey expectedFourteenKey = new StepKey(phase, ShrinkAction.NAME, ShrinkSetAliasStep.NAME);
-        StepKey expectedFifteenKey = new StepKey(phase, ShrinkAction.NAME, ShrunkenIndexCheckStep.NAME);
-        StepKey expectedSixteenKey = new StepKey(phase, ShrinkAction.NAME, ReplaceDataStreamBackingIndexStep.NAME);
-        StepKey expectedSeventeenKey = new StepKey(phase, ShrinkAction.NAME, DeleteStep.NAME);
+        StepKey expectedFourthKey = new StepKey(phase, ShrinkAction.NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME);
+        StepKey expectedFifthKey = new StepKey(phase, ShrinkAction.NAME, ReadOnlyAction.NAME);
+        StepKey expectedSixthKey = new StepKey(phase, ShrinkAction.NAME, CheckTargetShardsCountStep.NAME);
+        StepKey expectedSeventhKey = new StepKey(phase, ShrinkAction.NAME, CleanupShrinkIndexStep.NAME);
+        StepKey expectedEighthKey = new StepKey(phase, ShrinkAction.NAME, GenerateUniqueIndexNameStep.NAME);
+        StepKey expectedNinthKey = new StepKey(phase, ShrinkAction.NAME, SetSingleNodeAllocateStep.NAME);
+        StepKey expectedTenthKey = new StepKey(phase, ShrinkAction.NAME, CheckShrinkReadyStep.NAME);
+        StepKey expectedEleventhKey = new StepKey(phase, ShrinkAction.NAME, ShrinkStep.NAME);
+        StepKey expectedTwelveKey = new StepKey(phase, ShrinkAction.NAME, ShrunkShardsAllocatedStep.NAME);
+        StepKey expectedThirteenKey = new StepKey(phase, ShrinkAction.NAME, CopyExecutionStateStep.NAME);
+        StepKey expectedFourteenKey = new StepKey(phase, ShrinkAction.NAME, ShrinkAction.CONDITIONAL_DATASTREAM_CHECK_KEY);
+        StepKey expectedFifteenKey = new StepKey(phase, ShrinkAction.NAME, ShrinkSetAliasStep.NAME);
+        StepKey expectedSixteenKey = new StepKey(phase, ShrinkAction.NAME, ShrunkenIndexCheckStep.NAME);
+        StepKey expectedSeventeenKey = new StepKey(phase, ShrinkAction.NAME, ReplaceDataStreamBackingIndexStep.NAME);
+        StepKey expectedEighteenKey = new StepKey(phase, ShrinkAction.NAME, DeleteStep.NAME);
 
         assertTrue(steps.get(0) instanceof AsyncBranchingStep);
         assertThat(steps.get(0).getKey(), equalTo(expectedFirstKey));
@@ -295,72 +296,76 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
         assertThat(steps.get(2).getKey(), equalTo(expectedThirdKey));
         assertThat(steps.get(2).getNextStepKey(), equalTo(expectedFourthKey));
 
-        assertTrue(steps.get(3) instanceof ReadOnlyStep);
+        assertTrue(steps.get(3) instanceof WaitUntilTimeSeriesEndTimePassesStep);
         assertThat(steps.get(3).getKey(), equalTo(expectedFourthKey));
         assertThat(steps.get(3).getNextStepKey(), equalTo(expectedFifthKey));
 
-        assertTrue(steps.get(4) instanceof CheckTargetShardsCountStep);
+        assertTrue(steps.get(4) instanceof ReadOnlyStep);
         assertThat(steps.get(4).getKey(), equalTo(expectedFifthKey));
         assertThat(steps.get(4).getNextStepKey(), equalTo(expectedSixthKey));
 
-        assertTrue(steps.get(5) instanceof CleanupShrinkIndexStep);
+        assertTrue(steps.get(5) instanceof CheckTargetShardsCountStep);
         assertThat(steps.get(5).getKey(), equalTo(expectedSixthKey));
         assertThat(steps.get(5).getNextStepKey(), equalTo(expectedSeventhKey));
 
-        assertTrue(steps.get(6) instanceof GenerateUniqueIndexNameStep);
+        assertTrue(steps.get(6) instanceof CleanupShrinkIndexStep);
         assertThat(steps.get(6).getKey(), equalTo(expectedSeventhKey));
         assertThat(steps.get(6).getNextStepKey(), equalTo(expectedEighthKey));
 
-        assertTrue(steps.get(7) instanceof SetSingleNodeAllocateStep);
+        assertTrue(steps.get(7) instanceof GenerateUniqueIndexNameStep);
         assertThat(steps.get(7).getKey(), equalTo(expectedEighthKey));
         assertThat(steps.get(7).getNextStepKey(), equalTo(expectedNinthKey));
 
-        assertTrue(steps.get(8) instanceof ClusterStateWaitUntilThresholdStep);
-        assertThat(((ClusterStateWaitUntilThresholdStep) steps.get(8)).getStepToExecute(), is(instanceOf(CheckShrinkReadyStep.class)));
-        // assert in case the threshold is breached we go back to the "cleanup shrunk index" step
-        assertThat(((ClusterStateWaitUntilThresholdStep) steps.get(8)).getNextKeyOnThreshold(), is(expectedEighthKey));
+        assertTrue(steps.get(8) instanceof SetSingleNodeAllocateStep);
         assertThat(steps.get(8).getKey(), equalTo(expectedNinthKey));
         assertThat(steps.get(8).getNextStepKey(), equalTo(expectedTenthKey));
 
-        assertTrue(steps.get(9) instanceof ShrinkStep);
+        assertTrue(steps.get(9) instanceof ClusterStateWaitUntilThresholdStep);
+        assertThat(((ClusterStateWaitUntilThresholdStep) steps.get(9)).getStepToExecute(), is(instanceOf(CheckShrinkReadyStep.class)));
+        // assert in case the threshold is breached we go back to the "cleanup shrunk index" step
+        assertThat(((ClusterStateWaitUntilThresholdStep) steps.get(9)).getNextKeyOnThreshold(), is(expectedNinthKey));
         assertThat(steps.get(9).getKey(), equalTo(expectedTenthKey));
         assertThat(steps.get(9).getNextStepKey(), equalTo(expectedEleventhKey));
 
-        assertTrue(steps.get(10) instanceof ClusterStateWaitUntilThresholdStep);
+        assertTrue(steps.get(10) instanceof ShrinkStep);
         assertThat(steps.get(10).getKey(), equalTo(expectedEleventhKey));
         assertThat(steps.get(10).getNextStepKey(), equalTo(expectedTwelveKey));
+
+        assertTrue(steps.get(11) instanceof ClusterStateWaitUntilThresholdStep);
+        assertThat(steps.get(11).getKey(), equalTo(expectedTwelveKey));
+        assertThat(steps.get(11).getNextStepKey(), equalTo(expectedThirteenKey));
         assertThat(
-            ((ClusterStateWaitUntilThresholdStep) steps.get(10)).getStepToExecute(),
+            ((ClusterStateWaitUntilThresholdStep) steps.get(11)).getStepToExecute(),
             is(instanceOf(ShrunkShardsAllocatedStep.class))
         );
         // assert in case the threshold is breached we go back to the "cleanup shrunk index" step
-        assertThat(((ClusterStateWaitUntilThresholdStep) steps.get(10)).getNextKeyOnThreshold(), is(expectedSixthKey));
+        assertThat(((ClusterStateWaitUntilThresholdStep) steps.get(11)).getNextKeyOnThreshold(), is(expectedSeventhKey));
 
-        assertTrue(steps.get(11) instanceof CopyExecutionStateStep);
-        assertThat(steps.get(11).getKey(), equalTo(expectedTwelveKey));
-        assertThat(steps.get(11).getNextStepKey(), equalTo(expectedThirteenKey));
-
-        assertTrue(steps.get(12) instanceof BranchingStep);
+        assertTrue(steps.get(12) instanceof CopyExecutionStateStep);
         assertThat(steps.get(12).getKey(), equalTo(expectedThirteenKey));
-        expectThrows(IllegalStateException.class, () -> steps.get(12).getNextStepKey());
-        assertThat(((BranchingStep) steps.get(12)).getNextStepKeyOnFalse(), equalTo(expectedFourteenKey));
-        assertThat(((BranchingStep) steps.get(12)).getNextStepKeyOnTrue(), equalTo(expectedSixteenKey));
+        assertThat(steps.get(12).getNextStepKey(), equalTo(expectedFourteenKey));
 
-        assertTrue(steps.get(13) instanceof ShrinkSetAliasStep);
+        assertTrue(steps.get(13) instanceof BranchingStep);
         assertThat(steps.get(13).getKey(), equalTo(expectedFourteenKey));
-        assertThat(steps.get(13).getNextStepKey(), equalTo(expectedFifteenKey));
+        expectThrows(IllegalStateException.class, () -> steps.get(13).getNextStepKey());
+        assertThat(((BranchingStep) steps.get(13)).getNextStepKeyOnFalse(), equalTo(expectedFifteenKey));
+        assertThat(((BranchingStep) steps.get(13)).getNextStepKeyOnTrue(), equalTo(expectedSeventeenKey));
 
-        assertTrue(steps.get(14) instanceof ShrunkenIndexCheckStep);
+        assertTrue(steps.get(14) instanceof ShrinkSetAliasStep);
         assertThat(steps.get(14).getKey(), equalTo(expectedFifteenKey));
-        assertThat(steps.get(14).getNextStepKey(), equalTo(nextStepKey));
+        assertThat(steps.get(14).getNextStepKey(), equalTo(expectedSixteenKey));
 
-        assertTrue(steps.get(15) instanceof ReplaceDataStreamBackingIndexStep);
+        assertTrue(steps.get(15) instanceof ShrunkenIndexCheckStep);
         assertThat(steps.get(15).getKey(), equalTo(expectedSixteenKey));
-        assertThat(steps.get(15).getNextStepKey(), equalTo(expectedSeventeenKey));
+        assertThat(steps.get(15).getNextStepKey(), equalTo(nextStepKey));
 
-        assertTrue(steps.get(16) instanceof DeleteStep);
+        assertTrue(steps.get(16) instanceof ReplaceDataStreamBackingIndexStep);
         assertThat(steps.get(16).getKey(), equalTo(expectedSeventeenKey));
-        assertThat(steps.get(16).getNextStepKey(), equalTo(expectedFifteenKey));
+        assertThat(steps.get(16).getNextStepKey(), equalTo(expectedEighteenKey));
+
+        assertTrue(steps.get(17) instanceof DeleteStep);
+        assertThat(steps.get(17).getKey(), equalTo(expectedEighteenKey));
+        assertThat(steps.get(17).getNextStepKey(), equalTo(expectedSixteenKey));
     }
 
     private void setUpIndicesStatsRequestMock(String index, boolean withError) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStepTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ilm;
+
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.xcontent.ToXContentObject;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestCase<WaitUntilTimeSeriesEndTimePassesStep> {
+
+    @Override
+    protected WaitUntilTimeSeriesEndTimePassesStep createRandomInstance() {
+        Step.StepKey stepKey = randomStepKey();
+        Step.StepKey nextStepKey = randomStepKey();
+        return new WaitUntilTimeSeriesEndTimePassesStep(stepKey, nextStepKey, Instant::now, client);
+    }
+
+    @Override
+    protected WaitUntilTimeSeriesEndTimePassesStep mutateInstance(WaitUntilTimeSeriesEndTimePassesStep instance) {
+        Step.StepKey key = instance.getKey();
+        Step.StepKey nextKey = instance.getNextStepKey();
+
+        switch (between(0, 1)) {
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
+        }
+        return new WaitUntilTimeSeriesEndTimePassesStep(key, nextKey, Instant::now, client);
+    }
+
+    @Override
+    protected WaitUntilTimeSeriesEndTimePassesStep copyInstance(WaitUntilTimeSeriesEndTimePassesStep instance) {
+        return new WaitUntilTimeSeriesEndTimePassesStep(instance.getKey(), instance.getNextStepKey(), Instant::now, client);
+    }
+
+    public void testEvaluateCondition() {
+        Instant currentTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        // These ranges are on the edge of each other temporal boundaries.
+        Instant start1 = currentTime.minus(6, ChronoUnit.HOURS);
+        Instant end1 = currentTime.minus(2, ChronoUnit.HOURS);
+        Instant start2 = currentTime.minus(2, ChronoUnit.HOURS);
+        Instant end2 = currentTime.plus(2, ChronoUnit.HOURS);
+
+        String dataStreamName = "logs_my-app_prod";
+        var clusterState = DataStreamTestHelper.getClusterStateWithDataStream(
+            dataStreamName,
+            List.of(Tuple.tuple(start1, end1), Tuple.tuple(start2, end2))
+        );
+        DataStream dataStream = clusterState.getMetadata().dataStreams().get(dataStreamName);
+
+        WaitUntilTimeSeriesEndTimePassesStep step = new WaitUntilTimeSeriesEndTimePassesStep(
+            randomStepKey(),
+            randomStepKey(),
+            () -> currentTime,
+            client
+        );
+        {
+            // end_time has lapsed already so condition must be met
+            Index previousGeneration = dataStream.getIndices().get(0);
+
+            step.evaluateCondition(clusterState.metadata(), previousGeneration, new AsyncWaitStep.Listener() {
+
+                @Override
+                public void onResponse(boolean complete, ToXContentObject infomationContext) {
+                    assertThat(complete, is(true));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError("Unexpected method call", e);
+                }
+            }, MASTER_TIMEOUT);
+        }
+
+        {
+            // end_time is in the future
+            Index writeIndex = dataStream.getIndices().get(1);
+
+            step.evaluateCondition(clusterState.metadata(), writeIndex, new AsyncWaitStep.Listener() {
+
+                @Override
+                public void onResponse(boolean complete, ToXContentObject infomationContext) {
+                    assertThat(complete, is(false));
+                    String information = Strings.toString(infomationContext);
+                    assertThat(
+                        information,
+                        containsString(
+                            "The [index.time_series.end_time] setting for index ["
+                                + writeIndex.getName()
+                                + "] is ["
+                                + end2.toEpochMilli()
+                                + "]. Waiting until the index's time series end time lapses before proceeding with action ["
+                                + step.getKey().action()
+                                + "] as the index can still accept writes."
+                        )
+                    );
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError("Unexpected method call", e);
+                }
+            }, MASTER_TIMEOUT);
+        }
+
+        {
+            // regular indices (non-ts) meet the step condition
+            IndexMetadata indexMeta = IndexMetadata.builder(randomAlphaOfLengthBetween(10, 30))
+                .settings(
+                    Settings.builder()
+                        .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                        .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
+                        .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersion.current())
+                        .build()
+                )
+                .build();
+
+            Metadata newMetadata = Metadata.builder(clusterState.metadata()).put(indexMeta, true).build();
+            step.evaluateCondition(newMetadata, indexMeta.getIndex(), new AsyncWaitStep.Listener() {
+
+                @Override
+                public void onResponse(boolean complete, ToXContentObject infomationContext) {
+                    assertThat(complete, is(true));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError("Unexpected method call", e);
+                }
+            }, MASTER_TIMEOUT);
+        }
+    }
+}

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -105,7 +105,7 @@ public class ILMDownsampleDisruptionIT extends ESIntegTestCase {
                 IndexSettings.TIME_SERIES_START_TIME.getKey(),
                 DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(Instant.ofEpochMilli(startTime).toEpochMilli())
             )
-            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2106-01-08T23:40:53.384Z");
+            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2022-01-08T23:40:53.384Z");
 
         if (randomBoolean()) {
             settings.put(IndexMetadata.SETTING_INDEX_HIDDEN, randomBoolean());
@@ -147,7 +147,7 @@ public class ILMDownsampleDisruptionIT extends ESIntegTestCase {
             ensureGreen();
 
             final String sourceIndex = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-            long startTime = LocalDateTime.parse("2020-09-09T18:00:00").atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+            long startTime = LocalDateTime.parse("1993-09-09T18:00:00").atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
             setup(sourceIndex, 1, 0, startTime);
             final DownsampleConfig config = new DownsampleConfig(randomInterval());
             final SourceSupplier sourceSupplier = () -> {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.WaitUntilTimeSeriesEndTimePassesStep;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.junit.Before;
 
@@ -47,13 +48,16 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createIndexWithSettings;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.getBackingIndices;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getOnlyIndexSettings;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.index;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.rolloverMaxOneDocCondition;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.updatePolicy;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class DownsampleActionIT extends ESRestTestCase {
 
@@ -70,7 +74,44 @@ public class DownsampleActionIT extends ESRestTestCase {
                     "index": {
                         "number_of_replicas": 0,
                         "number_of_shards": 1,
-                        "mode": "time_series"
+                        "time_series": {
+                          "start_time": "%s",
+                          "end_time": "%s"
+                        },
+                        "routing_path": ["metricset"],
+                        "mode": "time_series",
+                        "lifecycle.name": "%s"
+                    }
+                },
+                "mappings":{
+                    "properties": {
+                        "@timestamp" : {
+                            "type": "date"
+                        },
+                        "metricset": {
+                            "type": "keyword",
+                            "time_series_dimension": true
+                        },
+                        "volume": {
+                            "type": "double",
+                            "time_series_metric": "gauge"
+                        }
+                    }
+                }
+            },
+            "data_stream": { }
+        }""";
+
+    private static final String TEMPLATE_NO_TIME_BOUNDARIES = """
+        {
+            "index_patterns": ["%s*"],
+            "template": {
+                "settings":{
+                    "index": {
+                        "number_of_replicas": 0,
+                        "number_of_shards": 1,
+                        "mode": "time_series",
+                        "routing_path": ["metricset"]
                     },
                     "index.lifecycle.name": "%s"
                 },
@@ -125,7 +166,7 @@ public class DownsampleActionIT extends ESRestTestCase {
             settings.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
                 .putList(IndexMetadata.INDEX_ROUTING_PATH.getKey(), List.of("metricset"))
                 .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2006-01-08T23:40:53.384Z")
-                .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2106-01-08T23:40:53.384Z");
+                .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2021-01-08T23:40:53.384Z");
         }
 
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -267,11 +308,12 @@ public class DownsampleActionIT extends ESRestTestCase {
 
         // Create a template
         Request createIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
-        createIndexTemplateRequest.setJsonEntity(Strings.format(TEMPLATE, dataStream, policy));
+        createIndexTemplateRequest.setJsonEntity(
+            Strings.format(TEMPLATE, dataStream, "2006-01-08T23:40:53.384Z", "2021-01-08T23:40:53.384Z", policy)
+        );
         assertOK(client().performRequest(createIndexTemplateRequest));
 
-        String now = DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(Instant.now());
-        index(client(), dataStream, true, null, "@timestamp", now, "volume", 11.0, "metricset", randomAlphaOfLength(5));
+        index(client(), dataStream, true, null, "@timestamp", "2020-01-01T05:10:00Z", "volume", 11.0, "metricset", randomAlphaOfLength(5));
 
         String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1);
         assertBusy(
@@ -283,6 +325,12 @@ public class DownsampleActionIT extends ESRestTestCase {
             30,
             TimeUnit.SECONDS
         );
+
+        // before we rollover, update template to not contain time boundaries anymore (rollover is blocked otherwise due to index time
+        // boundaries overlapping after rollover)
+        Request updateIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
+        updateIndexTemplateRequest.setJsonEntity(Strings.format(TEMPLATE_NO_TIME_BOUNDARIES, dataStream, policy));
+        assertOK(client().performRequest(updateIndexTemplateRequest));
 
         // Manual rollover the original index such that it's not the write index in the data stream anymore
         rolloverMaxOneDocCondition(client(), dataStream);
@@ -297,6 +345,49 @@ public class DownsampleActionIT extends ESRestTestCase {
             assertEquals(policy, settings.get(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
             assertEquals(DownsampleTaskStatus.SUCCESS.toString(), settings.get(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.getKey()));
         });
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testILMWaitsForTimeSeriesEndTimeToLapse() throws Exception {
+        // Create the ILM policy
+        DateHistogramInterval fixedInterval = ConfigTestHelpers.randomInterval();
+        createNewSingletonPolicy(client(), policy, "warm", new DownsampleAction(fixedInterval, DownsampleAction.DEFAULT_WAIT_TIMEOUT));
+
+        // Create a template
+        Request createIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
+        createIndexTemplateRequest.setJsonEntity(Strings.format(TEMPLATE_NO_TIME_BOUNDARIES, dataStream, policy));
+        assertOK(client().performRequest(createIndexTemplateRequest));
+
+        String now = DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(Instant.now());
+        index(client(), dataStream, true, null, "@timestamp", now, "volume", 11.0, "metricset", randomAlphaOfLength(5));
+
+        String backingIndexName = getBackingIndices(client(), dataStream).get(0);
+        assertBusy(
+            () -> assertThat(
+                "index must wait in the " + CheckNotDataStreamWriteIndexStep.NAME + " until it is not the write index anymore",
+                explainIndex(client(), backingIndexName).get("step"),
+                is(CheckNotDataStreamWriteIndexStep.NAME)
+            ),
+            30,
+            TimeUnit.SECONDS
+        );
+
+        // Manual rollover the original index such that it's not the write index in the data stream anymore
+        rolloverMaxOneDocCondition(client(), dataStream);
+
+        assertBusy(() -> {
+            assertThat(
+                "index must wait in the " + WaitUntilTimeSeriesEndTimePassesStep.NAME + " until its end time lapses",
+                explainIndex(client(), backingIndexName).get("step"),
+                is(WaitUntilTimeSeriesEndTimePassesStep.NAME)
+            );
+
+            assertThat(explainIndex(client(), backingIndexName).get("step_info"), is(notNullValue()));
+            assertThat(
+                (String) ((Map<String, Object>) explainIndex(client(), backingIndexName).get("step_info")).get("message"),
+                containsString("Waiting until the index's time series end time lapses")
+            );
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testRollupNonTSIndex() throws Exception {
@@ -343,11 +434,12 @@ public class DownsampleActionIT extends ESRestTestCase {
 
         // Create a template
         Request createIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
-        createIndexTemplateRequest.setJsonEntity(Strings.format(TEMPLATE, dataStream, policy));
+        createIndexTemplateRequest.setJsonEntity(
+            Strings.format(TEMPLATE, dataStream, "2006-01-08T23:40:53.384Z", "2021-01-08T23:40:53.384Z", policy)
+        );
         assertOK(client().performRequest(createIndexTemplateRequest));
 
-        String now = DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(Instant.now());
-        index(client(), dataStream, true, null, "@timestamp", now, "volume", 11.0, "metricset", randomAlphaOfLength(5));
+        index(client(), dataStream, true, null, "@timestamp", "2020-01-01T05:10:00Z", "volume", 11.0, "metricset", randomAlphaOfLength(5));
 
         String firstBackingIndex = DataStream.getDefaultBackingIndexName(dataStream, 1);
         logger.info("--> firstBackingIndex: {}", firstBackingIndex);
@@ -360,6 +452,12 @@ public class DownsampleActionIT extends ESRestTestCase {
             30,
             TimeUnit.SECONDS
         );
+
+        // before we rollover, update template to not contain time boundaries anymore (rollover is blocked otherwise due to index time
+        // boundaries overlapping after rollover)
+        Request updateIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
+        updateIndexTemplateRequest.setJsonEntity(Strings.format(TEMPLATE_NO_TIME_BOUNDARIES, dataStream, policy));
+        assertOK(client().performRequest(updateIndexTemplateRequest));
 
         // Manual rollover the original index such that it's not the write index in the data stream anymore
         rolloverMaxOneDocCondition(client(), dataStream);


### PR DESCRIPTION
This introduces a new ILM step, the `check-ts-end-time-passed` step that'll wait for the `index.time_series.end_time` to lapse for TS indices before allowing ILM to proceed with the execution of the following actions: * downsample * forcemerge * readonly * searchable_snapshot * shrink

TSDS indices are allowed to receive writes until the configured `index.time_series.end_time` time passes. This makes sure ILM doesn't block these indices from accepting writes prematurely.

NOTE: documentation is added in a subsequent PR

Fixes #99696

(cherry picked from commit 8bf8fc174f1518915a3302190af1b7dfdf187004)

Backport of #100179