### PR TITLE
Use safeAwait() in more places

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -44,12 +44,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReference;
@@ -626,18 +624,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
 
         TaskCancelHelper.cancel(task, "simulated");
 
-        final Runnable await = new Runnable() {
-            final CyclicBarrier barrier = new CyclicBarrier(2);
-
-            @Override
-            public void run() {
-                try {
-                    barrier.await(5, TimeUnit.SECONDS);
-                } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
-                    throw new AssertionError("unexpected", e);
-                }
-            }
-        };
+        final CyclicBarrier barrier = new CyclicBarrier(2);
 
         final Thread concurrentNotify = new Thread(() -> task.notifyIfCancelled(new ActionListener<Void>() {
             @Override
@@ -647,18 +634,18 @@ public class CancellableTasksTests extends TaskManagerTestCase {
 
             @Override
             public void onFailure(Exception e) {
-                await.run();
+                safeAwait(barrier);
                 // main thread calls notifyIfCancelled again between these two blocks
-                await.run();
+                safeAwait(barrier);
             }
         }), "concurrent notify");
         concurrentNotify.start();
 
-        await.run();
+        safeAwait(barrier);
         task.notifyIfCancelled(future);
         assertTrue(future.isDone());
         assertThat(expectThrows(TaskCancelledException.class, future::actionGet).getMessage(), equalTo("task cancelled [simulated]"));
-        await.run();
+        safeAwait(barrier);
         concurrentNotify.join();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/support/ListenableActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ListenableActionFutureTests.java
@@ -96,7 +96,7 @@ public class ListenableActionFutureTests extends ESTestCase {
             if (i < adderThreads) {
                 final String threadName = ADDER_THREAD_NAME_PREFIX + i;
                 threads[i] = new Thread(() -> {
-                    awaitSafe(barrier);
+                    safeAwait(barrier);
 
                     final AtomicBoolean isComplete = new AtomicBoolean();
                     if (completerThreads == 1 && postComplete.get()) {
@@ -143,7 +143,7 @@ public class ListenableActionFutureTests extends ESTestCase {
             } else {
                 final String threadName = COMPLETER_THREAD_NAME_PREFIX + i;
                 threads[i] = new Thread(() -> {
-                    awaitSafe(barrier);
+                    safeAwait(barrier);
 
                     preComplete.set(true);
                     future.onResponse(null);
@@ -155,19 +155,11 @@ public class ListenableActionFutureTests extends ESTestCase {
             threads[i].start();
         }
 
-        awaitSafe(barrier);
+        safeAwait(barrier);
         for (final Thread thread : threads) {
             thread.join();
         }
 
-    }
-
-    private static void awaitSafe(CyclicBarrier barrier) {
-        try {
-            barrier.await(10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
-        }
     }
 
     public void testAddedListenersReleasedOnCompletion() {

--- a/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
@@ -23,12 +23,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -375,19 +373,7 @@ public class CancellableSingleObjectCacheTests extends ESTestCase {
     }
 
     public void testForegroundRefreshCanBeCancelled() throws InterruptedException {
-
-        final Runnable awaitBarrier = new Runnable() {
-            final CyclicBarrier barrier = new CyclicBarrier(2);
-
-            @Override
-            public void run() {
-                try {
-                    barrier.await(10, TimeUnit.SECONDS);
-                } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
-                    throw new AssertionError("unexpected", e);
-                }
-            }
-        };
+        final CyclicBarrier barrier = new CyclicBarrier(2);
 
         final CancellableSingleObjectCache<String, String, Integer> testCache = new CancellableSingleObjectCache<>(testThreadContext) {
             @Override
@@ -398,8 +384,8 @@ public class CancellableSingleObjectCacheTests extends ESTestCase {
                 ActionListener<Integer> listener
             ) {
                 ActionListener.completeWith(listener, () -> {
-                    awaitBarrier.run(); // main-thread barrier 2; cancelled-thread barrier 1
-                    awaitBarrier.run(); // main-thread barrier 3; cancelled-thread barrier 2
+                    safeAwait(barrier); // main-thread barrier 2; cancelled-thread barrier 1
+                    safeAwait(barrier); // main-thread barrier 3; cancelled-thread barrier 2
                     ensureNotCancelled.run();
                     if (s.equals("cancelled")) {
                         throw new AssertionError("should have been cancelled");
@@ -421,11 +407,11 @@ public class CancellableSingleObjectCacheTests extends ESTestCase {
         final AtomicBoolean isCancelled = new AtomicBoolean();
         final Thread cancelledThread = new Thread(() -> {
             testCache.get("cancelled", isCancelled::get, cancelledFuture);
-            awaitBarrier.run(); // cancelled-thread barrier 3
+            safeAwait(barrier); // cancelled-thread barrier 3
         }, "cancelled-thread");
 
         cancelledThread.start();
-        awaitBarrier.run(); // main-thread barrier 1
+        safeAwait(barrier); // main-thread barrier 1
         isCancelled.set(true);
         testCache.get("successful", () -> false, successfulFuture);
         cancelledThread.join();


### PR DESCRIPTION
Various tests that use `CyclicBarrier` for synchronization pre-date the
introduction of `safeAwait()` and do all the necessary
exception-handling themselves instead. This commit update these usages
to use `safeAwait()`.