### PR TITLE
Fix NullPointerException in RotableSecret

### DIFF
--- a/docs/changelog/100779.yaml
+++ b/docs/changelog/100779.yaml
@@ -1,5 +1,5 @@
 pr: 100779
-summary: Fix bugs causing `RotatableSecretTests#testBasicRotation` to fail
+summary: Fix NullPointerException in RotableSecret
 area: Security
 type: bug
 issues:

--- a/docs/changelog/100779.yaml
+++ b/docs/changelog/100779.yaml
@@ -1,0 +1,6 @@
+pr: 100779
+summary: Fix bugs causing `RotatableSecretTests#testBasicRotation` to fail
+area: Security
+type: bug
+issues:
+ - 99759

--- a/server/src/test/java/org/elasticsearch/common/settings/RotatableSecretTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/RotatableSecretTests.java
@@ -27,7 +27,6 @@ public class RotatableSecretTests extends ESTestCase {
     private final SecureString secret2 = new SecureString(randomAlphaOfLength(10));
     private final SecureString secret3 = new SecureString(randomAlphaOfLength(10));
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99759")
     public void testBasicRotation() throws Exception {
         // initial state
         RotatableSecret rotatableSecret = new RotatableSecret(secret1);


### PR DESCRIPTION
This commit fixes two things:
1) `RotatableSecret#matches` could throw a `NullPointerException` when the current secret is null but the prior secret is not. 
2) `RotatableSecret#checkExpired` would not expire a prior secret when checking the same millisecond the prior secret was due to expire.

Both of these would cause intermittent test failures, the first based on randomization and the second based on timing.

Fixes #99759