### PR TITLE
[ML] Remove noisy 'Could not find trained model' message

### DIFF
--- a/docs/changelog/100760.yaml
+++ b/docs/changelog/100760.yaml
@@ -1,0 +1,5 @@
+pr: 100760
+summary: Remove noisy 'Could not find trained model' message
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -750,13 +750,14 @@ public class ModelLoadingService implements ClusterStateListener {
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        // If no changes to ingest pipelines and no model alias changes, nothing to do
-        if (event.changedCustomMetadataSet().contains(IngestMetadata.TYPE) == false
-            && event.changedCustomMetadataSet().contains(ModelAliasMetadata.NAME) == false) {
+        final boolean prefetchModels = event.state().nodes().getLocalNode().isIngestNode();
+        // If we are not prefetching models and there were no model alias changes, don't bother handling the changes
+        if ((prefetchModels == false)
+            && (event.changedCustomMetadataSet().contains(IngestMetadata.TYPE) == false)
+            && (event.changedCustomMetadataSet().contains(ModelAliasMetadata.NAME) == false)) {
             return;
         }
 
-        final boolean prefetchModels = event.state().nodes().getLocalNode().isIngestNode();
         ClusterState state = event.state();
         IngestMetadata currentIngestMetadata = state.metadata().custom(IngestMetadata.TYPE);
         Set<String> allReferencedModelKeys = event.changedCustomMetadataSet().contains(IngestMetadata.TYPE)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -656,26 +656,6 @@ public class ModelLoadingServiceTests extends ESTestCase {
         assertThat(modelLoadingService.getModelId("loaded_model_again"), equalTo(model1));
     }
 
-    public void testEarlyExitOnIrrelevantClusterChangeEvent() {
-        ModelLoadingService modelLoadingService = new ModelLoadingService(
-            trainedModelProvider,
-            auditor,
-            threadPool,
-            clusterService,
-            trainedModelStatsService,
-            Settings.EMPTY,
-            "test-node",
-            circuitBreaker,
-            mock(XPackLicenseState.class)
-        );
-
-        ClusterChangedEvent event = mock(ClusterChangedEvent.class);
-        when(event.changedCustomMetadataSet()).thenReturn(Set.of());
-        modelLoadingService.clusterChanged(event);
-
-        verify(event, never()).state();
-    }
-
     @SuppressWarnings("unchecked")
     private void withTrainedModel(String modelId, long size) {
         InferenceDefinition definition = mock(InferenceDefinition.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -656,6 +656,26 @@ public class ModelLoadingServiceTests extends ESTestCase {
         assertThat(modelLoadingService.getModelId("loaded_model_again"), equalTo(model1));
     }
 
+    public void testEarlyExitOnIrrelevantClusterChangeEvent() {
+        ModelLoadingService modelLoadingService = new ModelLoadingService(
+            trainedModelProvider,
+            auditor,
+            threadPool,
+            clusterService,
+            trainedModelStatsService,
+            Settings.EMPTY,
+            "test-node",
+            circuitBreaker,
+            mock(XPackLicenseState.class)
+        );
+
+        ClusterChangedEvent event = mock(ClusterChangedEvent.class);
+        when(event.changedCustomMetadataSet()).thenReturn(Set.of());
+        modelLoadingService.clusterChanged(event);
+
+        verify(event, never()).state();
+    }
+
     @SuppressWarnings("unchecked")
     private void withTrainedModel(String modelId, long size) {
         InferenceDefinition definition = mock(InferenceDefinition.class);


### PR DESCRIPTION
[ModelLoadingService](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java) watches for the creation of ingest pipelines that use the ingest processor and pre-loads the model referenced in the new pipeline. If the model does not exist because the pipeline has been created before the model an error message is logged, this can happen quite a lot producing spurious error messages. Often this will be because a solution creates ingest pipeline referencing the ELSER model before ELSER has been downloaded.

`ModelLoadingService` only handles DFA/Boosted tree models which are loaded on ingest nodes, it does not load PyTorch/NLP models but it first has to read the model config to know what type the model is.

If is very easy to cause the error message to be logged, just create a ingest processor with an unknown model id
```
PUT _ingest/pipeline/elser
{
  "processors": [
    {
      "inference": {
        "model_id": "not-a-model",
        "field_map": {
          "body": "text_field"
        },
        "target_field": "ml"
      }
    }
  ]
}
```

And the following is logged.

```
[2023-10-12T09:45:51,528][WARN ][o.e.x.m.i.l.ModelLoadingService] [host] [not-a-model] failed to load model configurationorg.elasticsearch.ResourceNotFoundException: Could not find trained model [not-a-model]
	at org.elasticsearch.ml@8.11.0/org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider.lambda$getTrainedModel$22(TrainedModelProvider.java:670)
	at org.elasticsearch.server@8.11.0/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:177)
	at org.elasticsearch.server@8.11.0/org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:32)
	at org.elasticsearch.server@8.11.0/org.elasticsearch.client.internal.node.NodeClient$SafelyWrappedActionListener.onResponse(NodeClient.java:161)
	at org.elasticsearch.server@8.11.0/org.elasticsearch.tasks.TaskManager$1.onResponse(TaskManager.java:203)
```