### PR TITLE
[8.11] Don't use an asserting searcher at all in MatchingDirectoryReader (#100668)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1513,7 +1513,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 @Override
                 public LeafReader wrap(LeafReader leaf) {
                     try {
-                        final IndexSearcher searcher = newSearcher(leaf, false, true, false);
+                        final IndexSearcher searcher = new IndexSearcher(leaf);
                         searcher.setQueryCache(null);
                         final Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
                         final Scorer scorer = weight.scorer(leaf.getContext());


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Don't use an asserting searcher at all in MatchingDirectoryReader (#100668)