### PR TITLE
[8.10] ILM the delete action waits for a TSDS index time/bounds to lapse (#100207)

### DIFF
--- a/docs/changelog/100207.yaml
+++ b/docs/changelog/100207.yaml
@@ -1,0 +1,5 @@
+pr: 100207
+summary: ILM the delete action waits for a TSDS index time/bounds to lapse
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -80,18 +81,39 @@ public class DeleteAction implements LifecycleAction {
     @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         Step.StepKey waitForNoFollowerStepKey = new Step.StepKey(phase, NAME, WaitForNoFollowersStep.NAME);
+        Step.StepKey waitTimeSeriesEndTimePassesKey = new Step.StepKey(phase, NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME);
         Step.StepKey deleteStepKey = new Step.StepKey(phase, NAME, DeleteStep.NAME);
         Step.StepKey cleanSnapshotKey = new Step.StepKey(phase, NAME, CleanupSnapshotStep.NAME);
 
         if (deleteSearchableSnapshot) {
-            WaitForNoFollowersStep waitForNoFollowersStep = new WaitForNoFollowersStep(waitForNoFollowerStepKey, cleanSnapshotKey, client);
+            WaitForNoFollowersStep waitForNoFollowersStep = new WaitForNoFollowersStep(
+                waitForNoFollowerStepKey,
+                waitTimeSeriesEndTimePassesKey,
+                client
+            );
+            WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
+                waitTimeSeriesEndTimePassesKey,
+                cleanSnapshotKey,
+                Instant::now,
+                client
+            );
             CleanupSnapshotStep cleanupSnapshotStep = new CleanupSnapshotStep(cleanSnapshotKey, deleteStepKey, client);
             DeleteStep deleteStep = new DeleteStep(deleteStepKey, nextStepKey, client);
-            return Arrays.asList(waitForNoFollowersStep, cleanupSnapshotStep, deleteStep);
+            return Arrays.asList(waitForNoFollowersStep, waitUntilTimeSeriesEndTimeStep, cleanupSnapshotStep, deleteStep);
         } else {
-            WaitForNoFollowersStep waitForNoFollowersStep = new WaitForNoFollowersStep(waitForNoFollowerStepKey, deleteStepKey, client);
+            WaitForNoFollowersStep waitForNoFollowersStep = new WaitForNoFollowersStep(
+                waitForNoFollowerStepKey,
+                waitTimeSeriesEndTimePassesKey,
+                client
+            );
+            WaitUntilTimeSeriesEndTimePassesStep waitUntilTimeSeriesEndTimeStep = new WaitUntilTimeSeriesEndTimePassesStep(
+                waitTimeSeriesEndTimePassesKey,
+                deleteStepKey,
+                Instant::now,
+                client
+            );
             DeleteStep deleteStep = new DeleteStep(deleteStepKey, nextStepKey, client);
-            return Arrays.asList(waitForNoFollowersStep, deleteStep);
+            return Arrays.asList(waitForNoFollowersStep, waitUntilTimeSeriesEndTimeStep, deleteStep);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteActionTests.java
@@ -47,31 +47,40 @@ public class DeleteActionTests extends AbstractActionTestCase<DeleteAction> {
         {
             List<Step> steps = DeleteAction.WITH_SNAPSHOT_DELETE.toSteps(null, phase, nextStepKey);
             assertNotNull(steps);
-            assertEquals(3, steps.size());
+            assertEquals(4, steps.size());
             StepKey expectedFirstStepKey = new StepKey(phase, DeleteAction.NAME, WaitForNoFollowersStep.NAME);
-            StepKey expectedSecondStepKey = new StepKey(phase, DeleteAction.NAME, CleanupSnapshotStep.NAME);
-            StepKey expectedThirdKey = new StepKey(phase, DeleteAction.NAME, DeleteStep.NAME);
+            StepKey expectedSecondStepKey = new StepKey(phase, DeleteAction.NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME);
+            StepKey expectedThirdKey = new StepKey(phase, DeleteAction.NAME, CleanupSnapshotStep.NAME);
+            StepKey expectedFourthKey = new StepKey(phase, DeleteAction.NAME, DeleteStep.NAME);
             WaitForNoFollowersStep firstStep = (WaitForNoFollowersStep) steps.get(0);
-            CleanupSnapshotStep secondStep = (CleanupSnapshotStep) steps.get(1);
-            DeleteStep thirdStep = (DeleteStep) steps.get(2);
+            WaitUntilTimeSeriesEndTimePassesStep secondStep = (WaitUntilTimeSeriesEndTimePassesStep) steps.get(1);
+            CleanupSnapshotStep thirdStep = (CleanupSnapshotStep) steps.get(2);
+            DeleteStep fourthStep = (DeleteStep) steps.get(3);
             assertEquals(expectedFirstStepKey, firstStep.getKey());
             assertEquals(expectedSecondStepKey, firstStep.getNextStepKey());
             assertEquals(expectedSecondStepKey, secondStep.getKey());
             assertEquals(expectedThirdKey, thirdStep.getKey());
-            assertEquals(nextStepKey, thirdStep.getNextStepKey());
+            assertEquals(expectedFourthKey, thirdStep.getNextStepKey());
+            assertEquals(expectedFourthKey, fourthStep.getKey());
+            assertEquals(nextStepKey, fourthStep.getNextStepKey());
         }
 
         {
             List<Step> steps = DeleteAction.NO_SNAPSHOT_DELETE.toSteps(null, phase, nextStepKey);
             StepKey expectedFirstStepKey = new StepKey(phase, DeleteAction.NAME, WaitForNoFollowersStep.NAME);
-            StepKey expectedSecondStepKey = new StepKey(phase, DeleteAction.NAME, DeleteStep.NAME);
-            assertEquals(2, steps.size());
+            StepKey expectedSecondStepKey = new StepKey(phase, DeleteAction.NAME, WaitUntilTimeSeriesEndTimePassesStep.NAME);
+            StepKey expectedThirdStepKey = new StepKey(phase, DeleteAction.NAME, DeleteStep.NAME);
+            assertEquals(3, steps.size());
             assertNotNull(steps);
             WaitForNoFollowersStep firstStep = (WaitForNoFollowersStep) steps.get(0);
-            DeleteStep secondStep = (DeleteStep) steps.get(1);
+            WaitUntilTimeSeriesEndTimePassesStep secondStep = (WaitUntilTimeSeriesEndTimePassesStep) steps.get(1);
+            DeleteStep thirdStep = (DeleteStep) steps.get(2);
             assertEquals(expectedFirstStepKey, firstStep.getKey());
             assertEquals(expectedSecondStepKey, firstStep.getNextStepKey());
-            assertEquals(nextStepKey, secondStep.getNextStepKey());
+            assertEquals(expectedSecondStepKey, secondStep.getKey());
+            assertEquals(expectedThirdStepKey, secondStep.getNextStepKey());
+            assertEquals(expectedThirdStepKey, thirdStep.getKey());
+            assertEquals(nextStepKey, thirdStep.getNextStepKey());
         }
     }
 


### PR DESCRIPTION
This adds the `check-ts-end-time-passed` step to the delete action so, for time series indices, we wait until they're not meant to accept new writes anymore before deleting them (i.e. until the time interval the covers the ingestion for `now` has lapsed)

(cherry picked from commit f32c8f51967c44a8713a93c135b876b49d047592)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #100207