### PR TITLE
ESQL: Ensure that the limit operator releases if closed before consumed

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -68,6 +69,7 @@ public final class ConstantNullBlock extends AbstractBlock {
 
     @Override
     public Block filter(int... positions) {
+        Releasables.closeExpectNoException(this);
         return new ConstantNullBlock(positions.length);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
@@ -114,7 +114,9 @@ public class LimitOperator implements Operator {
 
     @Override
     public void close() {
-
+        if (lastInput != null) {
+            lastInput.releaseBlocks();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -796,8 +796,30 @@ public class BasicBlockTests extends ESTestCase {
         int minDupsPerPosition,
         int maxDupsPerPosition
     ) {
+        return randomBlock(
+            BlockFactory.getNonBreakingInstance(),
+            elementType,
+            positionCount,
+            nullAllowed,
+            minValuesPerPosition,
+            maxValuesPerPosition,
+            minDupsPerPosition,
+            maxDupsPerPosition
+        );
+    }
+
+    public static RandomBlock randomBlock(
+        BlockFactory blockFactory,
+        ElementType elementType,
+        int positionCount,
+        boolean nullAllowed,
+        int minValuesPerPosition,
+        int maxValuesPerPosition,
+        int minDupsPerPosition,
+        int maxDupsPerPosition
+    ) {
         List<List<Object>> values = new ArrayList<>();
-        var builder = elementType.newBlockBuilder(positionCount);
+        var builder = elementType.newBlockBuilder(positionCount, blockFactory);
         for (int p = 0; p < positionCount; p++) {
             int valueCount = between(minValuesPerPosition, maxValuesPerPosition);
             if (valueCount == 0 || nullAllowed && randomBoolean()) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -20,6 +20,11 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class LimitOperatorTests extends OperatorTestCase {
     @Override
+    protected DriverContext driverContext() {
+        return breakingDriverContext();
+    }
+
+    @Override
     protected Operator.OperatorFactory simple(BigArrays bigArrays) {
         return new LimitOperator.Factory(100);
     }


### PR DESCRIPTION
This commit ensures that the limit operator releases the last inputPage if closed before consumed.