### PR TITLE
[8.11] Enable grok and dissect tests with stats (#100290)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -99,8 +99,7 @@ Anneke Preusig        | Anneke       | Preusig
 ;
 
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-dissectStats-Ignore
+dissectStats
 from employees | eval x = concat(gender, " foobar") | dissect x "%{a} %{b}" | stats n = max(emp_no) by a | keep a, n | sort a asc;
 
 a:keyword  | n:integer

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -83,8 +83,7 @@ Anneke Preusig        | Anneke       | Preusig
 ;
 
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-grokStats-Ignore
+grokStats
 from employees | eval x = concat(gender, " foobar") | grok x "%{WORD:a} %{WORD:b}" | stats n = max(emp_no) by a | keep a, n | sort a asc;
 
 a:keyword  | n:integer


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Enable grok and dissect tests with stats (#100290)