### PR TITLE
WellKnownBinary#toWKB should not throw an IOException

### DIFF
--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownBinary.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownBinary.java
@@ -24,6 +24,7 @@ import org.elasticsearch.geometry.ShapeType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -40,10 +41,13 @@ public class WellKnownBinary {
     /**
      * Converts the given {@link Geometry} to WKB with the provided {@link ByteOrder}
      */
-    public static byte[] toWKB(Geometry geometry, ByteOrder byteOrder) throws IOException {
+    public static byte[] toWKB(Geometry geometry, ByteOrder byteOrder) {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             toWKB(geometry, outputStream, ByteBuffer.allocate(8).order(byteOrder));
             return outputStream.toByteArray();
+        } catch (IOException ioe) {
+            // Should never happen as the only method throwing IOException is ByteArrayOutputStream#close and it is a NOOP
+            throw new UncheckedIOException(ioe);
         }
     }
 

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/utils/WKBTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/utils/WKBTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,47 +34,47 @@ public class WKBTests extends ESTestCase {
         assertEquals("Empty POINT cannot be represented in WKB", ex.getMessage());
     }
 
-    public void testPoint() throws IOException {
+    public void testPoint() {
         Point point = GeometryTestUtils.randomPoint(randomBoolean());
         assertWKB(point);
     }
 
-    public void testEmptyMultiPoint() throws IOException {
+    public void testEmptyMultiPoint() {
         MultiPoint multiPoint = MultiPoint.EMPTY;
         assertWKB(multiPoint);
     }
 
-    public void testMultiPoint() throws IOException {
+    public void testMultiPoint() {
         MultiPoint multiPoint = GeometryTestUtils.randomMultiPoint(randomBoolean());
         assertWKB(multiPoint);
     }
 
-    public void testEmptyLine() throws IOException {
+    public void testEmptyLine() {
         Line line = Line.EMPTY;
         assertWKB(line);
     }
 
-    public void testLine() throws IOException {
+    public void testLine() {
         Line line = GeometryTestUtils.randomLine(randomBoolean());
         assertWKB(line);
     }
 
-    public void tesEmptyMultiLine() throws IOException {
+    public void tesEmptyMultiLine() {
         MultiLine multiLine = MultiLine.EMPTY;
         assertWKB(multiLine);
     }
 
-    public void testMultiLine() throws IOException {
+    public void testMultiLine() {
         MultiLine multiLine = GeometryTestUtils.randomMultiLine(randomBoolean());
         assertWKB(multiLine);
     }
 
-    public void testEmptyPolygon() throws IOException {
+    public void testEmptyPolygon() {
         Polygon polygon = Polygon.EMPTY;
         assertWKB(polygon);
     }
 
-    public void testPolygon() throws IOException {
+    public void testPolygon() {
         final boolean hasZ = randomBoolean();
         Polygon polygon = GeometryTestUtils.randomPolygon(hasZ);
         if (randomBoolean()) {
@@ -89,22 +88,22 @@ public class WKBTests extends ESTestCase {
         assertWKB(polygon);
     }
 
-    public void testEmptyMultiPolygon() throws IOException {
+    public void testEmptyMultiPolygon() {
         MultiPolygon multiPolygon = MultiPolygon.EMPTY;
         assertWKB(multiPolygon);
     }
 
-    public void testMultiPolygon() throws IOException {
+    public void testMultiPolygon() {
         MultiPolygon multiPolygon = GeometryTestUtils.randomMultiPolygon(randomBoolean());
         assertWKB(multiPolygon);
     }
 
-    public void testEmptyGeometryCollection() throws IOException {
+    public void testEmptyGeometryCollection() {
         GeometryCollection<Geometry> collection = GeometryCollection.EMPTY;
         assertWKB(collection);
     }
 
-    public void testGeometryCollection() throws IOException {
+    public void testGeometryCollection() {
         GeometryCollection<Geometry> collection = GeometryTestUtils.randomGeometryCollection(randomBoolean());
         assertWKB(collection);
     }
@@ -115,7 +114,7 @@ public class WKBTests extends ESTestCase {
         assertEquals("Empty CIRCLE cannot be represented in WKB", ex.getMessage());
     }
 
-    public void testCircle() throws IOException {
+    public void testCircle() {
         Circle circle = GeometryTestUtils.randomCircle(randomBoolean());
         assertWKB(circle);
     }
@@ -129,7 +128,7 @@ public class WKBTests extends ESTestCase {
         assertEquals("Empty ENVELOPE cannot be represented in WKB", ex.getMessage());
     }
 
-    public void testRectangle() throws IOException {
+    public void testRectangle() {
         Rectangle rectangle = GeometryTestUtils.randomRectangle();
         assertWKB(rectangle);
     }
@@ -138,7 +137,7 @@ public class WKBTests extends ESTestCase {
         return randomBoolean() ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
     }
 
-    private void assertWKB(Geometry geometry) throws IOException {
+    private void assertWKB(Geometry geometry) {
         final boolean hasZ = geometry.hasZ();
         final ByteOrder byteOrder = randomByteOrder();
         final byte[] b = WellKnownBinary.toWKB(geometry, byteOrder);

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
@@ -583,7 +583,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
     }
 
     @Override
-    protected void index(DocumentParserContext context, ShapeBuilder<?, ?, ?> shapeBuilder) throws IOException {
+    protected void index(DocumentParserContext context, ShapeBuilder<?, ?, ?> shapeBuilder) {
         if (shapeBuilder == null) {
             return;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -22,7 +22,6 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -191,7 +190,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
     }
 
     @Override
-    protected void index(DocumentParserContext context, Geometry geometry) throws IOException {
+    protected void index(DocumentParserContext context, Geometry geometry) {
         if (geometry == null) {
             return;
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -340,7 +340,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
     }
 
     @Override
-    protected void index(DocumentParserContext context, Geometry geometry) throws IOException {
+    protected void index(DocumentParserContext context, Geometry geometry) {
         // TODO: Make common with the index method ShapeFieldMapper
         if (geometry == null) {
             return;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -150,7 +150,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
     }
 
     @Override
-    protected void index(DocumentParserContext context, CartesianPoint point) throws IOException {
+    protected void index(DocumentParserContext context, CartesianPoint point) {
         if (fieldType().isIndexed()) {
             context.doc().add(new XYPointField(fieldType().name(), (float) point.getX(), (float) point.getY()));
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -204,7 +204,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
     }
 
     @Override
-    protected void index(DocumentParserContext context, Geometry geometry) throws IOException {
+    protected void index(DocumentParserContext context, Geometry geometry) {
         // TODO: Make common with the index method GeoShapeWithDocValuesFieldMapper
         if (geometry == null) {
             return;


### PR DESCRIPTION
The only reason this method is throwing an exception is because the method ByteArrayOutputStream#close() is declaring it although it is a noop. Therefore it can be safely ignored.

Thanks @romseygeek for bringing into attention.