### PR TITLE
Allow VectorFixedBuilder to become released without build

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorFixedBuilder.java
@@ -69,6 +69,7 @@ final class BooleanVectorFixedBuilder implements BooleanVector.FixedBuilder {
     public void close() {
         if (nextIndex >= 0) {
             // If nextIndex < 0 we've already built the vector
+            nextIndex = -1;
             blockFactory.adjustBreaker(-preAdjustedBytes, false);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorFixedBuilder.java
@@ -69,6 +69,7 @@ final class DoubleVectorFixedBuilder implements DoubleVector.FixedBuilder {
     public void close() {
         if (nextIndex >= 0) {
             // If nextIndex < 0 we've already built the vector
+            nextIndex = -1;
             blockFactory.adjustBreaker(-preAdjustedBytes, false);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorFixedBuilder.java
@@ -69,6 +69,7 @@ final class IntVectorFixedBuilder implements IntVector.FixedBuilder {
     public void close() {
         if (nextIndex >= 0) {
             // If nextIndex < 0 we've already built the vector
+            nextIndex = -1;
             blockFactory.adjustBreaker(-preAdjustedBytes, false);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorFixedBuilder.java
@@ -69,6 +69,7 @@ final class LongVectorFixedBuilder implements LongVector.FixedBuilder {
     public void close() {
         if (nextIndex >= 0) {
             // If nextIndex < 0 we've already built the vector
+            nextIndex = -1;
             blockFactory.adjustBreaker(-preAdjustedBytes, false);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
@@ -69,6 +69,7 @@ final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
     public void close() {
         if (nextIndex >= 0) {
             // If nextIndex < 0 we've already built the vector
+            nextIndex = -1;
             blockFactory.adjustBreaker(-preAdjustedBytes, false);
         }
     }


### PR DESCRIPTION
VectorFixedBuilder can be closed without calling build and we should move its state to released in this case.