### PR TITLE
Add ShardRelocatedException to indicate relocation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2508,7 +2508,8 @@ public class InternalEngine extends Engine {
         } else if (translog.isOpen() == false && translog.getTragicException() != null) {
             failEngine("already closed by tragic event on the translog", translog.getTragicException());
             engineFailed = true;
-        } else if (failedEngine.get() == null && isClosed.get() == false) { // we are closed but the engine is not failed yet?
+        } else if (failedEngine.get() == null && isClosed.get() == false && ex instanceof ShardRelocatedException == false) {
+            // we are closed but the engine is not failed yet?
             // this smells like a bug - we only expect ACE if we are in a fatal case ie. either translog or IW is closed by
             // a tragic event or has closed itself. if that is not the case we are in a buggy state and raise an assertion error
             throw new AssertionError("Unexpected AlreadyClosedException", ex);

--- a/server/src/main/java/org/elasticsearch/index/engine/ShardRelocatedException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ShardRelocatedException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.engine;
+
+import org.apache.lucene.store.AlreadyClosedException;
+
+public class ShardRelocatedException extends AlreadyClosedException {
+    public ShardRelocatedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Currently the engine can throw already closed exceptions when underlying
resources are closed. Occasionally it is necessary to throw this
exception due to shard movements. This commit adds this exception for
these circumstances.