### PR TITLE
Add more debugging for file settings edge case

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsStartupIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsStartupIT.java
@@ -105,6 +105,10 @@ public class FileSettingsRoleMappingsStartupIT extends SecurityIntegTestCase {
                     clusterService.removeListener(this);
                     metadataVersion.set(event.state().metadata().version());
                     savedClusterState.countDown();
+                } else if (reservedState != null) {
+                    logger.debug(() -> "Got reserved state update without error metadata: " + reservedState);
+                } else {
+                    logger.debug(() -> "Got cluster state update: " + event.source());
                 }
             }
         });
@@ -112,7 +116,9 @@ public class FileSettingsRoleMappingsStartupIT extends SecurityIntegTestCase {
         return new Tuple<>(savedClusterState, metadataVersion);
     }
 
-    @TestLogging(value = "org.elasticsearch.common.file:DEBUG", reason = "https://github.com/elastic/elasticsearch/issues/98391")
+    @TestLogging(
+        value = "org.elasticsearch.common.file:DEBUG,org.elasticsearch.xpack.security:DEBUG,org.elasticsearch.cluster.metadata:DEBUG",
+        reason = "https://github.com/elastic/elasticsearch/issues/98391")
     public void testFailsOnStartMasterNodeWithError() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsStartupIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsStartupIT.java
@@ -118,7 +118,8 @@ public class FileSettingsRoleMappingsStartupIT extends SecurityIntegTestCase {
 
     @TestLogging(
         value = "org.elasticsearch.common.file:DEBUG,org.elasticsearch.xpack.security:DEBUG,org.elasticsearch.cluster.metadata:DEBUG",
-        reason = "https://github.com/elastic/elasticsearch/issues/98391")
+        reason = "https://github.com/elastic/elasticsearch/issues/98391"
+    )
     public void testFailsOnStartMasterNodeWithError() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 


### PR DESCRIPTION
In order to continue debugging #98391, this commit adds more debug logging to the test, to determine if the error metadata is not being placed in the cluster state correctly.