### PR TITLE
ESQL: Reenable another csv test

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -426,8 +426,7 @@ nullsum:integer | salary:integer
 null | 74999
 ;
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-evalWithNullAndAvg-Ignore
+evalWithNullAndAvg
 from employees | eval nullsum = salary + null | stats avg(nullsum), count(nullsum);
 
 avg(nullsum):double | count(nullsum):long


### PR DESCRIPTION
This one was also disabled as part of our effort to do Block tracking and now it passes. I believe it was disabled when we didn't close Blocks on the way into `EVAL`. But now we do, so we're good to enable this one!
