### PR TITLE
[8.11] ESQL: Reenable some tests (#100339)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -205,8 +205,7 @@ emp_no:integer | languages:integer | gender:keyword | first_name:keyword | abc:i
 10100 | 4 | F | Hironobu | 3
 ;
 
-# awaitsfix https://github.com/elastic/elasticsearch/issues/99826
-projectFromWithStatsAfterLimit-Ignore
+projectFromWithStatsAfterLimit
 from employees | sort emp_no | keep gender, avg_worked_seconds, first_name, last_name | limit 10 | stats m = max(avg_worked_seconds) by gender;
 
    m:long | gender:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/row.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/row.csv-spec
@@ -170,24 +170,21 @@ a:integer | b:integer | y:integer
 1 | 2 | null
 ;
 
-// AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-rowWithNullsInCount-Ignore
+rowWithNullsInCount
 row a = 1.5, b = 2.6, c = null | eval s = null + a + b | stats c = count(s);
 
 c:long
 0
 ;
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-rowWithNullsInAvg-Ignore
+rowWithNullsInAvg
 row a = 1.5, b = 2.6, c = null | eval s = null + a + b | stats c = avg(s);
 
 c:double
 null
 ;
 
-// AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-rowWithNullsInAvg2-Ignore
+rowWithNullsInAvg2
 row a = 1.5, b = 2.6, c = null | eval s = a - b * c | stats avg(s);
 
 avg(s):double
@@ -228,16 +225,14 @@ row a = 1 | limit 0;
 a:integer
 ;
 
-// AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-rowWithMultipleStats-Ignore
+rowWithMultipleStats
 row a = 1+3, b = 2, ab = 5 | eval x = 1 + b + 5 | stats avg = avg(x), min(x), max(x), count(x), avg(x), avg(ab), avg(a);
 
 avg:double | min(x):integer | max(x):integer | count(x):long | avg(x):double | avg(ab):double | avg(a):double
        8.0 |              8 |              8 |             1 |           8.0 |            5.0 |           4.0
 ;
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-rowWithMultipleStatsOverNull-Ignore
+rowWithMultipleStatsOverNull
 row x=1, y=2 | eval tot = null + y + x | stats c=count(tot), a=avg(tot), mi=min(tot), ma=max(tot), s=sum(tot);
 
 c:long | a:double |   mi:integer |  ma:integer | s:long

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/show.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/show.csv-spec
@@ -1,5 +1,4 @@
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-showInfo-Ignore
+showInfo
 show info | stats v = count(version);
 
 v:long

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -525,8 +525,7 @@ min(salary):i | max(salary):i | c:l
 25324         | 74999         | 100
 ;
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-statsWithLiterals-Ignore
+statsWithLiterals
 from employees | limit 10 | eval x = 1 | stats c = count(x);
 
 c:l

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/version.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/version.csv-spec
@@ -203,8 +203,7 @@ bad
 5.2.9-SNAPSHOT
 ;
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-groupByVersionCast-Ignore
+groupByVersionCast
 FROM apps | EVAL g = TO_VER(CONCAT("1.", TO_STR(version))) | STATS id = MAX(id) BY g | SORT id | DROP g;
 
 id:i


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Reenable some tests (#100339)