### PR TITLE
Don't test broken index templates

### DIFF
--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistryTests.java
@@ -316,21 +316,18 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
         Map<String, Integer> composableTemplates = new HashMap<>();
         Map<String, LifecyclePolicy> policies = new HashMap<>();
         for (String templateName : registry.getComponentTemplateConfigs().keySet()) {
-            // outdated (or missing) version
-            componentTemplates.put(templateName, frequently() ? ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION - 1 : null);
+            // outdated version
+            componentTemplates.put(templateName, randomIntBetween(1, ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION - 1));
         }
         for (String templateName : registry.getComposableTemplateConfigs().keySet()) {
-            // outdated (or missing) version
-            composableTemplates.put(templateName, frequently() ? ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION - 1 : null);
+            // outdated version
+            composableTemplates.put(templateName, randomIntBetween(1, ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION - 1));
         }
         for (LifecyclePolicy policy : registry.getLifecyclePolicies()) {
             // make a copy as we're modifying the version mapping
             Map<String, Object> metadata = new HashMap<>(policy.getMetadata());
-            if (frequently()) {
-                metadata.put("version", ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION - 1);
-            } else {
-                metadata.remove("version");
-            }
+            // outdated version
+            metadata.put("version", randomIntBetween(1, ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION - 1));
             policies.put(policy.getName(), new LifecyclePolicy(policy.getName(), policy.getPhases(), metadata));
         }
         ClusterState clusterState = createClusterState(Settings.EMPTY, componentTemplates, composableTemplates, policies, nodes);


### PR DESCRIPTION
So far we've tested in the index template registry tests for Universal Profiling what happens on outdated resources. However, the test not only tested for outdated resources but also for completely broken ones, i.e. that the `version` property is missing. That cannot happen in practice because the plugin itself controls installation of index templates where the `version` property is always present. Hence, we don't test for this case anymore.

Closes #99943