### PR TITLE
Simpler shard results collection in SnapshotsDeletion

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1018,7 +1018,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
          *     Shard-level results, see {@link ShardSnapshotMetaDeleteResult}.
          * </p>
          * <p>
-         *     Writes to this list are all synchronized (via {@link #addShardDeleteResult}, and happen-before it is read so the reads need
+         *     Writes to this list are all synchronized (via {@link #addShardDeleteResult}), and happen-before it is read so the reads need
          *     no further synchronization
          * </p>
          */

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1013,6 +1013,21 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             Collection<String> blobsToDelete
         ) {}
 
+        /**
+         * <p>
+         *     Shard-level results, see {@link ShardSnapshotMetaDeleteResult}.
+         * </p>
+         * <p>
+         *     Writes to this list are all synchronized (via {@link #addShardDeleteResult}, and happen-before it is read so the reads need
+         *     no further synchronization
+         * </p>
+         */
+        private final List<ShardSnapshotMetaDeleteResult> shardDeleteResults = new ArrayList<>();
+
+        private synchronized void addShardDeleteResult(ShardSnapshotMetaDeleteResult shardDeleteResult) {
+            shardDeleteResults.add(shardDeleteResult);
+        }
+
         // ---------------------------------------------------------------------------------------------------------------------------------
         // The overall flow of execution
 
@@ -1026,8 +1041,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         private void runWithUniqueShardMetadataNaming(SnapshotDeleteListener listener) {
             // First write the new shard state metadata (with the removed snapshot) and compute deletion targets
-            final ListenableFuture<Collection<ShardSnapshotMetaDeleteResult>> writeShardMetaDataAndComputeDeletesStep =
-                new ListenableFuture<>();
+            final ListenableFuture<Void> writeShardMetaDataAndComputeDeletesStep = new ListenableFuture<>();
             writeUpdatedShardMetadataAndComputeDeletes(writeShardMetaDataAndComputeDeletesStep);
             // Once we have put the new shard-level metadata into place, we can update the repository metadata as follows:
             // 1. Remove the snapshots from the list of existing snapshots
@@ -1037,7 +1051,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             // index-${gen_uuid} will not be referenced by the existing RepositoryData and new RepositoryData is only
             // written if all shard paths have been successfully updated.
             final ListenableFuture<RepositoryData> writeUpdatedRepoDataStep = new ListenableFuture<>();
-            writeShardMetaDataAndComputeDeletesStep.addListener(ActionListener.wrap(shardDeleteResults -> {
+            writeShardMetaDataAndComputeDeletesStep.addListener(ActionListener.wrap(ignored -> {
                 final ShardGenerations.Builder builder = ShardGenerations.builder();
                 for (ShardSnapshotMetaDeleteResult newGen : shardDeleteResults) {
                     builder.put(newGen.indexId, newGen.shardId, newGen.newGeneration);
@@ -1057,7 +1071,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 // Run unreferenced blobs cleanup in parallel to shard-level snapshot deletion
                 try (var refs = new RefCountingRunnable(listener::onDone)) {
                     cleanupUnlinkedRootAndIndicesBlobs(newRepositoryData, refs.acquireListener().map(ignored -> null));
-                    cleanupUnlinkedShardLevelBlobs(writeShardMetaDataAndComputeDeletesStep.result(), refs.acquireListener());
+                    cleanupUnlinkedShardLevelBlobs(shardDeleteResults, refs.acquireListener());
                 }
             }, listener::onFailure));
         }
@@ -1082,7 +1096,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             ActionRunnable.wrap(
                                 refs.acquireListener(),
                                 l0 -> writeUpdatedShardMetadataAndComputeDeletes(
-                                    l0.delegateFailure((l, shardDeleteResults) -> cleanupUnlinkedShardLevelBlobs(shardDeleteResults, l))
+                                    l0.delegateFailure((l, ignored) -> cleanupUnlinkedShardLevelBlobs(shardDeleteResults, l))
                                 )
                             )
                         );
@@ -1122,26 +1136,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         // ---------------------------------------------------------------------------------------------------------------------------------
         // Updating the shard-level metadata and accumulating results
 
-        // updates the shard state metadata for shards of a snapshot that is to be deleted. Also computes the files to be cleaned up.
-        private void writeUpdatedShardMetadataAndComputeDeletes(
-            ActionListener<Collection<ShardSnapshotMetaDeleteResult>> onAllShardsCompleted
-        ) {
-
-            final List<IndexId> indices = originalRepositoryData.indicesToUpdateAfterRemovingSnapshot(snapshotIds);
-
-            if (indices.isEmpty()) {
-                onAllShardsCompleted.onResponse(Collections.emptyList());
-                return;
-            }
-
-            // Listener that flattens out the delete results for each index
-            final ActionListener<Collection<ShardSnapshotMetaDeleteResult>> deleteIndexMetadataListener = new GroupedActionListener<>(
-                indices.size(),
-                onAllShardsCompleted.map(res -> res.stream().flatMap(Collection::stream).toList())
-            );
-
-            for (IndexId indexId : indices) {
-                new IndexSnapshotsDeletion(indexId).run(deleteIndexMetadataListener);
+        private void writeUpdatedShardMetadataAndComputeDeletes(ActionListener<Void> listener) {
+            try (var listeners = new RefCountingListener(listener)) {
+                for (IndexId indexId : originalRepositoryData.indicesToUpdateAfterRemovingSnapshot(snapshotIds)) {
+                    new IndexSnapshotsDeletion(indexId).run(listeners.acquire());
+                }
             }
         }
 
@@ -1163,8 +1162,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 shardCount = Math.max(shardCount, newShardCount);
             }
 
-            void run(ActionListener<Collection<ShardSnapshotMetaDeleteResult>> shardResultsListener) {
-                determineShardCount(shardResultsListener.delegateFailureAndWrap((l, v) -> processShards(l)));
+            void run(ActionListener<Void> listener) {
+                determineShardCount(listener.delegateFailureAndWrap((l, v) -> processShards(l)));
             }
 
             // -----------------------------------------------------------------------------------------------------------------------------
@@ -1203,14 +1202,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 }
             }
 
-            private void processShards(ActionListener<Collection<ShardSnapshotMetaDeleteResult>> listener) {
+            private void processShards(ActionListener<Void> listener) {
                 final Set<SnapshotId> survivingSnapshots = snapshotsWithIndex.stream()
                     .filter(id -> snapshotIds.contains(id) == false)
                     .collect(Collectors.toSet());
-                // Listener for collecting the results of removing the snapshot from each shard's metadata in the current index
-                final ActionListener<ShardSnapshotMetaDeleteResult> allShardsListener = new GroupedActionListener<>(shardCount, listener);
-                for (int shardId = 0; shardId < shardCount; shardId++) {
-                    snapshotExecutor.execute(new ShardSnapshotsDeletion(shardId, survivingSnapshots, allShardsListener));
+                try (var listeners = new RefCountingListener(listener)) {
+                    for (int shardId = 0; shardId < shardCount; shardId++) {
+                        snapshotExecutor.execute(new ShardSnapshotsDeletion(shardId, survivingSnapshots, listeners.acquire()));
+                    }
                 }
             }
 
@@ -1221,20 +1220,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
                 private final int shardId;
                 private final Set<SnapshotId> survivingSnapshots;
-                private final ActionListener<ShardSnapshotMetaDeleteResult> allShardsListener;
+                private final ActionListener<Void> listener;
 
                 // Computed at the start of doRun(), after forking, rather than in the constructor. TODO make these local variables perhaps?
                 private BlobContainer shardContainer;
                 private Set<String> originalShardBlobs;
 
-                ShardSnapshotsDeletion(
-                    int shardId,
-                    Set<SnapshotId> survivingSnapshots,
-                    ActionListener<ShardSnapshotMetaDeleteResult> allShardsListener
-                ) {
+                ShardSnapshotsDeletion(int shardId, Set<SnapshotId> survivingSnapshots, ActionListener<Void> listener) {
                     this.shardId = shardId;
                     this.survivingSnapshots = survivingSnapshots;
-                    this.allShardsListener = allShardsListener;
+                    this.listener = listener;
                 }
 
                 @Override
@@ -1258,7 +1253,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         newGen = tuple.v2() + 1;
                         blobStoreIndexShardSnapshots = tuple.v1();
                     }
-                    allShardsListener.onResponse(
+                    addShardDeleteResult(
                         deleteFromShardSnapshotMeta(blobStoreIndexShardSnapshots.withRetainedSnapshots(survivingSnapshots), newGen)
                     );
                 }
@@ -1342,13 +1337,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
                 @Override
                 public void onFailure(Exception ex) {
+                    // TODO: Should we fail the delete here? See https://github.com/elastic/elasticsearch/issues/100569.
                     logger.warn(
                         () -> format("%s failed to delete shard data for shard [%s][%s]", snapshotIds, indexId.getName(), shardId),
                         ex
                     );
-                    // Just passing null here to count down the listener instead of failing it, the stale data left behind
-                    // here will be retried in the next delete or repository cleanup
-                    allShardsListener.onResponse(null);
+                }
+
+                @Override
+                public void onAfter() {
+                    listener.onResponse(null);
                 }
             }
         }


### PR DESCRIPTION
No need for a `GroupedActionListener` to build a list of all the shard
results per index, which are then copied them to another list, stored in
another per-index `GroupedActionListener`, copied again, and finally
concatenated into the final list. This commit computes the resulting
list directly.