### PR TITLE
Unmute and fix IdLoaderTests#testSynthesizeIdMultipleSegments again.

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdLoaderTests.java
@@ -69,7 +69,6 @@ public class IdLoaderTests extends ESTestCase {
         prepareIndexReader(indexAndForceMerge(routing, docs), verify, false);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100580")
     public void testSynthesizeIdMultipleSegments() throws Exception {
         var routingPaths = List.of("dim1");
         var routing = createRouting(routingPaths);
@@ -203,6 +202,7 @@ public class IdLoaderTests extends ESTestCase {
             IndexWriterConfig config = LuceneTestCase.newIndexWriterConfig(random(), new MockAnalyzer(random()));
             if (noMergePolicy) {
                 config.setMergePolicy(NoMergePolicy.INSTANCE);
+                config.setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
             }
             Sort sort = new Sort(
                 new SortField(TimeSeriesIdFieldMapper.NAME, SortField.Type.STRING, false),


### PR DESCRIPTION
This time more segments were created than expected, because IWC#maxBufferedDocs was randomily set to a very small number causing more segments to be created then expected.

I also run this test again with -Dtests.iters=1024 without failure. So hopefully this test will not fail again because of random test issues.

Closes #100580