### PR TITLE
[DOCS] Minor tweaks to the 8.11 ES|QL release notes

### DIFF
--- a/docs/changelog/98309.yaml
+++ b/docs/changelog/98309.yaml
@@ -4,7 +4,7 @@ area: ES|QL
 type: feature
 issues: []
 highlight:
-  title: Introducing ES|QL — A new query language for flexible, iterative analytics
+  title: ES|QL — a new query language for flexible, iterative analytics in technical preview
   body: |-
     As the Elastic Platform has become more widely adopted for search, security, observability, and general analytics,
     analyst users require the ability to take data-as-ingested, transform it to fit their investigative needs

--- a/docs/changelog/98628.yaml
+++ b/docs/changelog/98628.yaml
@@ -1,5 +1,5 @@
 pr: 98628
-summary: Add ESQL own flavor of arithmetic operators
+summary: Add arithmetic operators
 area: ES|QL
 type: bug
 issues: []

--- a/docs/changelog/98711.yaml
+++ b/docs/changelog/98711.yaml
@@ -1,5 +1,5 @@
 pr: 98711
-summary: Support unsigned long in sqrt and log10 for ESQL
+summary: Support unsigned long in sqrt and log10
 area: ES|QL
 type: enhancement
 issues: []

--- a/docs/changelog/99303.yaml
+++ b/docs/changelog/99303.yaml
@@ -1,5 +1,5 @@
 pr: 99303
-summary: Use DEBUG log level to report ESQL execution steps
+summary: Use DEBUG log level to report execution steps
 area: ES|QL
 type: enhancement
 issues: []

--- a/docs/changelog/99588.yaml
+++ b/docs/changelog/99588.yaml
@@ -1,5 +1,5 @@
 pr: 99588
-summary: Make ESQL more resilient to non-indexed fields
+summary: Resilience to non-indexed fields
 area: ES|QL
 type: bug
 issues:


### PR DESCRIPTION
While reviewing the [8.11.0 BC1 release notes](https://github.com/elastic/elasticsearch/pull/100367), I noticed a few instances of "ESQL" (instead of "ES|QL"). This PR edits those entries. It also marks ES|QL as being in technical preview.