### PR TITLE
[7.17] Mute IndexRecoveryIT.testRerouteRecovery (#100209)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -460,6 +460,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99941")
     public void testRerouteRecovery() throws Exception {
         logger.info("--> start node A");
         final String nodeA = internalCluster().startNode();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Mute IndexRecoveryIT.testRerouteRecovery (#100209)