### PR TITLE
[ML] Only log long time unassigned message if not empty

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -267,8 +267,9 @@ public class MlAssignmentNotifier implements ClusterStateListener {
         }
 
         List<String> itemsToReport = findLongTimeUnassignedTasks(now, tasks);
-
-        logger.warn("ML persistent tasks unassigned for a long time [{}]", String.join("|", itemsToReport));
+        if (itemsToReport.isEmpty() == false) {
+            logger.warn("ML persistent tasks unassigned for a long time [{}]", String.join("|", itemsToReport));
+        }
     }
 
     /**


### PR DESCRIPTION
Followup to #100154

The log message about unassigned jobs is simply spam if there are no unassigned jobs, so it should only be logged if there's at least one item in the list.