### PR TITLE
[8.11] CCR: Use local cluster state request (#100323)

### DIFF
--- a/docs/changelog/100323.yaml
+++ b/docs/changelog/100323.yaml
@@ -1,0 +1,5 @@
+pr: 100323
+summary: "CCR: Use local cluster state request"
+area: CCR
+type: bug
+issues: []

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -303,6 +303,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
                         new ClusterStateRequest().clear()
                             .metadata(true)
                             .routingTable(true)
+                            .local(true)
                             .waitForMetadataVersion(metadataVersion)
                             .waitForTimeout(waitForMetadataTimeOut),
                         e -> handler.accept(null, e),


### PR DESCRIPTION
Backports the following commits to 8.11:
 - CCR: Use local cluster state request (#100323)