### PR TITLE
Cleanup+Dry up Percentile Rank Aggregation Iterators

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -77,22 +77,22 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         assertEquals(pcts.length, percentileList.size());
         for (int i = 0; i < pcts.length; ++i) {
             final Percentile percentile = percentileList.get(i);
-            assertThat(percentile.getValue(), equalTo(pcts[i]));
-            assertThat(percentile.getPercent(), greaterThanOrEqualTo(0.0));
-            assertThat(percentile.getPercent(), lessThanOrEqualTo(100.0));
+            assertThat(percentile.value(), equalTo(pcts[i]));
+            assertThat(percentile.percent(), greaterThanOrEqualTo(0.0));
+            assertThat(percentile.percent(), lessThanOrEqualTo(100.0));
 
-            if (percentile.getPercent() == 0) {
+            if (percentile.percent() == 0) {
                 double allowedError = minValue / Math.pow(10, numberSigDigits);
-                assertThat(percentile.getValue(), lessThanOrEqualTo(minValue + allowedError));
+                assertThat(percentile.value(), lessThanOrEqualTo(minValue + allowedError));
             }
-            if (percentile.getPercent() == 100) {
+            if (percentile.percent() == 100) {
                 double allowedError = maxValue / Math.pow(10, numberSigDigits);
-                assertThat(percentile.getValue(), greaterThanOrEqualTo(maxValue - allowedError));
+                assertThat(percentile.value(), greaterThanOrEqualTo(maxValue - allowedError));
             }
         }
 
         for (int i = 1; i < percentileList.size(); ++i) {
-            assertThat(percentileList.get(i).getValue(), greaterThanOrEqualTo(percentileList.get(i - 1).getValue()));
+            assertThat(percentileList.get(i).value(), greaterThanOrEqualTo(percentileList.get(i - 1).value()));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -80,22 +80,22 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
         assertEquals(pcts.length, percentileList.size());
         for (int i = 0; i < pcts.length; ++i) {
             final Percentile percentile = percentileList.get(i);
-            assertThat(percentile.getPercent(), equalTo(pcts[i]));
-            double value = percentile.getValue();
+            assertThat(percentile.percent(), equalTo(pcts[i]));
+            double value = percentile.value();
             double allowedError = value / Math.pow(10, numberSigDigits);
             assertThat(value, greaterThanOrEqualTo(minValue - allowedError));
             assertThat(value, lessThanOrEqualTo(maxValue + allowedError));
 
-            if (percentile.getPercent() == 0) {
+            if (percentile.percent() == 0) {
                 assertThat(value, closeTo(minValue, allowedError));
             }
-            if (percentile.getPercent() == 100) {
+            if (percentile.percent() == 100) {
                 assertThat(value, closeTo(maxValue, allowedError));
             }
         }
 
         for (int i = 1; i < percentileList.size(); ++i) {
-            assertThat(percentileList.get(i).getValue(), greaterThanOrEqualTo(percentileList.get(i - 1).getValue()));
+            assertThat(percentileList.get(i).value(), greaterThanOrEqualTo(percentileList.get(i - 1).value()));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -80,17 +80,17 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
         assertEquals(pcts.length, percentileList.size());
         for (int i = 0; i < pcts.length; ++i) {
             final Percentile percentile = percentileList.get(i);
-            assertThat(percentile.getValue(), equalTo(pcts[i]));
-            assertThat(percentile.getPercent(), greaterThanOrEqualTo(0.0));
-            assertThat(percentile.getPercent(), lessThanOrEqualTo(100.0));
+            assertThat(percentile.value(), equalTo(pcts[i]));
+            assertThat(percentile.percent(), greaterThanOrEqualTo(0.0));
+            assertThat(percentile.percent(), lessThanOrEqualTo(100.0));
 
-            if (percentile.getPercent() == 0) {
-                assertThat(percentile.getValue(), lessThanOrEqualTo((double) minValue));
+            if (percentile.percent() == 0) {
+                assertThat(percentile.value(), lessThanOrEqualTo((double) minValue));
             }
         }
 
         for (int i = 1; i < percentileList.size(); ++i) {
-            assertThat(percentileList.get(i).getValue(), greaterThanOrEqualTo(percentileList.get(i - 1).getValue()));
+            assertThat(percentileList.get(i).value(), greaterThanOrEqualTo(percentileList.get(i - 1).value()));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -82,21 +82,21 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
         assertEquals(pcts.length, percentileList.size());
         for (int i = 0; i < pcts.length; ++i) {
             final Percentile percentile = percentileList.get(i);
-            assertThat(percentile.getPercent(), equalTo(pcts[i]));
-            double value = percentile.getValue();
+            assertThat(percentile.percent(), equalTo(pcts[i]));
+            double value = percentile.value();
             assertThat(value, greaterThanOrEqualTo((double) minValue));
             assertThat(value, lessThanOrEqualTo((double) maxValue));
 
-            if (percentile.getPercent() == 0) {
+            if (percentile.percent() == 0) {
                 assertThat(value, equalTo((double) minValue));
             }
-            if (percentile.getPercent() == 100) {
+            if (percentile.percent() == 100) {
                 assertThat(value, equalTo((double) maxValue));
             }
         }
 
         for (int i = 1; i < percentileList.size(); ++i) {
-            assertThat(percentileList.get(i).getValue(), greaterThanOrEqualTo(percentileList.get(i - 1).getValue()));
+            assertThat(percentileList.get(i).value(), greaterThanOrEqualTo(percentileList.get(i - 1).value()));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -257,12 +257,12 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
 
     private void assertPercentileBucket(double[] values, PercentilesBucket percentiles) {
         for (Percentile percentile : percentiles) {
-            assertEquals(percentiles.percentile(percentile.getPercent()), percentile.getValue(), 0d);
+            assertEquals(percentiles.percentile(percentile.percent()), percentile.value(), 0d);
             if (values.length == 0) {
-                assertThat(percentile.getValue(), equalTo(Double.NaN));
+                assertThat(percentile.value(), equalTo(Double.NaN));
             } else {
-                int index = (int) Math.round((percentile.getPercent() / 100.0) * (values.length - 1));
-                assertThat(percentile.getValue(), equalTo(values[index]));
+                int index = (int) Math.round((percentile.percent() / 100.0) * (values.length - 1));
+                assertThat(percentile.value(), equalTo(values[index]));
             }
         }
     }
@@ -271,7 +271,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
         Iterator<Percentile> it = percentiles.iterator();
         for (int i = 0; i < percents.length; ++i) {
             assertTrue(it.hasNext());
-            assertEquals(percents[i], it.next().getPercent(), 0d);
+            assertEquals(percents[i], it.next().percent(), 0d);
         }
         assertFalse(it.hasNext());
         assertPercentileBucket(values, percentiles);

--- a/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -153,8 +153,12 @@ public class Iterators {
         }
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T, U> Iterator<U> map(Iterator<? extends T> input, Function<T, ? extends U> fn) {
         if (input.hasNext()) {
+            if (input instanceof MapIterator mapIterator) {
+                return new MapIterator<>(mapIterator.input, mapIterator.fn.andThen(fn));
+            }
             return new MapIterator<>(input, fn);
         } else {
             return Collections.emptyIterator();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentileRanks.java
@@ -12,30 +12,12 @@ import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Iterator;
 
 public class ParsedHDRPercentileRanks extends ParsedPercentileRanks {
 
     @Override
     public String getType() {
         return InternalHDRPercentileRanks.NAME;
-    }
-
-    @Override
-    public Iterator<Percentile> iterator() {
-        final Iterator<Percentile> iterator = super.iterator();
-        return new Iterator<Percentile>() {
-            @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
-
-            @Override
-            public Percentile next() {
-                Percentile percentile = iterator.next();
-                return new Percentile(percentile.getValue(), percentile.getPercent());
-            }
-        };
     }
 
     private static final ObjectParser<ParsedHDRPercentileRanks, Void> PARSER = new ObjectParser<>(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
@@ -8,6 +8,10 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.collect.Iterators;
+
+import java.util.Iterator;
+
 abstract class ParsedPercentileRanks extends ParsedPercentiles implements PercentileRanks {
 
     @Override
@@ -28,5 +32,10 @@ abstract class ParsedPercentileRanks extends ParsedPercentiles implements Percen
     @Override
     public Iterable<String> valueNames() {
         return percentiles.keySet().stream().map(d -> d.toString()).toList();
+    }
+
+    @Override
+    public Iterator<Percentile> iterator() {
+        return Iterators.map(super.iterator(), percentile -> new Percentile(percentile.value(), percentile.percent()));
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentiles.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -59,20 +60,7 @@ public abstract class ParsedPercentiles extends ParsedAggregation implements Ite
 
     @Override
     public Iterator<Percentile> iterator() {
-        return new Iterator<Percentile>() {
-            final Iterator<Map.Entry<Double, Double>> iterator = percentiles.entrySet().iterator();
-
-            @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
-
-            @Override
-            public Percentile next() {
-                Map.Entry<Double, Double> next = iterator.next();
-                return new Percentile(next.getKey(), next.getValue());
-            }
-        };
+        return Iterators.map(percentiles.entrySet().iterator(), next -> new Percentile(next.getKey(), next.getValue()));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentileRanks.java
@@ -12,30 +12,12 @@ import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Iterator;
 
 public class ParsedTDigestPercentileRanks extends ParsedPercentileRanks {
 
     @Override
     public String getType() {
         return InternalTDigestPercentileRanks.NAME;
-    }
-
-    @Override
-    public Iterator<Percentile> iterator() {
-        final Iterator<Percentile> iterator = super.iterator();
-        return new Iterator<Percentile>() {
-            @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
-
-            @Override
-            public Percentile next() {
-                Percentile percentile = iterator.next();
-                return new Percentile(percentile.getValue(), percentile.getPercent());
-            }
-        };
     }
 
     private static final ObjectParser<ParsedTDigestPercentileRanks, Void> PARSER = new ObjectParser<>(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Percentile.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Percentile.java
@@ -8,40 +8,4 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import java.util.Objects;
-
-public class Percentile {
-
-    private final double percent;
-    private final double value;
-
-    public Percentile(double percent, double value) {
-        this.percent = percent;
-        this.value = value;
-    }
-
-    public double getPercent() {
-        return percent;
-    }
-
-    public double getValue() {
-        return value;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Percentile that = (Percentile) o;
-        return Double.compare(that.percent, percent) == 0 && Double.compare(that.value, value) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(percent, value);
-    }
-}
+public record Percentile(double percent, double value) {}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationInspectionHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationInspectionHelper.java
@@ -224,7 +224,7 @@ public class AggregationInspectionHelper {
     }
 
     public static boolean hasValue(InternalPercentilesBucket agg) {
-        return StreamSupport.stream(agg.spliterator(), false).allMatch(p -> Double.isNaN(p.getValue())) == false;
+        return StreamSupport.stream(agg.spliterator(), false).allMatch(p -> Double.isNaN(p.value())) == false;
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesTestCase.java
@@ -110,7 +110,7 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
         T agg = createTestInstance("test", Collections.emptyMap(), keyed, docValueFormat, percents, new double[0], false);
 
         for (Percentile percentile : agg) {
-            Double value = percentile.getValue();
+            Double value = percentile.value();
             assertPercentile(agg, value);
         }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregatorTests.java
@@ -68,15 +68,15 @@ public class HDRPercentileRanksAggregatorTests extends AggregatorTestCase {
                 PercentileRanks ranks = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
-                assertEquals(0.1, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.equalTo(0d));
+                assertEquals(0.1, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.equalTo(0d));
                 rank = rankIterator.next();
-                assertEquals(0.5, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.greaterThan(0d));
-                assertThat(rank.getPercent(), Matchers.lessThan(100d));
+                assertEquals(0.5, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.greaterThan(0d));
+                assertThat(rank.percent(), Matchers.lessThan(100d));
                 rank = rankIterator.next();
-                assertEquals(12, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.equalTo(100d));
+                assertEquals(12, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.equalTo(100d));
                 assertFalse(rankIterator.hasNext());
                 assertTrue(AggregationInspectionHelper.hasValue((InternalHDRPercentileRanks) ranks));
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
@@ -101,10 +101,10 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
             String percentileName = nameIterator.next();
 
             assertEquals(percent, Double.valueOf(percentileName), 0.0d);
-            assertEquals(percent, percentile.getPercent(), 0.0d);
+            assertEquals(percent, percentile.percent(), 0.0d);
 
-            assertEquals(aggregation.percentile(percent), percentile.getValue(), 0.0d);
-            assertEquals(aggregation.value(String.valueOf(percent)), percentile.getValue(), 0.0d);
+            assertEquals(aggregation.percentile(percent), percentile.value(), 0.0d);
+            assertEquals(aggregation.value(String.valueOf(percent)), percentile.value(), 0.0d);
         }
         assertFalse(iterator.hasNext());
         assertFalse(nameIterator.hasNext());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesRanksTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesRanksTestCase.java
@@ -22,7 +22,7 @@ public abstract class InternalPercentilesRanksTestCase<T extends InternalAggrega
         PercentileRanks parsedPercentileRanks = (PercentileRanks) parsedAggregation;
 
         for (Percentile percentile : aggregation) {
-            Double value = percentile.getValue();
+            Double value = percentile.value();
             assertEquals(aggregation.percent(value), parsedPercentileRanks.percent(value), 0);
             assertEquals(aggregation.percentAsString(value), parsedPercentileRanks.percentAsString(value));
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesTestCase.java
@@ -23,7 +23,7 @@ public abstract class InternalPercentilesTestCase<T extends InternalAggregation 
         Percentiles parsedPercentiles = (Percentiles) parsedAggregation;
 
         for (Percentile percentile : aggregation) {
-            Double percent = percentile.getPercent();
+            Double percent = percentile.percent();
             assertEquals(aggregation.percentile(percent), parsedPercentiles.percentile(percent), 0);
             assertEquals(aggregation.percentileAsString(percent), parsedPercentiles.percentileAsString(percent));
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
@@ -142,10 +142,10 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
             String percentileName = nameIterator.next();
 
             assertEquals(percent, Double.valueOf(percentileName), 0.0d);
-            assertEquals(percent, percentile.getPercent(), 0.0d);
+            assertEquals(percent, percentile.percent(), 0.0d);
 
-            assertEquals(aggregation.percentile(percent), percentile.getValue(), 0.0d);
-            assertEquals(aggregation.value(String.valueOf(percent)), percentile.getValue(), 0.0d);
+            assertEquals(aggregation.percentile(percent), percentile.value(), 0.0d);
+            assertEquals(aggregation.value(String.valueOf(percent)), percentile.value(), 0.0d);
         }
         assertFalse(iterator.hasNext());
         assertFalse(nameIterator.hasNext());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregatorTests.java
@@ -55,8 +55,8 @@ public class TDigestPercentileRanksAggregatorTests extends AggregatorTestCase {
         try (IndexReader reader = new MultiReader()) {
             PercentileRanks ranks = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
             Percentile rank = ranks.iterator().next();
-            assertEquals(Double.NaN, rank.getPercent(), 0d);
-            assertEquals(0.5, rank.getValue(), 0d);
+            assertEquals(Double.NaN, rank.percent(), 0d);
+            assertEquals(0.5, rank.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(((InternalTDigestPercentileRanks) ranks)));
         }
     }
@@ -77,16 +77,16 @@ public class TDigestPercentileRanksAggregatorTests extends AggregatorTestCase {
                 PercentileRanks ranks = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
-                assertEquals(0.1, rank.getValue(), 0d);
+                assertEquals(0.1, rank.value(), 0d);
                 // TODO: Fix T-Digest: this assertion should pass but we currently get ~15
                 // https://github.com/elastic/elasticsearch/issues/14851
                 // assertThat(rank.getPercent(), Matchers.equalTo(0d));
                 rank = rankIterator.next();
-                assertEquals(0.5, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.greaterThan(0d));
-                assertThat(rank.getPercent(), Matchers.lessThan(100d));
+                assertEquals(0.5, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.greaterThan(0d));
+                assertThat(rank.percent(), Matchers.lessThan(100d));
                 rank = rankIterator.next();
-                assertEquals(12, rank.getValue(), 0d);
+                assertEquals(12, rank.value(), 0d);
                 // TODO: Fix T-Digest: this assertion should pass but we currently get ~59
                 // https://github.com/elastic/elasticsearch/issues/14851
                 // assertThat(rank.getPercent(), Matchers.equalTo(100d));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
@@ -79,7 +79,7 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
         ParsedPercentilesBucket parsedPercentiles = (ParsedPercentilesBucket) parsedAggregation;
 
         for (Percentile percentile : aggregation) {
-            Double percent = percentile.getPercent();
+            Double percent = percentile.percent();
             assertEquals(aggregation.percentile(percent), parsedPercentiles.percentile(percent), 0);
             // we cannot ensure we get the same as_string output for Double.NaN values since they are rendered as
             // null and we don't have a formatted string representation in the rest output
@@ -104,10 +104,10 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
             Percentile percentile = iterator.next();
             String percentileName = nameIterator.next();
 
-            assertEquals(percent, percentile.getPercent(), 0.0d);
+            assertEquals(percent, percentile.percent(), 0.0d);
             assertEquals(percent, Double.valueOf(percentileName), 0.0d);
 
-            assertEquals(aggregation.percentile(percent), percentile.getValue(), 0.0d);
+            assertEquals(aggregation.percentile(percent), percentile.value(), 0.0d);
         }
         assertFalse(iterator.hasNext());
         assertFalse(nameIterator.hasNext());
@@ -220,7 +220,7 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
 
     private double[] extractPercentiles(InternalPercentilesBucket instance) {
         List<Double> values = new ArrayList<>();
-        instance.iterator().forEachRemaining(percentile -> values.add(percentile.getValue()));
+        instance.iterator().forEachRemaining(percentile -> values.add(percentile.value()));
         double[] valuesArray = new double[values.size()];
         for (int i = 0; i < values.size(); i++) {
             valuesArray[i] = values.get(i);
@@ -230,7 +230,7 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
 
     private double[] extractPercents(InternalPercentilesBucket instance) {
         List<Double> percents = new ArrayList<>();
-        instance.iterator().forEachRemaining(percentile -> percents.add(percentile.getPercent()));
+        instance.iterator().forEachRemaining(percentile -> percents.add(percentile.percent()));
         double[] percentArray = new double[percents.size()];
         for (int i = 0; i < percents.size(); i++) {
             percentArray[i] = percents.get(i);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HDRPreAggregatedPercentileRanksAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HDRPreAggregatedPercentileRanksAggregatorTests.java
@@ -93,15 +93,15 @@ public class HDRPreAggregatedPercentileRanksAggregatorTests extends AggregatorTe
                 PercentileRanks ranks = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
-                assertEquals(0.1, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.equalTo(0d));
+                assertEquals(0.1, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.equalTo(0d));
                 rank = rankIterator.next();
-                assertEquals(0.5, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.greaterThan(0d));
-                assertThat(rank.getPercent(), Matchers.lessThan(100d));
+                assertEquals(0.5, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.greaterThan(0d));
+                assertThat(rank.percent(), Matchers.lessThan(100d));
                 rank = rankIterator.next();
-                assertEquals(12, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.equalTo(100d));
+                assertEquals(12, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.equalTo(100d));
                 assertFalse(rankIterator.hasNext());
                 assertTrue(AggregationInspectionHelper.hasValue((InternalHDRPercentileRanks) ranks));
             }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/TDigestPreAggregatedPercentileRanksAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/TDigestPreAggregatedPercentileRanksAggregatorTests.java
@@ -81,16 +81,16 @@ public class TDigestPreAggregatedPercentileRanksAggregatorTests extends Aggregat
                 PercentileRanks ranks = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldType));
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
-                assertEquals(0.1, rank.getValue(), 0d);
+                assertEquals(0.1, rank.value(), 0d);
                 // TODO: Fix T-Digest: this assertion should pass but we currently get ~15
                 // https://github.com/elastic/elasticsearch/issues/14851
                 // assertThat(rank.getPercent(), Matchers.equalTo(0d));
                 rank = rankIterator.next();
-                assertEquals(0.5, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.greaterThan(0d));
-                assertThat(rank.getPercent(), Matchers.lessThan(100d));
+                assertEquals(0.5, rank.value(), 0d);
+                assertThat(rank.percent(), Matchers.greaterThan(0d));
+                assertThat(rank.percent(), Matchers.lessThan(100d));
                 rank = rankIterator.next();
-                assertEquals(12, rank.getValue(), 0d);
+                assertEquals(12, rank.value(), 0d);
                 // TODO: Fix T-Digest: this assertion should pass but we currently get ~59
                 // https://github.com/elastic/elasticsearch/issues/14851
                 // assertThat(rank.getPercent(), Matchers.equalTo(100d));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/common/AbstractAucRoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/common/AbstractAucRoc.java
@@ -58,13 +58,13 @@ public abstract class AbstractAucRoc implements EvaluationMetric {
     protected static double[] percentilesArray(Percentiles percentiles) {
         double[] result = new double[99];
         percentiles.forEach(percentile -> {
-            if (Double.isNaN(percentile.getValue())) {
+            if (Double.isNaN(percentile.value())) {
                 throw ExceptionsHelper.badRequestException(
                     "[{}] requires at all the percentiles values to be finite numbers",
                     NAME.getPreferredName()
                 );
             }
-            result[((int) percentile.getPercent()) - 1] = percentile.getValue();
+            result[((int) percentile.percent()) - 1] = percentile.value();
         });
         return result;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
@@ -408,7 +408,7 @@ class AggregationToJsonProcessor {
 
     private boolean processPercentiles(Percentiles percentiles) {
         Iterator<Percentile> percentileIterator = percentiles.iterator();
-        boolean aggregationAdded = addMetricIfFinite(percentiles.getName(), percentileIterator.next().getValue());
+        boolean aggregationAdded = addMetricIfFinite(percentiles.getName(), percentileIterator.next().value());
         if (percentileIterator.hasNext()) {
             throw new IllegalArgumentException("Multi-percentile aggregation [" + percentiles.getName() + "] is not supported");
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
@@ -159,7 +159,7 @@ public final class AggregationTestUtils {
         List<Percentile> percentileList = new ArrayList<>();
         for (double value : values) {
             Percentile percentile = mock(Percentile.class);
-            when(percentile.getValue()).thenReturn(value);
+            when(percentile.value()).thenReturn(value);
             percentileList.add(percentile);
         }
         when(percentiles.iterator()).thenReturn(percentileList.iterator());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
@@ -158,9 +158,7 @@ public final class AggregationTestUtils {
         when(percentiles.getName()).thenReturn(name);
         List<Percentile> percentileList = new ArrayList<>();
         for (double value : values) {
-            Percentile percentile = mock(Percentile.class);
-            when(percentile.value()).thenReturn(value);
-            percentileList.add(percentile);
+            percentileList.add(new Percentile(0.0, value));
         }
         when(percentiles.iterator()).thenReturn(percentileList.iterator());
         return percentiles;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -330,10 +330,10 @@ public final class AggregationResultUtils {
             for (Percentile p : aggregation) {
                 // in case of sparse data percentiles might not have data, in this case it returns NaN,
                 // we need to guard the output and set null in this case
-                if (Numbers.isValidDouble(p.getValue()) == false) {
-                    percentiles.put(OutputFieldNameConverter.fromDouble(p.getPercent()), null);
+                if (Numbers.isValidDouble(p.value()) == false) {
+                    percentiles.put(OutputFieldNameConverter.fromDouble(p.percent()), null);
                 } else {
-                    percentiles.put(OutputFieldNameConverter.fromDouble(p.getPercent()), p.getValue());
+                    percentiles.put(OutputFieldNameConverter.fromDouble(p.percent()), p.value());
                 }
             }
 


### PR DESCRIPTION
Just a random find from reasearching something else:

* Percentile can be made a record, the equals method stays compatible
* We had a duplicate iterator implementation, we can dry this one and the parent up and make it more efficient by using the mapped iterator utility
