### PR TITLE
[8.11] Update doc links for the inference API (#100690)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete_model.json
@@ -1,7 +1,7 @@
 {
   "inference.delete_model":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/inference_delete_model.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html",
       "description":"Delete model in the Inference API"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get_model.json
@@ -1,7 +1,7 @@
 {
   "inference.get_model":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/inference_get_model.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-api.html",
       "description":"Get a model in the Inference API"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -1,7 +1,7 @@
 {
   "inference.inference":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/inference.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html",
       "description":"Perform inference on a model"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_model.json
@@ -1,7 +1,7 @@
 {
   "inference.put_model":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/inference_put_model.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html",
       "description":"Configure a model for use in the Inference API"
     },
     "stability":"experimental",


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Update doc links for the inference API (#100690)