### PR TITLE
[8.11] Relax ValueSources check in OrdinalsGroupingOperator (#100566)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -105,12 +105,6 @@ public class OrdinalsGroupingOperator implements Operator {
         DriverContext driverContext
     ) {
         Objects.requireNonNull(aggregatorFactories);
-        boolean bytesValues = sources.get(0).source() instanceof ValuesSource.Bytes;
-        for (int i = 1; i < sources.size(); i++) {
-            if (sources.get(i).source() instanceof ValuesSource.Bytes != bytesValues) {
-                throw new IllegalStateException("ValuesSources are mismatched");
-            }
-        }
         this.sources = sources;
         this.docChannel = docChannel;
         this.groupingField = groupingField;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1184,6 +1185,39 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         for (String fn : functions) {
             String query = String.format(Locale.ROOT, "from %s | stats s = %s by kw", indexName, fn);
             run(query).close();
+        }
+    }
+
+    public void testUnsupportedTypesOrdinalGrouping() {
+        assertAcked(
+            client().admin().indices().prepareCreate("index-1").setMapping("f1", "type=keyword", "f2", "type=keyword", "v", "type=long")
+        );
+        assertAcked(
+            client().admin().indices().prepareCreate("index-2").setMapping("f1", "type=object", "f2", "type=keyword", "v", "type=long")
+        );
+        Map<String, Long> groups = new HashMap<>();
+        int numDocs = randomIntBetween(10, 20);
+        for (int i = 0; i < numDocs; i++) {
+            String k = randomFrom("a", "b", "c");
+            long v = randomIntBetween(1, 10);
+            groups.merge(k, v, Long::sum);
+            groups.merge(null, v, Long::sum); // null group
+            client().prepareIndex("index-1").setSource("f1", k, "v", v).get();
+            client().prepareIndex("index-2").setSource("f2", k, "v", v).get();
+        }
+        client().admin().indices().prepareRefresh("index-1", "index-2").get();
+        for (String field : List.of("f1", "f2")) {
+            try (var resp = run("from index-1,index-2 | stats sum(v) by " + field)) {
+                Iterator<Iterator<Object>> values = resp.values();
+                Map<String, Long> actual = new HashMap<>();
+                while (values.hasNext()) {
+                    Iterator<Object> row = values.next();
+                    Long v = (Long) row.next();
+                    String k = (String) row.next();
+                    actual.put(k, v);
+                }
+                assertThat(actual, equalTo(groups));
+            }
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Relax ValueSources check in OrdinalsGroupingOperator (#100566)