### PR TITLE
Snapshot deletion process cleanups

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -318,11 +318,11 @@ class S3Repository extends MeteredBlobStoreRepository {
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
         final SnapshotDeleteListener wrappedListener;
-        if (SnapshotsService.useShardGenerations(repositoryMetaVersion)) {
+        if (SnapshotsService.useShardGenerations(repositoryFormatIndexVersion)) {
             wrappedListener = listener;
         } else {
             wrappedListener = new SnapshotDeleteListener() {
@@ -354,7 +354,7 @@ class S3Repository extends MeteredBlobStoreRepository {
                 }
             };
         }
-        super.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryMetaVersion, wrappedListener);
+        super.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryFormatIndexVersion, wrappedListener);
     }
 
     /**

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -317,7 +317,7 @@ class S3Repository extends MeteredBlobStoreRepository {
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {
@@ -354,7 +354,7 @@ class S3Repository extends MeteredBlobStoreRepository {
                 }
             };
         }
-        super.deleteSnapshots(snapshotIds, repositoryStateId, repositoryMetaVersion, wrappedListener);
+        super.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryMetaVersion, wrappedListener);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -74,10 +74,10 @@ public class FilterRepository implements Repository {
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
-        in.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryMetaVersion, listener);
+        in.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryFormatIndexVersion, listener);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -73,11 +73,11 @@ public class FilterRepository implements Repository {
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {
-        in.deleteSnapshots(snapshotIds, repositoryStateId, repositoryMetaVersion, listener);
+        in.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryMetaVersion, listener);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/InvalidRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/InvalidRepository.java
@@ -81,7 +81,7 @@ public class InvalidRepository extends AbstractLifecycleComponent implements Rep
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(createCreationException());

--- a/server/src/main/java/org/elasticsearch/repositories/InvalidRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/InvalidRepository.java
@@ -80,7 +80,7 @@ public class InvalidRepository extends AbstractLifecycleComponent implements Rep
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -138,14 +138,14 @@ public interface Repository extends LifecycleComponent {
      * Deletes snapshots
      *
      * @param snapshotIds           snapshot ids
-     * @param repositoryDataGeneration the generation of the {@link RepositoryData} in the repository at the start of the deletion
-     * @param repositoryMetaVersion version of the updated repository metadata to write
+     * @param repositoryDataGeneration     the generation of the {@link RepositoryData} in the repository at the start of the deletion
+     * @param repositoryFormatIndexVersion the version of repository format to use, indicating the layout of blobs (for bwc)
      * @param listener              completion listener
      */
     void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     );
 

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -137,10 +137,10 @@ public interface Repository extends LifecycleComponent {
     /**
      * Deletes snapshots
      *
-     * @param snapshotIds           snapshot ids
+     * @param snapshotIds                  snapshot ids to delete
      * @param repositoryDataGeneration     the generation of the {@link RepositoryData} in the repository at the start of the deletion
      * @param repositoryFormatIndexVersion the version of repository format to use, indicating the layout of blobs (for bwc)
-     * @param listener              completion listener
+     * @param listener                     completion listener, see {@link SnapshotDeleteListener}.
      */
     void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -138,13 +138,13 @@ public interface Repository extends LifecycleComponent {
      * Deletes snapshots
      *
      * @param snapshotIds           snapshot ids
-     * @param repositoryStateId     the unique id identifying the state of the repository when the snapshot deletion began
+     * @param repositoryDataGeneration the generation of the {@link RepositoryData} in the repository at the start of the deletion
      * @param repositoryMetaVersion version of the updated repository metadata to write
      * @param listener              completion listener
      */
     void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     );

--- a/server/src/main/java/org/elasticsearch/repositories/UnknownTypeRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/UnknownTypeRepository.java
@@ -79,7 +79,7 @@ public class UnknownTypeRepository extends AbstractLifecycleComponent implements
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(createUnknownTypeException());

--- a/server/src/main/java/org/elasticsearch/repositories/UnknownTypeRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/UnknownTypeRepository.java
@@ -78,7 +78,7 @@ public class UnknownTypeRepository extends AbstractLifecycleComponent implements
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1139,7 +1139,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private ShardSnapshotMetaDeleteResult deleteFromShardSnapshotMeta(
         Set<SnapshotId> survivingSnapshots,
         IndexId indexId,
-        int snapshotShardId,
+        int shardId,
         Collection<SnapshotId> snapshotIds,
         BlobContainer shardContainer,
         Set<String> blobs,
@@ -1151,7 +1151,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         ShardGeneration writtenGeneration = null;
         try {
             if (updatedSnapshots.snapshots().isEmpty()) {
-                return new ShardSnapshotMetaDeleteResult(indexId, snapshotShardId, ShardGenerations.DELETED_SHARD_GEN, blobs);
+                return new ShardSnapshotMetaDeleteResult(indexId, shardId, ShardGenerations.DELETED_SHARD_GEN, blobs);
             } else {
                 if (indexGeneration < 0L) {
                     writtenGeneration = ShardGeneration.newGeneration();
@@ -1163,7 +1163,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 final Set<String> survivingSnapshotUUIDs = survivingSnapshots.stream().map(SnapshotId::getUUID).collect(Collectors.toSet());
                 return new ShardSnapshotMetaDeleteResult(
                     indexId,
-                    snapshotShardId,
+                    shardId,
                     writtenGeneration,
                     unusedBlobs(blobs, survivingSnapshotUUIDs, updatedSnapshots)
                 );

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -948,7 +948,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         newRepositoryData,
                         refs.acquireListener()
                     );
-                    asyncCleanupUnlinkedShardLevelBlobs(
+                    cleanupUnlinkedShardLevelBlobs(
                         originalRepositoryData,
                         snapshotIds,
                         writeShardMetaDataAndComputeDeletesStep.result(),
@@ -987,7 +987,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                         originalRepositoryData,
                                         false,
                                         l0.delegateFailure(
-                                            (l, deleteResults) -> asyncCleanupUnlinkedShardLevelBlobs(
+                                            (l, deleteResults) -> cleanupUnlinkedShardLevelBlobs(
                                                 originalRepositoryData,
                                                 snapshotIds,
                                                 deleteResults,
@@ -1234,7 +1234,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         cleanupStaleBlobs(deletedSnapshots, foundIndices, rootBlobs, updatedRepoData, listener.map(ignored -> null));
     }
 
-    private void asyncCleanupUnlinkedShardLevelBlobs(
+    private void cleanupUnlinkedShardLevelBlobs(
         RepositoryData oldRepositoryData,
         Collection<SnapshotId> snapshotIds,
         Collection<ShardSnapshotMetaDeleteResult> deleteResults,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1079,18 +1079,21 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         @Override
                         protected void doRun() throws Exception {
                             final BlobContainer shardContainer = shardContainer(indexId, shardId);
-                            final Set<String> blobs = shardContainer.listBlobs(OperationPurpose.SNAPSHOT).keySet();
+                            final Set<String> originalShardBlobs = shardContainer.listBlobs(OperationPurpose.SNAPSHOT).keySet();
                             final BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots;
                             final long newGen;
                             if (useShardGenerations) {
                                 newGen = -1L;
                                 blobStoreIndexShardSnapshots = buildBlobStoreIndexShardSnapshots(
-                                    blobs,
+                                    originalShardBlobs,
                                     shardContainer,
                                     oldRepositoryData.shardGenerations().getShardGen(indexId, shardId)
                                 ).v1();
                             } else {
-                                Tuple<BlobStoreIndexShardSnapshots, Long> tuple = buildBlobStoreIndexShardSnapshots(blobs, shardContainer);
+                                Tuple<BlobStoreIndexShardSnapshots, Long> tuple = buildBlobStoreIndexShardSnapshots(
+                                    originalShardBlobs,
+                                    shardContainer
+                                );
                                 newGen = tuple.v2() + 1;
                                 blobStoreIndexShardSnapshots = tuple.v1();
                             }
@@ -1101,7 +1104,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                     shardId,
                                     snapshotIds,
                                     shardContainer,
-                                    blobs,
+                                    originalShardBlobs,
                                     blobStoreIndexShardSnapshots,
                                     newGen
                                 )

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1225,13 +1225,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     // Cleaning up dangling blobs
 
     private void cleanupUnlinkedRootAndIndicesBlobs(
-        Collection<SnapshotId> deletedSnapshots,
+        Collection<SnapshotId> snapshotIds,
         Map<String, BlobContainer> foundIndices,
         Map<String, BlobMetadata> rootBlobs,
         RepositoryData updatedRepoData,
         ActionListener<Void> listener
     ) {
-        cleanupStaleBlobs(deletedSnapshots, foundIndices, rootBlobs, updatedRepoData, listener.map(ignored -> null));
+        cleanupStaleBlobs(snapshotIds, foundIndices, rootBlobs, updatedRepoData, listener.map(ignored -> null));
     }
 
     private void cleanupUnlinkedShardLevelBlobs(

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1227,11 +1227,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private void cleanupUnlinkedRootAndIndicesBlobs(
         Collection<SnapshotId> snapshotIds,
         Map<String, BlobContainer> originalIndexContainers,
-        Map<String, BlobMetadata> rootBlobs,
+        Map<String, BlobMetadata> originalRootBlobs,
         RepositoryData updatedRepoData,
         ActionListener<Void> listener
     ) {
-        cleanupStaleBlobs(snapshotIds, originalIndexContainers, rootBlobs, updatedRepoData, listener.map(ignored -> null));
+        cleanupStaleBlobs(snapshotIds, originalIndexContainers, originalRootBlobs, updatedRepoData, listener.map(ignored -> null));
     }
 
     private void cleanupUnlinkedShardLevelBlobs(

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1241,10 +1241,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private void cleanupUnlinkedShardLevelBlobs(
         RepositoryData oldRepositoryData,
         Collection<SnapshotId> snapshotIds,
-        Collection<ShardSnapshotMetaDeleteResult> deleteResults,
+        Collection<ShardSnapshotMetaDeleteResult> shardDeleteResults,
         ActionListener<Void> listener
     ) {
-        final Iterator<String> filesToDelete = resolveFilesToDelete(oldRepositoryData, snapshotIds, deleteResults);
+        final Iterator<String> filesToDelete = resolveFilesToDelete(oldRepositoryData, snapshotIds, shardDeleteResults);
         if (filesToDelete.hasNext() == false) {
             listener.onResponse(null);
             return;

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1226,12 +1226,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private void cleanupUnlinkedRootAndIndicesBlobs(
         Collection<SnapshotId> snapshotIds,
-        Map<String, BlobContainer> foundIndices,
+        Map<String, BlobContainer> originalIndexContainers,
         Map<String, BlobMetadata> rootBlobs,
         RepositoryData updatedRepoData,
         ActionListener<Void> listener
     ) {
-        cleanupStaleBlobs(snapshotIds, foundIndices, rootBlobs, updatedRepoData, listener.map(ignored -> null));
+        cleanupStaleBlobs(snapshotIds, originalIndexContainers, rootBlobs, updatedRepoData, listener.map(ignored -> null));
     }
 
     private void cleanupUnlinkedShardLevelBlobs(

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1228,10 +1228,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Collection<SnapshotId> snapshotIds,
         Map<String, BlobContainer> originalIndexContainers,
         Map<String, BlobMetadata> originalRootBlobs,
-        RepositoryData updatedRepoData,
+        RepositoryData newRepositoryData,
         ActionListener<Void> listener
     ) {
-        cleanupStaleBlobs(snapshotIds, originalIndexContainers, originalRootBlobs, updatedRepoData, listener.map(ignored -> null));
+        cleanupStaleBlobs(snapshotIds, originalIndexContainers, originalRootBlobs, newRepositoryData, listener.map(ignored -> null));
     }
 
     private void cleanupUnlinkedShardLevelBlobs(

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -922,9 +922,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             // index-${gen_uuid} will not be referenced by the existing RepositoryData and new RepositoryData is only
             // written if all shard paths have been successfully updated.
             final ListenableFuture<RepositoryData> writeUpdatedRepoDataStep = new ListenableFuture<>();
-            writeShardMetaDataAndComputeDeletesStep.addListener(ActionListener.wrap(deleteResults -> {
+            writeShardMetaDataAndComputeDeletesStep.addListener(ActionListener.wrap(shardDeleteResults -> {
                 final ShardGenerations.Builder builder = ShardGenerations.builder();
-                for (ShardSnapshotMetaDeleteResult newGen : deleteResults) {
+                for (ShardSnapshotMetaDeleteResult newGen : shardDeleteResults) {
                     builder.put(newGen.indexId, newGen.shardId, newGen.newGeneration);
                 }
                 final RepositoryData newRepositoryData = originalRepositoryData.removeSnapshots(snapshotIds, builder.build());

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -893,8 +893,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param originalRepositoryDataGeneration {@link RepositoryData} generation at the start of the process.
      * @param originalIndexContainers          All index containers at the start of the operation, obtained by listing the repository
      *                                         contents.
-     * @param rootBlobs         All blobs found at the root of the repository before executing any writes to the repository during this
-     *                          delete operation
+     * @param originalRootBlobs                All blobs found at the root of the repository at the start of the operation, obtained by
+     *                                         listing the repository contents.
      * @param repositoryData    RepositoryData found the in the repository before executing this delete
      * @param listener          Listener to invoke once finished
      */
@@ -902,7 +902,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Collection<SnapshotId> snapshotIds,
         long originalRepositoryDataGeneration,
         Map<String, BlobContainer> originalIndexContainers,
-        Map<String, BlobMetadata> rootBlobs,
+        Map<String, BlobMetadata> originalRootBlobs,
         RepositoryData repositoryData,
         IndexVersion repoMetaVersion,
         SnapshotDeleteListener listener
@@ -942,7 +942,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     cleanupUnlinkedRootAndIndicesBlobs(
                         snapshotIds,
                         originalIndexContainers,
-                        rootBlobs,
+                        originalRootBlobs,
                         updatedRepoData,
                         refs.acquireListener()
                     );
@@ -971,7 +971,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         cleanupUnlinkedRootAndIndicesBlobs(
                             snapshotIds,
                             originalIndexContainers,
-                            rootBlobs,
+                            originalRootBlobs,
                             newRepoData,
                             refs.acquireListener()
                         );

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -832,7 +832,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {
@@ -843,14 +843,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 @Override
                 protected void doRun() throws Exception {
                     final Map<String, BlobMetadata> rootBlobs = blobContainer().listBlobs(OperationPurpose.SNAPSHOT);
-                    final RepositoryData repositoryData = safeRepositoryData(repositoryStateId, rootBlobs);
+                    final RepositoryData repositoryData = safeRepositoryData(repositoryDataGeneration, rootBlobs);
                     // Cache the indices that were found before writing out the new index-N blob so that a stuck master will never
                     // delete an index that was created by another master node after writing this index-N blob.
                     final Map<String, BlobContainer> foundIndices = blobStore().blobContainer(indicesPath())
                         .children(OperationPurpose.SNAPSHOT);
                     doDeleteShardSnapshots(
                         snapshotIds,
-                        repositoryStateId,
+                        repositoryDataGeneration,
                         foundIndices,
                         rootBlobs,
                         repositoryData,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1184,11 +1184,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     // Unused blobs are all previous index-, data- and meta-blobs and that are not referenced by the new index- as well as all
     // temporary blobs
     private static List<String> unusedBlobs(
-        Set<String> blobs,
+        Set<String> originalShardBlobs,
         Set<String> survivingSnapshotUUIDs,
         BlobStoreIndexShardSnapshots updatedSnapshots
     ) {
-        return blobs.stream()
+        return originalShardBlobs.stream()
             .filter(
                 blob -> blob.startsWith(SNAPSHOT_INDEX_PREFIX)
                     || (blob.startsWith(SNAPSHOT_PREFIX)

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1010,7 +1010,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private void writeUpdatedShardMetaDataAndComputeDeletes(
         Collection<SnapshotId> snapshotIds,
         RepositoryData oldRepositoryData,
-        boolean useUUIDs,
+        boolean useShardGenerations,
         ActionListener<Collection<ShardSnapshotMetaDeleteResult>> onAllShardsCompleted
     ) {
 
@@ -1082,7 +1082,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             final Set<String> blobs = shardContainer.listBlobs(OperationPurpose.SNAPSHOT).keySet();
                             final BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots;
                             final long newGen;
-                            if (useUUIDs) {
+                            if (useShardGenerations) {
                                 newGen = -1L;
                                 blobStoreIndexShardSnapshots = buildBlobStoreIndexShardSnapshots(
                                     blobs,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1142,7 +1142,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         int shardId,
         Collection<SnapshotId> snapshotIds,
         BlobContainer shardContainer,
-        Set<String> blobs,
+        Set<String> originalShardBlobs,
         BlobStoreIndexShardSnapshots snapshots,
         long indexGeneration
     ) {
@@ -1151,7 +1151,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         ShardGeneration writtenGeneration = null;
         try {
             if (updatedSnapshots.snapshots().isEmpty()) {
-                return new ShardSnapshotMetaDeleteResult(indexId, shardId, ShardGenerations.DELETED_SHARD_GEN, blobs);
+                return new ShardSnapshotMetaDeleteResult(indexId, shardId, ShardGenerations.DELETED_SHARD_GEN, originalShardBlobs);
             } else {
                 if (indexGeneration < 0L) {
                     writtenGeneration = ShardGeneration.newGeneration();
@@ -1165,7 +1165,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     indexId,
                     shardId,
                     writtenGeneration,
-                    unusedBlobs(blobs, survivingSnapshotUUIDs, updatedSnapshots)
+                    unusedBlobs(originalShardBlobs, survivingSnapshotUUIDs, updatedSnapshots)
                 );
             }
         } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1242,12 +1242,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     private void cleanupUnlinkedShardLevelBlobs(
-        RepositoryData oldRepositoryData,
+        RepositoryData originalRepositoryData,
         Collection<SnapshotId> snapshotIds,
         Collection<ShardSnapshotMetaDeleteResult> shardDeleteResults,
         ActionListener<Void> listener
     ) {
-        final Iterator<String> filesToDelete = resolveFilesToDelete(oldRepositoryData, snapshotIds, shardDeleteResults);
+        final Iterator<String> filesToDelete = resolveFilesToDelete(originalRepositoryData, snapshotIds, shardDeleteResults);
         if (filesToDelete.hasNext() == false) {
             listener.onResponse(null);
             return;

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -833,7 +833,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
         if (isReadOnly()) {
@@ -854,7 +854,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         foundIndices,
                         rootBlobs,
                         repositoryData,
-                        repositoryMetaVersion,
+                        repositoryFormatIndexVersion,
                         listener
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1224,6 +1224,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Cleaning up dangling blobs
 
+    /**
+     * Delete any dangling blobs in the repository root (i.e. {@link RepositoryData}, {@link SnapshotInfo} and {@link Metadata} blobs)
+     * as well as any containers for indices that are now completely unreferenced.
+     */
     private void cleanupUnlinkedRootAndIndicesBlobs(
         Collection<SnapshotId> snapshotIds,
         Map<String, BlobContainer> originalIndexContainers,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -896,6 +896,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param originalRootBlobs                All blobs found at the root of the repository at the start of the operation, obtained by
      *                                         listing the repository contents.
      * @param originalRepositoryData           {@link RepositoryData} at the start of the operation.
+     * @param repositoryFormatIndexVersion     The minimum {@link IndexVersion} of the nodes in the cluster and the snapshots remaining in
+     *                                         the repository.
      * @param listener          Listener to invoke once finished
      */
     private void doDeleteShardSnapshots(
@@ -904,10 +906,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Map<String, BlobContainer> originalIndexContainers,
         Map<String, BlobMetadata> originalRootBlobs,
         RepositoryData originalRepositoryData,
-        IndexVersion repoMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
-        if (SnapshotsService.useShardGenerations(repoMetaVersion)) {
+        if (SnapshotsService.useShardGenerations(repositoryFormatIndexVersion)) {
             // First write the new shard state metadata (with the removed snapshot) and compute deletion targets
             final ListenableFuture<Collection<ShardSnapshotMetaDeleteResult>> writeShardMetaDataAndComputeDeletesStep =
                 new ListenableFuture<>();
@@ -929,7 +931,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 writeIndexGen(
                     updatedRepoData,
                     originalRepositoryDataGeneration,
-                    repoMetaVersion,
+                    repositoryFormatIndexVersion,
                     Function.identity(),
                     ActionListener.wrap(writeUpdatedRepoDataStep::onResponse, listener::onFailure)
                 );
@@ -960,7 +962,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             writeIndexGen(
                 updatedRepoData,
                 originalRepositoryDataGeneration,
-                repoMetaVersion,
+                repositoryFormatIndexVersion,
                 Function.identity(),
                 ActionListener.wrap(newRepoData -> {
                     try (var refs = new RefCountingRunnable(() -> {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotDeleteListener.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotDeleteListener.java
@@ -12,12 +12,14 @@ import org.elasticsearch.repositories.RepositoryData;
 public interface SnapshotDeleteListener {
 
     /**
-     * Invoked once a snapshot has been fully deleted from the repository.
+     * Invoked once the snapshots have been fully deleted from the repository, including all async cleanup operations, indicating that
+     * listeners waiting for the end of the deletion can now be notified.
      */
     void onDone();
 
     /**
-     * Invoked once the updated {@link RepositoryData} has been written to the repository.
+     * Invoked once the updated {@link RepositoryData} has been written to the repository and it is safe for the next repository operation
+     * to proceed.
      *
      * @param repositoryData updated repository data
      */

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -360,7 +360,7 @@ public class RepositoriesServiceTests extends ESTestCase {
         public void deleteSnapshots(
             Collection<SnapshotId> snapshotIds,
             long repositoryDataGeneration,
-            IndexVersion repositoryMetaVersion,
+            IndexVersion repositoryFormatIndexVersion,
             SnapshotDeleteListener listener
         ) {
             listener.onFailure(new UnsupportedOperationException());

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -359,7 +359,7 @@ public class RepositoriesServiceTests extends ESTestCase {
         @Override
         public void deleteSnapshots(
             Collection<SnapshotId> snapshotIds,
-            long repositoryStateId,
+            long repositoryDataGeneration,
             IndexVersion repositoryMetaVersion,
             SnapshotDeleteListener listener
         ) {

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -99,7 +99,7 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -100,7 +100,7 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(new UnsupportedOperationException());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -302,7 +302,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     @Override
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
-        long repositoryStateId,
+        long repositoryDataGeneration,
         IndexVersion repositoryMetaVersion,
         SnapshotDeleteListener listener
     ) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -303,7 +303,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryMetaVersion,
+        IndexVersion repositoryFormatIndexVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(new UnsupportedOperationException("Unsupported for repository of type: " + TYPE));


### PR DESCRIPTION
Reorders the methods involved in snapshot deletion to be closer together
and better match the flow of execution, and harmonises the names of many
parameters and local variables to make it easier to follow them through
the process.