### PR TITLE
[8.11] Release page in FilterOperator when all values null (#100440)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
@@ -44,6 +44,7 @@ public class FilterOperator extends AbstractPageMappingOperator {
         try (Block.Ref ref = evaluator.eval(page)) {
             if (ref.block().areAllValuesNull()) {
                 // All results are null which is like false. No values selected.
+                page.releaseBlocks();
                 return null;
             }
             BooleanBlock test = (BooleanBlock) ref.block();


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Release page in FilterOperator when all values null (#100440)