### PR TITLE
ESQL: Graceful handling of non-bool condition in the filter

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.hamcrest.Matchers.containsString;
 
+//@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE,org.elasticsearch.compute:TRACE", reason = "debug")
 public class VerifierTests extends ESTestCase {
 
     private static final EsqlParser parser = new EsqlParser();
@@ -292,9 +293,16 @@ public class VerifierTests extends ESTestCase {
         }
     }
 
+    public void testNestedAggField() {
+        assertEquals("1:27: Unknown column [avg]", error("from test | stats c = avg(avg)"));
+    }
+
+    public void testUnfinishedAggFunction() {
+        assertEquals("1:23: incomplete aggregate function declaration; add parenthesis to [avg]", error("from test | stats c = avg"));
+    }
+
     private String error(String query) {
         return error(query, defaultAnalyzer);
-
     }
 
     private String error(String query, Object... params) {


### PR DESCRIPTION
Improve the Verifier to handle queries with non-boolean expressions
 used in the WHERE clause (where 10)
In the process improve the readability of the Verifier class by
 extracting the checks into their own methods

Fix #100049 