### PR TITLE
Ensure JULBridgeTests resets root logging level after test

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -149,6 +149,7 @@ if (BuildParams.isSnapshotBuild() == false) {
 
 tasks.named("test").configure {
     systemProperty 'es.insecure_network_trace_enabled', 'true'
+    maxParallelForks = 1
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -149,7 +149,6 @@ if (BuildParams.isSnapshotBuild() == false) {
 
 tasks.named("test").configure {
     systemProperty 'es.insecure_network_trace_enabled', 'true'
-    maxParallelForks = 1
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
@@ -21,9 +21,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -31,7 +31,7 @@ public class JULBridgeTests extends ESTestCase {
 
     private static final java.util.logging.Logger logger = java.util.logging.Logger.getLogger("");
     private static java.util.logging.Level savedLevel;
-    private static java.util.logging.Handler[] savedHandlers;
+    private static Handler[] savedHandlers;
 
     @BeforeClass
     public static void saveLoggerState() {
@@ -60,10 +60,12 @@ public class JULBridgeTests extends ESTestCase {
 
     private void assertLogged(Runnable loggingCode, LoggingExpectation... expectations) {
         Logger testLogger = LogManager.getLogger("");
-        Loggers.setLevel(testLogger, Level.ALL);
+        Level savedLevel = testLogger.getLevel();
         MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
+
         try {
+            Loggers.setLevel(testLogger, Level.ALL);
+            mockAppender.start();
             Loggers.addAppender(testLogger, mockAppender);
             for (var expectation : expectations) {
                 mockAppender.addExpectation(expectation);
@@ -71,6 +73,7 @@ public class JULBridgeTests extends ESTestCase {
             loggingCode.run();
             mockAppender.assertAllExpectationsMatched();
         } finally {
+            Loggers.setLevel(testLogger, savedLevel);
             Loggers.removeAppender(testLogger, mockAppender);
             mockAppender.stop();
         }

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.snapshots;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
@@ -228,7 +227,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100434")
 public class SnapshotResiliencyTests extends ESTestCase {
 
     private DeterministicTaskQueue deterministicTaskQueue;


### PR DESCRIPTION
`JULBridgeTests` was inadvertently setting the logging level to `ALL` on the root logger and never resetting it back. This meant that subsequent tests run in the same worker were creating massive amounts of log output leading to undesirable behavior in CI.

Closes https://github.com/elastic/elasticsearch/issues/100434