### PR TITLE
Refactor remaining test uses of direct DiscoveryNode constructors

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
@@ -18,10 +18,9 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.settings.Settings;
@@ -60,14 +59,11 @@ public class TransportCreateIndexActionTests extends ESTestCase {
         .nodes(
             DiscoveryNodes.builder()
                 .add(
-                    new DiscoveryNode(
-                        "node-1",
-                        "node-1",
-                        new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                        Map.of(),
-                        Set.of(DiscoveryNodeRole.DATA_ROLE),
-                        VersionInformation.CURRENT
-                    )
+                    DiscoveryNodeUtils.builder("node-1")
+                        .name("node-1")
+                        .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                        .roles(Set.of(DiscoveryNodeRole.DATA_ROLE))
+                        .build()
                 )
                 .build()
         )

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -181,14 +181,13 @@ public class AutoExpandReplicasTests extends ESTestCase {
 
                 List<DiscoveryNode> nodesToAdd = conflictingNodes.stream()
                     .map(
-                        n -> new DiscoveryNode(
-                            n.getName(),
-                            n.getId(),
-                            buildNewFakeTransportAddress(),
-                            n.getAttributes(),
-                            n.getRoles(),
-                            n.getVersionInformation()
-                        )
+                        n -> DiscoveryNodeUtils.builder(n.getId())
+                            .name(n.getName())
+                            .address(buildNewFakeTransportAddress())
+                            .attributes(n.getAttributes())
+                            .roles(n.getRoles())
+                            .version(n.getVersionInformation())
+                            .build()
                     )
                     .collect(Collectors.toCollection(ArrayList::new));
 

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -473,14 +473,12 @@ public class DiscoveryNodesTests extends ESTestCase {
             }
         };
 
-        final BiFunction<Integer, VersionInformation, DiscoveryNode> nodeVersionFactory = (i, v) -> new DiscoveryNode(
-            "name" + i,
-            "id" + i,
-            buildNewFakeTransportAddress(),
-            Collections.emptyMap(),
-            new HashSet<>(randomSubsetOf(DiscoveryNodeRole.roles())),
-            v
-        );
+        final BiFunction<Integer, VersionInformation, DiscoveryNode> nodeVersionFactory = (i, v) -> DiscoveryNodeUtils.builder("id" + i)
+            .name("name" + i)
+            .address(buildNewFakeTransportAddress())
+            .roles(new HashSet<>(randomSubsetOf(DiscoveryNodeRole.roles())))
+            .version(v)
+            .build();
 
         final IntFunction<DiscoveryNode> nodeFactory = i -> nodeVersionFactory.apply(i, VersionInformation.CURRENT);
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.transport.AbstractSimpleTransportTestCase.IGNORE_DESERIALIZATION_ERRORS_SETTING;
 import static org.hamcrest.Matchers.containsString;
@@ -84,14 +83,12 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             transport,
             threadPool,
             transportInterceptor,
-            (boundAddress) -> new DiscoveryNode(
-                nodeNameAndId,
-                nodeNameAndId,
-                boundAddress.publishAddress(),
-                emptyMap(),
-                emptySet(),
-                nodeVersion
-            ),
+            (boundAddress) -> DiscoveryNodeUtils.builder(nodeNameAndId)
+                .name(nodeNameAndId)
+                .address(boundAddress.publishAddress())
+                .roles(emptySet())
+                .version(nodeVersion)
+                .build(),
             null,
             Collections.emptySet()
         );

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -175,14 +176,13 @@ public class MockTransportService extends TransportService {
             new StubbableTransport(transport),
             threadPool,
             interceptor,
-            boundAddress -> new DiscoveryNode(
-                Node.NODE_NAME_SETTING.get(settings),
-                UUIDs.randomBase64UUID(),
-                boundAddress.publishAddress(),
-                Node.NODE_ATTRIBUTES.getAsMap(settings),
-                DiscoveryNode.getRolesFromSettings(settings),
-                version
-            ),
+            boundAddress -> DiscoveryNodeUtils.builder(UUIDs.randomBase64UUID())
+                .name(Node.NODE_NAME_SETTING.get(settings))
+                .address(boundAddress.publishAddress())
+                .attributes(Node.NODE_ATTRIBUTES.getAsMap(settings))
+                .roles(DiscoveryNode.getRolesFromSettings(settings))
+                .version(version)
+                .build(),
             clusterSettings,
             createTaskManager(settings, threadPool, taskHeaders, Tracer.NOOP)
         );

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2330,7 +2330,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             )
         ) {
             TransportAddress address = service.boundAddress().publishAddress();
-            DiscoveryNode node = new DiscoveryNode("TS_TPC", "TS_TPC", address, emptyMap(), emptySet(), version0);
+            DiscoveryNode node = DiscoveryNodeUtils.builder("TS_TPC")
+                .name("TS_TPC")
+                .address(address)
+                .roles(emptySet())
+                .version(version0)
+                .build();
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(
                 1,
@@ -2364,14 +2369,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             )
         ) {
             TransportAddress address = service.boundAddress().publishAddress();
-            DiscoveryNode node = new DiscoveryNode(
-                "TS_TPC",
-                "TS_TPC",
-                address,
-                emptyMap(),
-                emptySet(),
-                VersionInformation.inferVersions(Version.fromString("2.0.0"))
-            );
+            DiscoveryNode node = DiscoveryNodeUtils.builder("TS_TPC")
+                .name("TS_TPC")
+                .address(address)
+                .roles(emptySet())
+                .version(VersionInformation.inferVersions(Version.fromString("2.0.0")))
+                .build();
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(
                 1,
@@ -2396,14 +2399,13 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             .build();
         try (TransportService service = buildService("TS_TPC", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY)) {
             PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
-            DiscoveryNode node = new DiscoveryNode(
-                "TS_TPC",
-                "TS_TPC",
-                service.boundAddress().publishAddress(),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode node = DiscoveryNodeUtils.builder("TS_TPC")
+                .name("TS_TPC")
+                .address(service.boundAddress().publishAddress())
+                .attributes(emptyMap())
+                .roles(emptySet())
+                .version(version0)
+                .build();
             originalTransport.openConnection(node, connectionProfile, future);
             try (Transport.Connection connection = future.actionGet()) {
                 assertBusy(() -> { assertTrue(originalTransport.getKeepAlive().successfulPingCount() > 30); });
@@ -2416,14 +2418,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         assumeTrue("only tcp transport has a handshake method", serviceA.getOriginalTransport() instanceof TcpTransport);
         ConnectionProfile connectionProfile = ConnectionProfile.buildDefaultConnectionProfile(Settings.EMPTY);
         try (TransportService service = buildService("TS_TPC", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY)) {
-            DiscoveryNode node = new DiscoveryNode(
-                "TS_TPC",
-                "TS_TPC",
-                service.boundAddress().publishAddress(),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode node = DiscoveryNodeUtils.builder("TS_TPC")
+                .name("TS_TPC")
+                .address(service.boundAddress().publishAddress())
+                .roles(emptySet())
+                .version(version0)
+                .build();
             PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
             serviceA.getOriginalTransport().openConnection(node, connectionProfile, future);
             try (Transport.Connection connection = future.actionGet()) {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
@@ -571,13 +571,12 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
     }
 
     private DiscoveryNode restartNode(DiscoveryNode node) {
-        return new DiscoveryNode(
-            node.getName(),
-            node.getId(),
-            node.getAddress(),
-            node.getAttributes(),
-            node.getRoles(),
-            node.getVersionInformation()
-        );
+        return DiscoveryNodeUtils.builder(node.getId())
+            .name(node.getName())
+            .address(node.getAddress())
+            .attributes(node.getAttributes())
+            .roles(node.getRoles())
+            .version(node.getVersionInformation())
+            .build();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -422,14 +422,13 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             Settings nodeSettings = Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), nodeName).build();
             oldNodeIds.add(nodeId);
             nodes.add(
-                new DiscoveryNode(
-                    Node.NODE_NAME_SETTING.get(nodeSettings),
-                    nodeId,
-                    new TransportAddress(TransportAddress.META_ADDRESS, nodePort),
-                    Node.NODE_ATTRIBUTES.getAsMap(nodeSettings),
-                    DiscoveryNode.getRolesFromSettings(nodeSettings),
-                    oldVersion
-                )
+                DiscoveryNodeUtils.builder(nodeId)
+                    .name(Node.NODE_NAME_SETTING.get(nodeSettings))
+                    .address(new TransportAddress(TransportAddress.META_ADDRESS, nodePort))
+                    .attributes(Node.NODE_ATTRIBUTES.getAsMap(nodeSettings))
+                    .roles(DiscoveryNode.getRolesFromSettings(nodeSettings))
+                    .version(oldVersion)
+                    .build()
             );
         }
 
@@ -502,14 +501,13 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
                 .build();
             oldNodeIds.add(nodeId);
             nodes.add(
-                new DiscoveryNode(
-                    Node.NODE_NAME_SETTING.get(nodeSettings),
-                    nodeId,
-                    new TransportAddress(TransportAddress.META_ADDRESS, nodePort),
-                    Node.NODE_ATTRIBUTES.getAsMap(nodeSettings),
-                    DiscoveryNode.getRolesFromSettings(nodeSettings),
-                    oldVersion
-                )
+                DiscoveryNodeUtils.builder(nodeId)
+                    .name(Node.NODE_NAME_SETTING.get(nodeSettings))
+                    .address(new TransportAddress(TransportAddress.META_ADDRESS, nodePort))
+                    .attributes(Node.NODE_ATTRIBUTES.getAsMap(nodeSettings))
+                    .roles(DiscoveryNode.getRolesFromSettings(nodeSettings))
+                    .version(oldVersion)
+                    .build()
             );
         }
         Set<String> nodeIds = new HashSet<>();
@@ -580,14 +578,13 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
                 .build();
             oldNodeIds.add(nodeId);
             nodes.add(
-                new DiscoveryNode(
-                    Node.NODE_NAME_SETTING.get(nodeSettings),
-                    nodeId,
-                    new TransportAddress(TransportAddress.META_ADDRESS, nodePort),
-                    Node.NODE_ATTRIBUTES.getAsMap(nodeSettings),
-                    DiscoveryNode.getRolesFromSettings(nodeSettings),
-                    oldVersion
-                )
+                DiscoveryNodeUtils.builder(nodeId)
+                    .name(Node.NODE_NAME_SETTING.get(nodeSettings))
+                    .address(new TransportAddress(TransportAddress.META_ADDRESS, nodePort))
+                    .attributes(Node.NODE_ATTRIBUTES.getAsMap(nodeSettings))
+                    .roles(DiscoveryNode.getRolesFromSettings(nodeSettings))
+                    .version(oldVersion)
+                    .build()
             );
         }
         Set<String> nodeIds = new HashSet<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlConfigVersionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlConfigVersionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.ml;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -116,34 +117,31 @@ public class MlConfigVersionTests extends ESTestCase {
         Map<String, String> nodeAttr3 = Map.of(MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR, MlConfigVersion.V_10.toString());
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(
-                new DiscoveryNode(
-                    "_node_name1",
-                    "_node_id1",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                    nodeAttr1,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("7.2.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id1")
+                    .name("_node_name1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr1)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.2.0")))
+                    .build()
             )
             .add(
-                new DiscoveryNode(
-                    "_node_name2",
-                    "_node_id2",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
-                    nodeAttr2,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("7.1.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id2")
+                    .name("_node_name2")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9301))
+                    .attributes(nodeAttr2)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.1.0")))
+                    .build()
             )
             .add(
-                new DiscoveryNode(
-                    "_node_name3",
-                    "_node_id3",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9302),
-                    nodeAttr3,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("7.0.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id3")
+                    .name("_node_name3")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9302))
+                    .attributes(nodeAttr3)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.0.0")))
+                    .build()
             )
             .build();
 
@@ -152,25 +150,22 @@ public class MlConfigVersionTests extends ESTestCase {
     }
 
     public void testGetMlConfigVersionForNode() {
-        DiscoveryNode node = new DiscoveryNode(
-            "_node_name4",
-            "_node_id4",
-            new TransportAddress(InetAddress.getLoopbackAddress(), 9303),
-            Collections.emptyMap(),
-            ROLES_WITH_ML,
-            VersionInformation.inferVersions(Version.fromString("8.7.0"))
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("_node_id4")
+            .name("_node_name4")
+            .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9303))
+            .roles(ROLES_WITH_ML)
+            .version(VersionInformation.inferVersions(Version.fromString("8.7.0")))
+            .build();
         MlConfigVersion mlConfigVersion = MlConfigVersion.getMlConfigVersionForNode(node);
         assertEquals(MlConfigVersion.V_8_7_0, mlConfigVersion);
 
-        DiscoveryNode node1 = new DiscoveryNode(
-            "_node_name5",
-            "_node_id5",
-            new TransportAddress(InetAddress.getLoopbackAddress(), 9304),
-            Map.of(MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR, MlConfigVersion.V_8_5_0.toString()),
-            ROLES_WITH_ML,
-            VersionInformation.inferVersions(Version.fromString("8.7.0"))
-        );
+        DiscoveryNode node1 = DiscoveryNodeUtils.builder("_node_id5")
+            .name("_node_name5")
+            .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9304))
+            .attributes(Map.of(MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR, MlConfigVersion.V_8_5_0.toString()))
+            .roles(ROLES_WITH_ML)
+            .version(VersionInformation.inferVersions(Version.fromString("8.7.0")))
+            .build();
         MlConfigVersion mlConfigVersion1 = MlConfigVersion.getMlConfigVersionForNode(node1);
         assertEquals(MlConfigVersion.fromVersion(Version.V_8_5_0), mlConfigVersion1);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformConfigVersionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformConfigVersionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.transform;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -121,34 +122,31 @@ public class TransformConfigVersionTests extends ESTestCase {
         );
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(
-                new DiscoveryNode(
-                    "_node_name1",
-                    "_node_id1",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                    nodeAttr1,
-                    ROLES_WITH_TRANSFORM,
-                    VersionInformation.inferVersions(Version.fromString("7.2.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id1")
+                    .name("_node_name1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr1)
+                    .roles(ROLES_WITH_TRANSFORM)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.2.0")))
+                    .build()
             )
             .add(
-                new DiscoveryNode(
-                    "_node_name2",
-                    "_node_id2",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
-                    nodeAttr2,
-                    ROLES_WITH_TRANSFORM,
-                    VersionInformation.inferVersions(Version.fromString("7.1.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id2")
+                    .name("_node_name2")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9301))
+                    .attributes(nodeAttr2)
+                    .roles(ROLES_WITH_TRANSFORM)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.1.0")))
+                    .build()
             )
             .add(
-                new DiscoveryNode(
-                    "_node_name3",
-                    "_node_id3",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9302),
-                    nodeAttr3,
-                    ROLES_WITH_TRANSFORM,
-                    VersionInformation.inferVersions(Version.fromString("7.0.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id3")
+                    .name("_node_name3")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9302))
+                    .attributes(nodeAttr3)
+                    .roles(ROLES_WITH_TRANSFORM)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.0.0")))
+                    .build()
             )
             .build();
 
@@ -157,25 +155,22 @@ public class TransformConfigVersionTests extends ESTestCase {
     }
 
     public void testGetTransformConfigVersionForNode() {
-        DiscoveryNode node = new DiscoveryNode(
-            "_node_name4",
-            "_node_id4",
-            new TransportAddress(InetAddress.getLoopbackAddress(), 9303),
-            Collections.emptyMap(),
-            ROLES_WITH_TRANSFORM,
-            VersionInformation.inferVersions(Version.fromString("8.7.0"))
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("_node_id4")
+            .name("_node_name4")
+            .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9303))
+            .roles(ROLES_WITH_TRANSFORM)
+            .version(VersionInformation.inferVersions(Version.fromString("8.7.0")))
+            .build();
         TransformConfigVersion transformConfigVersion = TransformConfigVersion.getTransformConfigVersionForNode(node);
         assertEquals(TransformConfigVersion.V_8_7_0, transformConfigVersion);
 
-        DiscoveryNode node1 = new DiscoveryNode(
-            "_node_name5",
-            "_node_id5",
-            new TransportAddress(InetAddress.getLoopbackAddress(), 9304),
-            Map.of(TransformConfigVersion.TRANSFORM_CONFIG_VERSION_NODE_ATTR, TransformConfigVersion.V_8_5_0.toString()),
-            ROLES_WITH_TRANSFORM,
-            VersionInformation.inferVersions(Version.fromString("8.7.0"))
-        );
+        DiscoveryNode node1 = DiscoveryNodeUtils.builder("_node_id5")
+            .name("_node_name5")
+            .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9304))
+            .attributes(Map.of(TransformConfigVersion.TRANSFORM_CONFIG_VERSION_NODE_ATTR, TransformConfigVersion.V_8_5_0.toString()))
+            .roles(ROLES_WITH_TRANSFORM)
+            .version(VersionInformation.inferVersions(Version.fromString("8.7.0")))
+            .build();
         TransformConfigVersion TransformConfigVersion1 = TransformConfigVersion.getTransformConfigVersionForNode(node1);
         assertEquals(TransformConfigVersion.fromVersion(Version.V_8_5_0), TransformConfigVersion1);
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
@@ -12,8 +12,8 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -98,14 +98,12 @@ public class MlAutoUpdateServiceIT extends MlSingleNodeTestCase {
                 .nodes(
                     DiscoveryNodes.builder()
                         .add(
-                            new DiscoveryNode(
-                                "node_name",
-                                "node_id",
-                                new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                                Collections.emptyMap(),
-                                Set.of(DiscoveryNodeRole.MASTER_ROLE),
-                                VersionInformation.inferVersions(Version.V_8_0_0)
-                            )
+                            DiscoveryNodeUtils.builder("node_id")
+                                .name("node_name")
+                                .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                                .roles(Set.of(DiscoveryNodeRole.MASTER_ROLE))
+                                .version(VersionInformation.inferVersions(Version.V_8_0_0))
+                                .build()
                         )
                         .localNodeId("node_id")
                         .masterNodeId("node_id")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -146,24 +147,27 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
     }
 
     private static DiscoveryNode createNode(int i, boolean isMlNode, Version nodeVersion, MlConfigVersion mlConfigVersion) {
-        return new DiscoveryNode(
-            "_node_name" + i,
-            "_node_id" + i,
-            new TransportAddress(InetAddress.getLoopbackAddress(), 9300 + i),
-            isMlNode
-                ? Map.of(
-                    "ml.machine_memory",
-                    String.valueOf(ByteSizeValue.ofGb(1).getBytes()),
-                    "ml.max_jvm_size",
-                    String.valueOf(ByteSizeValue.ofMb(400).getBytes()),
-                    MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR,
-                    mlConfigVersion.toString()
-                )
-                : Map.of(),
-            isMlNode
-                ? Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)
-                : Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE),
-            VersionInformation.inferVersions(nodeVersion)
-        );
+        return DiscoveryNodeUtils.builder("_node_id" + i)
+            .name("_node_name" + i)
+            .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300 + i))
+            .attributes(
+                isMlNode
+                    ? Map.of(
+                        "ml.machine_memory",
+                        String.valueOf(ByteSizeValue.ofGb(1).getBytes()),
+                        "ml.max_jvm_size",
+                        String.valueOf(ByteSizeValue.ofMb(400).getBytes()),
+                        MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR,
+                        mlConfigVersion.toString()
+                    )
+                    : Map.of()
+            )
+            .roles(
+                isMlNode
+                    ? Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)
+                    : Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE)
+            )
+            .version(VersionInformation.inferVersions(nodeVersion))
+            .build();
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -15,9 +15,8 @@ import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
-import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.TimeValue;
@@ -1012,22 +1011,18 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
             ),
 
             List.of(
-                new DiscoveryNode(
-                    "ml-node-name-1",
-                    "ml-node-1",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                    nodeAttr,
-                    Set.of(DiscoveryNodeRole.ML_ROLE),
-                    VersionInformation.CURRENT
-                ),
-                new DiscoveryNode(
-                    "ml-node-name-3",
-                    "ml-node-3",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                    nodeAttr,
-                    Set.of(DiscoveryNodeRole.ML_ROLE),
-                    VersionInformation.CURRENT
-                )
+                DiscoveryNodeUtils.builder("ml-node-1")
+                    .name("ml-node-name-1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build(),
+                DiscoveryNodeUtils.builder("ml-node-3")
+                    .name("ml-node-name-3")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build()
             ),
             PersistentTasksCustomMetadata.builder().build()
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -90,14 +90,13 @@ public class JobNodeSelectorTests extends ESTestCase {
     public void testNodeNameAndVersionForOldNode() {
         TransportAddress ta = new TransportAddress(InetAddress.getLoopbackAddress(), 9300);
         Map<String, String> attributes = Map.of("unrelated", "attribute");
-        DiscoveryNode node = new DiscoveryNode(
-            "_node_name2",
-            "_node_id2",
-            ta,
-            attributes,
-            ROLES_WITH_ML,
-            VersionInformation.inferVersions(Version.V_8_7_0)
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("_node_id2")
+            .name("_node_name2")
+            .address(ta)
+            .attributes(attributes)
+            .roles(ROLES_WITH_ML)
+            .version(VersionInformation.inferVersions(Version.V_8_7_0))
+            .build();
         assertEquals("{_node_name2}{ML config version=8.7.0}", JobNodeSelector.nodeNameAndVersion(node));
     }
 
@@ -913,24 +912,22 @@ public class JobNodeSelectorTests extends ESTestCase {
         );
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(
-                new DiscoveryNode(
-                    "_node_name1",
-                    "_node_id1",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                    nodeAttr1,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("7.2.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id1")
+                    .name("_node_name1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr1)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.2.0")))
+                    .build()
             )
             .add(
-                new DiscoveryNode(
-                    "_node_name2",
-                    "_node_id2",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
-                    nodeAttr2,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("7.1.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id2")
+                    .name("_node_name2")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9301))
+                    .attributes(nodeAttr2)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("7.1.0")))
+                    .build()
             )
             .build();
 
@@ -976,24 +973,22 @@ public class JobNodeSelectorTests extends ESTestCase {
         );
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(
-                new DiscoveryNode(
-                    "_node_name1",
-                    "_node_id1",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
-                    nodeAttr,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("6.2.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id1")
+                    .name("_node_name1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("6.2.0")))
+                    .build()
             )
             .add(
-                new DiscoveryNode(
-                    "_node_name2",
-                    "_node_id2",
-                    new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
-                    nodeAttr,
-                    ROLES_WITH_ML,
-                    VersionInformation.inferVersions(Version.fromString("6.4.0"))
-                )
+                DiscoveryNodeUtils.builder("_node_id2")
+                    .name("_node_name2")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9301))
+                    .attributes(nodeAttr)
+                    .roles(ROLES_WITH_ML)
+                    .version(VersionInformation.inferVersions(Version.fromString("6.4.0")))
+                    .build()
             )
             .build();
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -190,14 +190,12 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
         ConnectionProfile connectionProfile = ConnectionProfile.buildDefaultConnectionProfile(Settings.EMPTY);
         try (TransportService service = buildService("TS_TPC", VersionInformation.CURRENT, TransportVersion.current(), Settings.EMPTY)) {
-            DiscoveryNode node = new DiscoveryNode(
-                "TS_TPC",
-                "TS_TPC",
-                service.boundAddress().publishAddress(),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode node = DiscoveryNodeUtils.builder("TS_TPC")
+                .name("TS_TPC")
+                .address(service.boundAddress().publishAddress())
+                .roles(emptySet())
+                .version(version0)
+                .build();
             PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
             originalTransport.openConnection(node, connectionProfile, future);
             try (TcpTransport.NodeChannels connection = (TcpTransport.NodeChannels) future.actionGet()) {


### PR DESCRIPTION
An automated mechanical refactoring of remaining test uses of the raw `DiscoveryNode` constructor to `DiscoveryNodeUtils`. This is to make it easier to introduce features without changing large bits of test code too.