### PR TITLE
[8.10] [Transform] Shutdown the task immediately when `force` == `true` (#100203)

### DIFF
--- a/docs/changelog/100203.yaml
+++ b/docs/changelog/100203.yaml
@@ -1,0 +1,5 @@
+pr: 100203
+summary: Shutdown the task immediately when `force` == `true`
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -241,6 +241,20 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         }
 
         if (ids.contains(transformTask.getTransformId())) {
+            if (request.isForce()) {
+                // If force==true, we skip the additional step (setShouldStopAtCheckpoint) and move directly to shutting down the task.
+                // This way we ensure that the persistent task is removed ASAP (as opposed to being removed in one of the listeners).
+                try {
+                    // Here the task is deregistered in scheduler and marked as completed in persistent task service.
+                    transformTask.shutdown();
+                    // Here the indexer is aborted so that its thread finishes work ASAP.
+                    transformTask.onCancelled();
+                    listener.onResponse(new Response(true));
+                } catch (ElasticsearchException ex) {
+                    listener.onFailure(ex);
+                }
+                return;
+            }
             // move the call to the generic thread pool, so we do not block the network thread
             threadPool.generic().execute(() -> {
                 transformTask.setShouldStopAtCheckpoint(request.isWaitForCheckpoint(), ActionListener.wrap(r -> {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Transform] Shutdown the task immediately when `force` == `true` (#100203)](https://github.com/elastic/elasticsearch/pull/100203)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)