### PR TITLE
Support debugging integration tests with multiple test clusters

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -74,7 +74,6 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
     private final DistributionResolver distributionResolver;
 
-
     public AbstractLocalClusterFactory(DistributionResolver distributionResolver) {
         this.distributionResolver = distributionResolver;
     }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -71,9 +71,9 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
     private static final String TESTS_CLUSTER_FIPS_JAR_PATH_SYSPROP = "tests.cluster.fips.jars.path";
     private static final String TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP = "tests.cluster.debug.enabled";
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
-    private static final int DEFAULT_DEBUG_PORT = 5007;
 
     private final DistributionResolver distributionResolver;
+
 
     public AbstractLocalClusterFactory(DistributionResolver distributionResolver) {
         this.distributionResolver = distributionResolver;
@@ -106,6 +106,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
         private final Path configDir;
         private final Path tempDir;
         private final boolean usesSecureSecretsFile;
+        private final int debugPort;
 
         private Path distributionDir;
         private Version currentVersion;
@@ -135,6 +136,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
             this.logsDir = workingDir.resolve("logs");
             this.configDir = workingDir.resolve("config");
             this.tempDir = workingDir.resolve("tmp"); // elasticsearch temporary directory
+            this.debugPort = DefaultLocalClusterHandle.NEXT_DEBUG_PORT.getAndIncrement();
         }
 
         public synchronized void start(Version version) {
@@ -726,8 +728,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
             String debugArgs = "";
             if (Boolean.getBoolean(TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP)) {
-                int port = DEFAULT_DEBUG_PORT + spec.getCluster().getNodes().indexOf(spec);
-                debugArgs = ENABLE_DEBUG_JVM_ARGS + port;
+                debugArgs = ENABLE_DEBUG_JVM_ARGS + debugPort;
             }
 
             String heapSize = System.getProperty("tests.heap.size", "512m");

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -30,11 +30,14 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DefaultLocalClusterHandle implements LocalClusterHandle {
+    public static final AtomicInteger NEXT_DEBUG_PORT = new AtomicInteger(5007);
+
     private static final Logger LOGGER = LogManager.getLogger(DefaultLocalClusterHandle.class);
     private static final Duration CLUSTER_UP_TIMEOUT = Duration.ofSeconds(30);
 
@@ -96,6 +99,7 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
     @Override
     public void close() {
         stop(true);
+        NEXT_DEBUG_PORT.getAndUpdate(i -> i - nodes.size());
 
         executor.shutdownNow();
         try {


### PR DESCRIPTION
Add support for passing `--debug-server-jvm` to tests that declare multiple test clusters. This is common in tests for things like remote cluster security, CCS, CCR, etc.

The convention for port numbers and debug settings is the same. The JVM is expected to attach to an existing debugger in listen mode, starting at port 5007 and incrementing from there.

Closes #94175