### PR TITLE
Allowing reroute processor yaml rest tests to work with indices or data streams

### DIFF
--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
 restResources {
   restApi {
-    include '_common', 'ingest', 'cluster', 'indices', 'index', 'bulk', 'nodes', 'get', 'update', 'cat', 'mget'
+    include '_common', 'ingest', 'cluster', 'indices', 'index', 'bulk', 'nodes', 'get', 'update', 'cat', 'mget', 'search'
   }
 }
 

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/310_reroute_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/310_reroute_processor.yml
@@ -46,6 +46,8 @@ teardown:
   - do:
       index:
         index: logs-generic-default
+        refresh: true
+        op_type: create
         id: "1"
         pipeline: "pipeline-with-two-data-stream-processors"
         body: {
@@ -53,10 +55,13 @@ teardown:
         }
 
   - do:
-      get:
+      search:
         index: logs-first-default
-        id: "1"
-  - match: { _source.foo: "bar" }
+        body:
+          query:
+            match: {"_id": "1"}
+  - match: { hits.hits.0._source.foo: "bar" }
+
 ---
 "Test two stage routing":
   - skip:
@@ -123,6 +128,7 @@ teardown:
 
   - do:
       index:
+        refresh: true
         index: logs-nginx-default
         id: "example-log"
         op_type: create
@@ -134,7 +140,8 @@ teardown:
               path: "nginx-error.log"
 
   - do:
-      get:
-        index: logs-nginx.error-default
-        id: "example-log"
-  - match: { _source.message: "this is an error log" }
+      search:
+        body:
+          query:
+            match: {"_id": "example-log"}
+  - match: { hits.hits.0._source.message: "this is an error log" }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/310_reroute_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/310_reroute_processor.yml
@@ -115,22 +115,13 @@ teardown:
             ]
           }
   - match: { acknowledged: true }
-  - do:
-      allowed_warnings:
-        - "index template [logs-nginx] has index patterns [logs-nginx-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logs-nginx] will take precedence during new index creation"
-      indices.put_index_template:
-        name: logs-nginx
-        body:
-          index_patterns: [ "logs-nginx-*" ]
-          template:
-            settings:
-              index.default_pipeline: "logs-nginx"
 
   - do:
       index:
         refresh: true
         index: logs-nginx-default
         id: "example-log"
+        pipeline: "logs-nginx"
         op_type: create
         body:
           "@timestamp": "2022-04-13"
@@ -141,6 +132,7 @@ teardown:
 
   - do:
       search:
+        index: logs-nginx.error-default
         body:
           query:
             match: {"_id": "example-log"}


### PR DESCRIPTION
As it exists right now, `310_reroute_processor.yml` only works if the `logs-*` templates are not in place, resulting in `logs-generic-default` and  `logs-nginx.error-default` being created as indices rather than data streams. This change allows the test to succeed with those two things as either indices or data streams, paving the way for us to change them to data streams in the future.