### PR TITLE
[8.11] Release success blocks when reading from stream (#100376)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -97,8 +97,16 @@ public final class Page implements Writeable {
         int positionCount = in.readVInt();
         int blockPositions = in.readVInt();
         Block[] blocks = new Block[blockPositions];
-        for (int blockIndex = 0; blockIndex < blockPositions; blockIndex++) {
-            blocks[blockIndex] = in.readNamedWriteable(Block.class);
+        boolean success = false;
+        try {
+            for (int blockIndex = 0; blockIndex < blockPositions; blockIndex++) {
+                blocks[blockIndex] = in.readNamedWriteable(Block.class);
+            }
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.closeExpectNoException(blocks);
+            }
         }
         this.positionCount = positionCount;
         this.blocks = blocks;


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Release success blocks when reading from stream (#100376)