### PR TITLE
[8.11] [Transform] Shutdown the task immediately when `force` == `true` (#100203)

### DIFF
--- a/docs/changelog/100203.yaml
+++ b/docs/changelog/100203.yaml
@@ -1,0 +1,5 @@
+pr: 100203
+summary: Shutdown the task immediately when `force` == `true`
+area: Transform
+type: bug
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Transform] Shutdown the task immediately when `force` == `true` (#100203)](https://github.com/elastic/elasticsearch/pull/100203)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)