### PR TITLE
[8.11] Add healthcheck for shibboleth-idp in idp-fixture (again) (#100461)

### DIFF
--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -6,6 +6,11 @@ apply plugin: 'elasticsearch.test.fixtures'
 
 dockerCompose {
   composeAdditionalArgs = ['--compatibility']
+
+  if (System.getenv('BUILDKITE') == 'true') {
+    // This flag is only available on newer versions of docker-compose, and many Jenkins agents have older versions
+    upAdditionalArgs = ["--wait"]
+  }
 }
 
 tasks.named("preProcessFixture").configure {

--- a/x-pack/test/idp-fixture/docker-compose.yml
+++ b/x-pack/test/idp-fixture/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 services:
   openldap:
     command: --copy-service --loglevel debug
@@ -37,6 +37,12 @@ services:
     links:
       - openldap:openldap
     restart: always #ensure ephemeral port mappings are properly updated
+    healthcheck:
+      test: curl -f -s --http0.9 http://localhost:4443 --connect-timeout 10 --max-time 10 --output - > /dev/null
+      interval: 5s
+      timeout: 20s
+      retries: 60
+      start_period: 10s
 
   oidc-provider:
     build:

--- a/x-pack/test/idp-fixture/idp/bin/run-jetty.sh
+++ b/x-pack/test/idp-fixture/idp/bin/run-jetty.sh
@@ -10,4 +10,19 @@ fi
 export JETTY_ARGS="jetty.sslContext.keyStorePassword=$JETTY_BROWSER_SSL_KEYSTORE_PASSWORD jetty.backchannel.sslContext.keyStorePassword=$JETTY_BACKCHANNEL_SSL_KEYSTORE_PASSWORD"
 sed -i "s/^-Xmx.*$/-Xmx$JETTY_MAX_HEAP/g" /opt/shib-jetty-base/start.ini
 
-exec /opt/jetty-home/bin/jetty.sh run
+# For some reason, this container always immediately (in less than 1 second) exits with code 0 when starting for the first time
+# Even with a health check, docker-compose will immediately report the container as unhealthy when using --wait instead of waiting for it to become healthy
+# So, let's just start it a second time if it exits quickly
+set +e
+start_time=$(date +%s)
+/opt/jetty-home/bin/jetty.sh run
+exit_code=$?
+end_time=$(date +%s)
+
+duration=$((end_time - start_time))
+if [ $duration -lt 5 ]; then
+  /opt/jetty-home/bin/jetty.sh run
+  exit_code=$?
+fi
+
+exit $exit_code


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Add healthcheck for shibboleth-idp in idp-fixture (again) (#100461)](https://github.com/elastic/elasticsearch/pull/100461)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)