### PR TITLE
[8.10] Capture JVM crash dump logs in uploaded artifact bundle (#100627)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -28,6 +28,7 @@ if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(projec
             include("**/build/test-results/**/*.xml")
             include("**/build/testclusters/**")
             include("**/build/testrun/*/temp/**")
+            include("**/build/**/hs_err_pid*.log")
             exclude("**/build/testclusters/**/data/**")
             exclude("**/build/testclusters/**/distro/**")
             exclude("**/build/testclusters/**/repo/**")


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Capture JVM crash dump logs in uploaded artifact bundle (#100627)