### PR TITLE
Moving ClusterStatsMonitoringDoc to opaque string versions

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -208,7 +208,8 @@ public class ClusterStatsIT extends ESIntegTestCase {
         assertThat(msg, response.nodesStats.getJvm().getVersions().size(), Matchers.greaterThan(0));
 
         assertThat(msg, response.nodesStats.getVersions().size(), Matchers.greaterThan(0));
-        assertThat(msg, response.nodesStats.getVersions().contains(Version.CURRENT), Matchers.equalTo(true));
+        // TODO: Build.current().unqualifiedVersion() -- or Build.current().version() if/when we move NodeInfo to Build version(s)
+        assertThat(msg, response.nodesStats.getVersions().contains(Version.CURRENT.toString()), Matchers.equalTo(true));
         assertThat(msg, response.nodesStats.getPlugins().size(), Matchers.greaterThanOrEqualTo(0));
 
         assertThat(msg, response.nodesStats.getProcess().count, Matchers.greaterThan(0));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -41,7 +41,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -201,23 +204,23 @@ public class ClusterStatsIT extends ESIntegTestCase {
 
         ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         String msg = response.toString();
-        assertThat(msg, response.getTimestamp(), Matchers.greaterThan(946681200000L)); // 1 Jan 2000
-        assertThat(msg, response.indicesStats.getStore().getSizeInBytes(), Matchers.greaterThan(0L));
+        assertThat(msg, response.getTimestamp(), greaterThan(946681200000L)); // 1 Jan 2000
+        assertThat(msg, response.indicesStats.getStore().getSizeInBytes(), greaterThan(0L));
 
-        assertThat(msg, response.nodesStats.getFs().getTotal().getBytes(), Matchers.greaterThan(0L));
-        assertThat(msg, response.nodesStats.getJvm().getVersions().size(), Matchers.greaterThan(0));
+        assertThat(msg, response.nodesStats.getFs().getTotal().getBytes(), greaterThan(0L));
+        assertThat(msg, response.nodesStats.getJvm().getVersions().size(), greaterThan(0));
 
-        assertThat(msg, response.nodesStats.getVersions().size(), Matchers.greaterThan(0));
+        assertThat(msg, response.nodesStats.getVersions(), hasSize(greaterThan(0)));
         // TODO: Build.current().unqualifiedVersion() -- or Build.current().version() if/when we move NodeInfo to Build version(s)
-        assertThat(msg, response.nodesStats.getVersions().contains(Version.CURRENT.toString()), Matchers.equalTo(true));
-        assertThat(msg, response.nodesStats.getPlugins().size(), Matchers.greaterThanOrEqualTo(0));
+        assertThat(msg, response.nodesStats.getVersions(), hasItem(Version.CURRENT.toString()));
+        assertThat(msg, response.nodesStats.getPlugins(), hasSize(greaterThanOrEqualTo(0)));
 
-        assertThat(msg, response.nodesStats.getProcess().count, Matchers.greaterThan(0));
+        assertThat(msg, response.nodesStats.getProcess().count, greaterThan(0));
         // 0 happens when not supported on platform
-        assertThat(msg, response.nodesStats.getProcess().getAvgOpenFileDescriptors(), Matchers.greaterThanOrEqualTo(0L));
+        assertThat(msg, response.nodesStats.getProcess().getAvgOpenFileDescriptors(), greaterThanOrEqualTo(0L));
         // these can be -1 if not supported on platform
-        assertThat(msg, response.nodesStats.getProcess().getMinOpenFileDescriptors(), Matchers.greaterThanOrEqualTo(-1L));
-        assertThat(msg, response.nodesStats.getProcess().getMaxOpenFileDescriptors(), Matchers.greaterThanOrEqualTo(-1L));
+        assertThat(msg, response.nodesStats.getProcess().getMinOpenFileDescriptors(), greaterThanOrEqualTo(-1L));
+        assertThat(msg, response.nodesStats.getProcess().getMaxOpenFileDescriptors(), greaterThanOrEqualTo(-1L));
 
         NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats().setOs(true).get();
         long total = 0;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -136,7 +136,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         builder.endObject();
 
         builder.startArray(Fields.VERSIONS);
-        for (final var v : versions) {
+        for (var v : versions) {
             builder.value(v);
         }
         builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -48,7 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ClusterStatsNodes implements ToXContentFragment {
 
     private final Counts counts;
-    private final Set<Version> versions;
+    private final Set<String> versions;
     private final OsStats os;
     private final ProcessStats process;
     private final JvmStats jvm;
@@ -71,7 +70,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         for (ClusterStatsNodeResponse nodeResponse : nodeResponses) {
             nodeInfos.add(nodeResponse.nodeInfo());
             nodeStats.add(nodeResponse.nodeStats());
-            this.versions.add(nodeResponse.nodeInfo().getVersion());
+            this.versions.add(nodeResponse.nodeInfo().getVersion().toString());
             this.plugins.addAll(nodeResponse.nodeInfo().getInfo(PluginsAndModules.class).getPluginInfos());
 
             TransportAddress publishAddress = nodeResponse.nodeInfo().getInfo(TransportInfo.class).address().publishAddress();
@@ -95,7 +94,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         return this.counts;
     }
 
-    public Set<Version> getVersions() {
+    public Set<String> getVersions() {
         return versions;
     }
 
@@ -137,8 +136,8 @@ public class ClusterStatsNodes implements ToXContentFragment {
         builder.endObject();
 
         builder.startArray(Fields.VERSIONS);
-        for (Version v : versions) {
-            builder.value(v.toString());
+        for (final var v : versions) {
+            builder.value(v);
         }
         builder.endArray();
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollector.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.monitoring.collector.cluster;
 
 import org.apache.logging.log4j.util.Supplier;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
@@ -92,7 +92,7 @@ public class ClusterStatsCollector extends Collector {
 
         final String clusterName = clusterService.getClusterName().value();
         final String clusterUuid = clusterUuid(clusterState);
-        final String version = Version.CURRENT.toString();
+        final String version = Build.current().version();
         final License license = licenseService.getLicense();
         final List<XPackFeatureSet.Usage> xpackUsage = collect(usageSupplier);
         final boolean apmIndicesExist = doAPMIndicesExist(clusterState);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsCollectorTests.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.monitoring.collector.cluster;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsIndices;
@@ -266,7 +266,7 @@ public class ClusterStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(document.getId(), nullValue());
 
         assertThat(document.getClusterName(), equalTo(clusterName));
-        assertThat(document.getVersion(), equalTo(Version.CURRENT.toString()));
+        assertThat(document.getVersion(), equalTo(Build.current().version()));
         assertThat(document.getLicense(), equalTo(license));
         assertThat(document.getStatus(), equalTo(clusterStatus));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -56,7 +56,6 @@ import org.elasticsearch.monitor.process.ProcessStats;
 import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginRuntimeInfo;
 import org.elasticsearch.test.BuildUtils;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.transport.TransportInfo;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -102,7 +101,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
     public void setUp() throws Exception {
         super.setUp();
         clusterName = randomAlphaOfLength(5);
-        version = VersionUtils.randomVersion(random()).toString();
+        version = randomAlphaOfLengthBetween(6, 32);
         clusterStatus = randomFrom(ClusterHealthStatus.values());
         usages = emptyList();
         clusterStats = mock(ClusterStatsResponse.class);


### PR DESCRIPTION
After conversation with the Kibana team, we discovered that:
- The `cluster_stats` documents produced by this class are used for internal collection
- Kibana only (used to) use it as a source of telemetry data - not anymore
- Cluster stats monitoring is “owned” by stack monitoring
- Stack monitoring is OK with removing it, but thinks it might be good to still have it as opaque metadata for the on-prem users 
> stack monitoring server code has guards where the version is retrieved and is already expecting the property to not exist so removing it would not result in breakage. the version is however used in the UI and looks like useful metadata for on prem users so I’d be inclined to keep the value and use something else for serverless (the build hash sounds good)

So instead of removing it, we are migrating it to use `Build.current().version()` and to use String versions for nodes etc.

There are remaining transitive usages in ClusterStatsMonitoringDoc when it writes its XContent:
- PluginDescriptor - this is being dealt with
- DiscoveryNode.VersionInfo (via ClusterState)
- NodeInfo (via ClusterStatsResponse/ClusterStatsNodes - but we already moved this to String as soon as we read it)

These will be handled separately