### PR TITLE
[8.11] ESQL: support metric tsdb fields while querying index patterns (#100351)

### DIFF
--- a/docs/changelog/100351.yaml
+++ b/docs/changelog/100351.yaml
@@ -1,0 +1,6 @@
+pr: 100351
+summary: "ESQL: support metric tsdb fields while querying index patterns"
+area: ES|QL
+type: bug
+issues:
+ - 100144

--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/40_tsdb.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/40_tsdb.yml
@@ -1,0 +1,174 @@
+setup:
+  - do:
+      indices.create:
+          index: test1
+          body:
+            settings:
+              index:
+                mode: time_series
+                routing_path: [metricset, k8s.pod.uid]
+                time_series:
+                  start_time: 2021-04-28T00:00:00Z
+                  end_time: 2021-04-29T00:00:00Z
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                event.category:
+                  type: keyword
+                metricset:
+                  type: keyword
+                  time_series_dimension: true
+                k8s:
+                  properties:
+                    pod:
+                      properties:
+                        uid:
+                          type: keyword
+                          time_series_dimension: true
+                        name:
+                          type: keyword
+                        ip:
+                          type: ip
+                        network:
+                          properties:
+                            tx:
+                              type: long
+                              time_series_metric: counter
+                            rx:
+                              type: long
+                              time_series_metric: counter
+  - do:
+      bulk:
+        refresh: true
+        index: test1
+        body:
+          - '{"index": {}}'
+          - '{"id":1, "@timestamp": "2021-04-28T18:50:04.467Z", "event.category": "process", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.1", "network": {"tx": 2001818691, "rx": 802133794}}}}'
+          - '{"index": {}}'
+          - '{"id":2, "@timestamp": "2021-04-28T18:50:24.467Z", "event.category": "process", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.1", "network": {"tx": 2005177954, "rx": 801479970}}}}'
+          - '{"index": {}}'
+          - '{"id":3, "@timestamp": "2021-04-28T18:50:44.467Z", "event.category": "process", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.1", "network": {"tx": 2006223737, "rx": 802337279}}}}'
+          - '{"index": {}}'
+          - '{"id":4, "@timestamp": "2021-04-28T18:51:04.467Z", "event.category": "process", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.2", "network": {"tx": 2012916202, "rx": 803685721}}}}'
+          - '{"index": {}}'
+          - '{"id":5, "@timestamp": "2021-04-28T18:50:03.142Z", "event.category": "process", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434521831, "rx": 530575198}}}}'
+          - '{"index": {}}'
+          - '{"id":6, "@timestamp": "2021-04-28T18:50:23.142Z", "event.category": "process", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434577921, "rx": 530600088}}}}'
+          - '{"index": {}}'
+          - '{"id":7, "@timestamp": "2021-04-28T18:50:53.142Z", "event.category": "network", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434587694, "rx": 530604797}}}}'
+          - '{"index": {}}'
+          - '{"id":8, "@timestamp": "2021-04-28T18:51:03.142Z", "event.category": "network", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434595272, "rx": 530605511}}}}'
+
+  - do:
+      indices.create:
+        index: test2
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ dim ]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              event.category:
+                type: keyword
+              dim:
+                type: keyword
+                time_series_dimension: true
+              agg_metric:
+                type: aggregate_metric_double
+                metrics:
+                  - max
+                default_metric: max
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      ip:
+                        type: ip
+                      network:
+                        properties:
+                          tx:
+                            type: long
+  - do:
+      bulk:
+        refresh: true
+        index: test2
+        body:
+          - '{"index": {}}'
+          - '{"id":100, "@timestamp": "2021-04-28T18:49:04.467Z", "event.category": "network", "dim": "A", "agg_metric": {"max": 10}}'
+          - '{"index": {}}'
+          - '{"id":200, "@timestamp": "2021-04-28T18:49:24.467Z", "event.category": "process", "dim": "B", "agg_metric": {"max": 20}, "k8s.pod.network.tx": 2000000001}'
+          - '{"index": {}}'
+          - '{"id":300, "@timestamp": "2021-04-28T18:49:34.467Z", "event.category": "process", "dim": "B", "agg_metric": {"max": 20}, "k8s.pod.network.tx": 1}'
+
+---
+test* where counter:
+  - do:
+      eql.search:
+        index: test*
+        body:
+          query: 'process where k8s.pod.network.tx > 2000000000'
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 5}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.id: 200}
+  - match: {hits.events.1._source.id: 1}
+  - match: {hits.events.2._source.id: 2}
+  - match: {hits.events.3._source.id: 3}
+  - match: {hits.events.4._source.id: 4}
+
+---
+test1 where counter:
+  - do:
+      eql.search:
+        index: test1
+        body:
+          query: 'process where k8s.pod.network.tx > 2000000000'
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 4}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.id: 1}
+  - match: {hits.events.1._source.id: 2}
+  - match: {hits.events.2._source.id: 3}
+  - match: {hits.events.3._source.id: 4}
+
+---
+test2 where counter:
+  - do:
+      eql.search:
+        index: test2
+        body:
+          query: 'process where k8s.pod.network.tx > 2000000000'
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 1}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.id: 200}
+
+---
+test* where true:
+  - do:
+      eql.search:
+        index: test*
+        body:
+          query: 'process where true'
+
+  - match: {timed_out: false}
+  - match: {hits.total.value: 8}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.events.0._source.id: 200}
+  - match: {hits.events.1._source.id: 300}
+  - match: {hits.events.2._source.id: 5}
+  - match: {hits.events.3._source.id: 1}
+  - match: {hits.events.4._source.id: 6}
+  - match: {hits.events.5._source.id: 2}
+  - match: {hits.events.6._source.id: 3}
+  - match: {hits.events.7._source.id: 4}

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/40_tsdb.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/40_tsdb.yml
@@ -83,10 +83,20 @@ setup:
                 metrics:
                   - max
                 default_metric: max
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      ip:
+                        type: ip
+                      network:
+                        properties:
+                          tx:
+                            type: long
   - do:
       bulk:
         refresh: true
-        index: test
+        index: test2
         body:
           - '{"index": {}}'
           - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim": "A", "agg_metric": {"max": 10}}'
@@ -156,7 +166,11 @@ from doc with aggregate_metric_double:
   - match: {columns.1.type: "unsupported"}
   - match: {columns.2.name: "dim"}
   - match: {columns.2.type: "keyword"}
-  - length: {values: 0}
+  - match: {columns.3.name: "k8s.pod.ip"}
+  - match: {columns.3.type: "ip"}
+  - match: {columns.4.name: "k8s.pod.network.tx"}
+  - match: {columns.4.type: "long"}
+  - length: {values: 2}
 
 ---
 stats on aggregate_metric_double:
@@ -164,4 +178,39 @@ stats on aggregate_metric_double:
       catch: /Cannot use field \[agg_metric\] with unsupported type \[aggregate_metric_double\]/
       esql.query:
         body:
-          query: 'FROM test2 | STATS max(agg_metric) BY dim '
+          query: 'FROM test2 | STATS max(agg_metric) BY dim'
+
+---
+from index pattern unsupported counter:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test*'
+
+  - match: {columns.0.name: "@timestamp"}
+  - match: {columns.0.type: "date"}
+  - match: {columns.1.name: "agg_metric"}
+  - match: {columns.1.type: "unsupported"}
+  - match: {columns.2.name: "dim"}
+  - match: {columns.2.type: "keyword"}
+  - match: {columns.3.name: "k8s.pod.ip"}
+  - match: {columns.3.type: "ip"}
+  - match: {columns.4.name: "k8s.pod.name"}
+  - match: {columns.4.type: "keyword"}
+  - match: {columns.5.name: "k8s.pod.network.rx"}
+  - match: {columns.5.type: "unsupported"}
+  - match: {columns.6.name: "k8s.pod.network.tx"}
+  - match: {columns.6.type: "unsupported"}
+  - match: {columns.7.name: "k8s.pod.uid"}
+  - match: {columns.7.type: "keyword"}
+  - match: {columns.8.name: "metricset"}
+  - match: {columns.8.type: "keyword"}
+  - length: {values: 10}
+
+---
+from index pattern explicit counter use:
+  - do:
+      catch: '/Cannot use field \[k8s.pod.network.tx\] due to ambiguities being mapped as different metric types in indices: \[test, test2\]/'
+      esql.query:
+        body:
+          query: 'FROM test* | keep *.tx'

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolver.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.enrich.EnrichMetadata;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.session.EsqlSession;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 
 import java.util.Map;
@@ -117,7 +118,8 @@ public class EnrichPolicyResolver {
                     IndexResolver.ALL_FIELDS,
                     false,
                     Map.of(),
-                    listener.map(indexResult -> new ResolveResponse(new EnrichPolicyResolution(policyName, policy, indexResult)))
+                    listener.map(indexResult -> new ResolveResponse(new EnrichPolicyResolution(policyName, policy, indexResult))),
+                    EsqlSession::specificValidity
                 );
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.session;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
@@ -46,6 +47,7 @@ import org.elasticsearch.xpack.ql.plan.TableIdentifier;
 import org.elasticsearch.xpack.ql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.plan.logical.Project;
+import org.elasticsearch.xpack.ql.type.InvalidMappedField;
 import org.elasticsearch.xpack.ql.util.Holder;
 
 import java.util.HashSet;
@@ -57,6 +59,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.xpack.ql.index.IndexResolver.UNMAPPED;
 import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 import static org.elasticsearch.xpack.ql.util.StringUtils.WILDCARD;
 
@@ -173,7 +176,7 @@ public class EsqlSession {
             TableInfo tableInfo = preAnalysis.indices.get(0);
             TableIdentifier table = tableInfo.id();
             var fieldNames = fieldNames(parsed);
-            indexResolver.resolveAsMergedMapping(table.index(), fieldNames, false, Map.of(), listener);
+            indexResolver.resolveAsMergedMapping(table.index(), fieldNames, false, Map.of(), listener, EsqlSession::specificValidity);
         } else {
             try {
                 // occurs when dealing with local relations (row a = 1)
@@ -281,4 +284,36 @@ public class EsqlSession {
             return plan;
         }));
     }
+
+    public static InvalidMappedField specificValidity(String fieldName, Map<String, FieldCapabilities> types) {
+        boolean hasUnmapped = types.containsKey(UNMAPPED);
+        boolean hasTypeConflicts = types.size() > (hasUnmapped ? 2 : 1);
+        String metricConflictsTypeName = null;
+        boolean hasMetricConflicts = false;
+
+        if (hasTypeConflicts == false) {
+            for (Map.Entry<String, FieldCapabilities> type : types.entrySet()) {
+                if (UNMAPPED.equals(type.getKey())) {
+                    continue;
+                }
+                if (type.getValue().metricConflictsIndices() != null && type.getValue().metricConflictsIndices().length > 0) {
+                    hasMetricConflicts = true;
+                    metricConflictsTypeName = type.getKey();
+                    break;
+                }
+            }
+        }
+
+        InvalidMappedField result = null;
+        if (hasMetricConflicts) {
+            StringBuilder errorMessage = new StringBuilder();
+            errorMessage.append(
+                "mapped as different metric types in indices: ["
+                    + String.join(", ", types.get(metricConflictsTypeName).metricConflictsIndices())
+                    + "]"
+            );
+            result = new InvalidMappedField(fieldName, errorMessage.toString());
+        }
+        return result;
+    };
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.session.EsqlSession;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.type.DataType;
@@ -51,7 +52,12 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
             Map.of()
         );
         FieldCapabilitiesResponse caps = new FieldCapabilitiesResponse(indices, Map.of(fieldCap.getName(), Map.of(esTypeName, fieldCap)));
-        IndexResolution resolution = IndexResolver.mergedMappings(EsqlDataTypeRegistry.INSTANCE, "idx-*", caps);
+        IndexResolution resolution = IndexResolver.mergedMappings(
+            EsqlDataTypeRegistry.INSTANCE,
+            "idx-*",
+            caps,
+            EsqlSession::specificValidity
+        );
 
         EsField f = resolution.get().mapping().get(fieldCap.getName());
         assertThat(f.getDataType(), equalTo(expected));

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -134,7 +134,7 @@ public class IndexResolver {
     );
 
     public static final Set<String> ALL_FIELDS = Set.of("*");
-    private static final String UNMAPPED = "unmapped";
+    public static final String UNMAPPED = "unmapped";
 
     private final Client client;
     private final String clusterName;
@@ -340,17 +340,34 @@ public class IndexResolver {
         Map<String, Object> runtimeMappings,
         ActionListener<IndexResolution> listener
     ) {
+        resolveAsMergedMapping(indexWildcard, fieldNames, includeFrozen, runtimeMappings, listener, (fieldName, types) -> null);
+    }
+
+    /**
+     * Resolves a pattern to one (potentially compound meaning that spawns multiple indices) mapping.
+     */
+    public void resolveAsMergedMapping(
+        String indexWildcard,
+        Set<String> fieldNames,
+        boolean includeFrozen,
+        Map<String, Object> runtimeMappings,
+        ActionListener<IndexResolution> listener,
+        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> specificValidityVerifier
+    ) {
         FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, fieldNames, includeFrozen, runtimeMappings);
         client.fieldCaps(
             fieldRequest,
-            listener.delegateFailureAndWrap((l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response)))
+            listener.delegateFailureAndWrap(
+                (l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response, specificValidityVerifier))
+            )
         );
     }
 
     public static IndexResolution mergedMappings(
         DataTypeRegistry typeRegistry,
         String indexPattern,
-        FieldCapabilitiesResponse fieldCapsResponse
+        FieldCapabilitiesResponse fieldCapsResponse,
+        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> specificValidityVerifier
     ) {
 
         if (fieldCapsResponse.getIndices().length == 0) {
@@ -358,9 +375,13 @@ public class IndexResolver {
         }
 
         // merge all indices onto the same one
-        List<EsIndex> indices = buildIndices(typeRegistry, null, fieldCapsResponse, null, i -> indexPattern, (n, types) -> {
-            StringBuilder errorMessage = new StringBuilder();
+        List<EsIndex> indices = buildIndices(typeRegistry, null, fieldCapsResponse, null, i -> indexPattern, (fieldName, types) -> {
+            InvalidMappedField f = specificValidityVerifier.apply(fieldName, types);
+            if (f != null) {
+                return f;
+            }
 
+            StringBuilder errorMessage = new StringBuilder();
             boolean hasUnmapped = types.containsKey(UNMAPPED);
 
             if (types.size() > (hasUnmapped ? 2 : 1)) {
@@ -384,7 +405,7 @@ public class IndexResolver {
 
                 errorMessage.insert(0, "mapped as [" + (types.size() - (hasUnmapped ? 1 : 0)) + "] incompatible types: ");
 
-                return new InvalidMappedField(n, errorMessage.toString());
+                return new InvalidMappedField(fieldName, errorMessage.toString());
             }
             // type is okay, check aggregation
             else {
@@ -404,7 +425,7 @@ public class IndexResolver {
                 }
 
                 if (errorMessage.length() > 0) {
-                    return new InvalidMappedField(n, errorMessage.toString());
+                    return new InvalidMappedField(fieldName, errorMessage.toString());
                 }
             }
 
@@ -426,6 +447,14 @@ public class IndexResolver {
             EsIndex idx = indices.get(0);
             return IndexResolution.valid(new EsIndex(idx.name(), idx.mapping(), Set.of(indexNames)));
         }
+    }
+
+    public static IndexResolution mergedMappings(
+        DataTypeRegistry typeRegistry,
+        String indexPattern,
+        FieldCapabilitiesResponse fieldCapsResponse
+    ) {
+        return mergedMappings(typeRegistry, indexPattern, fieldCapsResponse, (fieldName, types) -> null);
     }
 
     private static EsField createField(

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -1167,6 +1167,226 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         );
     }
 
+    public void testTsdbMetrics() throws IOException {
+        createTsdb1();
+        createTsdb2();
+
+        String mode = randomMode();
+        // select all from tsdb1
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(
+            "columns",
+            Arrays.asList(
+                columnInfo(mode, "@timestamp", "datetime", JDBCType.DATE, 34),
+                columnInfo(mode, "k8s.pod.ip", "ip", JDBCType.VARCHAR, 45),
+                columnInfo(mode, "k8s.pod.name", "keyword", JDBCType.VARCHAR, 32766),
+                columnInfo(mode, "k8s.pod.network.rx", "long", JDBCType.BIGINT, 20),
+                columnInfo(mode, "k8s.pod.network.tx", "long", JDBCType.BIGINT, 20),
+                columnInfo(mode, "k8s.pod.uid", "keyword", JDBCType.VARCHAR, 32766),
+                columnInfo(mode, "metricset", "keyword", JDBCType.VARCHAR, 32766)
+            )
+        );
+        expected.put(
+            "rows",
+            singletonList(
+                Arrays.asList(
+                    "2021-04-28T18:50:04.467Z",
+                    "10.10.55.1",
+                    "cat",
+                    802133794,
+                    2001818691,
+                    "947e4ced-1786-4e53-9e0c-5c447e959507",
+                    "pod"
+                )
+            )
+        );
+        assertResponse(expected, runSql(mode, "SELECT * FROM tsdb1", false));
+
+        // select all from tsdb2
+        expected = new HashMap<>();
+        expected.put(
+            "columns",
+            Arrays.asList(
+                columnInfo(mode, "@timestamp", "datetime", JDBCType.DATE, 34),
+                columnInfo(mode, "dim", "keyword", JDBCType.VARCHAR, 32766),
+                columnInfo(mode, "k8s.pod.ip", "ip", JDBCType.VARCHAR, 45),
+                columnInfo(mode, "k8s.pod.network.tx", "long", JDBCType.BIGINT, 20)
+            )
+        );
+        expected.put("rows", singletonList(Arrays.asList("2021-04-28T18:50:04.467Z", "A", null, null)));
+        assertResponse(expected, runSql(mode, "SELECT * FROM tsdb2", false));
+
+        // select all from both indices
+        expected = new HashMap<>();
+        expected.put(
+            "columns",
+            Arrays.asList(
+                columnInfo(mode, "@timestamp", "datetime", JDBCType.DATE, 34),
+                columnInfo(mode, "dim", "keyword", JDBCType.VARCHAR, 32766),
+                columnInfo(mode, "k8s.pod.ip", "ip", JDBCType.VARCHAR, 45),
+                columnInfo(mode, "k8s.pod.name", "keyword", JDBCType.VARCHAR, 32766),
+                columnInfo(mode, "k8s.pod.network.rx", "long", JDBCType.BIGINT, 20),
+                columnInfo(mode, "k8s.pod.network.tx", "long", JDBCType.BIGINT, 20),
+                columnInfo(mode, "k8s.pod.uid", "keyword", JDBCType.VARCHAR, 32766),
+                columnInfo(mode, "metricset", "keyword", JDBCType.VARCHAR, 32766)
+            )
+        );
+        expected.put(
+            "rows",
+            Arrays.asList(
+                Arrays.asList(
+                    "2021-04-28T18:50:04.467Z",
+                    null,
+                    "10.10.55.1",
+                    "cat",
+                    802133794,
+                    2001818691,
+                    "947e4ced-1786-4e53-9e0c-5c447e959507",
+                    "pod"
+                ),
+                Arrays.asList("2021-04-28T18:50:04.467Z", "A", null, null, null, null, null, null)
+            )
+        );
+        assertResponse(expected, runSql(mode, "SELECT * FROM \\\"tsdb*\\\"", false));
+
+        // select the column that is both mapped as counter and as long
+        expected = new HashMap<>();
+        expected.put("columns", Arrays.asList(columnInfo(mode, "k8s.pod.network.tx", "long", JDBCType.BIGINT, 20)));
+        expected.put("rows", Arrays.asList(singletonList(2001818691), singletonList(null)));
+        assertResponse(expected, runSql(mode, "SELECT k8s.pod.network.tx FROM \\\"tsdb*\\\"", false));
+
+        deleteIndex(client(), "tsdb1");
+        deleteIndex(client(), "tsdb2");
+    }
+
+    private void createTsdb2() throws IOException {
+        Request request = new Request("PUT", "/tsdb2");
+        request.setJsonEntity("""
+            {
+                  "settings": {
+                      "index": {
+                          "mode": "time_series",
+                          "routing_path": ["dim"],
+                          "time_series": {
+                              "start_time": "2021-04-28T00:00:00Z",
+                              "end_time": "2021-04-29T00:00:00Z"
+                          }
+                      }
+                  },
+                  "mappings": {
+                      "properties": {
+                          "@timestamp": {
+                              "type": "date"
+                          },
+                          "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": "true"
+                          },
+                          "agg_metric": {
+                              "type": "aggregate_metric_double",
+                              "metrics": ["max"],
+                              "default_metric": "max"
+                          },
+                          "k8s": {
+                              "properties": {
+                                  "pod": {
+                                      "properties": {
+                                          "ip": {
+                                              "type": "ip"
+                                          },
+                                          "network": {
+                                              "properties": {
+                                                  "tx": {
+                                                      "type": "long"
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }""");
+        assertOK(client().performRequest(request));
+
+        request = new Request("POST", "/tsdb2/_doc");
+        request.addParameter("refresh", "true");
+        request.setJsonEntity("{\"@timestamp\": \"2021-04-28T18:50:04.467Z\", \"dim\": \"A\", \"agg_metric\": {\"max\": 10}}");
+        client().performRequest(request);
+    }
+
+    private void createTsdb1() throws IOException {
+        Request request = new Request("PUT", "/tsdb1");
+        request.setJsonEntity("""
+            {
+                 "settings": {
+                     "index": {
+                         "mode": "time_series",
+                         "routing_path": [
+                             "metricset",
+                             "k8s.pod.uid"
+                         ],
+                         "time_series": {
+                             "start_time": "2021-04-28T00:00:00Z",
+                             "end_time": "2021-04-29T00:00:00Z"
+                         }
+                     }
+                 },
+                 "mappings": {
+                     "properties": {
+                         "@timestamp": {
+                             "type": "date"
+                         },
+                         "metricset": {
+                             "type": "keyword",
+                             "time_series_dimension": true
+                         },
+                         "k8s": {
+                             "properties": {
+                                 "pod": {
+                                     "properties": {
+                                         "uid": {
+                                             "type": "keyword",
+                                             "time_series_dimension": true
+                                         },
+                                         "name": {
+                                             "type": "keyword"
+                                         },
+                                         "ip": {
+                                             "type": "ip"
+                                         },
+                                         "network": {
+                                             "properties": {
+                                                 "tx": {
+                                                     "type": "long",
+                                                     "time_series_metric": "counter"
+                                                 },
+                                                 "rx": {
+                                                     "type": "long",
+                                                     "time_series_metric": "counter"
+                                                 }
+                                             }
+                                         }
+                                     }
+                                 }
+                             }
+                         }
+                     }
+                 }
+             }""");
+        assertOK(client().performRequest(request));
+
+        request = new Request("POST", "/tsdb1/_doc");
+        request.addParameter("refresh", "true");
+        request.setJsonEntity(
+            "{\"@timestamp\": \"2021-04-28T18:50:04.467Z\", \"metricset\": \"pod\","
+                + "\"k8s\": {\"pod\": {\"name\": \"cat\", \"uid\":\"947e4ced-1786-4e53-9e0c-5c447e959507\", \"ip\": \"10.10.55.1\","
+                + "\"network\": {\"tx\": 2001818691, \"rx\": 802133794}}}}"
+        );
+        client().performRequest(request);
+    }
+
     private void executeQueryWithNextPage(String format, String expectedHeader, String expectedLineFormat) throws IOException {
         int size = 20;
         String[] docs = new String[size];


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: support metric tsdb fields while querying index patterns (#100351)