### PR TITLE
[8.10] [buildkite] Fix backport PR pipeline generation (#100427)

### DIFF
--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -116,9 +116,10 @@ export const generatePipelines = (
     .filter((x) => x);
 
   if (!changedFiles?.length) {
-    const mergeBase = execSync(`git merge-base origin/${process.env["GITHUB_PR_TARGET_BRANCH"]} HEAD`, {
-      cwd: PROJECT_ROOT,
-    })
+    const mergeBase = execSync(
+      `git fetch origin ${process.env["GITHUB_PR_TARGET_BRANCH"]}; git merge-base origin/${process.env["GITHUB_PR_TARGET_BRANCH"]} HEAD`,
+      { cwd: PROJECT_ROOT }
+    )
       .toString()
       .trim();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[buildkite] Fix backport PR pipeline generation (#100427)](https://github.com/elastic/elasticsearch/pull/100427)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)