### PR TITLE
Revert back to using DRA repository for ML artifacts on main branch

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,3 +1,6 @@
+import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
@@ -11,27 +14,42 @@ esplugin {
   extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
+def localRepo = providers.systemProperty('build.ml_cpp.repo').orNull
 if (useDra == false) {
   repositories {
     exclusiveContent {
+      filter {
+        includeGroup 'org.elasticsearch.ml'
+      }
       forRepository {
         ivy {
           name "ml-cpp"
-          url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
           metadataSources {
             // no repository metadata, look directly for the artifact
             artifact()
           }
-          patternLayout {
-            artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/[module]-[revision](-[classifier]).[ext]"
+          if (localRepo) {
+            url localRepo
+            patternLayout {
+              artifact "maven/[orgPath]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
+            }
+          } else {
+            url "https://artifacts-snapshot.elastic.co/"
+            patternLayout {
+              if (VersionProperties.isElasticsearchSnapshot()) {
+                artifact '/ml-cpp/[revision]/downloads/ml-cpp/[module]-[revision]-[classifier].[ext]'
+              } else {
+                // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
+                // Release builds are always done with a local repo.
+                artifact '/ml-cpp/[revision]-SNAPSHOT/downloads/ml-cpp/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
+              }
+            }
           }
         }
       }
-      filter {
-        includeGroup 'org.elasticsearch.ml'
-      }
     }
   }
+
 }
 
 configurations {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.internal.info.BuildParams
-
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
@@ -80,18 +78,13 @@ dependencies {
   api "org.apache.lucene:lucene-analysis-icu:${versions.lucene}"
   api "org.apache.lucene:lucene-analysis-kuromoji:${versions.lucene}"
   implementation 'org.ojalgo:ojalgo:51.2.0'
-  nativeBundle("org.elasticsearch.ml:ml-cpp:${mlCppVersion()}:deps@zip") {
+  nativeBundle("org.elasticsearch.ml:ml-cpp:${project.version}:deps@zip") {
     changing = true
   }
-  nativeBundle("org.elasticsearch.ml:ml-cpp:${mlCppVersion()}:nodeps@zip") {
+  nativeBundle("org.elasticsearch.ml:ml-cpp:${project.version}:nodeps@zip") {
     changing = true
   }
   testImplementation 'org.ini4j:ini4j:0.5.2'
-}
-
-def mlCppVersion(){
-  return (project.gradle.parent != null && BuildParams.isSnapshotBuild() == false) ?
-      (project.version + "-SNAPSHOT") : project.version;
 }
 
 artifacts {


### PR DESCRIPTION
This is a forward port of #94655.

ML artifacts are stored on both S3 and GCS. On GCS they're fronted by a CDN but on S3 they are not. About a year ago there were problems with the GCS CDN that led to many incomplete downloads. As a result the ML downloads were switched to use S3 in #92381. Those problems were supposed to be fixed about 6 months ago, and the 8.7 branch was switched back to GCS in #94655. However, the main branch was left using S3.

Now that we believe GCS is stable the benefits of having its CDN and hence fast downloads worldwide means it is best to switch back to it as the primary download location.