### PR TITLE
[8.11] Fix NPE in DocVector ramBytesUsed (#100575)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -203,6 +203,10 @@ public class DocVector extends AbstractVector implements Vector {
         return shards.equals(other.shards) && segments.equals(other.segments) && docs.equals(other.docs);
     }
 
+    private static long ramBytesOrZero(int[] array) {
+        return array == null ? 0 : RamUsageEstimator.shallowSizeOf(array);
+    }
+
     public static long ramBytesEstimated(
         IntVector shards,
         IntVector segments,
@@ -211,7 +215,7 @@ public class DocVector extends AbstractVector implements Vector {
         int[] shardSegmentDocMapBackwards
     ) {
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(shards) + RamUsageEstimator.sizeOf(segments) + RamUsageEstimator.sizeOf(docs)
-            + RamUsageEstimator.shallowSizeOf(shardSegmentDocMapForwards) + RamUsageEstimator.shallowSizeOf(shardSegmentDocMapBackwards);
+            + ramBytesOrZero(shardSegmentDocMapForwards) + ramBytesOrZero(shardSegmentDocMapBackwards);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
@@ -150,6 +150,17 @@ public class DocVectorTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("can't build page out of released blocks"));
     }
 
+    public void testRamBytesUsedWithout() {
+        DocVector docs = new DocVector(
+            IntBlock.newConstantBlockWith(0, 1).asVector(),
+            IntBlock.newConstantBlockWith(0, 1).asVector(),
+            IntBlock.newConstantBlockWith(0, 1).asVector(),
+            false
+        );
+        assertThat(docs.singleSegmentNonDecreasing(), is(false));
+        docs.ramBytesUsed(); // ensure non-singleSegmentNonDecreasing handles nulls in ramByteUsed
+    }
+
     IntVector intRange(int startInclusive, int endExclusive) {
         return IntVector.range(startInclusive, endExclusive, BlockFactory.getNonBreakingInstance());
     }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix NPE in DocVector ramBytesUsed (#100575)