### PR TITLE
Allow enrich_user to read/view enrich indices

### DIFF
--- a/docs/changelog/100707.yaml
+++ b/docs/changelog/100707.yaml
@@ -1,0 +1,5 @@
+pr: 100707
+summary: Allow `enrich_user` to read/view enrich indices
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -607,7 +607,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     "enrich_user",
                     new String[] { "manage_enrich", "manage_ingest_pipelines", "monitor" },
                     new RoleDescriptor.IndicesPrivileges[] {
-                        RoleDescriptor.IndicesPrivileges.builder().indices(".enrich-*").privileges("manage", "read", "write").build() },
+                        RoleDescriptor.IndicesPrivileges.builder()
+                            .indices(".enrich-*")
+                            .privileges("read", "view_index_metadata")
+                            .allowRestrictedIndices(true)
+                            .build(),
+                        RoleDescriptor.IndicesPrivileges.builder().indices(".enrich-*").privileges("manage", "write").build() },
                     null,
                     MetadataUtils.DEFAULT_RESERVED_METADATA
                 )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -3417,6 +3417,24 @@ public class ReservedRolesStoreTests extends ESTestCase {
         );
     }
 
+    public void testEnrichUserRole() {
+        final TransportRequest request = mock(TransportRequest.class);
+        final Authentication authentication = AuthenticationTestHelper.builder().build();
+
+        RoleDescriptor roleDescriptor = ReservedRolesStore.roleDescriptor("enrich_user");
+        assertNotNull(roleDescriptor);
+        assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
+
+        Role role = Role.buildFromRoleDescriptor(roleDescriptor, new FieldPermissionsCache(Settings.EMPTY), RESTRICTED_INDICES);
+        assertTrue(role.cluster().check("cluster:admin/xpack/enrich/put", request, authentication));
+        assertTrue(role.cluster().check("cluster:admin/xpack/enrich/execute", request, authentication));
+        assertTrue(role.cluster().check("cluster:admin/xpack/enrich/esql/resolve", request, authentication));
+        assertTrue(role.cluster().check("cluster:admin/xpack/enrich/esql/lookup", request, authentication));
+        assertFalse(role.runAs().check(randomAlphaOfLengthBetween(1, 30)));
+        assertFalse(role.indices().allowedIndicesMatcher(IndexAction.NAME).test(mockIndexAbstraction("foo")));
+        assertOnlyReadAllowed(role, ".enrich-foo");
+    }
+
     private IndexAbstraction mockIndexAbstraction(String name) {
         IndexAbstraction mock = mock(IndexAbstraction.class);
         when(mock.getName()).thenReturn(name);


### PR DESCRIPTION
> Error: [esql] > Unexpected error from Elasticsearch: security_exception - action [indices:data/read/esql/lookup] is unauthorized for user [guest] with effective roles [enrich_user,esql-read-role] on restricted indices [.enrich-group_lookup-1696927917972], this action is granted by the index privileges [read,all]

Currently, the enrich indices (.enrich-*) are restricted system indices managed by the enrich plugin. While the `enrich_user` should not be allowed to manage or write to these indices, they should be allowed to read and view_index_metadata. This is necessary for ESQL; otherwise, ESQL users would require broader privileges to perform enrich in ESQL.