### PR TITLE
[8.11] Fix the issue that PersistentTask.getState() return value may cause NullPointerException (#98061)

### DIFF
--- a/docs/changelog/98061.yaml
+++ b/docs/changelog/98061.yaml
@@ -1,0 +1,6 @@
+pr: 98061
+summary: Fix possible NPE when getting transform stats for failed transforms
+area: Transform
+type: bug
+issues:
+  - 98052

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -370,7 +370,7 @@ public class TransportGetDataFrameAnalyticsStatsAction extends TransportTasksAct
         String failureReason = null;
         if (analyticsState == DataFrameAnalyticsState.FAILED) {
             DataFrameAnalyticsTaskState taskState = (DataFrameAnalyticsTaskState) analyticsTask.getState();
-            failureReason = taskState.getReason();
+            failureReason = taskState != null ? taskState.getReason() : null;
         }
         DiscoveryNode node = null;
         String assignmentExplanation = null;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformUsageTransportAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformUsageTransportAction.java
@@ -48,6 +48,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -103,10 +104,10 @@ public class TransformUsageTransportAction extends XPackUsageFeatureTransportAct
         final Map<String, Long> transformsCountByState = new HashMap<>();
         for (PersistentTasksCustomMetadata.PersistentTask<?> transformTask : transformTasks) {
             TransformState transformState = (TransformState) transformTask.getState();
-            TransformTaskState taskState = transformState.getTaskState();
-            if (taskState != null) {
-                transformsCountByState.merge(taskState.value(), 1L, Long::sum);
-            }
+            Optional.ofNullable(transformState)
+                .map(TransformState::getTaskState)
+                .map(TransformTaskState::value)
+                .ifPresent(value -> transformsCountByState.merge(value, 1L, Long::sum));
         }
         final SetOnce<Map<String, Long>> transformsCountByFeature = new SetOnce<>();
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -163,7 +163,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 );
             } else {
                 TransformState transformState = (TransformState) existingTask.getState();
-                if (transformState.getTaskState() == TransformTaskState.FAILED) {
+                if (transformState != null && transformState.getTaskState() == TransformTaskState.FAILED) {
                     listener.onFailure(
                         new ElasticsearchStatusException(
                             TransformMessages.getMessage(CANNOT_START_FAILED_TRANSFORM, request.getId(), transformState.getReason()),


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix the issue that PersistentTask.getState() return value may cause NullPointerException (#98061)