### PR TITLE
[8.11] [Transform] Make Transform Feature Reset really wait for all the tasks (#100624)

### DIFF
--- a/docs/changelog/100624.yaml
+++ b/docs/changelog/100624.yaml
@@ -1,0 +1,5 @@
+pr: 100624
+summary: Make Transform Feature Reset really wait for all the tasks
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -101,7 +101,8 @@ public class TestFeatureResetIT extends TransformRestTestCase {
         assertThat((Integer) getTransforms("_all").get("count"), equalTo(0));
 
         // assert transform indices are gone
-        assertThat(ESRestTestCase.entityAsMap(adminClient().performRequest(new Request("GET", ".transform-*"))), is(anEmptyMap()));
+        Map<String, Object> transformIndices = ESRestTestCase.entityAsMap(adminClient().performRequest(new Request("GET", ".transform-*")));
+        assertThat("Indices were: " + transformIndices, transformIndices, is(anEmptyMap()));
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -426,7 +426,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
                 client.admin()
                     .cluster()
                     .prepareListTasks()
-                    .setActions(TransformField.TASK_NAME)
+                    .setActions(TransformField.TASK_NAME + "*")
                     .setWaitForCompletion(true)
                     .execute(ActionListener.wrap(listTransformTasks -> {
                         listTransformTasks.rethrowFailures("Waiting for transform tasks");


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [Transform] Make Transform Feature Reset really wait for all the tasks (#100624)