### PR TITLE
[8.11] [DOCS] Update links to migrating Search docs (#100237)

### DIFF
--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -40,8 +40,8 @@ Post an event to an Analytics Collection.
 
 [[post-analytics-collection-event-request-body]]
 ==== {api-request-body-title}
-Full request body parameters can be found in {enterprise-search-ref}/analytics-events-reference.html[Enterprise Analytics Events^].
 
+Full request body parameters can be found in: <<behavioral-analytics-event-reference>>.
 
 [[post-analytics-collection-event-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -448,11 +448,11 @@ configuration. See {fleet-guide}/install-standalone-elastic-agent.html[Install s
 
 [discrete]
 [[pipelines-in-enterprise-search]]
-=== Pipelines in Enterprise Search
+=== Pipelines for search indices
 
-When you create Elasticsearch indices for {enterprise-search-ref}/index.html[Enterprise Search^] use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines. 
+When you create Elasticsearch indices for search use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines.
 These processors help optimize your content for search.
-Refer to the {enterprise-search-ref}/ingest-pipelines.html[Enterprise Search documentation^] for more information.
+See <<ingest-pipeline-search>> for more information.
 
 [discrete]
 [[access-source-fields]]


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] Update links to migrating Search docs (#100237)