### PR TITLE
[7.17] Exclude BWC tests in platform support testing matrix (#100643)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -2,7 +2,7 @@ steps:
   - group: platform-support-unix
     steps:
       - label: "{{matrix.image}} / platform-support-unix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true check
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true platformSupportTests
         timeout_in_minutes: 420
         matrix:
           setup:
@@ -45,7 +45,6 @@ steps:
             GRADLE_TASK:
               - checkPart1
               - checkPart2
-              - bwcTestSnapshots
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
@@ -57,7 +56,7 @@ steps:
   - group: platform-support-arm
     steps:
       - label: "{{matrix.image}} / platform-support-arm"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true check
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true platformSupportTests
         timeout_in_minutes: 420
         matrix:
           setup:

--- a/build.gradle
+++ b/build.gradle
@@ -177,8 +177,8 @@ if (bwc_tests_enabled == false) {
   println "See ${bwc_tests_disabled_issue}"
   println "==========================================================="
 }
-if (project.gradle.startParameter.taskNames.find { it.startsWith("checkPart") } != null) {
-  // Disable BWC tests for checkPart* tasks as it's expected that this will run un it's own check
+if (project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'platformSupportTests' }) {
+  // Disable BWC tests for checkPart* tasks and platform support tests as it's expected that this will run on it's own check
   bwc_tests_enabled = false
 }
 
@@ -249,6 +249,8 @@ allprojects {
     for (String taskname : tasknames) {
       project.tasks.named(taskname).configure { enabled = false }
     }
+
+    tasks.register('platformSupportTests') { dependsOn 'check'}
   }
 
   /*


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Exclude BWC tests in platform support testing matrix (#100643)