### PR TITLE
[8.11] Ensure blocks released in ESQL disruption tests (#100295)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -9,12 +9,14 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -27,6 +29,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.equalTo;
+
 @TestLogging(value = "org.elasticsearch.xpack.esql.session:DEBUG", reason = "to better understand planning")
 public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
 
@@ -36,6 +40,18 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
             TransportEsqlQueryAction esqlQueryAction = internalCluster().getInstance(TransportEsqlQueryAction.class, node);
             ExchangeService exchangeService = esqlQueryAction.exchangeService();
             assertBusy(() -> assertTrue("Leftover exchanges " + exchangeService + " on node " + node, exchangeService.isEmpty()));
+        }
+    }
+
+    public void ensureBlocksReleased() {
+        for (String node : internalCluster().getNodeNames()) {
+            CircuitBreakerService breakerService = internalCluster().getInstance(CircuitBreakerService.class, node);
+            CircuitBreaker reqBreaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+            try {
+                assertBusy(() -> assertThat("Request breaker not reset to 0 on node: " + node, reqBreaker.getUsed(), equalTo(0L)));
+            } catch (Exception e) {
+                assertThat("Request breaker not reset to 0 on node: " + node, reqBreaker.getUsed(), equalTo(0L));
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
@@ -7,31 +7,27 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
-/**
- * Makes sure that the circuit breaker is "plugged in" to ESQL by configuring an
- * unreasonably small breaker and tripping it.
- */
-@ESIntegTestCase.ClusterScope(scope = SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
-public class EsqlActionBreakerIT extends AbstractEsqlIntegTestCase {
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100147")
+public class EsqlActionBreakerIT extends EsqlActionIT {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -44,7 +40,7 @@ public class EsqlActionBreakerIT extends AbstractEsqlIntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "1kb")
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "128mb")
             /*
              * Force standard settings for the request breaker or we may not break at all.
              * Without this we can randomly decide to use the `noop` breaker for request
@@ -62,29 +58,74 @@ public class EsqlActionBreakerIT extends AbstractEsqlIntegTestCase {
             .build();
     }
 
-    public void testBreaker() {
-        for (int i = 0; i < 5000; i++) {
-            DocWriteResponse response = client().prepareIndex("test").setId(Integer.toString(i)).setSource("foo", i, "bar", i * 2).get();
-            if (response.getResult() != DocWriteResponse.Result.CREATED) {
-                fail("failure: " + response);
-            }
-        }
-        client().admin().indices().prepareRefresh("test").get();
-        ensureYellow("test");
-        ElasticsearchException e = expectThrows(
-            ElasticsearchException.class,
-            () -> run("from test | stats avg(foo) by bar", QueryPragmas.EMPTY)
-        );
-        logger.info("expected error", e);
-        if (e instanceof CircuitBreakingException) {
-            // The failure occurred before starting the drivers
-            assertThat(e.getMessage(), containsString("Data too large"));
+    private void setRequestCircuitBreakerLimit(ByteSizeValue limit) {
+        if (limit != null) {
+            clusterAdmin().prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder().put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), limit).build()
+                )
+                .get();
         } else {
-            // The failure occurred after starting the drivers
-            assertThat(e.getMessage(), containsString("Compute engine failure"));
-            assertThat(e.getMessage(), containsString("Data too large"));
-            assertThat(e.getCause(), instanceOf(CircuitBreakingException.class));
-            assertThat(e.getCause().getMessage(), containsString("Data too large"));
+            clusterAdmin().prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder().putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey()).build()
+                )
+                .get();
+        }
+    }
+
+    @Override
+    protected EsqlQueryResponse run(String esqlCommands) {
+        try {
+            setRequestCircuitBreakerLimit(ByteSizeValue.ofBytes(between(128, 2048)));
+            try {
+                return super.run(esqlCommands);
+            } catch (Exception e) {
+                logger.info("request failed", e);
+                ensureBlocksReleased();
+            }
+            setRequestCircuitBreakerLimit(ByteSizeValue.ofMb(64));
+            return super.run(esqlCommands);
+        } finally {
+            setRequestCircuitBreakerLimit(null);
+        }
+    }
+
+    /**
+     * Makes sure that the circuit breaker is "plugged in" to ESQL by configuring an
+     * unreasonably small breaker and tripping it.
+     */
+    public void testBreaker() {
+        setRequestCircuitBreakerLimit(ByteSizeValue.ofKb(1));
+        try {
+            for (int i = 0; i < 5000; i++) {
+                DocWriteResponse response = client().prepareIndex("test")
+                    .setId(Integer.toString(i))
+                    .setSource("foo", i, "bar", i * 2)
+                    .get();
+                if (response.getResult() != DocWriteResponse.Result.CREATED) {
+                    fail("failure: " + response);
+                }
+            }
+            client().admin().indices().prepareRefresh("test").get();
+            ensureYellow("test");
+            ElasticsearchException e = expectThrows(
+                ElasticsearchException.class,
+                () -> super.run("from test | stats avg(foo) by bar", QueryPragmas.EMPTY).close()
+            );
+            logger.info("expected error", e);
+            if (e instanceof CircuitBreakingException) {
+                // The failure occurred before starting the drivers
+                assertThat(e.getMessage(), containsString("Data too large"));
+            } else {
+                // The failure occurred after starting the drivers
+                assertThat(e.getMessage(), containsString("Compute engine failure"));
+                assertThat(e.getMessage(), containsString("Data too large"));
+                assertThat(e.getCause(), instanceOf(CircuitBreakingException.class));
+                assertThat(e.getCause().getMessage(), containsString("Data too large"));
+            }
+        } finally {
+            setRequestCircuitBreakerLimit(null);
         }
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlDisruptionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlDisruptionIT.java
@@ -92,6 +92,7 @@ public class EsqlDisruptionIT extends EsqlActionIT {
             return future.actionGet(2, TimeUnit.MINUTES);
         } catch (Exception e) {
             assertTrue("request must be failed or completed after clearing disruption", future.isDone());
+            ensureBlocksReleased();
             logger.info("--> failed to execute esql query with disruption; retrying...", e);
             return client().execute(EsqlQueryAction.INSTANCE, request).actionGet(2, TimeUnit.MINUTES);
         }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Ensure blocks released in ESQL disruption tests (#100295)