### PR TITLE
MatchingDirectoryReader should not use a threaded searcher (#100527)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1513,7 +1513,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 @Override
                 public LeafReader wrap(LeafReader leaf) {
                     try {
-                        final IndexSearcher searcher = newSearcher(leaf, false);
+                        final IndexSearcher searcher = newSearcher(leaf, false, true, false);
                         searcher.setQueryCache(null);
                         final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
                         final Scorer scorer = weight.scorer(leaf.getContext());


### PR DESCRIPTION
MatchingDirectoryReader is a test reader wrapper that filters out 
documents matching a particular query. For each leaf, we create an 
IndexSearcher, execute the query against it and then use that as a 
filter for the leaf. This searcher is created using LuceneTestCase.newSearcher() 
and as such may be multi- threaded, which triggers extra index checks. 
For tests that are expecting certain methods to be called against internal 
readers a given number of times, these extra checks can add additional 
calls which then lead to a failure of test assumptions.

Because this IndexSearcher is only executed against a single leaf it will 
only ever use a single thread, and so we can explicitly disable threading here.

Fixes #100487
Fixes #99916
Fixes #100460