### PR TITLE
[8.11] Support debugging integration tests with multiple test clusters (#100304)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -71,7 +71,6 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
     private static final String TESTS_CLUSTER_FIPS_JAR_PATH_SYSPROP = "tests.cluster.fips.jars.path";
     private static final String TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP = "tests.cluster.debug.enabled";
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
-    private static final int DEFAULT_DEBUG_PORT = 5007;
 
     private final DistributionResolver distributionResolver;
 
@@ -106,6 +105,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
         private final Path configDir;
         private final Path tempDir;
         private final boolean usesSecureSecretsFile;
+        private final int debugPort;
 
         private Path distributionDir;
         private Version currentVersion;
@@ -135,6 +135,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
             this.logsDir = workingDir.resolve("logs");
             this.configDir = workingDir.resolve("config");
             this.tempDir = workingDir.resolve("tmp"); // elasticsearch temporary directory
+            this.debugPort = DefaultLocalClusterHandle.NEXT_DEBUG_PORT.getAndIncrement();
         }
 
         public synchronized void start(Version version) {
@@ -726,8 +727,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
             String debugArgs = "";
             if (Boolean.getBoolean(TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP)) {
-                int port = DEFAULT_DEBUG_PORT + spec.getCluster().getNodes().indexOf(spec);
-                debugArgs = ENABLE_DEBUG_JVM_ARGS + port;
+                debugArgs = ENABLE_DEBUG_JVM_ARGS + debugPort;
             }
 
             String heapSize = System.getProperty("tests.heap.size", "512m");

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -30,11 +30,14 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DefaultLocalClusterHandle implements LocalClusterHandle {
+    public static final AtomicInteger NEXT_DEBUG_PORT = new AtomicInteger(5007);
+
     private static final Logger LOGGER = LogManager.getLogger(DefaultLocalClusterHandle.class);
     private static final Duration CLUSTER_UP_TIMEOUT = Duration.ofSeconds(30);
 
@@ -96,6 +99,7 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
     @Override
     public void close() {
         stop(true);
+        NEXT_DEBUG_PORT.getAndUpdate(i -> i - nodes.size());
 
         executor.shutdownNow();
         try {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Support debugging integration tests with multiple test clusters (#100304)