### PR TITLE
ESQL: Reenable yaml tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -300,10 +300,6 @@ setup:
 
 ---
 "Test Mixed Input Params":
-  - skip:
-      version: all
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/99826"
-
   - do:
       esql.query:
         body:

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/20_aggs.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/20_aggs.yml
@@ -418,10 +418,6 @@ setup:
 
 ---
 "Test Eval With Null And Count":
-  - skip:
-      version: all
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/99826"
-
   - do:
       esql.query:
         body:

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/50_index_patterns.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/50_index_patterns.yml
@@ -235,36 +235,35 @@ disjoint_mappings:
   - length: { values: 1 }
   - match: { values.0.0: 2 }
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-#  - do:
-#      esql.query:
-#        body:
-#          query: 'from test1,test2 | sort message1, message2 | eval x = message1, y = message2 + 1 | keep message1, message2, x, y'
-#  - match: { columns.0.name: message1 }
-#  - match: { columns.0.type: keyword }
-#  - match: { columns.1.name: message2 }
-#  - match: { columns.1.type: long }
-#  - match: { columns.2.name: x }
-#  - match: { columns.2.type: keyword }
-#  - match: { columns.3.name: y }
-#  - match: { columns.3.type: long }
-#  - length: { values: 4 }
-#  - match: { values.0.0: foo1 }
-#  - match: { values.0.1: null }
-#  - match: { values.0.2: foo1 }
-#  - match: { values.0.3: null }
-#  - match: { values.1.0: foo2 }
-#  - match: { values.1.1: null }
-#  - match: { values.1.2: foo2 }
-#  - match: { values.1.3: null }
-#  - match: { values.2.0: null }
-#  - match: { values.2.1: 1 }
-#  - match: { values.2.2: null }
-#  - match: { values.2.3: 2 }
-#  - match: { values.3.0: null }
-#  - match: { values.3.1: 2 }
-#  - match: { values.3.2: null }
-#  - match: { values.3.3: 3 }
+  - do:
+      esql.query:
+        body:
+          query: 'from test1,test2 | sort message1, message2 | eval x = message1, y = message2 + 1 | keep message1, message2, x, y'
+  - match: { columns.0.name: message1 }
+  - match: { columns.0.type: keyword }
+  - match: { columns.1.name: message2 }
+  - match: { columns.1.type: long }
+  - match: { columns.2.name: x }
+  - match: { columns.2.type: keyword }
+  - match: { columns.3.name: y }
+  - match: { columns.3.type: long }
+  - length: { values: 4 }
+  - match: { values.0.0: foo1 }
+  - match: { values.0.1: null }
+  - match: { values.0.2: foo1 }
+  - match: { values.0.3: null }
+  - match: { values.1.0: foo2 }
+  - match: { values.1.1: null }
+  - match: { values.1.2: foo2 }
+  - match: { values.1.3: null }
+  - match: { values.2.0: null }
+  - match: { values.2.1: 1 }
+  - match: { values.2.2: null }
+  - match: { values.2.3: 2 }
+  - match: { values.3.0: null }
+  - match: { values.3.1: 2 }
+  - match: { values.3.2: null }
+  - match: { values.3.3: 3 }
 
 ---
 same_name_different_type:


### PR DESCRIPTION
This reenables are yaml tests we disabled while building block tracking. They all pass for me. I believe we've covered their cases.
