### PR TITLE
[8.11] ESQL: Don't log the parse tree (#100545)

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -52,9 +52,6 @@ appender.rolling_old.strategy.action.condition.nested_condition.type = IfAccumul
 appender.rolling_old.strategy.action.condition.nested_condition.exceeds = 2GB
 ################################################
 
-logger.esql.name = org.elasticsearch.xpack.esql
-logger.esql.level = trace
-
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.rolling.ref = rolling

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
@@ -72,8 +72,8 @@ public class EsqlParser {
 
             ParserRuleContext tree = parseFunction.apply(parser);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Parse tree: {}", tree.toStringTree());
+            if (log.isTraceEnabled()) {
+                log.trace("Parse tree: {}", tree.toStringTree());
             }
 
             return result.apply(new AstBuilder(paramTokens), tree);


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Don't log the parse tree (#100545)