### PR TITLE
Mute failing InternalEngineTests/testGetWithSearcherWrapper

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1039,6 +1039,7 @@ public class InternalEngineTests extends EngineTestCase {
         searchResult.close();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99916")
     public void testGetWithSearcherWrapper() throws Exception {
         engine.refresh("warm_up");
         engine.index(indexForDoc(createParsedDoc("1", null)));


### PR DESCRIPTION
Test `InternalEngineTests/testGetWithSearcherWrapper` fails with:

```
org.elasticsearch.index.engine.InternalEngineTests > testGetWithSearcherWrapper FAILED
    java.lang.AssertionError: expected:<0> but was:<1>
        at __randomizedtesting.SeedInfo.seed([B8C232CD98C68607:A62E178D70FDEDC1]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:631)
        at org.elasticsearch.index.engine.InternalEngineTests.testGetWithSearcherWrapper(InternalEngineTests.java:1096)
```

This PR mutes it.

relates https://github.com/elastic/elasticsearch/issues/99916