### PR TITLE
Use ActionTestUtils for non-failing listeners

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
@@ -65,7 +65,7 @@ public class ActionTestUtils {
     }
 
     public static <T> ActionListener<T> assertNoFailureListener(CheckedConsumer<T, Exception> consumer) {
-        return ActionListener.wrap(consumer, e -> { throw new AssertionError(e); });
+        return ActionListener.wrap(consumer, e -> { throw new AssertionError("unexpected", e); });
     }
 
     public static ResponseListener wrapAsRestResponseListener(ActionListener<Response> listener) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -596,7 +596,10 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
             final GroupedActionListener<Tuple<Index, Exception>> groupedListener = new GroupedActionListener<>(
                 leaderIndicesToFollow.size(),
                 ActionListener.wrap(rs -> resultHandler.accept(new AutoFollowResult(autoFollowPattenName, new ArrayList<>(rs))), e -> {
-                    throw new AssertionError("must never happen", e);
+                    final var illegalStateException = new IllegalStateException("must never happen", e);
+                    LOGGER.error("must never happen", illegalStateException);
+                    assert false : illegalStateException;
+                    throw illegalStateException;
                 })
             );
 

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/DataTiersUsageRestCancellationIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/DataTiersUsageRestCancellationIT.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.core.rest.action;
 
 import org.apache.http.client.methods.HttpGet;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.TransportAction;
@@ -80,9 +80,7 @@ public class DataTiersUsageRestCancellationIT extends ESIntegTestCase {
                 (handler, request, channel, task) -> {
                     tasksBlockedLatch.countDown();
                     nodeStatsRequestsReleaseListener.addListener(
-                        ActionListener.wrap(ignored -> handler.messageReceived(request, channel, task), e -> {
-                            throw new AssertionError("unexpected", e);
-                        })
+                        ActionTestUtils.assertNoFailureListener(ignored -> handler.messageReceived(request, channel, task))
                     );
                 }
             );


### PR DESCRIPTION
Some small cleanups around assertions to make use of
`ActionTestUtils#assertNoFailureListener` where applicable. Also removes
an assertion that would take down the node in production.