### PR TITLE
Cleanup manually created empty iterators

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
@@ -9,6 +9,7 @@ package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.core.TimeValue;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -96,17 +97,7 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
     private static class NoBackoff extends BackoffPolicy {
         @Override
         public Iterator<TimeValue> iterator() {
-            return new Iterator<TimeValue>() {
-                @Override
-                public boolean hasNext() {
-                    return false;
-                }
-
-                @Override
-                public TimeValue next() {
-                    throw new NoSuchElementException("No backoff");
-                }
-            };
+            return Collections.emptyIterator();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -53,6 +53,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -138,17 +139,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
             return new DirectoryStream<>() {
                 @Override
                 public Iterator<Path> iterator() {
-                    return new Iterator<>() {
-                        @Override
-                        public boolean hasNext() {
-                            return false;
-                        }
-
-                        @Override
-                        public Path next() {
-                            return null;
-                        }
-                    };
+                    return Collections.emptyIterator();
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/script/field/EmptyField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/EmptyField.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.script.field;
 
+import java.util.Collections;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 /**
  * A script {@code Field} with no mapping, always returns {@code defaultValue}.
@@ -47,16 +47,6 @@ public class EmptyField implements Field<Object> {
 
     @Override
     public Iterator<Object> iterator() {
-        return new Iterator<>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
-
-            @Override
-            public Object next() {
-                throw new NoSuchElementException();
-            }
-        };
+        return Collections.emptyIterator();
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
@@ -37,12 +37,12 @@ public class IteratorsTests extends ESTestCase {
     }
 
     public void testEmptyConcatenation() {
-        Iterator<Integer> iterator = Iterators.<Integer>concat(empty());
+        Iterator<Integer> iterator = Iterators.<Integer>concat(Collections.emptyIterator());
         assertEmptyIterator(iterator);
     }
 
     public void testMultipleEmptyConcatenation() {
-        Iterator<Integer> iterator = Iterators.concat(empty(), empty());
+        Iterator<Integer> iterator = Iterators.concat(Collections.emptyIterator(), Collections.emptyIterator());
         assertEmptyIterator(iterator);
     }
 
@@ -53,12 +53,12 @@ public class IteratorsTests extends ESTestCase {
 
     public void testEmptyBeforeSingleton() {
         int value = randomInt();
-        assertSingleton(value, empty(), singletonIterator(value));
+        assertSingleton(value, Collections.emptyIterator(), singletonIterator(value));
     }
 
     public void testEmptyAfterSingleton() {
         int value = randomInt();
-        assertSingleton(value, singletonIterator(value), empty());
+        assertSingleton(value, singletonIterator(value), Collections.emptyIterator());
     }
 
     public void testRandomSingleton() {
@@ -68,7 +68,7 @@ public class IteratorsTests extends ESTestCase {
         @SuppressWarnings({ "rawtypes", "unchecked" })
         Iterator<Integer>[] iterators = new Iterator[numberOfIterators];
         for (int i = 0; i < numberOfIterators; i++) {
-            iterators[i] = i != singletonIndex ? empty() : singletonIterator(value);
+            iterators[i] = i != singletonIndex ? Collections.emptyIterator() : singletonIterator(value);
         }
         assertSingleton(value, iterators);
     }
@@ -94,7 +94,12 @@ public class IteratorsTests extends ESTestCase {
     public void testTwoEntries() {
         int first = randomInt();
         int second = randomInt();
-        Iterator<Integer> concat = Iterators.concat(singletonIterator(first), empty(), empty(), singletonIterator(second));
+        Iterator<Integer> concat = Iterators.concat(
+            singletonIterator(first),
+            Collections.emptyIterator(),
+            Collections.emptyIterator(),
+            singletonIterator(second)
+        );
         assertContainsInOrder(concat, first, second);
     }
 
@@ -109,7 +114,7 @@ public class IteratorsTests extends ESTestCase {
 
     public void testNullIterator() {
         try {
-            Iterators.concat(singletonIterator(1), empty(), null, empty(), singletonIterator(2));
+            Iterators.concat(singletonIterator(1), Collections.emptyIterator(), null, Collections.emptyIterator(), singletonIterator(2));
             fail("expected " + NullPointerException.class.getSimpleName());
         } catch (NullPointerException e) {
 
@@ -266,20 +271,6 @@ public class IteratorsTests extends ESTestCase {
     private <T> void assertSingleton(T value, Iterator<T>... iterators) {
         Iterator<T> concat = Iterators.concat(iterators);
         assertContainsInOrder(concat, value);
-    }
-
-    private <T> Iterator<T> empty() {
-        return new Iterator<T>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
-
-            @Override
-            public T next() {
-                throw new NoSuchElementException();
-            }
-        };
     }
 
     @SafeVarargs

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.async.AsyncResponse;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 
 import static org.elasticsearch.rest.RestStatus.OK;
@@ -216,7 +217,7 @@ public class AsyncSearchResponse extends ActionResponse implements ChunkedToXCon
             }
             return builder;
         }),
-            searchResponse == null ? Iterators.concat() : searchResponse.toXContentChunked(params),
+            searchResponse == null ? Collections.emptyIterator() : searchResponse.toXContentChunked(params),
             ChunkedToXContentHelper.singleChunk((builder, p) -> {
                 if (error != null) {
                     builder.startObject("error");


### PR DESCRIPTION
Random find ... No need for these, the JDK has an empty iterator built in.
