### PR TITLE
[8.11] ESQL: Graceful handling of non-bool condition in the filter (#100645)

### DIFF
--- a/docs/changelog/100645.yaml
+++ b/docs/changelog/100645.yaml
@@ -1,0 +1,7 @@
+pr: 100645
+summary: "ESQL: Graceful handling of non-bool condition in the filter"
+area: ES|QL
+type: bug
+issues:
+ - 100049
+ - 100409

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -55,6 +55,7 @@ import static org.elasticsearch.xpack.esql.stats.FeatureMetric.LIMIT;
 import static org.elasticsearch.xpack.esql.stats.FeatureMetric.SORT;
 import static org.elasticsearch.xpack.esql.stats.FeatureMetric.STATS;
 import static org.elasticsearch.xpack.esql.stats.FeatureMetric.WHERE;
+import static org.elasticsearch.xpack.ql.analyzer.VerifierChecks.checkFilterConditionType;
 import static org.elasticsearch.xpack.ql.common.Failure.fail;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.FIRST;
 
@@ -121,79 +122,19 @@ public class Verifier {
 
         // Concrete verifications
         plan.forEachDown(p -> {
-            if (p instanceof Aggregate agg) {
-                agg.aggregates().forEach(e -> {
-                    var exp = e instanceof Alias ? ((Alias) e).child() : e;
-                    if (exp instanceof AggregateFunction aggFunc) {
-                        Expression field = aggFunc.field();
-
-                        // TODO: allow an expression?
-                        if ((field instanceof FieldAttribute
-                            || field instanceof MetadataAttribute
-                            || field instanceof ReferenceAttribute
-                            || field instanceof Literal) == false) {
-                            failures.add(
-                                fail(
-                                    e,
-                                    "aggregate function's field must be an attribute or literal; found ["
-                                        + field.sourceText()
-                                        + "] of type ["
-                                        + field.nodeName()
-                                        + "]"
-                                )
-                            );
-                        }
-                    } else if (agg.groupings().contains(exp) == false) { // TODO: allow an expression?
-                        failures.add(
-                            fail(
-                                exp,
-                                "expected an aggregate function or group but got ["
-                                    + exp.sourceText()
-                                    + "] of type ["
-                                    + exp.nodeName()
-                                    + "]"
-                            )
-                        );
-                    }
-                });
-            } else if (p instanceof RegexExtract re) {
-                Expression expr = re.input();
-                DataType type = expr.dataType();
-                if (EsqlDataTypes.isString(type) == false) {
-                    failures.add(
-                        fail(
-                            expr,
-                            "{} only supports KEYWORD or TEXT values, found expression [{}] type [{}]",
-                            re.getClass().getSimpleName(),
-                            expr.sourceText(),
-                            type
-                        )
-                    );
-                }
-            } else if (p instanceof Row row) {
-                failures.addAll(validateRow(row));
-            } else if (p instanceof Eval eval) {
-                failures.addAll(validateEval(eval));
+            // if the children are unresolved, so will this node; counting it will only add noise
+            if (p.childrenResolved() == false) {
+                return;
             }
+            checkFilterConditionType(p, failures);
+            checkAggregate(p, failures);
+            checkRegexExtractOnlyOnStrings(p, failures);
 
-            p.forEachExpression(BinaryOperator.class, bo -> {
-                Failure f = validateUnsignedLongOperator(bo);
-                if (f != null) {
-                    failures.add(f);
-                }
-            });
-            p.forEachExpression(BinaryComparison.class, bc -> {
-                Failure f = validateBinaryComparison(bc);
-                if (f != null) {
-                    failures.add(f);
-                }
-            });
-            p.forEachExpression(Neg.class, neg -> {
-                Failure f = validateUnsignedLongNegation(neg);
-                if (f != null) {
-                    failures.add(f);
-                }
-            });
+            checkRow(p, failures);
+            checkEvalFields(p, failures);
+
+            checkOperationsOnUnsignedLong(p, failures);
+            checkBinaryComparison(p, failures);
         });
 
         // gather metrics
@@ -202,6 +143,107 @@ public class Verifier {
         }
 
         return failures;
+    }
+
+    private static void checkAggregate(LogicalPlan p, Set<Failure> failures) {
+        if (p instanceof Aggregate agg) {
+            agg.aggregates().forEach(e -> {
+                var exp = e instanceof Alias ? ((Alias) e).child() : e;
+                if (exp instanceof AggregateFunction aggFunc) {
+                    Expression field = aggFunc.field();
+
+                    // TODO: allow an expression?
+                    if ((field instanceof FieldAttribute
+                        || field instanceof MetadataAttribute
+                        || field instanceof ReferenceAttribute
+                        || field instanceof Literal) == false) {
+                        failures.add(
+                            fail(
+                                e,
+                                "aggregate function's field must be an attribute or literal; found ["
+                                    + field.sourceText()
+                                    + "] of type ["
+                                    + field.nodeName()
+                                    + "]"
+                            )
+                        );
+                    }
+                } else if (agg.groupings().contains(exp) == false) { // TODO: allow an expression?
+                    failures.add(
+                        fail(
+                            exp,
+                            "expected an aggregate function or group but got [" + exp.sourceText() + "] of type [" + exp.nodeName() + "]"
+                        )
+                    );
+                }
+            });
+        }
+    }
+
+    private static void checkRegexExtractOnlyOnStrings(LogicalPlan p, Set<Failure> failures) {
+        if (p instanceof RegexExtract re) {
+            Expression expr = re.input();
+            DataType type = expr.dataType();
+            if (EsqlDataTypes.isString(type) == false) {
+                failures.add(
+                    fail(
+                        expr,
+                        "{} only supports KEYWORD or TEXT values, found expression [{}] type [{}]",
+                        re.getClass().getSimpleName(),
+                        expr.sourceText(),
+                        type
+                    )
+                );
+            }
+        }
+    }
+
+    private static void checkRow(LogicalPlan p, Set<Failure> failures) {
+        if (p instanceof Row row) {
+            row.fields().forEach(a -> {
+                if (EsqlDataTypes.isRepresentable(a.dataType()) == false) {
+                    failures.add(fail(a, "cannot use [{}] directly in a row assignment", a.child().sourceText()));
+                }
+            });
+        }
+    }
+
+    private static void checkEvalFields(LogicalPlan p, Set<Failure> failures) {
+        if (p instanceof Eval eval) {
+            eval.fields().forEach(field -> {
+                DataType dataType = field.dataType();
+                if (EsqlDataTypes.isRepresentable(dataType) == false) {
+                    failures.add(
+                        fail(field, "EVAL does not support type [{}] in expression [{}]", dataType.typeName(), field.child().sourceText())
+                    );
+                }
+            });
+        }
+    }
+
+    private static void checkOperationsOnUnsignedLong(LogicalPlan p, Set<Failure> failures) {
+        p.forEachExpression(e -> {
+            Failure f = null;
+
+            if (e instanceof BinaryOperator<?, ?, ?, ?> bo) {
+                f = validateUnsignedLongOperator(bo);
+            } else if (e instanceof Neg neg) {
+                f = validateUnsignedLongNegation(neg);
+            }
+
+            if (f != null) {
+                failures.add(f);
+            }
+        });
+    }
+
+    private static void checkBinaryComparison(LogicalPlan p, Set<Failure> failures) {
+        p.forEachExpression(BinaryComparison.class, bc -> {
+            Failure f = validateBinaryComparison(bc);
+            if (f != null) {
+                failures.add(f);
+            }
+        });
     }
 
     private void gatherMetrics(LogicalPlan plan) {
@@ -226,29 +268,6 @@ public class Verifier {
         for (int i = b.nextSetBit(0); i >= 0; i = b.nextSetBit(i + 1)) {
             metrics.inc(FeatureMetric.values()[i]);
         }
-    }
-
-    private static Collection<Failure> validateRow(Row row) {
-        List<Failure> failures = new ArrayList<>(row.fields().size());
-        row.fields().forEach(a -> {
-            if (EsqlDataTypes.isRepresentable(a.dataType()) == false) {
-                failures.add(fail(a, "cannot use [{}] directly in a row assignment", a.child().sourceText()));
-            }
-        });
-        return failures;
-    }
-
-    private static Collection<Failure> validateEval(Eval eval) {
-        List<Failure> failures = new ArrayList<>(eval.fields().size());
-        eval.fields().forEach(field -> {
-            DataType dataType = field.dataType();
-            if (EsqlDataTypes.isRepresentable(dataType) == false) {
-                failures.add(
-                    fail(field, "EVAL does not support type [{}] in expression [{}]", dataType.typeName(), field.child().sourceText())
-                );
-            }
-        });
-        return failures;
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -292,6 +292,14 @@ public class VerifierTests extends ESTestCase {
         }
     }
 
+    public void testFilterNonBoolField() {
+        assertEquals("1:19: Condition expression needs to be boolean, found [INTEGER]", error("from test | where emp_no"));
+    }
+
+    public void testFilterDateConstant() {
+        assertEquals("1:19: Condition expression needs to be boolean, found [DATE_PERIOD]", error("from test | where 1 year"));
+    }
+
     private String error(String query) {
         return error(query, defaultAnalyzer);
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Graceful handling of non-bool condition in the filter (#100645)