### PR TITLE
Fix BreakingBytesRefBuilderTests testGrow failing

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/BreakingBytesRefBuilderTests.java
@@ -51,7 +51,6 @@ public class BreakingBytesRefBuilderTests extends ESTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99649")
     public void testAddBytesRef() {
         testAgainstOracle(() -> new TestIteration() {
             BytesRef ref = new BytesRef(randomAlphaOfLengthBetween(1, 100));
@@ -73,7 +72,6 @@ public class BreakingBytesRefBuilderTests extends ESTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99649")
     public void testGrow() {
         testAgainstOracle(() -> new TestIteration() {
             int length = between(1, 100);
@@ -123,7 +121,7 @@ public class BreakingBytesRefBuilderTests extends ESTestCase {
                 boolean willResize = builder.length() + iteration.size() >= builder.bytes().length;
                 if (willResize) {
                     long resizeMemoryUsage = BreakingBytesRefBuilder.SHALLOW_SIZE + ramForArray(builder.bytes().length);
-                    resizeMemoryUsage += ramForArray(ArrayUtil.oversize(builder.bytes().length + iteration.size(), Byte.BYTES));
+                    resizeMemoryUsage += ramForArray(ArrayUtil.oversize(builder.length() + iteration.size(), Byte.BYTES));
                     if (resizeMemoryUsage > limit) {
                         Exception e = expectThrows(CircuitBreakingException.class, () -> iteration.applyToBuilder(builder));
                         assertThat(e.getMessage(), equalTo("over test limit"));


### PR DESCRIPTION
This commit fixes the intermittent failure of BreakingBytesRefBuilderTests. The issue is that the test uses the BreakingBytesRefBuilder's internal BytesRef array length to determine whether to expect a circuit breaker exception or not. Where it should use the builders length (not the capacity, a.k.a the internal BytesRef array length).

The test failed intermittently about one in 10-20 runs before the change. The test passes successfully 100s of thousands of times with the fix.

closes #99649