### PR TITLE
[8.10] Convert core xpack rest tests to new test framework (#100301)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.util.Version;
  */
 public enum FeatureFlag {
     TIME_SERIES_MODE("es.index_mode_feature_flag_registered=true", Version.fromString("8.0.0"), null),
+    INFERENCE_RESCORER("es.inference_rescorer_feature_flag_enabled", Version.fromString("8.10.0"), null),
     DATA_STREAM_LIFECYCLE_ENABLED("es.dlm_feature_flag_enabled=true", Version.fromString("8.8.0"), null);
 
     public final String systemProperty;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -19,6 +19,7 @@ public class DefaultLocalClusterSpecBuilder extends AbstractLocalClusterSpecBuil
 
     public DefaultLocalClusterSpecBuilder() {
         super();
+        this.apply(c -> c.systemProperty("ingest.geoip.downloader.enabled.default", "false"));
         this.apply(new FipsEnabledClusterConfigProvider());
         this.settings(new DefaultSettingsProvider());
         this.environment(new DefaultEnvironmentProvider());

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -1,10 +1,11 @@
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 import org.elasticsearch.gradle.util.GradleUtils
 
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.validate-rest-spec'
 apply plugin: 'elasticsearch.internal-test-artifact'
 
@@ -15,6 +16,7 @@ base {
 dependencies {
   testImplementation project(xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation(testArtifact(project(":x-pack:plugin:security:qa:service-account"), "javaRestTest"))
   testImplementation project(':test:yaml-rest-runner')
 }
 
@@ -33,32 +35,6 @@ artifacts {
   restXpackTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }
 
-// location for keys and certificates
-File extraResourceDir = file("$buildDir/extra_resource")
-File nodeKey = file("$extraResourceDir/testnode.pem")
-File nodeCert = file("$extraResourceDir/testnode.crt")
-// location for service tokens
-File serviceTokens = file("$extraResourceDir/service_tokens")
-
-// Add key and certs to test classpath: it expects them there
-// User cert and key PEM files instead of a JKS Keystore for the cluster's trust material so that
-// it can run in a FIPS 140 JVM
-// TODO: Remove all existing uses of cross project file references when the new approach for referencing static files is available
-// https://github.com/elastic/elasticsearch/pull/32201
-tasks.register("copyExtraResources", Copy) {
-  from(project(':x-pack:plugin:core').file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/')) {
-    include 'testnode.crt', 'testnode.pem'
-  }
-  from(project(':x-pack:plugin:security:qa:service-account').file('src/javaRestTest/resources/')) {
-    include 'service_tokens'
-  }
-  into extraResourceDir
-}
-// Add keystores to test classpath: it expects it there
-sourceSets.yamlRestTest.resources.srcDir(extraResourceDir)
-tasks.named("processYamlRestTestResources").configure {
-  dependsOn("copyExtraResources")
-}
 def restTestBlacklist = []
 // TODO: fix this rest test to not depend on a hardcoded port!
 restTestBlacklist.addAll(['getting_started/10_monitor_cluster_health/*'])
@@ -75,9 +51,12 @@ if (BuildParams.isSnapshotBuild() == false) {
   restTestBlacklist.add('privileges/11_builtin/Test get builtin privileges')
 }
 
+tasks.withType(StandaloneRestIntegTestTask).configureEach {
+  usesDefaultDistribution()
+}
+
 tasks.named("yamlRestTest").configure {
   systemProperty 'tests.rest.blacklist', restTestBlacklist.join(',')
-  dependsOn "copyExtraResources"
 }
 
 tasks.named("yamlRestTestV7CompatTest").configure {
@@ -194,38 +173,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
     "action [cluster:admin/xpack/security/api_key/invalidate] is unauthorized for user [api_key_user_1] with effective roles [user_role], this action is granted by the cluster privileges [manage_api_key,manage_security,all]",
     "Test invalidate api key by username"
   )
-}
-
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT' // this is important since we use the reindex module in ML
-  setting 'xpack.ml.enabled', 'true'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.watcher.enabled', 'false'
-  // Integration tests are supposed to enable/disable exporters before/after each test
-  setting 'xpack.security.authc.token.enabled', 'true'
-  setting 'xpack.security.authc.api_key.enabled', 'true'
-  setting 'xpack.security.transport.ssl.enabled', 'true'
-  setting 'xpack.security.transport.ssl.key', nodeKey.name
-  setting 'xpack.security.transport.ssl.certificate', nodeCert.name
-  setting 'xpack.security.transport.ssl.verification_mode', 'certificate'
-  setting 'xpack.security.audit.enabled', 'true'
-  setting 'xpack.license.self_generated.type', 'trial'
-  // disable ILM history, since it disturbs tests using _all
-  setting 'indices.lifecycle.history_index_enabled', 'false'
-  keystore 'bootstrap.password', 'x-pack-test-password'
-  keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-  setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
-  setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
-
-  user username: "x_pack_rest_user", password: "x-pack-test-password"
-  extraConfigFile nodeKey.name, nodeKey
-  extraConfigFile nodeCert.name, nodeCert
-  extraConfigFile serviceTokens.name, serviceTokens
-
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
-  requiresFeature 'es.inference_rescorer_feature_flag_enabled', Version.fromString("8.10.0")
-  requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 tasks.register('enforceApiSpecsConvention').configure {

--- a/x-pack/plugin/src/yamlRestTest/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/yamlRestTest/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -9,10 +9,46 @@ package org.elasticsearch.xpack.test.rest;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.junit.Before;
+import org.junit.ClassRule;
 
 public class XPackRestIT extends AbstractXPackRestTest {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .name("yamlRestTest")
+        .setting("xpack.ml.enabled", "true")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.watcher.enabled", "false")
+        // Integration tests are supposed to enable/disable exporters before/after each test
+        .setting("xpack.security.authc.token.enabled", "true")
+        .setting("xpack.security.authc.api_key.enabled", "true")
+        .setting("xpack.security.transport.ssl.enabled", "true")
+        .setting("xpack.security.transport.ssl.key", "testnode.pem")
+        .setting("xpack.security.transport.ssl.certificate", "testnode.crt")
+        .setting("xpack.security.transport.ssl.verification_mode", "certificate")
+        .setting("xpack.security.audit.enabled", "true")
+        .setting("xpack.license.self_generated.type", "trial")
+        // disable ILM history, since it disturbs tests using _all
+        .setting("indices.lifecycle.history_index_enabled", "false")
+        .keystore("bootstrap.password", "x-pack-test-password")
+        .keystore("xpack.security.transport.ssl.secure_key_passphrase", "testnode")
+        .setting("xpack.searchable.snapshot.shared_cache.size", "16MB")
+        .setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB")
+        .user("x_pack_rest_user", "x-pack-test-password")
+        .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.INFERENCE_RESCORER)
+        .feature(FeatureFlag.DATA_STREAM_LIFECYCLE_ENABLED)
+        .configFile("testnode.pem", Resource.fromClasspath("org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem"))
+        .configFile("testnode.crt", Resource.fromClasspath("org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"))
+        .configFile("service_tokens", Resource.fromClasspath("service_tokens"))
+        .build();
 
     public XPackRestIT(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -29,5 +65,10 @@ public class XPackRestIT extends AbstractXPackRestTest {
     @Before
     public void setupLicense() {
         super.waitForLicense();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Convert core xpack rest tests to new test framework (#100301)