### PR TITLE
MatchingDirectoryReader should not use a threaded searcher

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1039,7 +1039,6 @@ public class InternalEngineTests extends EngineTestCase {
         searchResult.close();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99916")
     public void testGetWithSearcherWrapper() throws Exception {
         engine.refresh("warm_up");
         engine.index(indexForDoc(createParsedDoc("1", null)));

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
@@ -94,8 +94,7 @@ public class ShardGetServiceTests extends IndexShardTestCase {
         String sourceOptions = noSource ? "\"enabled\": false" : randomBoolean() ? "\"excludes\": [\"fo*\"]" : "\"includes\": [\"ba*\"]";
         runGetFromTranslogWithOptions(docToIndex, sourceOptions, noSource ? "" : "{\"bar\":\"bar\"}", "\"text\"", "foo", false);
     }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100487")
+    
     public void testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields() throws IOException {
         String docToIndex = """
             {"foo" : 7, "bar" : 42}

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardGetServiceTests.java
@@ -94,7 +94,7 @@ public class ShardGetServiceTests extends IndexShardTestCase {
         String sourceOptions = noSource ? "\"enabled\": false" : randomBoolean() ? "\"excludes\": [\"fo*\"]" : "\"includes\": [\"ba*\"]";
         runGetFromTranslogWithOptions(docToIndex, sourceOptions, noSource ? "" : "{\"bar\":\"bar\"}", "\"text\"", "foo", false);
     }
-    
+
     public void testGetFromTranslogWithLongSourceMappingOptionsAndStoredFields() throws IOException {
         String docToIndex = """
             {"foo" : 7, "bar" : 42}

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1509,7 +1509,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 @Override
                 public LeafReader wrap(LeafReader leaf) {
                     try {
-                        final IndexSearcher searcher = newSearcher(leaf, false);
+                        final IndexSearcher searcher = newSearcher(leaf, false, true, false);
                         searcher.setQueryCache(null);
                         final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
                         final Scorer scorer = weight.scorer(leaf.getContext());


### PR DESCRIPTION
MatchingDirectoryReader is a test reader wrapper that filters out documents
matching a particular query.  For each leaf, we create an IndexSearcher, 
execute the query against it and then use that as a filter for the leaf.  This searcher
is created using `LuceneTestCase.newSearcher()` and as such may be multi-
threaded, which triggers extra index checks.  For tests that are expecting certain
methods to be called against internal readers a given number of times, these extra
checks can add additional calls which then lead to a failure of test assumptions.

Because this IndexSearcher is only executed against a single leaf it will only ever use
a single thread, and so we can explicitly disable threading here.

Fixes #100487
Fixes #99916 