### PR TITLE
[8.11] Fixing exists query REST tests for sparse_vector_fields (#100030)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -1,5 +1,5 @@
 ---
-"Indexing and searching sparse vectors":
+"Indexing and searching sparse vectors in >=8.11":
 
   - skip:
       version: " - 8.10.99"
@@ -77,16 +77,24 @@
         index: test
         id: "3"
         body:
-          text: "doing nothing will result in nothing"
+          text: "empty array with no nested values - should not be retrieved in exists queries"
           ml:
-            tokens: {}
+            tokens: [ ]
+  - do:
+      index:
+        index: test
+        id: "4"
+        body:
+          text: "should still respond to exists queries if when empty"
+          ml:
+            tokens: { }
 
   - match: { result: "created" }
 
   - do:
       index:
         index: test
-        id: "4"
+        id: "5"
         body:
           text: "other embeddings available only"
           embeddings:
@@ -144,9 +152,9 @@
 ---
 "Sparse vector in 7.x":
   - skip:
-      features: allowed_warnings
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/100003"
+      features: ["allowed_warnings"]
+      version: "8.0.0 - "
+      reason: "sparse_vector field type supported in 7.x"
   - do:
       allowed_warnings:
         - "The [sparse_vector] field type is deprecated and will be removed in 8.0."
@@ -164,17 +172,16 @@
   - match: { acknowledged: true }
 
   - do:
-      catch: /\[sparse_vector\] fields do not support \[exists\] queries/
+      allowed_warnings:
+        - "[sparse_vector] field type in old 7.x indices is allowed to contain [sparse_vector] fields, but they cannot be indexed or searched."
       search:
-        rest_total_hits_as_int: true
         index: test
         body:
           query:
             exists:
               field: ml.tokens
-
 ---
-"Sparse vector in 8.x":
+"Sparse vector in 8.0.0 <= x < 8.11.0":
   - skip:
       version: " - 7.99.99, 8.11.0 - "
       reason: "sparse_vector field type not supported in 8.x until 8.11.0"
@@ -189,3 +196,12 @@
                 type: text
               ml.tokens:
                 type: sparse_vector
+  - do:
+      catch: /\[sparse_vector\] fields do not support \[exists\] queries|no such index.*/
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            exists:
+              field: ml.tokens

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.mapper.vectors;
 
 import org.apache.lucene.document.FeatureField;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.logging.DeprecationCategory;
@@ -110,8 +111,11 @@ public class SparseVectorFieldMapper extends FieldMapper {
 
         @Override
         public Query existsQuery(SearchExecutionContext context) {
-            // No support for exists queries prior to this version
-            if (context.getIndexSettings().getIndexVersionCreated().before(SPARSE_VECTOR_IN_FIELD_NAMES_INDEX_VERSION)) {
+            if (context.getIndexSettings().getIndexVersionCreated().before(PREVIOUS_SPARSE_VECTOR_INDEX_VERSION)) {
+                deprecationLogger.warn(DeprecationCategory.MAPPINGS, "sparse_vector", ERROR_MESSAGE_7X);
+                return new MatchNoDocsQuery();
+            } else if (context.getIndexSettings().getIndexVersionCreated().before(SPARSE_VECTOR_IN_FIELD_NAMES_INDEX_VERSION)) {
+                // No support for exists queries prior to this version on 8.x
                 throw new IllegalArgumentException("[sparse_vector] fields do not support [exists] queries");
             }
             return super.existsQuery(context);


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fixing exists query REST tests for sparse_vector_fields (#100030)