### PR TITLE
Mute failing ClusterSearchShardsResponseTests/testSerialization

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.cluster.shards;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -38,6 +39,7 @@ import java.util.Set;
 
 public class ClusterSearchShardsResponseTests extends ESTestCase {
 
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100482")
     public void testSerialization() throws Exception {
         Map<String, AliasFilter> indicesAndFilters = new HashMap<>();
         Set<DiscoveryNode> nodes = new HashSet<>();


### PR DESCRIPTION
Test `ClusterSearchShardsResponseTests/testSerialization` fails with output

```
org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponseTests > testSerialization FAILED |  
-- | --
  | java.lang.IllegalArgumentException: Node versions can only be inferred before release version 8.10.0 |  
  | at __randomizedtesting.SeedInfo.seed([8D8D9B5E7417133A:D955FA1653452EA6]:0) |  
  | at org.elasticsearch.cluster.node.VersionInformation.inferVersions(VersionInformation.java:42) |  
  | at org.elasticsearch.cluster.node.DiscoveryNodeUtils$Builder.build(DiscoveryNodeUtils.java:152) |  
  | at org.elasticsearch.cluster.node.DiscoveryNodeUtils.create(DiscoveryNodeUtils.java:39) |  
  | at org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponseTests.testSerialization(ClusterSearchShardsResponseTests.java:52)
```

Mute it.

Relates #100482