### PR TITLE
Don't use an asserting searcher at all in MatchingDirectoryReader

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1509,7 +1509,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 @Override
                 public LeafReader wrap(LeafReader leaf) {
                     try {
-                        final IndexSearcher searcher = newSearcher(leaf, false, true, false);
+                        final IndexSearcher searcher = new IndexSearcher(leaf);
                         searcher.setQueryCache(null);
                         final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
                         final Scorer scorer = weight.scorer(leaf.getContext());


### PR DESCRIPTION
Follow up to #100527

We are not testing anything to do with searching with this searcher, and so
there is no point in using `LuceneTestCase.newSearcher()` which will wrap
it with all sorts of extra checks that may access the underlying reader in
ways that are not anticipated by tests.

Fixes #100460
Fixes #99024 