### PR TITLE
Unmuting UpgradeClusterClientYamlTestSuiteIT for risk assesment

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Continue scroll after upgrade":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/91637"
   - do:
       get:
         index: scroll_index


### PR DESCRIPTION
In order to determine risk I would like to enable this test again.

Relates to #91637 