### PR TITLE
[8.10] [buildkite] Pin version of bun being used due to bug in latest (1.0.5) (#100720)

### DIFF
--- a/.buildkite/scripts/pull-request/pipeline.sh
+++ b/.buildkite/scripts/pull-request/pipeline.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo --- Installing bun
-npm install -g bun
+npm install -g bun@1.0.4
 
 echo --- Generating pipeline
 bun .buildkite/scripts/pull-request/pipeline.generate.ts


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[buildkite] Pin version of bun being used due to bug in latest (1.0.5) (#100720)](https://github.com/elastic/elasticsearch/pull/100720)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)