### PR TITLE
Speedup OperationRouting.computeTargetedShards

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1604,7 +1604,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             .searchShards(
                 clusterState,
                 concreteIndices,
-                Objects.requireNonNullElseGet(routingMap, Map::of),
+                routingMap,
                 searchRequest.preference(),
                 searchService.getResponseCollectorService(),
                 searchTransportService.getPendingSearchRequests()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -341,8 +341,6 @@ public final class IndicesPermission {
         @Nullable
         private final IndexAbstraction indexAbstraction;
 
-        public Collection<String> concreteIndices;
-
         private IndexResource(String name, @Nullable IndexAbstraction abstraction) {
             assert name != null : "Resource name cannot be null";
             assert abstraction == null || abstraction.getName().equals(name)


### PR DESCRIPTION
This one still shows up in field caps benchmarking. For field caps we don't have any search routing, hence we don't need to get the index metadata in the loop here which costs a couple percent in CPU time for realistic field caps requests on the coordinating node.
Also removed an unused field in the related logic in `IndicesPermissions` (not super related here but didn't justify a stand-alone PR IMO).