### PR TITLE
[8.11] ESQL: Reeanble another test (#100342)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/HeapAttackIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/HeapAttackIT.java
@@ -104,7 +104,6 @@ public class HeapAttackIT extends ESRestTestCase {
     /**
      * This groups on about 200 columns which is a lot but has never caused us trouble.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99826")
     public void testGroupOnSomeLongs() throws IOException {
         initManyLongs();
         Map<?, ?> map = XContentHelper.convertToMap(


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Reeanble another test (#100342)