### PR TITLE
[7.17][ML] defend against negative datafeed start times

### DIFF
--- a/docs/changelog/100284.yaml
+++ b/docs/changelog/100284.yaml
@@ -1,0 +1,5 @@
+pr: 100284
+summary: Defend against negative datafeed start times
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -193,6 +193,9 @@ public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
 
         public DatafeedParams(String datafeedId, long startTime) {
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
+            if (startTime < 0) {
+                throw new IllegalArgumentException("[" + START_TIME.getPreferredName() + "] must not be negative [" + startTime + "].");
+            }
             this.startTime = startTime;
         }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.KillProcessAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -834,7 +835,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testStartDatafeed_GivenNegativeStartTime_Returns408() throws Exception {
-        client().admin().indices().prepareCreate("data-1").setMapping("time", "type=date").get();
+        client().admin().indices().prepareCreate("data-1").addMapping("type", "time", "type=date").get();
         long numDocs = 100;
         long now = System.currentTimeMillis();
         long oneWeekAgo = now - 604800000;


### PR DESCRIPTION
A negative start time in the datafeed can cause significant disruption to an entire cluster.

This PR checks that the start time is greater than or equal to 0 and throws an exception otherwise.

Backports #100284