### PR TITLE
Reinstate RepositoryData BwC

### DIFF
--- a/docs/changelog/100405.yaml
+++ b/docs/changelog/100405.yaml
@@ -1,0 +1,5 @@
+pr: 100405
+summary: Reinstate `RepositoryData` BwC
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -29,6 +29,11 @@ BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
       numberOfNodes = 2
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
+      if (v.contains('8.10.')) {
+        // 8.10.x versions contain a bogus assertion that trips when reading repositories touched by newer versions
+        // see https://github.com/elastic/elasticsearch/issues/98454 for details
+        jvmArgs '-da'
+      }
     }
   }
 

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.upgrades;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.client.Request;
@@ -46,7 +45,6 @@ import static org.hamcrest.Matchers.is;
  * </ul>
  */
 @SuppressWarnings("removal")
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98454")
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {


### PR DESCRIPTION
This commit moves back to using a `"major.minor.patch"` string for the
version field in snapshots stored in `RepositoryData`, using the marker
string `"8.11.0"` to allow older versions to filter out newer snapshots
and adding a new `index_version` field alongside.

This format is fully backwardly-compatible, except that it trips an
assertion in the versions of 8.10.x released today. When running without
assertions enabled, things work correctly in all versions.

Relates #98454
