### PR TITLE
Add pull request check for validating changelogs

### DIFF
--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: validate-changelogs
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed validateChangelogs
+    timeout_in_minutes: 300
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: custom-32-98304
+      buildDirectory: /dev/shm/bk

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+validate-changelogs.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+validate-changelogs.yml
@@ -1,0 +1,5 @@
+---
+jjbb-template: pull-request-gradle-unix.yml
+vars:
+  - pr-job: "validate-changelogs"
+  - gradle-args: "-Dignore.tests.seed validateChangelogs"


### PR DESCRIPTION
Add an explicit CI job which runs `validateChangeLogs` task. This normally runs as part of intake in the `precommit` task but we don't run that separately for pull requests.

Closes #93840