### PR TITLE
ESQL: Don't log the parse tree

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -52,9 +52,6 @@ appender.rolling_old.strategy.action.condition.nested_condition.type = IfAccumul
 appender.rolling_old.strategy.action.condition.nested_condition.exceeds = 2GB
 ################################################
 
-logger.esql.name = org.elasticsearch.xpack.esql
-logger.esql.level = trace
-
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.rolling.ref = rolling

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
@@ -72,8 +72,8 @@ public class EsqlParser {
 
             ParserRuleContext tree = parseFunction.apply(parser);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Parse tree: {}", tree.toStringTree());
+            if (log.isTraceEnabled()) {
+                log.trace("Parse tree: {}", tree.toStringTree());
             }
 
             return result.apply(new AstBuilder(paramTokens), tree);


### PR DESCRIPTION
ESQL would log the antlr parse tree of it statements. These are kind of unreadable:
```
{"@timestamp":"2023-10-09T15:13:43.921Z", "log.level":"DEBUG", "message":"Parse tree: ([] ([94] ([2 94] ([2 2 94] ([2 2 2 94] ([2 2 2 2 94] ([2 2 2 2 2 94] ([2 2 2 2 2 2 94] ([98 2 2 2 2 2 2 94] ([109 98 2 2 2 2 2 2 94] from ([256 109 98 2 2 2 2 2 2 94] employees)))) | ([102 2 2 2 2 2 94] ([118 102 2 2 2 2 2 94] sort ([364 118 102 2 2 2 2 2 94] ([372 364 118 102 2 2 2 2 2 94] ([135 372 364 118 102 2 2 2 2 2 94] ([189 135 372 364 118 102 2 2 2 2 2 94] ([197 189 135 372 364 118 102 2 2 2 2 2 94] ([214 197 189 135 372 364 118 102 2 2 2 2 2 94] ([306 214 197 189 135 372 364 118 102 2 2 2 2 2 94] emp_no)))))))))) | ([102 2 2 2 2 94] ([120 102 2 2 2 2 94] where ([130 120 102 2 2 2 2 94] ([135 130 120 102 2 2 2 2 94] ([190 135 130 120 102 2 2 2 2 94] ([197 190 135 130 120 102 2 2 2 2 94] ([215 197 190 135 130 120 102 2 2 2 2 94] ([222 215 197 190 135 130 120 102 2 2 2 2 94] mv_count) ( ([225 215 197 190 135 130 120 102 2 2 2 2 94] ([135 225 215 197 190 135 130 120 102 2 2 2 2 94] ([189 135 225 215 197 190 135 130 120 102 2 2 2 2 94] ([197 189 135 225 215 197 190 135 130 120 102 2 2 2 2 94] ([214 197 189 135 225 215 197 190 135 130 120 102 2 2 2 2 94] ([306 214 197 189 135 225 215 197 190 135 130 120 102 2 2 2 2 94] job_positions)))))) )))) ([191 135 130 120 102 2 2 2 2 94] <=) ([192 135 130 120 102 2 2 2 2 94] ([197 192 135 130 120 102 2 2 2 2 94] ([213 197 192 135 130 120 102 2 2 2 2 94] ([321 213 197 192 135 130 120 102 2 2 2 2 94] 1))))))))) | ([102 2 2 2 94] ([120 102 2 2 2 94] where ([130 120 102 2 2 2 94] ([135 130 120 102 2 2 2 94] ([190 135 130 120 102 2 2 2 94] ([197 190 135 130 120 102 2 2 2 94] ([214 197 190 135 130 120 102 2 2 2 94] ([306 214 197 190 135 130 120 102 2 2 2 94] emp_no)))) ([191 135 130 120 102 2 2 2 94] >=) ([192 135 130 120 102 2 2 2 94] ([197 192 135 130 120 102 2 2 2 94] ([213 197 192 135 130 120 102 2 2 2 94] ([321 213 197 192 135 130 120 102 2 2 2 94] 10024))))))))) | ([102 2 2 94] ([116 102 2 2 94] limit 3))) | ([102 2 94] ([117 102 2 94] keep ([381 117 102 2 94] emp_no) , ([383 117 102 2 94] job_positions)))) | ([102 94] ([114 102 94] eval ([280 114 102 94] ([240 280 114 102 94] ([249 240 280 114 102 94] ([306 249 240 280 114 102 94] is_in)) = ([251 240 280 114 102 94] ([137 251 240 280 114 102 94] ([189 137 251 240 280 114 102 94] ([197 189 137 251 240 280 114 102 94] ([214 197 189 137 251 240 280 114 102 94] ([306 214 197 189 137 251 240 280 114 102 94] job_positions))))) in ( ([143 251 240 280 114 102 94] ([189 143 251 240 280 114 102 94] ([197 189 143 251 240 280 114 102 94] ([213 197 189 143 251 240 280 114 102 94] ([324 213 197 189 143 251 240 280 114 102 94] \"Accountant\"))))) , ([145 251 240 280 114 102 94] ([189 145 251 240 280 114 102 94] ([197 189 145 251 240 280 114 102 94] ([213 197 189 145 251 240 280 114 102 94] ([324 213 197 189 145 251 240 280 114 102 94] \"Internship\"))))) , ([145 251 240 280 114 102 94] ([189 145 251 240 280 114 102 94] ([197 189 145 251 240 280 114 102 94] ([213 197 189 145 251 240 280 114 102 94] null)))) ))))))) <EOF>)", "ecs.version": "1.2.0","service.name":"ES_ECS","event.dataset":"elasticsearch.server","process.thread.name":"elasticsearch[javaRestTest-0][esql][T#8]","log.logger":"org.elasticsearch.xpack.esql.parser.EsqlParser","elasticsearch.cluster.uuid":"CqmNvJFtTdWUGNY9m-7ccw","elasticsearch.node.id":"njbEEK7jTqiZned-iIMKuQ","elasticsearch.node.name":"javaRestTest-0","elasticsearch.cluster.name":"javaRestTest"}
```

See? That's useful if you are debugging ANTLR, but unless you really need it it's kind of in the way. And, if the query is really big, it's like an 80mb single line string. Oooof. Bad times.

So! This moves that log from `debug` to `trace` and turn off trace level logging in esql. Which I'd left on accidentally a long while back.

Closes #100538

