### PR TITLE
[8.11] ESQL: Simple check if all blocks get released (#100199)

### DIFF
--- a/docs/changelog/100199.yaml
+++ b/docs/changelog/100199.yaml
@@ -1,0 +1,5 @@
+pr: 100199
+summary: "ESQL: Simple check if all blocks get released"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
@@ -124,4 +124,11 @@ public class FilterOperatorTests extends OperatorTestCase {
     protected DriverContext driverContext() { // TODO remove this when the parent uses a breaking block factory
         return breakingDriverContext();
     }
+
+    // TODO: remove this once possible
+    // https://github.com/elastic/elasticsearch/issues/99826
+    @Override
+    protected boolean canLeak() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -90,6 +90,13 @@ public class LimitOperatorTests extends OperatorTestCase {
         assertFalse(op.needsInput());
     }
 
+    // TODO: remove this once possible
+    // https://github.com/elastic/elasticsearch/issues/99826
+    @Override
+    protected boolean canLeak() {
+        return true;
+    }
+
     public void testBlockBiggerThanRemaining() {
         BlockFactory blockFactory = driverContext().blockFactory();
         for (int i = 0; i < 100; i++) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
@@ -133,4 +133,11 @@ public class MvExpandOperatorTests extends OperatorTestCase {
         assertThat(status.pagesProcessed(), equalTo(1));
         assertThat(status.noops(), equalTo(0));
     }
+
+    // TODO: remove this once possible
+    // https://github.com/elastic/elasticsearch/issues/99826
+    @Override
+    protected boolean canLeak() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockTestUtils;
 import org.elasticsearch.compute.data.Page;
@@ -179,6 +180,14 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
 
     protected final void assertSimple(DriverContext context, int size) {
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(context.blockFactory(), size));
+
+        List<Block> inputBlocks = new ArrayList<>();
+        for (Page p : input) {
+            for (int i = 0; i < p.getBlockCount(); i++) {
+                inputBlocks.add(p.getBlock(i));
+            }
+        }
+
         // Clone the input so that the operator can close it, then, later, we can read it again to build the assertion.
         List<Page> origInput = BlockTestUtils.deepCopyOf(input, BlockFactory.getNonBreakingInstance());
         BigArrays bigArrays = context.bigArrays().withCircuitBreaking();
@@ -187,6 +196,25 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         assertSimpleOutput(origInput, results);
         assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
 
+        List<Block> resultBlocks = new ArrayList<>();
+        // Release all result blocks. After this, all input blocks should be released as well, otherwise we have a leak.
+        for (Page p : results) {
+            for (int i = 0; i < p.getBlockCount(); i++) {
+                resultBlocks.add(p.getBlock(i));
+            }
+
+            p.releaseBlocks();
+        }
+
+        int unreleasedInputs = 0;
+        for (Block b : inputBlocks) {
+            if (b.isReleased() == false) {
+                unreleasedInputs++;
+            }
+        }
+        if ((canLeak() == false) && unreleasedInputs > 0) {
+            throw new AssertionError("[" + unreleasedInputs + "] unreleased input blocks");
+        }
     }
 
     // Tests that finish then close without calling getOutput to retrieve a potential last page, releases all memory
@@ -275,6 +303,12 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         } finally {
             terminate(threadPool);
         }
+    }
+
+    // TODO: Remove this once all operators do not leak anymore
+    // https://github.com/elastic/elasticsearch/issues/99826
+    protected boolean canLeak() {
+        return false;
     }
 
     public static void assertDriverContext(DriverContext driverContext) {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Simple check if all blocks get released (#100199)