### PR TITLE
[8.11] [ML] Defend against negative datafeed start times (#100284)

### DIFF
--- a/docs/changelog/100284.yaml
+++ b/docs/changelog/100284.yaml
@@ -1,0 +1,5 @@
+pr: 100284
+summary: Defend against negative datafeed start times
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -190,6 +190,9 @@ public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
 
         public DatafeedParams(String datafeedId, long startTime) {
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
+            if (startTime < 0) {
+                throw new IllegalArgumentException("[" + START_TIME.getPreferredName() + "] must not be negative [" + startTime + "].");
+            }
             this.startTime = startTime;
         }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -823,6 +823,38 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         assertThat(e.status(), equalTo(RestStatus.REQUEST_TIMEOUT));
     }
 
+    public void testStartDatafeed_GivenNegativeStartTime_Returns408() throws Exception {
+        client().admin().indices().prepareCreate("data-1").setMapping("time", "type=date").get();
+        long numDocs = 100;
+        long now = System.currentTimeMillis();
+        long oneWeekAgo = now - 604800000;
+        long negativeStartTime = -1000;
+        indexDocs(logger, "data-1", numDocs, oneWeekAgo, now);
+
+        String jobId = "job-for-start-datafeed-timeout";
+        String datafeedId = jobId + "-datafeed";
+
+        Job.Builder job = createScheduledJob(jobId);
+        putJob(job);
+        openJob(job.getId());
+        assertBusy(() -> assertEquals(getJobStats(job.getId()).get(0).getState(), JobState.OPENED));
+
+        DatafeedConfig.Builder datafeedConfigBuilder = createDatafeedBuilder(
+            job.getId() + "-datafeed",
+            job.getId(),
+            Collections.singletonList("data-1")
+        );
+        DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+        putDatafeed(datafeedConfig);
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new StartDatafeedAction.Request(datafeedId, negativeStartTime)
+        );
+
+        assertThat(e.getMessage(), equalTo("[start] must not be negative [-1000]."));
+    }
+
     public void testStart_GivenAggregateMetricDoubleWithoutAggs() throws Exception {
         final String index = "index-with-aggregate-metric-double";
         String mapping = """


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [ML] Defend against negative datafeed start times (#100284)