### PR TITLE
[8.11] ESQL: Reenable another csv test (#100411)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -426,8 +426,7 @@ nullsum:integer | salary:integer
 null | 74999
 ;
 
-# AwaitsFix https://github.com/elastic/elasticsearch/issues/99826
-evalWithNullAndAvg-Ignore
+evalWithNullAndAvg
 from employees | eval nullsum = salary + null | stats avg(nullsum), count(nullsum);
 
 avg(nullsum):double | count(nullsum):long


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Reenable another csv test (#100411)