### PR TITLE
Add pattern for concurrent context searcher to tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
@@ -90,7 +90,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w.close();
         ShardId shard = new ShardId("index", "_na_", 0);
         r = ElasticsearchDirectoryReader.wrap(r, shard);
-        IndexSearcher s = new IndexSearcher(r);
+        IndexSearcher s = new IndexSearcher(r); // TODO: Use Concurrent Index Searcher?
         s.setQueryCachingPolicy(TrivialQueryCachingPolicy.ALWAYS);
 
         Settings settings = Settings.builder()
@@ -161,7 +161,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w1.close();
         ShardId shard1 = new ShardId("index", "_na_", 0);
         r1 = ElasticsearchDirectoryReader.wrap(r1, shard1);
-        IndexSearcher s1 = new IndexSearcher(r1);
+        IndexSearcher s1 = new IndexSearcher(r1); // TODO: Use Concurrent Index Searcher?
         s1.setQueryCachingPolicy(TrivialQueryCachingPolicy.ALWAYS);
 
         Directory dir2 = newDirectory();
@@ -171,7 +171,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w2.close();
         ShardId shard2 = new ShardId("index", "_na_", 1);
         r2 = ElasticsearchDirectoryReader.wrap(r2, shard2);
-        IndexSearcher s2 = new IndexSearcher(r2);
+        IndexSearcher s2 = new IndexSearcher(r2); // TODO: Use Concurrent Index Searcher?
         s2.setQueryCachingPolicy(TrivialQueryCachingPolicy.ALWAYS);
 
         Settings settings = Settings.builder()

--- a/server/src/test/java/org/elasticsearch/search/SearchCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchCancellationTests.java
@@ -38,8 +38,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.equalTo;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-@Repeat(iterations = 100)
 public class SearchCancellationTests extends ESTestCase {
 
     private static final String STRING_FIELD_NAME = "foo";

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
@@ -12,7 +12,6 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Sort;
@@ -79,14 +78,8 @@ public class TimeSeriesCancellationTests extends ESTestCase {
     }
 
     public void testLowLevelCancellationActions() throws IOException {
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
-        );
-        TimeSeriesIndexSearcher timeSeriesIndexSearcher = new TimeSeriesIndexSearcher(searcher, List.of(() -> {
+        ContextIndexSearcher searcher = newContextSearcher(reader);
+        TimeSeriesIndexSearcher timeSeriesIndexSearcher = new TimeSeriesIndexSearcher(searcher, List.of(() -> { // TODO: Use Concurrent Index Searcher?
             throw new TaskCancelledException("Cancel");
         }));
         CountingBucketCollector bc = new CountingBucketCollector();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesCancellationTests.java
@@ -79,7 +79,8 @@ public class TimeSeriesCancellationTests extends ESTestCase {
 
     public void testLowLevelCancellationActions() throws IOException {
         ContextIndexSearcher searcher = newContextSearcher(reader);
-        TimeSeriesIndexSearcher timeSeriesIndexSearcher = new TimeSeriesIndexSearcher(searcher, List.of(() -> { // TODO: Use Concurrent Index Searcher?
+        // TODO: Use Concurrent Index Searcher?
+        TimeSeriesIndexSearcher timeSeriesIndexSearcher = new TimeSeriesIndexSearcher(searcher, List.of(() -> {
             throw new TaskCancelledException("Cancel");
         }));
         CountingBucketCollector bc = new CountingBucketCollector();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcherTests.java
@@ -86,7 +86,7 @@ public class TimeSeriesIndexSearcherTests extends ESTestCase {
         IndexReader reader = DirectoryReader.open(dir);
         IndexSearcher searcher = newSearcher(reader);
 
-        TimeSeriesIndexSearcher indexSearcher = new TimeSeriesIndexSearcher(searcher, List.of());
+        TimeSeriesIndexSearcher indexSearcher = new TimeSeriesIndexSearcher(searcher, List.of()); // TODO: Use Concurrent Index Searcher?
 
         BucketCollector collector = getBucketCollector(THREADS * DOC_COUNTS);
 
@@ -122,7 +122,7 @@ public class TimeSeriesIndexSearcherTests extends ESTestCase {
         IndexReader reader = DirectoryReader.open(dir);
         IndexSearcher searcher = newSearcher(reader);
 
-        TimeSeriesIndexSearcher indexSearcher = new TimeSeriesIndexSearcher(searcher, List.of());
+        TimeSeriesIndexSearcher indexSearcher = new TimeSeriesIndexSearcher(searcher, List.of()); // TODO: Use Concurrent Index Searcher?
         indexSearcher.setMinimumScore(2f);
 
         {
@@ -195,7 +195,7 @@ public class TimeSeriesIndexSearcherTests extends ESTestCase {
         IndexReader reader = DirectoryReader.open(dir);
         IndexSearcher searcher = newSearcher(reader);
 
-        TimeSeriesIndexSearcher indexSearcher = new TimeSeriesIndexSearcher(searcher, List.of());
+        TimeSeriesIndexSearcher indexSearcher = new TimeSeriesIndexSearcher(searcher, List.of()); // TODO: Use Concurrent Index Searcher?
 
         BucketCollector collector = getBucketCollector(2 * DOC_COUNTS);
 

--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -216,8 +216,7 @@ public class ContextIndexSearcherTests extends ESTestCase {
         try (Directory directory = newDirectory()) {
             indexDocs(directory);
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
-                ContextIndexSearcher searcher = new ContextIndexSearcherBuilder(directoryReader)
-                    .workerExecutor(executor)
+                ContextIndexSearcher searcher = new ContextIndexSearcherBuilder(directoryReader).workerExecutor(executor)
                     .maximumNumberOfSlices(Integer.MAX_VALUE) // create as many slices as possible
                     .build();
                 int numSegments = directoryReader.getContext().leaves().size();
@@ -241,8 +240,7 @@ public class ContextIndexSearcherTests extends ESTestCase {
         try (Directory directory = newDirectory()) {
             int numDocs = indexDocs(directory);
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
-                ContextIndexSearcher searcher = new ContextIndexSearcherBuilder(directoryReader)
-                    .workerExecutor(executor)
+                ContextIndexSearcher searcher = new ContextIndexSearcherBuilder(directoryReader).workerExecutor(executor)
                     .maximumNumberOfSlices(Integer.MAX_VALUE) // create as many slices as possible
                     .build();
                 Integer totalHits = searcher.search(new MatchAllDocsQuery(), new TotalHitCountCollectorManager());
@@ -520,11 +518,9 @@ public class ContextIndexSearcherTests extends ESTestCase {
                 final boolean[] reduceCalled;
                 LeafSlice[] leafSlices;
                 try (
-                    ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcherBuilder(directoryReader)
-                        .workerExecutor(executorTestWrapper)
-                        .maximumNumberOfSlices(executor.getMaximumPoolSize())
-                        .wrapWithExitableDirectoryReader(true)
-                        .build();
+                    ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcherBuilder(directoryReader).workerExecutor(
+                        executorTestWrapper
+                    ).maximumNumberOfSlices(executor.getMaximumPoolSize()).wrapWithExitableDirectoryReader(true).build();
                 ) {
                     leafSlices = contextIndexSearcher.getSlicesForCollection();
                     int numThrowingLeafSlices = randomIntBetween(1, 3);
@@ -651,11 +647,9 @@ public class ContextIndexSearcherTests extends ESTestCase {
                 final boolean[] reduceCalled;
                 LeafSlice[] leafSlices;
                 try (
-                    ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcherBuilder(directoryReader)
-                        .workerExecutor(executorTestWrapper)
-                        .maximumNumberOfSlices(executor.getMaximumPoolSize())
-                        .wrapWithExitableDirectoryReader(true)
-                        .build();
+                    ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcherBuilder(directoryReader).workerExecutor(
+                        executorTestWrapper
+                    ).maximumNumberOfSlices(executor.getMaximumPoolSize()).wrapWithExitableDirectoryReader(true).build();
                 ) {
                     leafSlices = contextIndexSearcher.getSlicesForCollection();
                     int numThrowingLeafSlices = randomIntBetween(1, 3);

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
@@ -76,9 +76,7 @@ public class QueryProfilerTests extends ESTestCase {
     @Before
     public void initSearcher() throws IOException {
         if (searcher == null) {
-            searcher = new ContextIndexSearcherBuilder(reader)
-                .queryCachingPolicy(TrivialQueryCachingPolicy.ALWAYS)
-                .build();
+            searcher = new ContextIndexSearcherBuilder(reader).queryCachingPolicy(TrivialQueryCachingPolicy.ALWAYS).build();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -1051,9 +1051,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         reader = DirectoryReader.open(dir);
 
         final List<Query> executed = new ArrayList<>();
-        ContextIndexSearcher searcher = new ContextIndexSearcherBuilder(reader)
-            .wrapWithExitableDirectoryReader(true)
-            .instantiation((builderValues) -> new ContextIndexSearcher(
+        ContextIndexSearcher searcher = new ContextIndexSearcherBuilder(reader).wrapWithExitableDirectoryReader(true)
+            .instantiation(
+                (builderValues) -> new ContextIndexSearcher(
                     builderValues.reader(),
                     builderValues.similarity(),
                     builderValues.queryCache(),
@@ -1069,7 +1069,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
                         return super.search(query, collectorManager);
                     }
                 }
-            ).build();
+            )
+            .build();
 
         SearchContext context = new TestSearchContext(null, indexShard, searcher) {
             @Override
@@ -1116,8 +1117,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
     private static final QueryCachingPolicy NEVER_CACHE_POLICY = new QueryCachingPolicy() {
         @Override
-        public void onUse(Query query) {
-        }
+        public void onUse(Query query) {}
 
         @Override
         public boolean shouldCache(Query query) {
@@ -1126,10 +1126,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
     };
 
     private ContextIndexSearcher createContextSearcher(IndexReader reader) throws IOException {
-        return new ContextIndexSearcherBuilder(reader)
-            .queryCachingPolicy(NEVER_CACHE_POLICY)
-            .wrapWithExitableDirectoryReader(true)
-            .build();
+        return new ContextIndexSearcherBuilder(reader).queryCachingPolicy(NEVER_CACHE_POLICY).wrapWithExitableDirectoryReader(true).build();
     }
 
     private ContextIndexSearcher noCollectionContextSearcher(IndexReader reader) throws IOException {
@@ -1137,10 +1134,10 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     private ContextIndexSearcher earlyTerminationContextSearcher(IndexReader reader, int size) throws IOException {
-        return new ContextIndexSearcherBuilder(reader)
-            .queryCachingPolicy(NEVER_CACHE_POLICY)
+        return new ContextIndexSearcherBuilder(reader).queryCachingPolicy(NEVER_CACHE_POLICY)
             .wrapWithExitableDirectoryReader(true)
-            .instantiation((builderValues) -> new ContextIndexSearcher(
+            .instantiation(
+                (builderValues) -> new ContextIndexSearcher(
                     builderValues.reader(),
                     builderValues.similarity(),
                     builderValues.queryCache(),
@@ -1161,7 +1158,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
                                     @Override
                                     public void collect(int doc) throws IOException {
-                                        assert collected <= size : "should not collect more than " + size + " doc per segment, got " + collected;
+                                        assert collected <= size
+                                            : "should not collect more than " + size + " doc per segment, got " + collected;
                                         ++collected;
                                         super.collect(doc);
                                     }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
@@ -98,8 +98,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
     }
 
     private ContextIndexSearcher createContextSearcher(IndexReader reader) throws IOException {
-        return new ContextIndexSearcherBuilder(reader)
-            .queryCachingPolicy(LuceneTestCase.MAYBE_CACHE_POLICY)
+        return new ContextIndexSearcherBuilder(reader).queryCachingPolicy(LuceneTestCase.MAYBE_CACHE_POLICY)
             .wrapWithExitableDirectoryReader(true)
             .build();
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -430,11 +430,9 @@ public abstract class AggregatorTestCase extends ESTestCase {
         SearchContext ctx = mock(SearchContext.class);
         try {
             when(ctx.searcher()).thenReturn(
-                new ContextIndexSearcherBuilder(searchExecutionContext.searcher().getIndexReader())
-                    .similarity(searchExecutionContext.searcher().getSimilarity())
-                    .queryCache(DisabledQueryCache.INSTANCE)
-                    .queryCachingPolicy(TrivialQueryCachingPolicy.NEVER)
-                    .build()
+                new ContextIndexSearcherBuilder(searchExecutionContext.searcher().getIndexReader()).similarity(
+                    searchExecutionContext.searcher().getSimilarity()
+                ).queryCache(DisabledQueryCache.INSTANCE).queryCachingPolicy(TrivialQueryCachingPolicy.NEVER).build()
             );
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1434,6 +1434,7 @@ public abstract class ESTestCase extends LuceneTestCase {
          *                 }
          *             }
          *         ).build();
+         * }
          * </pre>
          *
          * @param instantiator A function used to instantiate the ContextIndexSearcher, containing the desired

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -19,6 +19,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import com.carrotsearch.randomizedtesting.rules.TestRuleAdapter;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1319,7 +1320,6 @@ public abstract class ESTestCase extends LuceneTestCase {
     @Nullable
     private final List<ThreadPoolExecutor> ContextIndexSearcherExecutors = new ArrayList<>();
 
-
     /**
      * Use this builder to instantiate {@link ContextIndexSearcher}s for tests.  It randomly creates both concurrent
      * and non-concurrent versions to exercise both code paths using various random settings.
@@ -1337,11 +1337,10 @@ public abstract class ESTestCase extends LuceneTestCase {
             Executor executor,
             int maximumNumberOfSlices,
             int minimumDocsPerSlice
-        ) {
-        }
+        ) {}
 
-        private CheckedFunction<BuilderInstantiationValues, ContextIndexSearcher, IOException> instantiator = (builderValues) ->
-            new ContextIndexSearcher(
+        private CheckedFunction<BuilderInstantiationValues, ContextIndexSearcher, IOException> instantiator = (
+            builderValues) -> new ContextIndexSearcher(
                 builderValues.reader,
                 builderValues.similarity,
                 builderValues.queryCache,
@@ -1393,16 +1392,18 @@ public abstract class ESTestCase extends LuceneTestCase {
                 }
             });
 
-            return instantiator.apply(new BuilderInstantiationValues(
-                reader,
-                similarity,
-                queryCache,
-                queryCachingPolicy,
-                wrapWithExitableDirectoryReader,
-                exec,
-                maximumNumberOfSlices.orElse(numThreads),
-                minimumDocsPerSlice.orElse(1)
-            ));
+            return instantiator.apply(
+                new BuilderInstantiationValues(
+                    reader,
+                    similarity,
+                    queryCache,
+                    queryCachingPolicy,
+                    wrapWithExitableDirectoryReader,
+                    exec,
+                    maximumNumberOfSlices.orElse(numThreads),
+                    minimumDocsPerSlice.orElse(1)
+                )
+            );
         }
 
         /**
@@ -1460,8 +1461,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             return this;
         }
 
-        public ContextIndexSearcherBuilder wrapWithExitableDirectoryReader(
-            boolean wrapWithExitableDirectoryReader) {
+        public ContextIndexSearcherBuilder wrapWithExitableDirectoryReader(boolean wrapWithExitableDirectoryReader) {
             this.wrapWithExitableDirectoryReader = wrapWithExitableDirectoryReader;
             return this;
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1310,14 +1310,12 @@ public abstract class ESTestCase extends LuceneTestCase {
      * If you need a reference, construct and pass your own into the IndexSearcherBuilder's threadPoolExecutor.
      * A test may instantiate multiple instances of a ContextIndexSearcher, so we must keep track for cleanup.
      */
-    @Nullable
     private final List<ThreadPool> contextIndexSearcherThreadPools = new ArrayList<>();
 
     /**
      * If you need a reference, construct and pass your own into the IndexSearcherBuilder.
      * A test may instantiate multiple instances of a ContextIndexSearcher, so we must keep track for cleanup.
      */
-    @Nullable
     private final List<ThreadPoolExecutor> ContextIndexSearcherExecutors = new ArrayList<>();
 
     /**


### PR DESCRIPTION
This PR adds a mechanism for constructing a concurrent ContextIndexSearcher in the tests.  

I found many of the subclasses of ESTestCase which construct a ContextIndexSearcher using an IntelliJ heirarchy search:
![image](https://github.com/elastic/elasticsearch/assets/14946056/fdcc6434-c516-4b09-9ae4-649645d434d2)

I left a few TODOs which may or may not require further action, but should be removed for the final draft. They are not a complete list.