### PR TITLE
[8.11] ExchangeBuffer should release inbound page when no more input is expected (#100259)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeBuffer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeBuffer.java
@@ -41,9 +41,13 @@ final class ExchangeBuffer {
     }
 
     void addPage(Page page) {
-        queue.add(page);
-        if (queueSize.incrementAndGet() == 1) {
-            notifyNotEmpty();
+        if (noMoreInputs) {
+            page.releaseBlocks();
+        } else {
+            queue.add(page);
+            if (queueSize.incrementAndGet() == 1) {
+                notifyNotEmpty();
+            }
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -184,7 +184,6 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
     // operator that throws - fails. The primary motivation for this is to ensure that the driver
     // runner behaves correctly and also releases all resources (bigArrays) appropriately.
     // @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100145")
     public final void testManyInitialManyPartialFinalRunnerThrowing() throws Exception {
         DriverContext driverContext = driverContext();
         BigArrays bigArrays = nonBreakingBigArrays();


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ExchangeBuffer should release inbound page when no more input is expected (#100259)