### PR TITLE
ESQL: Switch visibility to public in ESQL REST spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
@@ -5,7 +5,7 @@
       "description":"Executes an ESQL request"
     },
     "stability":"experimental",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]
@@ -32,7 +32,7 @@
       }
     },
     "body":{
-      "description":"Use the `query` element to start a query. Use `time_zone` to specify an execution time zone and 'columnar' to format the answer.",
+      "description":"Use the `query` element to start a query. Use `time_zone` to specify an execution time zone and `columnar` to format the answer.",
       "required":true
     }
   }


### PR DESCRIPTION
This update the visibility field in ESQL's REST spec to public.

It also updates the types of quotes used for one the REST object paramter to backticks, to be consistent.
