### PR TITLE
Fix build failures when setting RUNTIME_JAVA_HOME

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.java.installations.auto-detect=false
 
 # log some dependency verification info to console
 org.gradle.dependency.verification.console=verbose
+
+# allow user to specify toolchain via the RUNTIME_JAVA_HOME environment variable
+org.gradle.java.installations.fromEnv=RUNTIME_JAVA_HOME


### PR DESCRIPTION
Follow up to #99922. Removing `org.gradle.java.installations.fromEnv` from our `gradle.properties` file had the side effect of breaking the `RUNTIME_JAVA_HOME` environment variable since Gradle is unaware of this toolchain. We need to add `RUNTIME_JAVA_HOME` back here so that setting this environment variable still works and avoid failures like this one: https://gradle-enterprise.elastic.co/s/gaezgaglsn76o/failure?expanded-stacktrace=WyIwLTEtMiJd#1