### PR TITLE
Log a debug level message for deleting non-existing snapshot

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2355,7 +2355,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                         @Override
                         public void onFailure(Exception e) {
-                            logger.debug("failed to complete snapshot deletion [{}] for reason: [{}]", deleteEntry, e.getMessage());
+                            logger.debug("failed to complete snapshot deletion [" + deleteEntry + "]", e);
                             submitUnbatchedTask(
                                 "remove snapshot deletion metadata after failed delete",
                                 new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2055,6 +2055,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public void onFailure(Exception e) {
                 endingSnapshots.removeAll(completedNoCleanup);
+                logger.debug("failed to complete enqueued snapshot deletion [{}] for reason: [{}]", newDelete, e.getMessage());
                 listener.onFailure(e);
             }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1931,7 +1931,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         final SnapshotId foundId = snapshotsIdsInRepository.get(snapshotOrPattern);
                         if (foundId == null) {
                             if (snapshotIds.stream().noneMatch(snapshotId -> snapshotId.getName().equals(snapshotOrPattern))) {
-                                throw new SnapshotMissingException(repositoryName, snapshotOrPattern);
+                                final var snapshotMissingException = new SnapshotMissingException(repositoryName, snapshotOrPattern);
+                                logger.debug(snapshotMissingException.getMessage());
+                                throw snapshotMissingException;
                             }
                         } else {
                             snapshotIds.add(foundId);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2055,7 +2055,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public void onFailure(Exception e) {
                 endingSnapshots.removeAll(completedNoCleanup);
-                logger.debug("failed to complete enqueued snapshot deletion [{}] for reason: [{}]", newDelete, e.getMessage());
                 listener.onFailure(e);
             }
 
@@ -2356,6 +2355,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                         @Override
                         public void onFailure(Exception e) {
+                            logger.debug("failed to complete snapshot deletion [{}] for reason: [{}]", deleteEntry, e.getMessage());
                             submitUnbatchedTask(
                                 "remove snapshot deletion metadata after failed delete",
                                 new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2355,7 +2355,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                         @Override
                         public void onFailure(Exception e) {
-                            logger.debug("failed to complete snapshot deletion [" + deleteEntry + "]", e);
+                            logger.debug(() -> "failed to complete snapshot deletion [" + deleteEntry + "]", e);
                             submitUnbatchedTask(
                                 "remove snapshot deletion metadata after failed delete",
                                 new RemoveSnapshotDeletionAndContinueTask(deleteEntry, repositoryData) {


### PR DESCRIPTION
The new message helps pairing with the "deleting snapshots" log message at info level.
