### PR TITLE
Reinstate RepositoryData BwC

### DIFF
--- a/docs/changelog/100433.yaml
+++ b/docs/changelog/100433.yaml
@@ -1,0 +1,5 @@
+pr: 100433
+summary: Reinstate `RepositoryData` BwC
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -95,12 +95,12 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
         return true;
     }
 
-    public void testCreateAndRestoreSnapshot() throws IOException {
-        assumeTrue(
-            "test does not work for downgrades before 8.10.0, see https://github.com/elastic/elasticsearch/issues/98454",
-            OLD_CLUSTER_VERSION.onOrAfter(Version.V_8_10_0)
-        );
+    @Override
+    protected boolean resetFeatureStates() {
+        return false; // remove when https://github.com/elastic/elasticsearch/pull/100423 is merged
+    }
 
+    public void testCreateAndRestoreSnapshot() throws IOException {
         final String repoName = getTestName();
         try {
             final int shards = 3;
@@ -147,11 +147,6 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     }
 
     public void testReadOnlyRepo() throws IOException {
-        assumeTrue(
-            "test does not fully work for downgrades before 8.10.0, see https://github.com/elastic/elasticsearch/issues/98454",
-            OLD_CLUSTER_VERSION.onOrAfter(Version.V_8_10_0) || TEST_STEP != TestStep.STEP3_OLD_CLUSTER
-        );
-
         final String repoName = getTestName();
         final int shards = 3;
         final boolean readOnly = TEST_STEP.ordinal() > 1; // only restore from read-only repo in steps 3 and 4
@@ -185,11 +180,6 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     );
 
     public void testUpgradeMovesRepoToNewMetaVersion() throws IOException {
-        assumeTrue(
-            "test does not work for downgrades before 8.10.0, see https://github.com/elastic/elasticsearch/issues/98454",
-            OLD_CLUSTER_VERSION.onOrAfter(Version.V_8_10_0)
-        );
-
         final String repoName = getTestName();
         try {
             final int shards = 3;

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.upgrades;
 
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -77,8 +76,6 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     }
 
     private static final TestStep TEST_STEP = TestStep.parse(System.getProperty("tests.rest.suite"));
-
-    private static final Version OLD_CLUSTER_VERSION = Version.fromString(System.getProperty("tests.old_cluster_version"));
 
     @Override
     protected boolean preserveSnapshotsUponCompletion() {


### PR DESCRIPTION
This commit moves `RepositoryData` to using separate fields for the
old-style `"major.minor.patch"` snapshot index versions and new-style
numeric versions. This field is optional, so older versions will
tolerate its omission and will go and re-read it from the authoritative
`SnapshotInfo` source if it's needed.

Relates #98454