### PR TITLE
Revert back to using docker compose v1 CLI for test fixtures

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -123,6 +123,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
             composeExtension.getRemoveContainers().set(true);
             composeExtension.getCaptureContainersOutput()
                 .set(EnumSet.of(LogLevel.INFO, LogLevel.DEBUG).contains(project.getGradle().getStartParameter().getLogLevel()));
+            composeExtension.getUseDockerComposeV2().set(false);
             composeExtension.getExecutable().set(this.providerFactory.provider(() -> {
                 String composePath = dockerSupport.get().getDockerAvailability().dockerComposePath();
                 LOGGER.debug("Docker Compose path: {}", composePath);


### PR DESCRIPTION
#100059 changed the default here. We've started seeing errors in CI starting certain test fixtures. For now let's go back to the previous behavior of using the V1 CLI and see if that changes things.