### PR TITLE
Pass newRepositoryData to cleanupUnlinkedRootAndIndicesBlobs

### DIFF
--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.test.fixtures.hdfs.HdfsClientThreadLeakFilter;
 import java.util.Collection;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 @ThreadLeakFilters(filters = HdfsClientThreadLeakFilter.class)
@@ -55,11 +54,7 @@ public class HdfsRepositoryTests extends AbstractThirdPartyRepositoryTestCase {
 
     // HDFS repository doesn't have precise cleanup stats so we only check whether or not any blobs were removed
     @Override
-    protected void assertCleanupResponse(CleanupRepositoryResponse response, long bytes, long blobs) {
-        if (blobs > 0) {
-            assertThat(response.result().blobs(), greaterThan(0L));
-        } else {
-            assertThat(response.result().blobs(), equalTo(0L));
-        }
+    protected void assertCleanupResponse(CleanupRepositoryResponse response) {
+        assertThat(response.result().blobs(), greaterThan(0L));
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1184,9 +1184,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 updateRepositoryData(
                     originalRepositoryData,
                     releasingListener.delegateFailureAndWrap(
-                        // TODO should we pass newRepositoryData to cleanupStaleBlobs()?
                         (l, newRepositoryData) -> cleanupUnlinkedRootAndIndicesBlobs(
-                            originalRepositoryData,
+                            newRepositoryData,
                             l.map(ignored -> DeleteResult.of(blobsDeleted.get(), bytesDeleted.get()))
                         )
                     )

--- a/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
@@ -233,12 +233,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
         createDanglingIndex(repo, genericExec);
 
         logger.info("--> Execute repository cleanup");
-        final CleanupRepositoryResponse response = clusterAdmin().prepareCleanupRepository(
-            TEST_REQUEST_TIMEOUT,
-            TEST_REQUEST_TIMEOUT,
-            TEST_REPO_NAME
-        ).get();
-        assertCleanupResponse(response, 3L, 1L);
+        assertCleanupResponse(clusterAdmin().prepareCleanupRepository(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, TEST_REPO_NAME).get());
     }
 
     public void testIndexLatest() throws Exception {
@@ -416,9 +411,9 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
         }
     }
 
-    protected void assertCleanupResponse(CleanupRepositoryResponse response, long bytes, long blobs) {
-        assertThat(response.result().blobs(), equalTo(1L + 2L));
-        assertThat(response.result().bytes(), equalTo(3L + 2 * 3L));
+    protected void assertCleanupResponse(CleanupRepositoryResponse response) {
+        assertThat(response.result().blobs(), equalTo(4L));
+        assertThat(response.result().bytes(), greaterThan(9L));
     }
 
     private static void createDanglingIndex(final BlobStoreRepository repo, final Executor genericExec) throws Exception {


### PR DESCRIPTION
During cleanup these `RepositoryData` objects refer to the same
snapshots so it doesn't really matter, but for the sake of consistency
we should use the updated `RepositoryData` here.

Relates a comment on #100657