### PR TITLE
Mute failing ShardGetServiceTests/testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
@@ -95,6 +95,7 @@ public class ShardGetServiceTests extends IndexShardTestCase {
         runGetFromTranslogWithOptions(docToIndex, sourceOptions, noSource ? "" : "{\"bar\":\"bar\"}", "\"text\"", "foo", false);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100487")
     public void testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields() throws IOException {
         String docToIndex = """
             {"foo" : 7, "bar" : 42}


### PR DESCRIPTION
Test `ShardGetServiceTests/testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields` fails with:

```
org.elasticsearch.index.shard.ShardGetServiceTests > testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields FAILED
    java.lang.AssertionError: expected:<0> but was:<1>
        at __randomizedtesting.SeedInfo.seed([61581A6063309088:E3CD1213503CCA95]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:631)
        at org.elasticsearch.index.shard.ShardGetServiceTests.runGetFromTranslogWithOptions(ShardGetServiceTests.java:165)
        at org.elasticsearch.index.shard.ShardGetServiceTests.testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields(ShardGetServiceTests.java:104)
```
Mute it.

Relates #100487

