### PR TITLE
[8.10] Search of remote clusters with no shards results in successful status. (#100354)

### DIFF
--- a/docs/changelog/100354.yaml
+++ b/docs/changelog/100354.yaml
@@ -1,0 +1,5 @@
+pr: 100354
+summary: Search of remote clusters with no shards results in successful status
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -800,14 +800,15 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     ) {
         /*
          * Cluster Status logic:
-         * 1) FAILED if all shards failed and skip_unavailable=false
-         * 2) SKIPPED if all shards failed and skip_unavailable=true
+         * 1) FAILED if total_shards > 0 && all shards failed && skip_unavailable=false
+         * 2) SKIPPED if total_shards > 0 && all shards failed && skip_unavailable=true
          * 3) PARTIAL if it timed out
          * 4) PARTIAL if it at least one of the shards succeeded but not all
          * 5) SUCCESSFUL if no shards failed (and did not time out)
          */
         SearchResponse.Cluster.Status status;
-        if (searchResponse.getFailedShards() >= searchResponse.getTotalShards()) {
+        int totalShards = searchResponse.getTotalShards();
+        if (totalShards > 0 && searchResponse.getFailedShards() >= totalShards) {
             if (skipUnavailable) {
                 status = SearchResponse.Cluster.Status.SKIPPED;
             } else {


### PR DESCRIPTION
Backports the following commits to 8.10:

Search of remote clusters with no shards results in successful status. (https://github.com/elastic/elasticsearch/pull/100354)