### PR TITLE
Ensure deterministic in rename.DuplicateProjectEval

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/rename.csv-spec
@@ -94,7 +94,7 @@ x:integer | y:integer | x2:integer | y2:integer
 ;
 
 duplicateProjectEval
-from employees | eval y = languages, x = languages | keep x, y | eval x2 = x + 1 | eval y2 = y + 2 | limit 3 | sort x;
+from employees | sort emp_no | eval y = languages, x = languages | keep x, y | eval x2 = x + 1 | eval y2 = y + 2 | limit 3 | sort x;
 
 x:integer | y:integer | x2:integer | y2:integer
 2 | 2 | 3 | 4


### PR DESCRIPTION
Without sort, the result can be out of order in the multi-node environment