### PR TITLE
[8.11] [ML] Remove noisy 'Could not find trained model' message (#100760)

### DIFF
--- a/docs/changelog/100760.yaml
+++ b/docs/changelog/100760.yaml
@@ -1,0 +1,5 @@
+pr: 100760
+summary: Remove noisy 'Could not find trained model' message
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -491,7 +491,12 @@ public class ModelLoadingService implements ClusterStateListener {
                 handleLoadFailure(modelId, failure);
             }));
         }, failure -> {
-            logger.warn(() -> "[" + modelId + "] failed to load model configuration", failure);
+            if (consumer != Consumer.PIPELINE) {
+                // The model loading was triggered by an ingest pipeline change
+                // referencing a model that cannot be found. This is not an error
+                // as the model may be put later
+                logger.warn(() -> "[" + modelId + "] failed to load model configuration ", failure);
+            }
             handleLoadFailure(modelId, failure);
         }));
     }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [ML] Remove noisy 'Could not find trained model' message (#100760)