### PR TITLE
[7.17] Revert back to using docker compose v1 CLI for test fixtures (#100206)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -114,6 +114,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
             composeExtension.getRemoveContainers().set(true);
             composeExtension.getCaptureContainersOutput()
                 .set(EnumSet.of(LogLevel.INFO, LogLevel.DEBUG).contains(project.getGradle().getStartParameter().getLogLevel()));
+            composeExtension.getUseDockerComposeV2().set(false);
             composeExtension.getExecutable()
                 .set(project.file("/usr/local/bin/docker-compose").exists() ? "/usr/local/bin/docker-compose" : "/usr/bin/docker-compose");
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Revert back to using docker compose v1 CLI for test fixtures (#100206)