### PR TITLE
ESQL Ensure that the error delta is positive in PercentileIntGroupingAggregatorFunctionTests 

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunctionTests.java
@@ -58,7 +58,8 @@ public class PercentileIntGroupingAggregatorFunctionTests extends GroupingAggreg
         if (td.size() > 0) {
             double expected = td.quantile(percentile / 100);
             double value = ((DoubleBlock) result).getDouble(position);
-            assertThat(value, closeTo(expected, expected * 0.1));
+            double errorDelta = Math.abs(expected * 0.1);
+            assertThat(value, closeTo(expected, errorDelta));
         } else {
             assertTrue(result.isNull(position));
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -129,7 +129,6 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         assertDriverContext(driverContext);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99160")
     public final void testManyInitialManyPartialFinal() {
         BigArrays bigArrays = nonBreakingBigArrays();
         DriverContext driverContext = driverContext();


### PR DESCRIPTION
This commit fixes the usage of an error delta in a test. Hamcrest's closeTo matcher does not like it when we give it a negative delta!

closes #99160