### PR TITLE
[8.10] Document ILM waits for tsds end_time to lapse in some actions (#100204)

### DIFF
--- a/docs/reference/data-streams/downsampling-ilm.asciidoc
+++ b/docs/reference/data-streams/downsampling-ilm.asciidoc
@@ -37,8 +37,17 @@ To enable downsampling, add a <<ilm-downsample,Downsample action>> and set
 which you want to aggregate the original time series data.
 
 In this example, an ILM policy is configured for the `hot` phase. The downsample
-takes place after the initial index rollover, which for demonstration
-purposes is set to run after five minutes.
+takes place after the index is rolled over and the <<index-time-series-end-time, index time series end time>>
+has lapsed as the source index is still expected to receive major writes until then.
+{ilm-cap} will not proceed with any action that expects the index to not receive
+writes anymore until the <<index-time-series-end-time, index's end time>> has 
+passed. The {ilm-cap} actions that wait on the end time before proceeding are:
+- <<ilm-delete>>
+- <<ilm-downsample>>
+- <<ilm-forcemerge>>
+- <<ilm-readonly>>
+- <<ilm-searchable-snapshot>>
+- <<ilm-shrink>>
 
 [source,console]
 ----

--- a/docs/reference/data-streams/tsds-index-settings.asciidoc
+++ b/docs/reference/data-streams/tsds-index-settings.asciidoc
@@ -33,6 +33,10 @@ days). Only indices with an `index.mode` of `time_series` support this setting.
 For more information, refer to <<tsds-look-ahead-time>>. Additionally this setting
 can not be less than `time_series.poll_interval` cluster setting.
 
+NOTE: Increasing the `look_ahead_time` will also increase the amount of time {ilm-cap}
+waits before being able to proceed with executing the actions that expect the 
+index to not receive any writes anymore. For more information, refer to <<time-bound-indices>>.
+
 [[index-routing-path]] `index.routing_path`::
 (<<_static_index_settings,Static>>, string or array of strings) Plain `keyword`
 fields used to route documents in a TSDS to index shards. Supports wildcards

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -218,10 +218,17 @@ if the index isn't the most recent backing index.
 
 image::images/data-streams/time-bound-indices.svg[align="center"]
 
-TIP: Some {ilm-init} actions, such as <<ilm-forcemerge,`forcemerge`>>,
-<<ilm-shrink,`shrink`>>, and <<ilm-searchable-snapshot,`searchable_snapshot`>>,
-make a backing index read-only. You cannot add documents to read-only indices.
-Keep this in mind when defining the index lifecycle policy for your TSDS.
+TIP: Some {ilm-init} actions mark the source index as read-only, or expect the index
+to not be actively written anymore in order to provide good performance. These actions are:
+- <<ilm-delete>>
+- <<ilm-downsample>>
+- <<ilm-forcemerge>>
+- <<ilm-readonly>>
+- <<ilm-searchable-snapshot>>
+- <<ilm-shrink>>
+{ilm-cap} will **not** proceed with executing these actions until the upper time-bound 
+for accepting writes, represented by the <<index-time-series-end-time,`index.time_series.end_time`>> 
+index setting, has lapsed. 
 
 If no backing index can accept a document's `@timestamp` value, {es} rejects the
 document.


### PR DESCRIPTION
(cherry picked from commit 632c97b234a1455bf7c211a63332ca1a7efb906f)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #100204