### PR TITLE
Mute failing MedianAbsoluteDeviationIntGroupingAggregatorFunctionTests/testSimpleFinishClose

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -218,6 +218,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
     }
 
     // Tests that finish then close without calling getOutput to retrieve a potential last page, releases all memory
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100496")
     public void testSimpleFinishClose() {
         DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), 1));


### PR DESCRIPTION
Test `MedianAbsoluteDeviationIntGroupingAggregatorFunctionTests/testSimpleFinishClose` is failing with
```
org.elasticsearch.compute.aggregation.MedianAbsoluteDeviationLongGroupingAggregatorFunctionTests > testSimpleFinishClose FAILED
    java.lang.AssertionError: 2
        at org.elasticsearch.compute.operator.OperatorTestCase.testSimpleFinishClose(OperatorTestCase.java:224)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:578)
        at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
```

Mute it.

Relates #100496
