### PR TITLE
Fix testIndexCompatibilityChecks

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -558,7 +558,6 @@ public class NodeEnvironmentTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100319")
     public void testIndexCompatibilityChecks() throws IOException {
         final Settings settings = buildEnvSettings(Settings.EMPTY);
 
@@ -600,7 +599,11 @@ public class NodeEnvironmentTests extends ESTestCase {
                 allOf(
                     containsString("Cannot start this node"),
                     containsString("it holds metadata for indices with version [" + oldIndexVersion + "]"),
-                    containsString("Revert this node to version [" + previousNodeVersion + "]")
+                    containsString(
+                        "Revert this node to version ["
+                            + (previousNodeVersion.major == Version.V_8_0_0.major ? Version.V_7_17_0 : previousNodeVersion)
+                            + "]"
+                    )
                 )
             );
 
@@ -621,8 +624,13 @@ public class NodeEnvironmentTests extends ESTestCase {
                 () -> checkForIndexCompatibility(logger, env.dataPaths())
             );
 
-            assertThat(ex.getMessage(), startsWith("cannot upgrade a node from version [" + oldVersion + "] directly"));
-            assertThat(ex.getMessage(), containsString("upgrade to version [" + Build.current().minWireCompatVersion()));
+            assertThat(
+                ex.getMessage(),
+                allOf(
+                    startsWith("cannot upgrade a node from version [" + oldVersion + "] directly"),
+                    containsString("upgrade to version [" + Build.current().minWireCompatVersion())
+                )
+            );
         }
     }
 


### PR DESCRIPTION
This test was sometimes picking a v8.x version for the previous node,
but such a node cannot have any indices incompatible with `CURRENT`.
We've changed the logic for creating the downgrade advice message
recently so that it defaults to v7.17.0 in this situation, and this
commit updates the test to match.

Closes #100319