### PR TITLE
Compute repo format version within delete/cleanup

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -313,11 +313,11 @@ class S3Repository extends MeteredBlobStoreRepository {
     }
 
     @Override
-    protected SnapshotDeleteListener wrapWithWeakConsistencyProtection(SnapshotDeleteListener snapshotDeleteListener) {
+    protected SnapshotDeleteListener wrapWithWeakConsistencyProtection(SnapshotDeleteListener listener) {
         return new SnapshotDeleteListener() {
             @Override
             public void onDone() {
-                snapshotDeleteListener.onDone();
+                listener.onDone();
             }
 
             @Override
@@ -326,7 +326,7 @@ class S3Repository extends MeteredBlobStoreRepository {
                 final Scheduler.Cancellable existing = finalizationFuture.getAndSet(threadPool.schedule(() -> {
                     final Scheduler.Cancellable cancellable = finalizationFuture.getAndSet(null);
                     assert cancellable != null;
-                    snapshotDeleteListener.onRepositoryDataWritten(repositoryData);
+                    listener.onRepositoryDataWritten(repositoryData);
                 }, coolDown, snapshotExecutor));
                 assert existing == null : "Already have an ongoing finalization " + finalizationFuture;
             }
@@ -337,7 +337,7 @@ class S3Repository extends MeteredBlobStoreRepository {
                 final Scheduler.Cancellable existing = finalizationFuture.getAndSet(threadPool.schedule(() -> {
                     final Scheduler.Cancellable cancellable = finalizationFuture.getAndSet(null);
                     assert cancellable != null;
-                    snapshotDeleteListener.onFailure(e);
+                    listener.onFailure(e);
                 }, coolDown, snapshotExecutor));
                 assert existing == null : "Already have an ongoing finalization " + finalizationFuture;
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.admin.cluster.repositories.cleanup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
@@ -213,23 +212,10 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                     public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                         startedCleanup = true;
                         logger.debug("Initialized repository cleanup in cluster state for [{}][{}]", repositoryName, repositoryStateId);
-                        // We fork here just to call SnapshotsService#minCompatibleVersion (which may be to expensive to run directly) but
-                        // BlobStoreRepository#cleanup forks again straight away. TODO reduce the forking here.
-                        threadPool.executor(ThreadPool.Names.SNAPSHOT)
-                            .execute(
-                                ActionRunnable.wrap(
-                                    delegate,
-                                    l -> blobStoreRepository.cleanup(
-                                        repositoryStateId,
-                                        SnapshotsService.minCompatibleVersion(
-                                            newState.nodes().getMaxDataNodeCompatibleIndexVersion(),
-                                            repositoryData,
-                                            null
-                                        ),
-                                        ActionListener.wrap(result -> after(null, result), e -> after(e, null))
-                                    )
-                                )
-                            );
+                        ActionListener.run(
+                            ActionListener.<RepositoryCleanupResult>wrap(result -> after(null, result), e -> after(e, null)),
+                            l -> blobStoreRepository.cleanup(repositoryStateId, newState.nodes().getMaxDataNodeCompatibleIndexVersion(), l)
+                        );
                     }
 
                     private void after(@Nullable Exception failure, @Nullable RepositoryCleanupResult result) {

--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -74,10 +74,10 @@ public class FilterRepository implements Repository {
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryFormatIndexVersion,
+        IndexVersion minimumNodeVersion,
         SnapshotDeleteListener listener
     ) {
-        in.deleteSnapshots(snapshotIds, repositoryDataGeneration, repositoryFormatIndexVersion, listener);
+        in.deleteSnapshots(snapshotIds, repositoryDataGeneration, minimumNodeVersion, listener);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/InvalidRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/InvalidRepository.java
@@ -81,7 +81,7 @@ public class InvalidRepository extends AbstractLifecycleComponent implements Rep
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryFormatIndexVersion,
+        IndexVersion minimumNodeVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(createCreationException());

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -139,13 +139,14 @@ public interface Repository extends LifecycleComponent {
      *
      * @param snapshotIds                  snapshot ids to delete
      * @param repositoryDataGeneration     the generation of the {@link RepositoryData} in the repository at the start of the deletion
-     * @param repositoryFormatIndexVersion the version of repository format to use, indicating the layout of blobs (for bwc)
+     * @param minimumNodeVersion           the minimum {@link IndexVersion} across the nodes in the cluster, with which the repository
+     *                                     format must remain compatible
      * @param listener                     completion listener, see {@link SnapshotDeleteListener}.
      */
     void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryFormatIndexVersion,
+        IndexVersion minimumNodeVersion,
         SnapshotDeleteListener listener
     );
 

--- a/server/src/main/java/org/elasticsearch/repositories/UnknownTypeRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/UnknownTypeRepository.java
@@ -79,7 +79,7 @@ public class UnknownTypeRepository extends AbstractLifecycleComponent implements
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryFormatIndexVersion,
+        IndexVersion minimumNodeVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(createUnknownTypeException());

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -896,16 +896,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         } else {
             threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
                 final var originalRootBlobs = blobContainer().listBlobs(OperationPurpose.SNAPSHOT);
+
+                // One final best-effort check for other clusters concurrently writing to the repository:
                 final var originalRepositoryData = safeRepositoryData(repositoryDataGeneration, originalRootBlobs);
-                final var repositoryFormatIndexVersion = SnapshotsService.minCompatibleVersion(
-                    minimumNodeVersion,
-                    originalRepositoryData,
-                    snapshotIds
-                );
+
                 return new SnapshotsDeletion(
                     snapshotIds,
                     repositoryDataGeneration,
-                    repositoryFormatIndexVersion,
+                    SnapshotsService.minCompatibleVersion(minimumNodeVersion, originalRepositoryData, snapshotIds),
                     originalRootBlobs,
                     blobStore().blobContainer(indicesPath()).children(OperationPurpose.SNAPSHOT),
                     originalRepositoryData

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -364,6 +364,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     threadPool.absoluteTimeInMillis(),
                     repositoryData.getGenId(),
                     minCompatibleVersion(currentState.nodes().getMaxDataNodeCompatibleIndexVersion(), repositoryData, null)
+                // NB minCompatibleVersion iterates over all the snapshots in the current repositoryData, which probably should happen on a
+                // different thread. Also is the _current_ repositoryData the right thing to consider? The minimum repository format version
+                // can only advance during a snapshot delete which today is never concurrent to other writes, but a future version may allow
+                // for more concurrency between deletes and writes that breaks some assumptions in this area.
                 );
                 return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, snapshots.withAddedEntry(newEntry)).build();
             }
@@ -3757,6 +3761,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
             final Map<String, IndexId> indexIds = repositoryData.resolveNewIndices(indices, allIndices);
             final IndexVersion version = minCompatibleVersion(
+                // NB minCompatibleVersion iterates over all the snapshots in the current repositoryData, which probably should happen on a
+                // different thread. Also is the _current_ repositoryData the right thing to consider? The minimum repository format version
+                // can only advance during a snapshot delete which today is never concurrent to other writes, but a future version may allow
+                // for more concurrency between deletes and writes that breaks some assumptions in this area.
                 currentState.nodes().getMaxDataNodeCompatibleIndexVersion(),
                 repositoryData,
                 null

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -360,7 +360,7 @@ public class RepositoriesServiceTests extends ESTestCase {
         public void deleteSnapshots(
             Collection<SnapshotId> snapshotIds,
             long repositoryDataGeneration,
-            IndexVersion repositoryFormatIndexVersion,
+            IndexVersion minimumNodeVersion,
             SnapshotDeleteListener listener
         ) {
             listener.onFailure(new UnsupportedOperationException());

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -100,7 +100,7 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryFormatIndexVersion,
+        IndexVersion minimumNodeVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(new UnsupportedOperationException());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -303,7 +303,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     public void deleteSnapshots(
         Collection<SnapshotId> snapshotIds,
         long repositoryDataGeneration,
-        IndexVersion repositoryFormatIndexVersion,
+        IndexVersion minimumNodeVersion,
         SnapshotDeleteListener listener
     ) {
         listener.onFailure(new UnsupportedOperationException("Unsupported for repository of type: " + TYPE));


### PR DESCRIPTION
Today we rely on the caller computing the appropriate repository format
version based on the nodes in the cluster and the snapshots in (some
recent copy of) the `RepositoryData`. This commit moves that computation
into `createSnapshotsDeletion` so that (a) we can be sure to use the
same `RepositoryData` used for the rest of the process, and (b) we avoid
dispatching work to the SNAPSHOT pool twice.

Relates a comment on #100657