### PR TITLE
[ML] More checks and tests for parsing Inference processor config

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -17,10 +17,11 @@ ingested in the pipeline.
 |======
 | Name                                  | Required  | Default                        | Description
 | `model_id` .                          | yes       | -                              | (String) The ID or alias for the trained model, or the ID of the deployment.
-| `input_output`                        | no        | (List) Input fields for inference and output (destination) fields for the inference results. This options is incompatible with the `target_field` and `field_map` options.
+| `input_output`                        | no        | -                              | (List) Input fields for inference and output (destination) fields for the inference results. This options is incompatible with the `target_field` and `field_map` options.
 | `target_field`                        | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
 | `field_map`                           | no        | If defined the model's default field map | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
 | `inference_config`                    | no        | The default settings defined in the model  | (Object) Contains the inference type and its options.
+| `ignore_missing`                      | no        | `false`  | (Boolean) If `true` and any of the input fields defined in `input_ouput` are missing then those missing fields are quietly ignored, otherwise a missing field causes a failure. Only applies when using `input_output` configurations to explicitly list the input fields.
 include::common-options.asciidoc[]
 |======
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
@@ -209,8 +209,13 @@ public class ClassificationInferenceResultsTests extends InferenceResultsTestCas
     }
 
     @Override
-    void assertFieldValues(ClassificationInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        String path = resultsField + "." + createdInstance.getResultsField();
+    void assertFieldValues(
+        ClassificationInferenceResults createdInstance,
+        IngestDocument document,
+        String parentField,
+        String resultsField
+    ) {
+        String path = parentField + resultsField;
         switch (createdInstance.getPredictionFieldType()) {
             case NUMBER -> assertThat(document.getFieldValue(path, Double.class), equalTo(createdInstance.predictedValue()));
             case STRING -> assertThat(document.getFieldValue(path, String.class), equalTo(createdInstance.predictedValue()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ErrorInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ErrorInferenceResultsTests.java
@@ -34,7 +34,7 @@ public class ErrorInferenceResultsTests extends InferenceResultsTestCase<ErrorIn
     }
 
     @Override
-    void assertFieldValues(ErrorInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        assertThat(document.getFieldValue(resultsField + ".error", String.class), equalTo(createdInstance.getException().getMessage()));
+    void assertFieldValues(ErrorInferenceResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        assertThat(document.getFieldValue(parentField + "error", String.class), equalTo(createdInstance.getException().getMessage()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResultsTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResultsTestCase.java
@@ -18,6 +18,8 @@ import org.elasticsearch.xcontent.XContentFactory;
 import java.io.IOException;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+
 abstract class InferenceResultsTestCase<T extends InferenceResults> extends AbstractWireSerializingTestCase<T> {
 
     public void testWriteToIngestDoc() throws IOException {
@@ -34,11 +36,57 @@ abstract class InferenceResultsTestCase<T extends InferenceResults> extends Abst
                 document.setFieldValue(parentField, Map.of());
             }
             InferenceResults.writeResult(inferenceResult, document, parentField, modelId);
-            assertFieldValues(inferenceResult, document, alreadyHasResult ? parentField + ".1" : parentField);
+
+            String expectedOutputPath = alreadyHasResult ? parentField + ".1." : parentField + ".";
+
+            assertThat(
+                document.getFieldValue(expectedOutputPath + InferenceResults.MODEL_ID_RESULTS_FIELD, String.class),
+                equalTo(modelId)
+            );
+            if (inferenceResult instanceof NlpInferenceResults nlpInferenceResults && nlpInferenceResults.isTruncated()) {
+                assertTrue(document.getFieldValue(expectedOutputPath + "is_truncated", Boolean.class));
+            }
+
+            assertFieldValues(inferenceResult, document, expectedOutputPath, inferenceResult.getResultsField());
         }
     }
 
-    abstract void assertFieldValues(T createdInstance, IngestDocument document, String resultsField);
+    private void testWriteToIngestDocField() throws IOException {
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; ++i) {
+            T inferenceResult = createTestInstance();
+            if (randomBoolean()) {
+                inferenceResult = copyInstance(inferenceResult, TransportVersion.current());
+            }
+            IngestDocument document = TestIngestDocument.emptyIngestDocument();
+            String outputField = randomAlphaOfLength(10);
+            String modelId = randomAlphaOfLength(10);
+            String parentField = randomBoolean() ? null : randomAlphaOfLength(10);
+            boolean writeModelId = randomBoolean();
+
+            boolean alreadyHasResult = randomBoolean();
+            if (alreadyHasResult && parentField != null) {
+                document.setFieldValue(parentField, Map.of());
+            }
+            InferenceResults.writeResultToField(inferenceResult, document, parentField, outputField, modelId, writeModelId);
+
+            String expectedOutputPath = parentField == null ? "" : parentField + ".";
+            if (alreadyHasResult && parentField != null) {
+                expectedOutputPath = expectedOutputPath + "1.";
+            }
+
+            if (writeModelId) {
+                String modelIdPath = expectedOutputPath + InferenceResults.MODEL_ID_RESULTS_FIELD;
+                assertThat(document.getFieldValue(modelIdPath, String.class), equalTo(modelId));
+            }
+            if (inferenceResult instanceof NlpInferenceResults nlpInferenceResults && nlpInferenceResults.isTruncated()) {
+                assertTrue(document.getFieldValue(expectedOutputPath + "is_truncated", Boolean.class));
+            }
+
+            assertFieldValues(inferenceResult, document, expectedOutputPath, outputField);
+        }
+    }
+
+    abstract void assertFieldValues(T createdInstance, IngestDocument document, String parentField, String resultsField);
 
     public void testWriteToDocAndSerialize() throws IOException {
         for (int i = 0; i < NUMBER_OF_TEST_RUNS; ++i) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/NerResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/NerResultsTests.java
@@ -92,15 +92,12 @@ public class NerResultsTests extends InferenceResultsTestCase<NerResults> {
 
     @Override
     @SuppressWarnings("unchecked")
-    void assertFieldValues(NerResults createdInstance, IngestDocument document, String resultsField) {
-        assertThat(
-            document.getFieldValue(resultsField + "." + createdInstance.getResultsField(), String.class),
-            equalTo(createdInstance.getAnnotatedResult())
-        );
+    void assertFieldValues(NerResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        assertThat(document.getFieldValue(parentField + resultsField, String.class), equalTo(createdInstance.getAnnotatedResult()));
 
         if (createdInstance.getEntityGroups().size() > 0) {
             List<Map<String, Object>> resultList = (List<Map<String, Object>>) document.getFieldValue(
-                resultsField + "." + ENTITY_FIELD,
+                parentField + ENTITY_FIELD,
                 List.class
             );
             assertThat(resultList.size(), equalTo(createdInstance.getEntityGroups().size()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/NlpClassificationInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/NlpClassificationInferenceResultsTests.java
@@ -79,8 +79,13 @@ public class NlpClassificationInferenceResultsTests extends InferenceResultsTest
     }
 
     @Override
-    void assertFieldValues(NlpClassificationInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        String path = resultsField + "." + createdInstance.getResultsField();
+    void assertFieldValues(
+        NlpClassificationInferenceResults createdInstance,
+        IngestDocument document,
+        String parentField,
+        String resultsField
+    ) {
+        String path = parentField + resultsField;
         assertThat(document.getFieldValue(path, String.class), equalTo(createdInstance.predictedValue()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/PyTorchPassThroughResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/PyTorchPassThroughResultsTests.java
@@ -58,10 +58,7 @@ public class PyTorchPassThroughResultsTests extends InferenceResultsTestCase<PyT
     }
 
     @Override
-    void assertFieldValues(PyTorchPassThroughResults createdInstance, IngestDocument document, String resultsField) {
-        assertArrayEquals(
-            createdInstance.getInference(),
-            document.getFieldValue(resultsField + "." + createdInstance.getResultsField(), double[][].class)
-        );
+    void assertFieldValues(PyTorchPassThroughResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        assertArrayEquals(createdInstance.getInference(), document.getFieldValue(parentField + resultsField, double[][].class));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/QuestionAnsweringInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/QuestionAnsweringInferenceResultsTests.java
@@ -83,8 +83,13 @@ public class QuestionAnsweringInferenceResultsTests extends InferenceResultsTest
     }
 
     @Override
-    void assertFieldValues(QuestionAnsweringInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        String path = resultsField + "." + createdInstance.getResultsField();
+    void assertFieldValues(
+        QuestionAnsweringInferenceResults createdInstance,
+        IngestDocument document,
+        String parentField,
+        String resultsField
+    ) {
+        String path = parentField + resultsField;
         assertThat(document.getFieldValue(path, String.class), equalTo(createdInstance.predictedValue()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
@@ -95,10 +95,7 @@ public class RegressionInferenceResultsTests extends InferenceResultsTestCase<Re
     }
 
     @Override
-    void assertFieldValues(RegressionInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        assertThat(
-            document.getFieldValue(resultsField + "." + createdInstance.getResultsField(), Double.class),
-            closeTo(createdInstance.value(), 1e-10)
-        );
+    void assertFieldValues(RegressionInferenceResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        assertThat(document.getFieldValue(parentField + resultsField, Double.class), closeTo(createdInstance.value(), 1e-10));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextEmbeddingResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextEmbeddingResultsTests.java
@@ -55,11 +55,7 @@ public class TextEmbeddingResultsTests extends InferenceResultsTestCase<TextEmbe
     }
 
     @Override
-    void assertFieldValues(TextEmbeddingResults createdInstance, IngestDocument document, String resultsField) {
-        assertArrayEquals(
-            document.getFieldValue(resultsField + "." + createdInstance.getResultsField(), double[].class),
-            createdInstance.getInference(),
-            1e-10
-        );
+    void assertFieldValues(TextEmbeddingResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        assertArrayEquals(document.getFieldValue(parentField + resultsField, double[].class), createdInstance.getInference(), 1e-10);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
@@ -47,11 +47,8 @@ public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpa
 
     @Override
     @SuppressWarnings("unchecked")
-    void assertFieldValues(TextExpansionResults createdInstance, IngestDocument document, String resultsField) {
-        var ingestedTokens = (Map<String, Object>) document.getFieldValue(
-            resultsField + '.' + createdInstance.getResultsField(),
-            Map.class
-        );
+    void assertFieldValues(TextExpansionResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        var ingestedTokens = (Map<String, Object>) document.getFieldValue(parentField + resultsField, Map.class);
         var tokenMap = createdInstance.getWeightedTokens()
             .stream()
             .collect(Collectors.toMap(TextExpansionResults.WeightedToken::token, TextExpansionResults.WeightedToken::weight));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextSimilarityInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextSimilarityInferenceResultsTests.java
@@ -33,8 +33,13 @@ public class TextSimilarityInferenceResultsTests extends InferenceResultsTestCas
     }
 
     @Override
-    void assertFieldValues(TextSimilarityInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        String path = resultsField + "." + createdInstance.getResultsField();
+    void assertFieldValues(
+        TextSimilarityInferenceResults createdInstance,
+        IngestDocument document,
+        String parentField,
+        String resultsField
+    ) {
+        String path = parentField + resultsField;
         assertThat(document.getFieldValue(path, Double.class), equalTo(createdInstance.predictedValue()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
@@ -33,7 +33,7 @@ public class WarningInferenceResultsTests extends InferenceResultsTestCase<Warni
     }
 
     @Override
-    void assertFieldValues(WarningInferenceResults createdInstance, IngestDocument document, String resultsField) {
-        assertThat(document.getFieldValue(resultsField + ".warning", String.class), equalTo(createdInstance.getWarning()));
+    void assertFieldValues(WarningInferenceResults createdInstance, IngestDocument document, String parentField, String resultsField) {
+        assertThat(document.getFieldValue(parentField + "warning", String.class), equalTo(createdInstance.getWarning()));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -87,6 +87,7 @@ public class InferenceProcessor extends AbstractProcessor {
     public static final String TYPE = "inference";
     public static final String MODEL_ID = "model_id";
     public static final String INFERENCE_CONFIG = "inference_config";
+    public static final String IGNORE_MISSING = "ignore_missing";
 
     // target field style mappings
     public static final String TARGET_FIELD = "target_field";
@@ -106,9 +107,10 @@ public class InferenceProcessor extends AbstractProcessor {
         String description,
         String modelId,
         InferenceConfigUpdate inferenceConfig,
-        List<Factory.InputConfig> inputs
+        List<Factory.InputConfig> inputs,
+        boolean ignoreMissing
     ) {
-        return new InferenceProcessor(client, auditor, tag, description, null, modelId, inferenceConfig, null, inputs, true);
+        return new InferenceProcessor(client, auditor, tag, description, null, modelId, inferenceConfig, null, inputs, true, ignoreMissing);
     }
 
     public static InferenceProcessor fromTargetFieldConfiguration(
@@ -121,7 +123,20 @@ public class InferenceProcessor extends AbstractProcessor {
         InferenceConfigUpdate inferenceConfig,
         Map<String, String> fieldMap
     ) {
-        return new InferenceProcessor(client, auditor, tag, description, targetField, modelId, inferenceConfig, fieldMap, null, false);
+        // ignore_missing only applies to when using the input_field config
+        return new InferenceProcessor(
+            client,
+            auditor,
+            tag,
+            description,
+            targetField,
+            modelId,
+            inferenceConfig,
+            fieldMap,
+            null,
+            false,
+            false
+        );
     }
 
     private final Client client;
@@ -134,6 +149,7 @@ public class InferenceProcessor extends AbstractProcessor {
     private final AtomicBoolean shouldAudit = new AtomicBoolean(true);
     private final List<Factory.InputConfig> inputs;
     private final boolean configuredWithInputsFields;
+    private final boolean ignoreMissing;
 
     private InferenceProcessor(
         Client client,
@@ -145,7 +161,8 @@ public class InferenceProcessor extends AbstractProcessor {
         InferenceConfigUpdate inferenceConfig,
         Map<String, String> fieldMap,
         List<Factory.InputConfig> inputs,
-        boolean configuredWithInputsFields
+        boolean configuredWithInputsFields,
+        boolean ignoreMissing
     ) {
         super(tag, description);
         this.configuredWithInputsFields = configuredWithInputsFields;
@@ -153,6 +170,7 @@ public class InferenceProcessor extends AbstractProcessor {
         this.auditor = ExceptionsHelper.requireNonNull(auditor, "auditor");
         this.modelId = ExceptionsHelper.requireNonNull(modelId, MODEL_ID);
         this.inferenceConfig = ExceptionsHelper.requireNonNull(inferenceConfig, INFERENCE_CONFIG);
+        this.ignoreMissing = ignoreMissing;
 
         if (configuredWithInputsFields) {
             this.inputs = ExceptionsHelper.requireNonNull(inputs, INPUT_OUTPUT);
@@ -205,23 +223,36 @@ public class InferenceProcessor extends AbstractProcessor {
     }
 
     InferModelAction.Request buildRequest(IngestDocument ingestDocument) {
-        Map<String, Object> fields = new HashMap<>(ingestDocument.getSourceAndMetadata());
-        // Add ingestMetadata as previous processors might have added metadata from which we are predicting (see: foreach processor)
-        if (ingestDocument.getIngestMetadata().isEmpty() == false) {
-            fields.put(INGEST_KEY, ingestDocument.getIngestMetadata());
-        }
-
         if (configuredWithInputsFields) {
+            // ignore missing only applies when using an input field list
             List<String> requestInputs = new ArrayList<>();
             for (var inputFields : inputs) {
-                var lookup = (String) fields.get(inputFields.inputField);
-                if (lookup == null) {
-                    lookup = ""; // need to send a non-null request to the same number of results back
+                try {
+                    var inputText = ingestDocument.getFieldValue(inputFields.inputField, String.class, ignoreMissing);
+                    // field is missing and ignoreMissing == true then a null value is returned.
+                    if (inputText == null) {
+                        inputText = "";  // need to send a non-null request to the same number of results back
+                    }
+                    requestInputs.add(inputText);
+                } catch (IllegalArgumentException e) {
+                    if (ingestDocument.hasField(inputFields.inputField())) {
+                        // field is present but of the wrong type, translate to a more meaningful message
+                        throw new IllegalArgumentException(
+                            "input field [" + inputFields.inputField + "] cannot be processed because it is not a text field"
+                        );
+                    } else {
+                        throw e;
+                    }
                 }
-                requestInputs.add(lookup);
             }
             return InferModelAction.Request.forTextInput(modelId, inferenceConfig, requestInputs);
         } else {
+            Map<String, Object> fields = new HashMap<>(ingestDocument.getSourceAndMetadata());
+            // Add ingestMetadata as previous processors might have added metadata from which we are predicting (see: foreach processor)
+            if (ingestDocument.getIngestMetadata().isEmpty() == false) {
+                fields.put(INGEST_KEY, ingestDocument.getIngestMetadata());
+            }
+
             LocalModel.mapFieldsIfNecessary(fields, fieldMap);
             return InferModelAction.Request.forIngestDocs(modelId, List.of(fields), inferenceConfig, previouslyLicensed);
         }
@@ -342,6 +373,7 @@ public class InferenceProcessor extends AbstractProcessor {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public InferenceProcessor create(
             Map<String, Processor.Factory> processorFactories,
             String tag,
@@ -373,11 +405,31 @@ public class InferenceProcessor extends AbstractProcessor {
                 inferenceConfigUpdate = inferenceConfigUpdateFromMap(inferenceConfigMap);
             }
 
-            List<Map<String, Object>> inputs = ConfigurationUtils.readOptionalList(TYPE, tag, config, INPUT_OUTPUT);
+            Object inputOutputs = config.remove(INPUT_OUTPUT);
+            List<Map<String, Object>> inputs = null;
+            if (inputOutputs != null) {
+                // input_output may be a single map or a list of maps
+                if (inputOutputs instanceof List<?> inputOutputList) {
+                    if (inputOutputList.isEmpty() == false) {
+                        // check it is a list of maps
+                        if (inputOutputList.get(0) instanceof Map == false) {
+                            throw ConfigurationUtils.newConfigurationException(TYPE, tag, INPUT_FIELD, "property isn't a list of maps");
+                        }
+                    }
+                    inputs = (List<Map<String, Object>>) inputOutputList;
+                } else if (inputOutputs instanceof Map) {
+                    inputs = List.of((Map<String, Object>) inputOutputs);
+                } else {
+                    throw ConfigurationUtils.newConfigurationException(TYPE, tag, INPUT_FIELD, "property isn't a map or list of maps");
+                }
+            }
+
             boolean configuredWithInputFields = inputs != null;
             if (configuredWithInputFields) {
                 // new style input/output configuration
                 var parsedInputs = parseInputFields(tag, inputs);
+                // ignore missing only applies to input field config
+                boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, tag, config, IGNORE_MISSING, false);
 
                 // validate incompatible settings are not present
                 String targetField = ConfigurationUtils.readOptionalStringProperty(TYPE, tag, config, TARGET_FIELD);
@@ -414,7 +466,16 @@ public class InferenceProcessor extends AbstractProcessor {
                     );
                 }
 
-                return fromInputFieldConfiguration(client, auditor, tag, description, modelId, inferenceConfigUpdate, parsedInputs);
+                return fromInputFieldConfiguration(
+                    client,
+                    auditor,
+                    tag,
+                    description,
+                    modelId,
+                    inferenceConfigUpdate,
+                    parsedInputs,
+                    ignoreMissing
+                );
             } else {
                 // old style configuration with target field
                 String defaultTargetField = tag == null ? DEFAULT_TARGET_FIELD : DEFAULT_TARGET_FIELD + "." + tag;
@@ -553,7 +614,7 @@ public class InferenceProcessor extends AbstractProcessor {
 
         List<InputConfig> parseInputFields(String tag, List<Map<String, Object>> inputs) {
             if (inputs.isEmpty()) {
-                throw newConfigurationException(TYPE, tag, INPUT_OUTPUT, "cannot be empty at least one is required");
+                throw newConfigurationException(TYPE, tag, INPUT_OUTPUT, "property cannot be empty at least one is required");
             }
             var inputNames = new HashSet<String>();
             var outputNames = new HashSet<String>();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -767,7 +767,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
                 ElasticsearchParseException.class,
                 () -> processorFactory.create(Collections.emptyMap(), "processor_with_bad_config", null, config)
             );
-            assertThat(e.getMessage(), containsString("[input_field] property isn't a list of maps"));
+            assertThat(e.getMessage(), containsString("[input_output] property isn't a list of maps"));
         }
         {
             Map<String, Object> config = new HashMap<>();
@@ -778,7 +778,20 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
                 ElasticsearchParseException.class,
                 () -> processorFactory.create(Collections.emptyMap(), "processor_with_bad_config", null, config)
             );
-            assertThat(e.getMessage(), containsString("[input_field] property isn't a map or list of maps"));
+            assertThat(e.getMessage(), containsString("[input_output] property isn't a map or list of maps"));
+        }
+        {
+            Map<Boolean, String> badMap = new HashMap<>();
+            badMap.put(Boolean.TRUE, "foo");
+            Map<String, Object> config = new HashMap<>();
+            config.put(InferenceProcessor.MODEL_ID, "my_model");
+            config.put(InferenceProcessor.INPUT_OUTPUT, badMap);
+
+            var e = expectThrows(
+                ElasticsearchParseException.class,
+                () -> processorFactory.create(Collections.emptyMap(), "processor_with_bad_config", null, config)
+            );
+            assertThat(e.getMessage(), containsString("[input_field] required property is missing"));
         }
         {
             // empty list

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -647,10 +647,16 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             randomBoolean()
         );
 
-        Map<String, Object> inputMap = new HashMap<>() {
+        Map<String, Object> inputMap1 = new HashMap<>() {
             {
-                put(InferenceProcessor.INPUT_FIELD, "in");
-                put(InferenceProcessor.OUTPUT_FIELD, "out");
+                put(InferenceProcessor.INPUT_FIELD, "in1");
+                put(InferenceProcessor.OUTPUT_FIELD, "out1");
+            }
+        };
+        Map<String, Object> inputMap2 = new HashMap<>() {
+            {
+                put(InferenceProcessor.INPUT_FIELD, "in2");
+                put(InferenceProcessor.OUTPUT_FIELD, "out2");
             }
         };
 
@@ -671,8 +677,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>() {
             {
                 put(InferenceProcessor.MODEL_ID, "my_model");
-                put(InferenceProcessor.INPUT_OUTPUT, List.of(inputMap));
-                put(InferenceProcessor.INFERENCE_CONFIG, Collections.singletonMap(inferenceConfigType, Collections.emptyMap()));
+                put(InferenceProcessor.INPUT_OUTPUT, List.of(inputMap1, inputMap2));
             }
         };
         // create valid inference configs with required fields
@@ -693,11 +698,100 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         assertTrue(inferenceProcessor.isConfiguredWithInputsFields());
 
         var inputs = inferenceProcessor.getInputs();
-        assertThat(inputs, hasSize(1));
-        assertEquals(inputs.get(0), new InferenceProcessor.Factory.InputConfig("in", null, "out", Map.of()));
+        assertThat(inputs, hasSize(2));
+        assertEquals(inputs.get(0), new InferenceProcessor.Factory.InputConfig("in1", null, "out1", Map.of()));
+        assertEquals(inputs.get(1), new InferenceProcessor.Factory.InputConfig("in2", null, "out2", Map.of()));
 
         assertNull(inferenceProcessor.getFieldMap());
         assertNull(inferenceProcessor.getTargetField());
+    }
+
+    public void testCreateProcessorWithInputFieldSingleOrList() {
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(
+            client,
+            clusterService,
+            Settings.EMPTY,
+            randomBoolean()
+        );
+
+        for (var isList : new boolean[] { true, false }) {
+            Map<String, Object> inputMap = new HashMap<>() {
+                {
+                    put(InferenceProcessor.INPUT_FIELD, "in");
+                    put(InferenceProcessor.OUTPUT_FIELD, "out");
+                }
+            };
+
+            Map<String, Object> config = new HashMap<>();
+            config.put(InferenceProcessor.MODEL_ID, "my_model");
+            if (isList) {
+                config.put(InferenceProcessor.INPUT_OUTPUT, List.of(inputMap));
+            } else {
+                config.put(InferenceProcessor.INPUT_OUTPUT, inputMap);
+            }
+
+            if (randomBoolean()) {
+                config.put(
+                    InferenceProcessor.INFERENCE_CONFIG,
+                    Collections.singletonMap(TextExpansionConfigUpdate.NAME, Collections.emptyMap())
+                );
+            }
+
+            var inferenceProcessor = processorFactory.create(Collections.emptyMap(), "processor_with_single_input", null, config);
+            assertEquals("my_model", inferenceProcessor.getModelId());
+            assertTrue(inferenceProcessor.isConfiguredWithInputsFields());
+
+            var inputs = inferenceProcessor.getInputs();
+            assertThat(inputs, hasSize(1));
+            assertEquals(inputs.get(0), new InferenceProcessor.Factory.InputConfig("in", null, "out", Map.of()));
+
+            assertNull(inferenceProcessor.getFieldMap());
+            assertNull(inferenceProcessor.getTargetField());
+        }
+    }
+
+    public void testCreateProcessorWithInputFieldWrongType() {
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(
+            client,
+            clusterService,
+            Settings.EMPTY,
+            randomBoolean()
+        );
+
+        {
+            Map<String, Object> config = new HashMap<>();
+            config.put(InferenceProcessor.MODEL_ID, "my_model");
+            config.put(InferenceProcessor.INPUT_OUTPUT, List.of(1, 2, 3));
+
+            var e = expectThrows(
+                ElasticsearchParseException.class,
+                () -> processorFactory.create(Collections.emptyMap(), "processor_with_bad_config", null, config)
+            );
+            assertThat(e.getMessage(), containsString("[input_field] property isn't a list of maps"));
+        }
+        {
+            Map<String, Object> config = new HashMap<>();
+            config.put(InferenceProcessor.MODEL_ID, "my_model");
+            config.put(InferenceProcessor.INPUT_OUTPUT, Boolean.TRUE);
+
+            var e = expectThrows(
+                ElasticsearchParseException.class,
+                () -> processorFactory.create(Collections.emptyMap(), "processor_with_bad_config", null, config)
+            );
+            assertThat(e.getMessage(), containsString("[input_field] property isn't a map or list of maps"));
+        }
+        {
+            // empty list
+            Map<String, Object> config = new HashMap<>();
+            config.put(InferenceProcessor.MODEL_ID, "my_model");
+            config.put(InferenceProcessor.INPUT_OUTPUT, List.of());
+
+            var e = expectThrows(
+                ElasticsearchParseException.class,
+                () -> processorFactory.create(Collections.emptyMap(), "processor_with_bad_config", null, config)
+            );
+            assertThat(e.getMessage(), containsString("[input_output] property cannot be empty at least one is required"));
+        }
     }
 
     public void testParsingInputFields() {
@@ -785,7 +879,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         );
 
         var e = expectThrows(ElasticsearchParseException.class, () -> processorFactory.parseInputFields("my_processor", List.of()));
-        assertThat(e.getMessage(), containsString("[input_output] cannot be empty at least one is required"));
+        assertThat(e.getMessage(), containsString("[input_output] property cannot be empty at least one is required"));
     }
 
     private static ClusterState buildClusterStateWithModelReferences(String... modelId) throws IOException {


### PR DESCRIPTION
Following on from #100205 this PR adds more tests and checks for corner cases when parsing the configuration. Also updates the docs with missing details.