### PR TITLE
[main] Update 8.10.3.asciidoc (#100590)

### DIFF
--- a/docs/reference/release-notes/8.10.3.asciidoc
+++ b/docs/reference/release-notes/8.10.3.asciidoc
@@ -1,7 +1,11 @@
 [[release-notes-8.10.3]]
 == {es} version 8.10.3
 
-coming[8.10.3]
+[[known-issues-8.10.3]]
+[float]
+=== Known issues
+
+include::8.10.0.asciidoc[tag=repositorydata-format-change]
 
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.10` to `main`:
 - [Update 8.10.3.asciidoc (#100590)](https://github.com/elastic/elasticsearch/pull/100590)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)