### PR TITLE
[Fleet] using all privileges

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -194,10 +194,7 @@ class KibanaOwnedReservedRoleDescriptors {
                 // Fleet telemetry queries Agent Logs indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-elastic_agent*").privileges("read").build(),
                 // Fleet publishes Agent metrics in kibana task runner
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("metrics-fleet_server*")
-                    .privileges("auto_configure", "read", "write", "delete")
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("metrics-fleet_server*").privileges("all").build(),
                 // Legacy "Alerts as data" used in Security Solution.
                 // Kibana user creates these indices; reads / writes to them.
                 RoleDescriptor.IndicesPrivileges.builder().indices(ReservedRolesStore.ALERTS_LEGACY_INDEX).privileges("all").build(),


### PR DESCRIPTION
Follow up after https://github.com/elastic/elasticsearch/pull/100684

The issue with the FTR tests hasn't resolved, because I left out `delete_index` privilege. I decided to use `all` to make sure nothing else is missing.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`? yes
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. yes
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? yes
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.