### PR TITLE
Avoiding using the _template API in an ingest-common yaml rest test

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
@@ -102,12 +102,13 @@ teardown:
 "Test Change Target Index with Default Pipeline":
 
 - do:
-    indices.put_template:
+    indices.put_index_template:
       name: index_template
       body:
         index_patterns: test
-        settings:
-          default_pipeline: "retarget"
+        template:
+          settings:
+            default_pipeline: "retarget"
 
 - do:
     ingest.put_pipeline:


### PR DESCRIPTION
This change updates `230_change_target_index` to use the `/_index_template` API rather than the legacy `/_template` API.