### PR TITLE
[8.11] [ML] Only log long time unassigned message if not empty (#100417)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -267,8 +267,9 @@ public class MlAssignmentNotifier implements ClusterStateListener {
         }
 
         List<String> itemsToReport = findLongTimeUnassignedTasks(now, tasks);
-
-        logger.warn("ML persistent tasks unassigned for a long time [{}]", String.join("|", itemsToReport));
+        if (itemsToReport.isEmpty() == false) {
+            logger.warn("ML persistent tasks unassigned for a long time [{}]", String.join("|", itemsToReport));
+        }
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [ML] Only log long time unassigned message if not empty (#100417)