### PR TITLE
Increase timeout in MixedClusterClientYamlTestSuiteIT

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterClientYamlTestSuiteIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterClientYamlTestSuiteIT.java
@@ -15,7 +15,7 @@ import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
 public class MixedClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     public MixedClusterClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
This suite now has a couple of thousand tests, some of which take a
couple of seconds, so it times out occasionally. Relaxing the timeout
further.