### PR TITLE
[8.11] Support $ and / in ccr follow (#99892)

### DIFF
--- a/docs/changelog/99892.yaml
+++ b/docs/changelog/99892.yaml
@@ -1,0 +1,6 @@
+pr: 99892
+summary: Support $ and / in restore rename replacements
+area: Snapshot/Restore
+type: bug
+issues:
+ - 99078

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -630,6 +630,13 @@ public class IndexFollowingIT extends CcrIntegTestCase {
         );
     }
 
+    public void testFollowWith$InIndexName() throws Exception {
+        String indexSettings = getIndexSettings(1, 0);
+        assertAcked(leaderClient().admin().indices().prepareCreate("test-leader$").setSource(indexSettings, XContentType.JSON).get());
+        followerClient().execute(PutFollowAction.INSTANCE, putFollow("test-leader$", "test-follower$")).actionGet();
+        ensureFollowerGreen("test-follower$");
+    }
+
     public void testFollowIndexMaxOperationSizeInBytes() throws Exception {
         final String leaderIndexSettings = getIndexSettings(1, between(0, 1));
         assertAcked(leaderClient().admin().indices().prepareCreate("index1").setSource(leaderIndexSettings, XContentType.JSON));

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -52,6 +52,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.DataStream.BACKING_INDEX_PREFIX;
@@ -186,7 +187,7 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
         )
             .indicesOptions(request.indicesOptions())
             .renamePattern("^(.*)$")
-            .renameReplacement(request.getFollowerIndex())
+            .renameReplacement(Matcher.quoteReplacement(request.getFollowerIndex()))
             .masterNodeTimeout(request.masterNodeTimeout())
             .indexSettings(overrideSettings)
             .quiet(true);


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Support $ and / in ccr follow (#99892)