### PR TITLE
[8.11] Fix system property value for inference rescorer tests feature flag (#100366)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -16,7 +16,7 @@ import org.elasticsearch.test.cluster.util.Version;
  */
 public enum FeatureFlag {
     TIME_SERIES_MODE("es.index_mode_feature_flag_registered=true", Version.fromString("8.0.0"), null),
-    INFERENCE_RESCORER("es.inference_rescorer_feature_flag_enabled", Version.fromString("8.10.0"), null);
+    INFERENCE_RESCORER("es.inference_rescorer_feature_flag_enabled=true", Version.fromString("8.10.0"), null);
 
     public final String systemProperty;
     public final Version from;


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix system property value for inference rescorer tests feature flag (#100366)