### PR TITLE
[8.11] Mute testCancelViaAsyncSearchDelete (#100384)

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -1246,6 +1246,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         assertThat(json, matchesRegex(".*task (was)?\s*cancelled.*"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99519")
     public void testCancelViaAsyncSearchDelete() throws Exception {
         Map<String, Object> testClusterInfo = setupTwoClusters();
         String localIndex = (String) testClusterInfo.get("local.index");


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Mute testCancelViaAsyncSearchDelete (#100384)