### PR TITLE
Disable parallel collection in top hits aggregator

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -921,4 +921,9 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
     }
+
+    @Override
+    public boolean supportsParallelCollection() {
+        return false;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
@@ -183,4 +183,8 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
             XContentType.JSON
         );
     }
+
+    public void testSupportsParallelCollection() {
+        assertFalse(createTestAggregatorBuilder().supportsParallelCollection());
+    }
 }


### PR DESCRIPTION
TopHitsAggregator calls TopFieldCollector#populateScores from each slice, which in turn relies on createWeight calls against the searcher. This means that the createWeight call gets parallelized with Lucene 9.9, but it should not as we are already executing multiple slices concurrently. We have protecions in place in Lucene to avoid this problem, but we have to adapt our execution code in ContextIndexSearcher accordingly.

The goal is to utilize plain TaskExecutor from Lucene and avoid code duplication. In the meantime, we can disable concurrency for top hits aggregations as it causes actual issues currently in the lucene_snapshot branch.

This fix is not necessary on main because Lucene 9.8 does not parallelize createWeight, hence top hits is fine being parallelized on main. I plan on addressing this issue overall before we merge back lucene_snapshot into main.