### PR TITLE
Adjust error on MedianAbsoluteDeviationAggregatorTests for concurrency

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
@@ -100,7 +100,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
             sample.add(point);
             return singleton(new SortedNumericDocValuesField(FIELD_NAME, point));
         }), agg -> {
-            assertThat(agg.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(sample)));
+            assertThat(agg.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(sample), 0.2));
             assertTrue(AggregationInspectionHelper.hasValue(agg));
         });
     }
@@ -112,7 +112,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
             sample.add(point);
             return singleton(new NumericDocValuesField(FIELD_NAME, point));
         }), agg -> {
-            assertThat(agg.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(sample)));
+            assertThat(agg.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(sample), 0.2));
             assertTrue(AggregationInspectionHelper.hasValue(agg));
         });
     }


### PR DESCRIPTION
Due to the recent introduction of concurrency, this test can fail because the different way of calculating the values. Adjust the error from 0.1 to 0.2. There is no scientific reason I choose that value but no other than other test setting that value.

fixes https://github.com/elastic/elasticsearch/issues/100689