### PR TITLE
[8.11] Exclude BWC tests in platform support testing matrix (#100643)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -2,7 +2,7 @@ steps:
   - group: platform-support-unix
     steps:
       - label: "{{matrix.image}} / platform-support-unix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true check
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true platformSupportTests
         timeout_in_minutes: 420
         matrix:
           setup:
@@ -46,7 +46,6 @@ steps:
               - checkPart1
               - checkPart2
               - checkPart3
-              - bwcTestSnapshots
               - checkRestCompat
         agents:
           provider: gcp
@@ -70,7 +69,6 @@ steps:
               - checkPart1
               - checkPart2
               - checkPart3
-              - bwcTestSnapshots
               - checkRestCompat
         agents:
           provider: aws

--- a/build.gradle
+++ b/build.gradle
@@ -186,8 +186,8 @@ if (bwc_tests_enabled == false) {
   println "See ${bwc_tests_disabled_issue}"
   println "==========================================================="
 }
-if (project.gradle.startParameter.taskNames.find { it.startsWith("checkPart") } != null) {
-  // Disable BWC tests for checkPart* tasks as it's expected that this will run un it's own check
+if (project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'platformSupportTests' }) {
+  // Disable BWC tests for checkPart* tasks and platform support tests as it's expected that this will run on it's own check
   bwc_tests_enabled = false
 }
 
@@ -255,6 +255,8 @@ allprojects {
     } else {
       tasks.register('checkPart1') { dependsOn 'check' }
     }
+
+    tasks.register('platformSupportTests') { dependsOn 'check'}
   }
 
   /*


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Exclude BWC tests in platform support testing matrix (#100643)