### PR TITLE
Handle all keys null in BlockHash

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
-import org.elasticsearch.compute.data.ConstantIntVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
@@ -42,7 +41,7 @@ final class BooleanBlockHash extends BlockHash {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             everSeen[NULL_ORD] = true;
-            try (IntVector groupIds = new ConstantIntVector(0, block.getPositionCount(), blockFactory)) {
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
                 addInput.add(0, groupIds);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -20,7 +20,6 @@ import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.ConstantIntVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
@@ -58,7 +57,7 @@ final class BytesRefBlockHash extends BlockHash {
         Block block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;
-            try (IntVector groupIds = new ConstantIntVector(0, block.getPositionCount(), blockFactory)) {
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
                 addInput.add(0, groupIds);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.ConstantIntVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.IntBlock;
@@ -52,7 +51,7 @@ final class DoubleBlockHash extends BlockHash {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;
-            try (IntVector groupIds = new ConstantIntVector(0, block.getPositionCount(), blockFactory)) {
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
                 addInput.add(0, groupIds);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.ConstantIntVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
@@ -49,7 +48,7 @@ final class IntBlockHash extends BlockHash {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;
-            try (IntVector groupIds = new ConstantIntVector(0, block.getPositionCount(), blockFactory)) {
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
                 addInput.add(0, groupIds);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.ConstantIntVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
@@ -52,7 +51,7 @@ final class LongBlockHash extends BlockHash {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;
-            try (IntVector groupIds = new ConstantIntVector(0, block.getPositionCount(), blockFactory)) {
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
                 addInput.add(0, groupIds);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -204,6 +204,13 @@ public class BlockFactory {
         return b;
     }
 
+    public IntVector newConstantIntVector(int value, int positions) {
+        adjustBreaker(ConstantIntVector.RAM_BYTES_USED, false);
+        var v = new ConstantIntVector(value, positions, this);
+        adjustBreaker(v.ramBytesUsed() - ConstantIntVector.RAM_BYTES_USED, true);
+        return v;
+    }
+
     public LongBlock.Builder newLongBlockBuilder(int estimatedSize) {
         return new LongBlockBuilder(estimatedSize, this);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
@@ -638,4 +638,17 @@ public abstract class BatchEncoder implements Accountable {
             }
         }
     }
+
+    protected static final class DirectNulls extends DirectEncoder {
+        DirectNulls(Block block) {
+            super(block);
+            assert block.areAllValuesNull() : block;
+        }
+
+        @Override
+        protected int readValueAtBlockIndex(int valueIndex, BytesRefBuilder dst) {
+            assert false : "all positions all nulls";
+            throw new IllegalStateException("all positions all nulls");
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
@@ -129,6 +129,9 @@ public final class MultivalueDedupe {
      * things like hashing many fields together.
      */
     public static BatchEncoder batchEncoder(Block.Ref ref, int batchSize, boolean allowDirectEncoder) {
+        if (ref.block().areAllValuesNull()) {
+            return new BatchEncoder.DirectNulls(ref.block());
+        }
         var elementType = ref.block().elementType();
         if (allowDirectEncoder && ref.block().mvDeduplicated()) {
             var block = ref.block();


### PR DESCRIPTION
We should remove the ConstantNullBlock implementation, but it will take some time to do so. This PR ensures that BlockHash handles cases where all keys are null.

Closes #100186