### PR TITLE
[ML] Fixing put inference service request hanging

### DIFF
--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/TestInferenceServicePlugin.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/TestInferenceServicePlugin.java
@@ -103,11 +103,6 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
 
         }
 
-        // @Override
-        // public String name() {
-        // return NAME;
-        // }
-
         @Override
         public TestServiceModel parseRequestConfig(
             String modelId,

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/TestInferenceServicePlugin.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/TestInferenceServicePlugin.java
@@ -42,7 +42,7 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
 
     @Override
     public List<Factory> getInferenceServiceFactories() {
-        return List.of(TestInferenceService::new);
+        return List.of(TestInferenceService::new, TestInferenceServiceClusterService::new);
     }
 
     @Override
@@ -54,9 +54,38 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
         );
     }
 
-    public static class TestInferenceService implements InferenceService {
-
+    public static class TestInferenceService extends TestInferenceServiceBase {
         private static final String NAME = "test_service";
+
+        public TestInferenceService(InferenceServiceFactoryContext context) {
+            super(context);
+        }
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+    }
+
+    public static class TestInferenceServiceClusterService extends TestInferenceServiceBase {
+        private static final String NAME = "test_service_in_cluster_service";
+
+        public TestInferenceServiceClusterService(InferenceServiceFactoryContext context) {
+            super(context);
+        }
+
+        @Override
+        public boolean isInClusterService() {
+            return true;
+        }
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+    }
+
+    public abstract static class TestInferenceServiceBase implements InferenceService {
 
         private static Map<String, Object> getTaskSettingsMap(Map<String, Object> settings) {
             Map<String, Object> taskSettingsMap;
@@ -70,14 +99,14 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
             return taskSettingsMap;
         }
 
-        public TestInferenceService(InferenceServicePlugin.InferenceServiceFactoryContext context) {
+        public TestInferenceServiceBase(InferenceServicePlugin.InferenceServiceFactoryContext context) {
 
         }
 
-        @Override
-        public String name() {
-            return NAME;
-        }
+        // @Override
+        // public String name() {
+        // return NAME;
+        // }
 
         @Override
         public TestServiceModel parseRequestConfig(
@@ -93,11 +122,11 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
             var taskSettingsMap = getTaskSettingsMap(config);
             var taskSettings = TestTaskSettings.fromMap(taskSettingsMap);
 
-            throwIfNotEmptyMap(config, NAME);
-            throwIfNotEmptyMap(serviceSettingsMap, NAME);
-            throwIfNotEmptyMap(taskSettingsMap, NAME);
+            throwIfNotEmptyMap(config, name());
+            throwIfNotEmptyMap(serviceSettingsMap, name());
+            throwIfNotEmptyMap(taskSettingsMap, name());
 
-            return new TestServiceModel(modelId, taskType, NAME, serviceSettings, taskSettings, secretSettings);
+            return new TestServiceModel(modelId, taskType, name(), serviceSettings, taskSettings, secretSettings);
         }
 
         @Override
@@ -116,7 +145,7 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
             var taskSettingsMap = getTaskSettingsMap(config);
             var taskSettings = TestTaskSettings.fromMap(taskSettingsMap);
 
-            return new TestServiceModel(modelId, taskType, NAME, serviceSettings, taskSettings, secretSettings);
+            return new TestServiceModel(modelId, taskType, name(), serviceSettings, taskSettings, secretSettings);
         }
 
         @Override
@@ -125,7 +154,7 @@ public class TestInferenceServicePlugin extends Plugin implements InferenceServi
                 case SPARSE_EMBEDDING -> listener.onResponse(TextExpansionResultsTests.createRandomResults(1, 10));
                 default -> listener.onFailure(
                     new ElasticsearchStatusException(
-                        TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), NAME),
+                        TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
                         RestStatus.BAD_REQUEST
                     )
                 );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -127,10 +127,10 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         String modelId,
         TaskType taskType,
         Map<String, Object> config,
-        Set<String> platfromArchitectures,
+        Set<String> platformArchitectures,
         ActionListener<PutInferenceModelAction.Response> listener
     ) {
-        var model = service.parseRequestConfig(modelId, taskType, config, platfromArchitectures);
+        var model = service.parseRequestConfig(modelId, taskType, config, platformArchitectures);
         // model is valid good to persist then start
         this.modelRegistry.storeModel(model, ActionListener.wrap(r -> { startModel(service, model, listener); }, listener::onFailure));
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -102,8 +102,17 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
             // information when creating the model
             MlPlatformArchitecturesUtil.getMlNodesArchitecturesSet(ActionListener.wrap(architectures -> {
                 if (architectures.isEmpty() && clusterIsInElasticCloud(clusterService.getClusterSettings())) {
-                    // In Elastic cloud ml nodes run on Linux x86
-                    architectures = Set.of("linux-x86_64");
+                    parseAndStoreModel(
+                        service.get(),
+                        request.getModelId(),
+                        request.getTaskType(),
+                        requestAsMap,
+                        // In Elastic cloud ml nodes run on Linux x86
+                        Set.of("linux-x86_64"),
+                        listener
+                    );
+                } else {
+                    // The architecture field could be an empty set, the individual services will need to handle that
                     parseAndStoreModel(service.get(), request.getModelId(), request.getTaskType(), requestAsMap, architectures, listener);
                 }
             }, listener::onFailure), client, threadPool.executor(InferencePlugin.UTILITY_THREAD_POOL_NAME));


### PR DESCRIPTION
This PR fixes an issue with the inference plugin where `listener.onResponse` wasn't being called for the elser service. The bug can be encountered when interacting with the elser service locally.

## Testing

- Download elser v2
- Do the following put request and it should succeed

```
curl --location --request PUT 'http://localhost:9200/_inference/sparse_embedding/test' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic ZWxhc3RpYzpwYXNzd29yZA==' \
--data '{
    "service": "elser_mlnode",
    "service_settings": {
        "num_allocations": 1,
        "num_threads": 1
    },
    "task_settings": {
    }
}'
```