### PR TITLE
[8.11] Tracing: Use doPriv when working with spans, use SpanId  (#100232)

### DIFF
--- a/docs/changelog/100232.yaml
+++ b/docs/changelog/100232.yaml
@@ -1,0 +1,5 @@
+pr: 100232
+summary: "Tracing: Use `doPriv` when working with spans, use `SpanId`"
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -114,6 +114,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
 import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.telemetry.tracing.SpanId;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.Scheduler.Cancellable;
@@ -492,7 +493,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private DfsSearchResult executeDfsPhase(ShardSearchRequest request, SearchShardTask task) throws IOException {
         ReaderContext readerContext = createOrGetReaderContext(request);
         try (@SuppressWarnings("unused") // withScope call is necessary to instrument search execution
-        Releasable scope = tracer.withScope(task);
+        Releasable scope = tracer.withScope(SpanId.forTask(task));
             Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
             SearchContext context = createContext(readerContext, request, task, ResultsType.DFS, false)
         ) {
@@ -658,8 +659,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      */
     private SearchPhaseResult executeQueryPhase(ShardSearchRequest request, SearchShardTask task) throws Exception {
         final ReaderContext readerContext = createOrGetReaderContext(request);
+        SpanId spanId = SpanId.forTask(task);
         try (
-            Releasable scope = tracer.withScope(task);
+            Releasable scope = tracer.withScope(spanId);
             Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
             SearchContext context = createContext(readerContext, request, task, ResultsType.QUERY, true)
         ) {
@@ -672,7 +674,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 }
                 afterQueryTime = executor.success();
             } finally {
-                tracer.stopTrace();
+                tracer.stopTrace(spanId);
             }
             if (request.numberOfShards() == 1 && (request.source() == null || request.source().rankBuilder() == null)) {
                 // we already have query results, but we can run fetch at the same time
@@ -702,7 +704,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private QueryFetchSearchResult executeFetchPhase(ReaderContext reader, SearchContext context, long afterQueryTime) {
         try (
-            Releasable scope = tracer.withScope(context.getTask());
+            Releasable scope = tracer.withScope(SpanId.forTask(context.getTask()));
             SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(context, true, afterQueryTime)
         ) {
             shortcutDocIdsToLoad(context);

--- a/server/src/main/java/org/elasticsearch/telemetry/tracing/Tracer.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/tracing/Tracer.java
@@ -178,13 +178,6 @@ public interface Tracer {
     Releasable withScope(SpanId spanId);
 
     /**
-     * @see Tracer#withScope(SpanId)
-     */
-    default Releasable withScope(Task task) {
-        return withScope(SpanId.forTask(task));
-    }
-
-    /**
      * A Tracer implementation that does nothing. This is used when no tracer is configured,
      * in order to avoid null checks everywhere.
      */
@@ -236,11 +229,6 @@ public interface Tracer {
 
         @Override
         public Releasable withScope(SpanId spanId) {
-            return () -> {};
-        }
-
-        @Override
-        public Releasable withScope(Task task) {
             return () -> {};
         }
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Tracing: Use doPriv when working with spans, use SpanId  (#100232)](https://github.com/elastic/elasticsearch/pull/100232)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

Fixes:
#100410