### PR TITLE
[8.11] Fix nonforking fast path in InboundHandler (#100389)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -268,7 +268,7 @@ public class InboundHandler {
                 assert requestId > 0;
                 request.setRequestId(requestId);
                 verifyRequestReadFully(stream, requestId, action);
-                if (ThreadPool.Names.SAME.equals(reg.getExecutor())) {
+                if (reg.getExecutor() == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                     try (var ignored = threadPool.getThreadContext().newTraceContext()) {
                         doHandleRequest(reg, request, transportChannel);
                     }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix nonforking fast path in InboundHandler (#100389)