### PR TITLE
[8.11] ESQL: Test evaluators with cranky breaker (#100302)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupeBoolean.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupeBoolean.java
@@ -48,8 +48,7 @@ public class MultivalueDedupeBoolean {
         if (false == block.mayHaveMultivaluedFields()) {
             return ref;
         }
-        try (ref) {
-            BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(block.getPositionCount(), blockFactory);
+        try (ref; BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(block.getPositionCount(), blockFactory)) {
             for (int p = 0; p < block.getPositionCount(); p++) {
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
@@ -72,23 +71,24 @@ public class MultivalueDedupeBoolean {
      * @param everSeen array tracking if the values {@code false} and {@code true} are ever seen
      */
     public IntBlock hash(boolean[] everSeen) {
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
-        for (int p = 0; p < block.getPositionCount(); p++) {
-            int count = block.getValueCount(p);
-            int first = block.getFirstValueIndex(p);
-            switch (count) {
-                case 0 -> {
-                    everSeen[NULL_ORD] = true;
-                    builder.appendInt(NULL_ORD);
-                }
-                case 1 -> builder.appendInt(hashOrd(everSeen, block.getBoolean(first)));
-                default -> {
-                    readValues(first, count);
-                    hashValues(everSeen, builder);
+        try (IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount())) {
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> {
+                        everSeen[NULL_ORD] = true;
+                        builder.appendInt(NULL_ORD);
+                    }
+                    case 1 -> builder.appendInt(hashOrd(everSeen, block.getBoolean(first)));
+                    default -> {
+                        readValues(first, count);
+                        hashValues(everSeen, builder);
+                    }
                 }
             }
+            return builder.build();
         }
-        return builder.build();
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -78,8 +78,7 @@ $endif$
         if (block.mvDeduplicated()) {
             return ref;
         }
-        try (ref) {
-            $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount(), blockFactory);
+        try (ref; $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount(), blockFactory)) {
             for (int p = 0; p < block.getPositionCount(); p++) {
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
@@ -132,8 +131,7 @@ $endif$
         if (block.mvDeduplicated()) {
             return ref;
         }
-        try (ref) {
-            $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount(), blockFactory);
+        try (ref; $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount(), blockFactory)) {
             for (int p = 0; p < block.getPositionCount(); p++) {
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
@@ -166,8 +164,7 @@ $endif$
         if (block.mvDeduplicated()) {
             return ref;
         }
-        try (ref) {
-            $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount(), blockFactory);
+        try (ref; $Type$Block.Builder builder = $Type$Block.newBlockBuilder(block.getPositionCount(), blockFactory)) {
             for (int p = 0; p < block.getPositionCount(); p++) {
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
@@ -197,36 +194,37 @@ $if(BytesRef)$
 $else$
     public MultivalueDedupe.HashResult hash(LongHash hash) {
 $endif$
-        IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount());
-        boolean sawNull = false;
-        for (int p = 0; p < block.getPositionCount(); p++) {
-            int count = block.getValueCount(p);
-            int first = block.getFirstValueIndex(p);
-            switch (count) {
-                case 0 -> {
-                    sawNull = true;
-                    builder.appendInt(0);
-                }
-                case 1 -> {
+        try (IntBlock.Builder builder = IntBlock.newBlockBuilder(block.getPositionCount())) {
+            boolean sawNull = false;
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> {
+                        sawNull = true;
+                        builder.appendInt(0);
+                    }
+                    case 1 -> {
 $if(BytesRef)$
-                    BytesRef v = block.getBytesRef(first, work[0]);
+                        BytesRef v = block.getBytesRef(first, work[0]);
 $else$
-                    $type$ v = block.get$Type$(first);
+                        $type$ v = block.get$Type$(first);
 $endif$
-                    hash(builder, hash, v);
-                }
-                default -> {
-                    if (count < ALWAYS_COPY_MISSING) {
-                        copyMissing(first, count);
-                        hashUniquedWork(hash, builder);
-                    } else {
-                        copyAndSort(first, count);
-                        hashSortedWork(hash, builder);
+                        hash(builder, hash, v);
+                    }
+                    default -> {
+                        if (count < ALWAYS_COPY_MISSING) {
+                            copyMissing(first, count);
+                            hashUniquedWork(hash, builder);
+                        } else {
+                            copyAndSort(first, count);
+                            hashSortedWork(hash, builder);
+                        }
                     }
                 }
             }
+            return new MultivalueDedupe.HashResult(builder.build(), sawNull);
         }
-        return new MultivalueDedupe.HashResult(builder.build(), sawNull);
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Test evaluators with cranky breaker (#100302)