### PR TITLE
Removing the Coming in 8.10.3 line from the release notes

### DIFF
--- a/docs/reference/release-notes/8.10.3.asciidoc
+++ b/docs/reference/release-notes/8.10.3.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.10.3]]
 == {es} version 8.10.3
 
-coming[8.10.3]
-
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
 [[bug-8.10.3]]


### PR DESCRIPTION
Removing the `Coming in 8.10.3` line from the release notes now that 8.10.3 has been released