### PR TITLE
Fix testWaitForClusterStateToBeAppliedOnSourceNode

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1623,7 +1623,6 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100222")
     public void testWaitForClusterStateToBeAppliedOnSourceNode() throws Exception {
         internalCluster().startMasterOnlyNode();
         final var primaryNode = internalCluster().startDataOnlyNode();

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/RecoveryClusterStateDelayListeners.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/RecoveryClusterStateDelayListeners.java
@@ -74,7 +74,6 @@ public class RecoveryClusterStateDelayListeners implements Releasable {
     }
 
     public void delayUntilRecoveryStart(SubscribableListener<Void> listener) {
-        ESTestCase.assertFalse(startRecoveryListener.isDone());
         startRecoveryListener.addListener(listener);
     }
 }


### PR DESCRIPTION
The tripping assertion here is just bogus, it's entirely possible that
the replica node has sent (and the primary node has received) the
`START_RECOVERY` message before the replica notifies its cluster state
listener waiting to see the new routing table.

Closes #100222