### PR TITLE
Enable additional logging

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
@@ -52,7 +52,7 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
         );
         internalCluster().setDisruptionScheme(networkDisruption);
 
-        logger.debug("--> updating cluster settings");
+        logger.info("--> updating cluster settings");
         var future = client(masterNode).admin()
             .cluster()
             .prepareUpdateSettings()
@@ -60,18 +60,18 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
             .setMasterNodeTimeout(TimeValue.timeValueMillis(10L))
             .execute();
 
-        logger.debug("--> waiting for cluster state update to be blocked");
-        BlockingClusterSettingTestPlugin.blockLatch.await();
+        logger.info("--> waiting for cluster state update to be blocked");
+        safeAwait(BlockingClusterSettingTestPlugin.blockLatch);
 
-        logger.debug("--> isolating master eligible node [{}] from other nodes", blockedNode);
+        logger.info("--> isolating master eligible node [{}] from other nodes", blockedNode);
         networkDisruption.startDisrupting();
 
-        logger.debug("--> unblocking cluster state update");
+        logger.info("--> unblocking cluster state update");
         BlockingClusterSettingTestPlugin.releaseLatch.countDown();
 
         assertThat("--> cluster settings update should not be acknowledged", future.get().isAcknowledged(), equalTo(false));
 
-        logger.debug("--> stop network disruption");
+        logger.info("--> stop network disruption");
         networkDisruption.stopDisrupting();
         ensureStableCluster(3);
     }
@@ -86,11 +86,13 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
 
         public static final Setting<Boolean> TEST_BLOCKING_SETTING = Setting.boolSetting("cluster.test.blocking_setting", false, value -> {
             if (blockOnce.compareAndSet(false, true)) {
-                logger.debug("--> setting validation is now blocking cluster state update");
+                logger.info("--> setting validation is now blocking cluster state update");
                 blockLatch.countDown();
-                logger.debug("--> setting validation is now waiting for release");
+                logger.info("--> setting validation is now waiting for release");
                 safeAwait(releaseLatch);
-                logger.debug("--> setting validation is done");
+                logger.info("--> setting validation is done");
+            } else {
+                logger.info("--> setting validation was blocked before");
             }
         }, Setting.Property.NodeScope, Setting.Property.Dynamic);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.NetworkDisruption;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.Collection;
@@ -36,6 +37,10 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
         return List.of(BlockingClusterSettingTestPlugin.class, MockTransportService.TestPlugin.class);
     }
 
+    @TestLogging(
+        reason = "https://github.com/elastic/elasticsearch/issues/98918",
+        value = "org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction:TRACE"
+    )
     public void testClusterSettingsUpdateNotAcknowledged() throws Exception {
         final var nodes = internalCluster().startMasterOnlyNodes(3);
         final String masterNode = internalCluster().getMasterName();


### PR DESCRIPTION
This change enables additional logging for
testClusterSettingsUpdateNotAcknowledged and makes sure the wait time is bound.

Related to: #98918 