### PR TITLE
[8.11] Add known-issue docs for snapshot downgrades bug (#100412)

### DIFF
--- a/docs/reference/release-notes/8.10.0.asciidoc
+++ b/docs/reference/release-notes/8.10.0.asciidoc
@@ -3,6 +3,36 @@
 
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
+[[known-issues-8.10.0]]
+[float]
+=== Known issues
+
+// tag::repositorydata-format-change[]
+* Snapshot-based downgrades
++
+The snapshot repository format changed in a manner that prevents earlier
+versions of Elasticsearch from reading the repository contents if it contains
+snapshots from this version and the last cluster to write to this repository
+was in the 8.10 series. This will prevent you from reverting an upgrade to the
+8.10 series by restoring a snapshot taken before the upgrade.
++
+Snapshot repositories written by clusters running versions 8.11.0 and later are
+compatible with all earlier versions. Moreover, clusters running version 8.11.0
+or later will also automatically repair the repository format the first time
+they write to the repository to take or delete a snapshot, making it so that
+all earlier versions can read its contents again.
++
+If you wish to downgrade to a version prior to 8.9.0, take or delete a snapshot
+using a cluster running version 8.11.0 or later to repair the repository format
+first. If you cannot repair the repository in this way, first delete all the
+snapshots in the repository taken with version 8.9.0 or later. To do this will
+require using a cluster running version 8.10.0 or later.
++
+If you wish to downgrade to a version in the 8.9 series, you must take or
+delete a snapshot using a cluster running version 8.11.0 or later to repair the
+repository format first.
+// end::repositorydata-format-change[]
+
 [[breaking-8.10.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.10.1.asciidoc
+++ b/docs/reference/release-notes/8.10.1.asciidoc
@@ -3,6 +3,12 @@
 
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
+[[known-issues-8.10.1]]
+[float]
+=== Known issues
+
+include::8.10.0.asciidoc[tag=repositorydata-format-change]
+
 [[bug-8.10.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.10.2.asciidoc
+++ b/docs/reference/release-notes/8.10.2.asciidoc
@@ -1,6 +1,10 @@
 [[release-notes-8.10.2]]
 == {es} version 8.10.2
 
-8.10.2 contains no significant changes.
+[[known-issues-8.10.2]]
+[float]
+=== Known issues
+
+include::8.10.0.asciidoc[tag=repositorydata-format-change]
 
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Add known-issue docs for snapshot downgrades bug (#100412)