### PR TITLE
ESQL: Make test less precise

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.closeTo;
 
 public class MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
 
@@ -58,10 +58,8 @@ public class MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests extend
 
     @Override
     protected void assertSimpleGroup(List<Page> input, Block result, int position, Long group) {
-        assertThat(
-            ((DoubleBlock) result).getDouble(position),
-            equalTo(medianAbsoluteDeviation(input.stream().flatMapToDouble(p -> allDoubles(p, group))))
-        );
+        double medianAbsoluteDeviation = medianAbsoluteDeviation(input.stream().flatMapToDouble(p -> allDoubles(p, group)));
+        assertThat(((DoubleBlock) result).getDouble(position), closeTo(medianAbsoluteDeviation, medianAbsoluteDeviation * .000001));
     }
 
     static double medianAbsoluteDeviation(DoubleStream s) {


### PR DESCRIPTION
This changes an assertion in a test for median absolute deviation that hit floating point rounding errors. It happens fairly rarely, maybe 2% of the time but is reproducable with the right key.
