### PR TITLE
ESQL: Handle queries with non-existing enrich policies and no field

### DIFF
--- a/docs/changelog/100647.yaml
+++ b/docs/changelog/100647.yaml
@@ -1,0 +1,6 @@
+pr: 100647
+summary: "ESQL: Handle queries with non-existing enrich policies and no field"
+area: ES|QL
+type: bug
+issues:
+ - 100593

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -219,7 +219,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 )
                 : plan.policyName();
 
-            var matchField = plan.matchField() == null || plan.matchField() instanceof EmptyAttribute
+            var matchField = policy != null && (plan.matchField() == null || plan.matchField() instanceof EmptyAttribute)
                 ? new UnresolvedAttribute(plan.source(), policy.getMatchField())
                 : plan.matchField();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1256,6 +1256,14 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("unresolved enrich policy [foo]"));
     }
 
+    public void testNonExistingEnrichNoMatchField() {
+        var e = expectThrows(VerificationException.class, () -> analyze("""
+            from test
+            | enrich foo
+            """));
+        assertThat(e.getMessage(), containsString("unresolved enrich policy [foo]"));
+    }
+
     public void testNonExistingEnrichPolicyWithSimilarName() {
         var e = expectThrows(VerificationException.class, () -> analyze("""
             from test


### PR DESCRIPTION
When dealing with non-existing policies, the validation code kept trying
 to determine the matching field resulting in a NPE.

Fix #100593