### PR TITLE
ESQL: Release drivers and their containing operators in case of failure during setup

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -769,12 +769,20 @@ public class LocalExecutionPlanner {
 
         public List<Driver> createDrivers(String sessionId) {
             List<Driver> drivers = new ArrayList<>();
-            for (DriverFactory df : driverFactories) {
-                for (int i = 0; i < df.driverParallelism.instanceCount; i++) {
-                    drivers.add(df.driverSupplier.apply(sessionId));
+            boolean success = false;
+            try {
+                for (DriverFactory df : driverFactories) {
+                    for (int i = 0; i < df.driverParallelism.instanceCount; i++) {
+                        drivers.add(df.driverSupplier.apply(sessionId));
+                    }
+                }
+                success = true;
+                return drivers;
+            } finally {
+                if (success == false) {
+                    Releasables.close(() -> Releasables.close(drivers));
                 }
             }
-            return drivers;
         }
 
         @Override


### PR DESCRIPTION
Another small change to release previously created Drivers (and their containing operators), in the case of failure during pipeline creation.

This was spotted during the hunt to track down leaks resulting from trying to stabalize EsqlActionBreakerIT.