### PR TITLE
ESQL: Do not leak filtered blocks

### DIFF
--- a/docs/changelog/100278.yaml
+++ b/docs/changelog/100278.yaml
@@ -1,0 +1,5 @@
+pr: 100278
+summary: "ESQL: Do not leak filtered blocks"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -25,6 +25,7 @@ public sealed class BooleanVectorBlock extends AbstractVectorBlock implements Bo
 
         @Override
         public void close() {
+            released = true;
             BooleanVectorBlock.this.close();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -13,7 +13,21 @@ import org.elasticsearch.core.Releasables;
  * Block view of a BooleanVector.
  * This class is generated. Do not edit it.
  */
-public final class BooleanVectorBlock extends AbstractVectorBlock implements BooleanBlock {
+public sealed class BooleanVectorBlock extends AbstractVectorBlock implements BooleanBlock permits BooleanVectorBlock.ShallowCopy {
+
+    final class ShallowCopy extends BooleanVectorBlock {
+        /**
+         * The vector must be a shallow copy of the original vector.
+         */
+        ShallowCopy(BooleanVector vector) {
+            super(vector);
+        }
+
+        @Override
+        public void close() {
+            BooleanVectorBlock.this.close();
+        }
+    }
 
     private final BooleanVector vector;
 
@@ -44,7 +58,7 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
 
     @Override
     public BooleanBlock filter(int... positions) {
-        return new FilterBooleanVector(vector, positions).asBlock();
+        return new ShallowCopy(new FilterBooleanVector(vector, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -26,6 +26,7 @@ public sealed class BytesRefVectorBlock extends AbstractVectorBlock implements B
 
         @Override
         public void close() {
+            released = true;
             BytesRefVectorBlock.this.close();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -14,7 +14,21 @@ import org.elasticsearch.core.Releasables;
  * Block view of a BytesRefVector.
  * This class is generated. Do not edit it.
  */
-public final class BytesRefVectorBlock extends AbstractVectorBlock implements BytesRefBlock {
+public sealed class BytesRefVectorBlock extends AbstractVectorBlock implements BytesRefBlock permits BytesRefVectorBlock.ShallowCopy {
+
+    final class ShallowCopy extends BytesRefVectorBlock {
+        /**
+         * The vector must be a shallow copy of the original vector.
+         */
+        ShallowCopy(BytesRefVector vector) {
+            super(vector);
+        }
+
+        @Override
+        public void close() {
+            BytesRefVectorBlock.this.close();
+        }
+    }
 
     private final BytesRefVector vector;
 
@@ -45,7 +59,7 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
 
     @Override
     public BytesRefBlock filter(int... positions) {
-        return new FilterBytesRefVector(vector, positions).asBlock();
+        return new ShallowCopy(new FilterBytesRefVector(vector, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -25,6 +25,7 @@ public sealed class DoubleVectorBlock extends AbstractVectorBlock implements Dou
 
         @Override
         public void close() {
+            released = true;
             DoubleVectorBlock.this.close();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -13,7 +13,21 @@ import org.elasticsearch.core.Releasables;
  * Block view of a DoubleVector.
  * This class is generated. Do not edit it.
  */
-public final class DoubleVectorBlock extends AbstractVectorBlock implements DoubleBlock {
+public sealed class DoubleVectorBlock extends AbstractVectorBlock implements DoubleBlock permits DoubleVectorBlock.ShallowCopy {
+
+    final class ShallowCopy extends DoubleVectorBlock {
+        /**
+         * The vector must be a shallow copy of the original vector.
+         */
+        ShallowCopy(DoubleVector vector) {
+            super(vector);
+        }
+
+        @Override
+        public void close() {
+            DoubleVectorBlock.this.close();
+        }
+    }
 
     private final DoubleVector vector;
 
@@ -44,7 +58,7 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
 
     @Override
     public DoubleBlock filter(int... positions) {
-        return new FilterDoubleVector(vector, positions).asBlock();
+        return new ShallowCopy(new FilterDoubleVector(vector, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVector.java
@@ -20,12 +20,9 @@ public final class FilterBooleanVector extends AbstractFilterVector implements B
 
     private final BooleanVector vector;
 
-    private final BooleanBlock block;
-
     FilterBooleanVector(BooleanVector vector, int... positions) {
         super(positions, vector.blockFactory());
         this.vector = vector;
-        this.block = new BooleanVectorBlock(this);
     }
 
     @Override
@@ -35,7 +32,7 @@ public final class FilterBooleanVector extends AbstractFilterVector implements B
 
     @Override
     public BooleanBlock asBlock() {
-        return block;
+        return new BooleanVectorBlock(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVector.java
@@ -21,12 +21,9 @@ public final class FilterBytesRefVector extends AbstractFilterVector implements 
 
     private final BytesRefVector vector;
 
-    private final BytesRefBlock block;
-
     FilterBytesRefVector(BytesRefVector vector, int... positions) {
         super(positions, vector.blockFactory());
         this.vector = vector;
-        this.block = new BytesRefVectorBlock(this);
     }
 
     @Override
@@ -36,7 +33,7 @@ public final class FilterBytesRefVector extends AbstractFilterVector implements 
 
     @Override
     public BytesRefBlock asBlock() {
-        return block;
+        return new BytesRefVectorBlock(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVector.java
@@ -20,12 +20,9 @@ public final class FilterDoubleVector extends AbstractFilterVector implements Do
 
     private final DoubleVector vector;
 
-    private final DoubleBlock block;
-
     FilterDoubleVector(DoubleVector vector, int... positions) {
         super(positions, vector.blockFactory());
         this.vector = vector;
-        this.block = new DoubleVectorBlock(this);
     }
 
     @Override
@@ -35,7 +32,7 @@ public final class FilterDoubleVector extends AbstractFilterVector implements Do
 
     @Override
     public DoubleBlock asBlock() {
-        return block;
+        return new DoubleVectorBlock(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVector.java
@@ -20,12 +20,9 @@ public final class FilterIntVector extends AbstractFilterVector implements IntVe
 
     private final IntVector vector;
 
-    private final IntBlock block;
-
     FilterIntVector(IntVector vector, int... positions) {
         super(positions, vector.blockFactory());
         this.vector = vector;
-        this.block = new IntVectorBlock(this);
     }
 
     @Override
@@ -35,7 +32,7 @@ public final class FilterIntVector extends AbstractFilterVector implements IntVe
 
     @Override
     public IntBlock asBlock() {
-        return block;
+        return new IntVectorBlock(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVector.java
@@ -20,12 +20,9 @@ public final class FilterLongVector extends AbstractFilterVector implements Long
 
     private final LongVector vector;
 
-    private final LongBlock block;
-
     FilterLongVector(LongVector vector, int... positions) {
         super(positions, vector.blockFactory());
         this.vector = vector;
-        this.block = new LongVectorBlock(this);
     }
 
     @Override
@@ -35,7 +32,7 @@ public final class FilterLongVector extends AbstractFilterVector implements Long
 
     @Override
     public LongBlock asBlock() {
-        return block;
+        return new LongVectorBlock(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -13,7 +13,21 @@ import org.elasticsearch.core.Releasables;
  * Block view of a IntVector.
  * This class is generated. Do not edit it.
  */
-public final class IntVectorBlock extends AbstractVectorBlock implements IntBlock {
+public sealed class IntVectorBlock extends AbstractVectorBlock implements IntBlock permits IntVectorBlock.ShallowCopy {
+
+    final class ShallowCopy extends IntVectorBlock {
+        /**
+         * The vector must be a shallow copy of the original vector.
+         */
+        ShallowCopy(IntVector vector) {
+            super(vector);
+        }
+
+        @Override
+        public void close() {
+            IntVectorBlock.this.close();
+        }
+    }
 
     private final IntVector vector;
 
@@ -44,7 +58,7 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
 
     @Override
     public IntBlock filter(int... positions) {
-        return new FilterIntVector(vector, positions).asBlock();
+        return new ShallowCopy(new FilterIntVector(vector, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -25,6 +25,7 @@ public sealed class IntVectorBlock extends AbstractVectorBlock implements IntBlo
 
         @Override
         public void close() {
+            released = true;
             IntVectorBlock.this.close();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -25,6 +25,7 @@ public sealed class LongVectorBlock extends AbstractVectorBlock implements LongB
 
         @Override
         public void close() {
+            released = true;
             LongVectorBlock.this.close();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -13,7 +13,21 @@ import org.elasticsearch.core.Releasables;
  * Block view of a LongVector.
  * This class is generated. Do not edit it.
  */
-public final class LongVectorBlock extends AbstractVectorBlock implements LongBlock {
+public sealed class LongVectorBlock extends AbstractVectorBlock implements LongBlock permits LongVectorBlock.ShallowCopy {
+
+    final class ShallowCopy extends LongVectorBlock {
+        /**
+         * The vector must be a shallow copy of the original vector.
+         */
+        ShallowCopy(LongVector vector) {
+            super(vector);
+        }
+
+        @Override
+        public void close() {
+            LongVectorBlock.this.close();
+        }
+    }
 
     private final LongVector vector;
 
@@ -44,7 +58,7 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
 
     @Override
     public LongBlock filter(int... positions) {
-        return new FilterLongVector(vector, positions).asBlock();
+        return new ShallowCopy(new FilterLongVector(vector, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -210,8 +210,15 @@ public class DocVector extends AbstractVector implements Vector {
         int[] shardSegmentDocMapForwards,
         int[] shardSegmentDocMapBackwards
     ) {
-        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(shards) + RamUsageEstimator.sizeOf(segments) + RamUsageEstimator.sizeOf(docs)
-            + RamUsageEstimator.shallowSizeOf(shardSegmentDocMapForwards) + RamUsageEstimator.shallowSizeOf(shardSegmentDocMapBackwards);
+        long bytesUsed = BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(shards) + RamUsageEstimator.sizeOf(segments) + RamUsageEstimator
+            .sizeOf(docs);
+        if ((shardSegmentDocMapForwards == null) == false) {
+            bytesUsed += RamUsageEstimator.shallowSizeOf(shardSegmentDocMapForwards);
+        }
+        if ((shardSegmentDocMapBackwards == null) == false) {
+            bytesUsed += RamUsageEstimator.shallowSizeOf(shardSegmentDocMapBackwards);
+        }
+        return bytesUsed;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVector.java.st
@@ -23,12 +23,9 @@ public final class Filter$Type$Vector extends AbstractFilterVector implements $T
 
     private final $Type$Vector vector;
 
-    private final $Type$Block block;
-
     Filter$Type$Vector($Type$Vector vector, int... positions) {
         super(positions, vector.blockFactory());
         this.vector = vector;
-        this.block = new $Type$VectorBlock(this);
     }
 
     @Override
@@ -43,7 +40,7 @@ $endif$
 
     @Override
     public $Type$Block asBlock() {
-        return block;
+        return new $Type$VectorBlock(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -28,6 +28,7 @@ public sealed class $Type$VectorBlock extends AbstractVectorBlock implements $Ty
 
         @Override
         public void close() {
+            released = true;
             $Type$VectorBlock.this.close();
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -16,7 +16,21 @@ import org.elasticsearch.core.Releasables;
  * Block view of a $Type$Vector.
  * This class is generated. Do not edit it.
  */
-public final class $Type$VectorBlock extends AbstractVectorBlock implements $Type$Block {
+public sealed class $Type$VectorBlock extends AbstractVectorBlock implements $Type$Block permits $Type$VectorBlock.ShallowCopy {
+
+    final class ShallowCopy extends $Type$VectorBlock {
+        /**
+         * The vector must be a shallow copy of the original vector.
+         */
+        ShallowCopy($Type$Vector vector) {
+            super(vector);
+        }
+
+        @Override
+        public void close() {
+            $Type$VectorBlock.this.close();
+        }
+    }
 
     private final $Type$Vector vector;
 
@@ -52,7 +66,7 @@ $endif$
 
     @Override
     public $Type$Block filter(int... positions) {
-        return new Filter$Type$Vector(vector, positions).asBlock();
+        return new ShallowCopy(new Filter$Type$Vector(vector, positions));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -46,12 +46,13 @@ public class FilteredBlockTests extends ESTestCase {
     public void testFilterAllPositions() {
         var positionCount = 100;
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
-        var filteredVector = vector.filter();
+        var block = vector.asBlock();
+        var filteredBlock = block.filter();
+        var filteredVector = filteredBlock.asVector();
 
         assertEquals(0, filteredVector.getPositionCount());
         expectThrows(ArrayIndexOutOfBoundsException.class, () -> filteredVector.getInt(0));
 
-        var filteredBlock = vector.asBlock().filter();
         assertEquals(0, filteredBlock.getPositionCount());
         expectThrows(ArrayIndexOutOfBoundsException.class, () -> filteredBlock.getInt(0));
         releaseAndAssertBreaker(filteredBlock);
@@ -61,13 +62,14 @@ public class FilteredBlockTests extends ESTestCase {
         var positionCount = 100;
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
         var positions = IntStream.range(0, positionCount).toArray();
+        var block = vector.asBlock();
+        var filteredBlock = block.filter(positions);
+        var filteredVector = filteredBlock.asVector();
 
-        var filteredVector = vector.filter(positions);
         assertEquals(positionCount, filteredVector.getPositionCount());
         var anyPosition = randomPosition(positionCount);
         assertEquals(anyPosition, filteredVector.getInt(anyPosition));
 
-        var filteredBlock = vector.filter(positions).asBlock();
         assertEquals(positionCount, filteredBlock.getPositionCount());
         assertEquals(anyPosition, filteredBlock.getInt(anyPosition));
         releaseAndAssertBreaker(filteredBlock);
@@ -77,14 +79,15 @@ public class FilteredBlockTests extends ESTestCase {
         var positionCount = 100;
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
         var positions = IntStream.range(0, positionCount).filter(i -> i % 2 == 0).toArray();
+        var block = vector.asBlock();
+        var filteredBlock = block.filter(positions);
+        var filteredVector = filteredBlock.asVector();
 
-        var filteredVector = vector.filter(positions);
         assertEquals(positionCount / 2, filteredVector.getPositionCount());
         var anyPosition = randomIntBetween(0, (positionCount / 2) - 1);
         assertEquals(anyPosition * 2, filteredVector.getInt(anyPosition));
-        assertEquals(anyPosition * 2, filteredVector.asBlock().getInt(anyPosition));
+        assertEquals(anyPosition * 2, filteredBlock.getInt(anyPosition));
 
-        var filteredBlock = vector.asBlock().filter(positions);
         assertEquals(positionCount / 2, filteredBlock.getPositionCount());
         assertEquals(anyPosition * 2, filteredBlock.getInt(anyPosition));
         releaseAndAssertBreaker(filteredBlock);
@@ -93,9 +96,9 @@ public class FilteredBlockTests extends ESTestCase {
     public void testFilterOnFilter() {  // TODO: tired of this sv / mv block here. do more below
         var positionCount = 100;
         var vector = blockFactory.newIntArrayVector(IntStream.range(0, positionCount).toArray(), positionCount);
-
-        var filteredVector = vector.filter(IntStream.range(0, positionCount).filter(i1 -> i1 % 2 == 0).toArray());
-        var filteredTwice = filteredVector.filter(IntStream.range(0, positionCount / 2).filter(i -> i % 2 == 0).toArray());
+        var block = vector.asBlock();
+        var filteredBlock = block.filter(IntStream.range(0, positionCount).filter(i1 -> i1 % 2 == 0).toArray());
+        var filteredTwice = filteredBlock.filter(IntStream.range(0, positionCount / 2).filter(i -> i % 2 == 0).toArray());
 
         assertEquals(positionCount / 4, filteredTwice.getPositionCount());
         var anyPosition = randomIntBetween(0, positionCount / 4 - 1);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
@@ -124,11 +124,4 @@ public class FilterOperatorTests extends OperatorTestCase {
     protected DriverContext driverContext() { // TODO remove this when the parent uses a breaking block factory
         return breakingDriverContext();
     }
-
-    // TODO: remove this once possible
-    // https://github.com/elastic/elasticsearch/issues/99826
-    @Override
-    protected boolean canLeak() {
-        return true;
-    }
 }


### PR DESCRIPTION
Calling `Block::filter` creates a _new_ block with data from the old, filtered block. The old block never gets closed; while its memory seems to be released when closing the new block, we cannot ensure this properly in tests.

To fix this, each time we filter a block, create a shallow copy of the old block. When we close the shallow copy, close the old block as well.