### PR TITLE
[8.11] ESQL: Copy blocks on expand (#100778)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.stream.IntStream;
 
 /**
  * Block implementation that stores an array of boolean.
@@ -83,12 +82,21 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
         if (firstValueIndexes == null) {
             return this;
         }
-        int end = firstValueIndexes[getPositionCount()];
-        if (nullsMask == null) {
-            return new BooleanArrayVector(values, end).asBlock();
+        // TODO use reference counting to share the values
+        try (var builder = blockFactory.newBooleanBlockBuilder(firstValueIndexes[getPositionCount()])) {
+            for (int pos = 0; pos < getPositionCount(); pos++) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int first = getFirstValueIndex(pos);
+                int end = first + getValueCount(pos);
+                for (int i = first; i < end; i++) {
+                    builder.appendBoolean(getBoolean(i));
+                }
+            }
+            return builder.mvOrdering(MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING).build();
         }
-        int[] firstValues = IntStream.range(0, end + 1).toArray();
-        return new BooleanArrayBlock(values, end, firstValues, shiftNullsToExpandedPositions(), MvOrdering.UNORDERED, blockFactory);
     }
 
     public static long ramBytesEstimated(boolean[] values, int[] firstValueIndexes, BitSet nullsMask) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
 import java.util.BitSet;
-import java.util.stream.IntStream;
 
 /**
  * Block implementation that stores an array of BytesRef.
@@ -86,12 +85,22 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
         if (firstValueIndexes == null) {
             return this;
         }
-        int end = firstValueIndexes[getPositionCount()];
-        if (nullsMask == null) {
-            return new BytesRefArrayVector(values, end).asBlock();
+        // TODO use reference counting to share the values
+        final BytesRef scratch = new BytesRef();
+        try (var builder = blockFactory.newBytesRefBlockBuilder(firstValueIndexes[getPositionCount()])) {
+            for (int pos = 0; pos < getPositionCount(); pos++) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int first = getFirstValueIndex(pos);
+                int end = first + getValueCount(pos);
+                for (int i = first; i < end; i++) {
+                    builder.appendBytesRef(getBytesRef(i, scratch));
+                }
+            }
+            return builder.mvOrdering(MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING).build();
         }
-        int[] firstValues = IntStream.range(0, end + 1).toArray();
-        return new BytesRefArrayBlock(values, end, firstValues, shiftNullsToExpandedPositions(), MvOrdering.UNORDERED, blockFactory);
     }
 
     public static long ramBytesEstimated(BytesRefArray values, int[] firstValueIndexes, BitSet nullsMask) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.stream.IntStream;
 
 /**
  * Block implementation that stores an array of double.
@@ -83,12 +82,21 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
         if (firstValueIndexes == null) {
             return this;
         }
-        int end = firstValueIndexes[getPositionCount()];
-        if (nullsMask == null) {
-            return new DoubleArrayVector(values, end).asBlock();
+        // TODO use reference counting to share the values
+        try (var builder = blockFactory.newDoubleBlockBuilder(firstValueIndexes[getPositionCount()])) {
+            for (int pos = 0; pos < getPositionCount(); pos++) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int first = getFirstValueIndex(pos);
+                int end = first + getValueCount(pos);
+                for (int i = first; i < end; i++) {
+                    builder.appendDouble(getDouble(i));
+                }
+            }
+            return builder.mvOrdering(MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING).build();
         }
-        int[] firstValues = IntStream.range(0, end + 1).toArray();
-        return new DoubleArrayBlock(values, end, firstValues, shiftNullsToExpandedPositions(), MvOrdering.UNORDERED, blockFactory);
     }
 
     public static long ramBytesEstimated(double[] values, int[] firstValueIndexes, BitSet nullsMask) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.stream.IntStream;
 
 /**
  * Block implementation that stores an array of int.
@@ -83,12 +82,21 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
         if (firstValueIndexes == null) {
             return this;
         }
-        int end = firstValueIndexes[getPositionCount()];
-        if (nullsMask == null) {
-            return new IntArrayVector(values, end).asBlock();
+        // TODO use reference counting to share the values
+        try (var builder = blockFactory.newIntBlockBuilder(firstValueIndexes[getPositionCount()])) {
+            for (int pos = 0; pos < getPositionCount(); pos++) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int first = getFirstValueIndex(pos);
+                int end = first + getValueCount(pos);
+                for (int i = first; i < end; i++) {
+                    builder.appendInt(getInt(i));
+                }
+            }
+            return builder.mvOrdering(MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING).build();
         }
-        int[] firstValues = IntStream.range(0, end + 1).toArray();
-        return new IntArrayBlock(values, end, firstValues, shiftNullsToExpandedPositions(), MvOrdering.UNORDERED, blockFactory);
     }
 
     public static long ramBytesEstimated(int[] values, int[] firstValueIndexes, BitSet nullsMask) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.stream.IntStream;
 
 /**
  * Block implementation that stores an array of long.
@@ -83,12 +82,21 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
         if (firstValueIndexes == null) {
             return this;
         }
-        int end = firstValueIndexes[getPositionCount()];
-        if (nullsMask == null) {
-            return new LongArrayVector(values, end).asBlock();
+        // TODO use reference counting to share the values
+        try (var builder = blockFactory.newLongBlockBuilder(firstValueIndexes[getPositionCount()])) {
+            for (int pos = 0; pos < getPositionCount(); pos++) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int first = getFirstValueIndex(pos);
+                int end = first + getValueCount(pos);
+                for (int i = first; i < end; i++) {
+                    builder.appendLong(getLong(i));
+                }
+            }
+            return builder.mvOrdering(MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING).build();
         }
-        int[] firstValues = IntStream.range(0, end + 1).toArray();
-        return new LongArrayBlock(values, end, firstValues, shiftNullsToExpandedPositions(), MvOrdering.UNORDERED, blockFactory);
     }
 
     public static long ramBytesEstimated(long[] values, int[] firstValueIndexes, BitSet nullsMask) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -19,7 +19,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import java.util.Arrays;
 $endif$
 import java.util.BitSet;
-import java.util.stream.IntStream;
 
 /**
  * Block implementation that stores an array of $type$.
@@ -69,9 +68,9 @@ $endif$
 
     @Override
     public $Type$Block filter(int... positions) {
-    $if(BytesRef)$
+$if(BytesRef)$
         final BytesRef scratch = new BytesRef();
-    $endif$
+$endif$
         try (var builder = blockFactory.new$Type$BlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
@@ -104,12 +103,28 @@ $endif$
         if (firstValueIndexes == null) {
             return this;
         }
-        int end = firstValueIndexes[getPositionCount()];
-        if (nullsMask == null) {
-            return new $Type$ArrayVector(values, end).asBlock();
+        // TODO use reference counting to share the values
+$if(BytesRef)$
+        final BytesRef scratch = new BytesRef();
+$endif$
+        try (var builder = blockFactory.new$Type$BlockBuilder(firstValueIndexes[getPositionCount()])) {
+            for (int pos = 0; pos < getPositionCount(); pos++) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int first = getFirstValueIndex(pos);
+                int end = first + getValueCount(pos);
+                for (int i = first; i < end; i++) {
+$if(BytesRef)$
+                    builder.append$Type$(get$Type$(i, scratch));
+$else$
+                    builder.append$Type$(get$Type$(i));
+$endif$
+                }
+            }
+            return builder.mvOrdering(MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING).build();
         }
-        int[] firstValues = IntStream.range(0, end + 1).toArray();
-        return new $Type$ArrayBlock(values, end, firstValues, shiftNullsToExpandedPositions(), MvOrdering.UNORDERED, blockFactory);
     }
 
     public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int[] firstValueIndexes, BitSet nullsMask) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -11,7 +11,14 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,20 +52,23 @@ public class BlockMultiValuedTests extends ESTestCase {
 
     public void testMultiValued() {
         int positionCount = randomIntBetween(1, 16 * 1024);
-        var b = BasicBlockTests.randomBlock(elementType, positionCount, nullAllowed, 0, 10, 0, 0);
+        var b = BasicBlockTests.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 10, 0, 0);
+        try {
+            assertThat(b.block().getPositionCount(), equalTo(positionCount));
+            assertThat(b.block().getTotalValueCount(), equalTo(b.valueCount()));
+            for (int p = 0; p < positionCount; p++) {
+                BlockTestUtils.assertPositionValues(b.block(), p, equalTo(b.values().get(p)));
+            }
 
-        assertThat(b.block().getPositionCount(), equalTo(positionCount));
-        assertThat(b.block().getTotalValueCount(), equalTo(b.valueCount()));
-        for (int p = 0; p < positionCount; p++) {
-            BlockTestUtils.assertPositionValues(b.block(), p, equalTo(b.values().get(p)));
+            assertThat(b.block().mayHaveMultivaluedFields(), equalTo(b.values().stream().anyMatch(l -> l != null && l.size() > 1)));
+        } finally {
+            b.block().close();
         }
-
-        assertThat(b.block().mayHaveMultivaluedFields(), equalTo(b.values().stream().anyMatch(l -> l != null && l.size() > 1)));
     }
 
     public void testExpand() {
         int positionCount = randomIntBetween(1, 16 * 1024);
-        var b = BasicBlockTests.randomBlock(elementType, positionCount, nullAllowed, 0, 100, 0, 0);
+        var b = BasicBlockTests.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 100, 0, 0);
         assertExpanded(b.block());
     }
 
@@ -96,31 +106,37 @@ public class BlockMultiValuedTests extends ESTestCase {
 
     private void assertFiltered(boolean all, boolean shuffled) {
         int positionCount = randomIntBetween(1, 16 * 1024);
-        var b = BasicBlockTests.randomBlock(elementType, positionCount, nullAllowed, 0, 10, 0, 0);
-        int[] positions = randomFilterPositions(b.block(), all, shuffled);
-        Block filtered = b.block().filter(positions);
+        var b = BasicBlockTests.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 10, 0, 0);
+        try {
+            int[] positions = randomFilterPositions(b.block(), all, shuffled);
+            Block filtered = b.block().filter(positions);
+            try {
+                assertThat(filtered.getPositionCount(), equalTo(positions.length));
 
-        assertThat(filtered.getPositionCount(), equalTo(positions.length));
-
-        int expectedValueCount = 0;
-        for (int p : positions) {
-            List<Object> values = b.values().get(p);
-            if (values != null) {
-                expectedValueCount += values.size();
+                int expectedValueCount = 0;
+                for (int p : positions) {
+                    List<Object> values = b.values().get(p);
+                    if (values != null) {
+                        expectedValueCount += values.size();
+                    }
+                }
+                assertThat(filtered.getTotalValueCount(), equalTo(expectedValueCount));
+                for (int r = 0; r < positions.length; r++) {
+                    if (b.values().get(positions[r]) == null) {
+                        assertThat(filtered.getValueCount(r), equalTo(0));
+                        assertThat(filtered.isNull(r), equalTo(true));
+                    } else {
+                        assertThat(filtered.getValueCount(r), equalTo(b.values().get(positions[r]).size()));
+                        assertThat(BasicBlockTests.valuesAtPositions(filtered, r, r + 1).get(0), equalTo(b.values().get(positions[r])));
+                    }
+                }
+            } finally {
+                filtered.close();
             }
+            assertThat(b.block().mayHaveMultivaluedFields(), equalTo(b.values().stream().anyMatch(l -> l != null && l.size() > 1)));
+        } finally {
+            b.block().close();
         }
-        assertThat(filtered.getTotalValueCount(), equalTo(expectedValueCount));
-        for (int r = 0; r < positions.length; r++) {
-            if (b.values().get(positions[r]) == null) {
-                assertThat(filtered.getValueCount(r), equalTo(0));
-                assertThat(filtered.isNull(r), equalTo(true));
-            } else {
-                assertThat(filtered.getValueCount(r), equalTo(b.values().get(positions[r]).size()));
-                assertThat(BasicBlockTests.valuesAtPositions(filtered, r, r + 1).get(0), equalTo(b.values().get(positions[r])));
-            }
-        }
-
-        assertThat(b.block().mayHaveMultivaluedFields(), equalTo(b.values().stream().anyMatch(l -> l != null && l.size() > 1)));
     }
 
     private int[] randomFilterPositions(Block orig, boolean all, boolean shuffled) {
@@ -135,30 +151,65 @@ public class BlockMultiValuedTests extends ESTestCase {
     }
 
     private void assertExpanded(Block orig) {
-        Block expanded = orig.expand();
-        assertThat(expanded.getPositionCount(), equalTo(orig.getTotalValueCount() + orig.nullValuesCount()));
-        assertThat(expanded.getTotalValueCount(), equalTo(orig.getTotalValueCount()));
+        try (orig; Block expanded = orig.expand()) {
+            assertThat(expanded.getPositionCount(), equalTo(orig.getTotalValueCount() + orig.nullValuesCount()));
+            assertThat(expanded.getTotalValueCount(), equalTo(orig.getTotalValueCount()));
 
-        int np = 0;
-        for (int op = 0; op < orig.getPositionCount(); op++) {
-            if (orig.isNull(op)) {
-                assertThat(expanded.isNull(np), equalTo(true));
-                assertThat(expanded.getValueCount(np++), equalTo(0));
-                continue;
-            }
-            List<Object> oValues = BasicBlockTests.valuesAtPositions(orig, op, op + 1).get(0);
-            for (Object ov : oValues) {
-                assertThat(expanded.isNull(np), equalTo(false));
-                assertThat(expanded.getValueCount(np), equalTo(1));
-                assertThat(BasicBlockTests.valuesAtPositions(expanded, np, ++np).get(0), equalTo(List.of(ov)));
+            int np = 0;
+            for (int op = 0; op < orig.getPositionCount(); op++) {
+                if (orig.isNull(op)) {
+                    assertThat(expanded.isNull(np), equalTo(true));
+                    assertThat(expanded.getValueCount(np++), equalTo(0));
+                    continue;
+                }
+                List<Object> oValues = BasicBlockTests.valuesAtPositions(orig, op, op + 1).get(0);
+                for (Object ov : oValues) {
+                    assertThat(expanded.isNull(np), equalTo(false));
+                    assertThat(expanded.getValueCount(np), equalTo(1));
+                    assertThat(BasicBlockTests.valuesAtPositions(expanded, np, ++np).get(0), equalTo(List.of(ov)));
+                }
             }
         }
     }
 
     private void assertFilteredThenExpanded(boolean all, boolean shuffled) {
         int positionCount = randomIntBetween(1, 16 * 1024);
-        var b = BasicBlockTests.randomBlock(elementType, positionCount, nullAllowed, 0, 10, 0, 0);
-        int[] positions = randomFilterPositions(b.block(), all, shuffled);
-        assertExpanded(b.block().filter(positions));
+        var b = BasicBlockTests.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 10, 0, 0);
+        try {
+            int[] positions = randomFilterPositions(b.block(), all, shuffled);
+            assertExpanded(b.block().filter(positions));
+        } finally {
+            b.block().close();
+        }
+    }
+
+    private final List<CircuitBreaker> breakers = new ArrayList<>();
+    private final List<BlockFactory> blockFactories = new ArrayList<>();
+
+    /**
+     * A {@link DriverContext} with a breaking {@link BigArrays} and {@link BlockFactory}.
+     */
+    protected BlockFactory blockFactory() { // TODO move this to driverContext once everyone supports breaking
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        breakers.add(breaker);
+        BlockFactory factory = new MockBlockFactory(breaker, bigArrays);
+        blockFactories.add(factory);
+        return factory;
+    }
+
+    @After
+    public void allBreakersEmpty() throws Exception {
+        // first check that all big arrays are released, which can affect breakers
+        MockBigArrays.ensureAllArraysAreReleased();
+
+        for (CircuitBreaker breaker : breakers) {
+            for (var factory : blockFactories) {
+                if (factory instanceof MockBlockFactory mockBlockFactory) {
+                    mockBlockFactory.ensureAllBlocksAreReleased();
+                }
+            }
+            assertThat("Unexpected used in breaker: " + breaker, breaker.getUsed(), equalTo(0L));
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
@@ -40,8 +40,8 @@ public class MvExpandOperatorTests extends OperatorTestCase {
             protected Page createPage(int positionOffset, int length) {
                 idx += length;
                 return new Page(
-                    randomBlock(ElementType.INT, length, true, 1, 10, 0, 0).block(),
-                    randomBlock(ElementType.INT, length, false, 1, 10, 0, 0).block()
+                    randomBlock(blockFactory, ElementType.INT, length, true, 1, 10, 0, 0).block(),
+                    randomBlock(blockFactory, ElementType.INT, length, false, 1, 10, 0, 0).block()
                 );
             }
         };
@@ -256,5 +256,10 @@ public class MvExpandOperatorTests extends OperatorTestCase {
         List<Page> origInput = deepCopyOf(input, BlockFactory.getNonBreakingInstance());
         List<Page> results = drive(new MvExpandOperator(0, randomIntBetween(1, 1000)), input.iterator(), context);
         assertSimpleOutput(origInput, results);
+    }
+
+    @Override
+    protected DriverContext driverContext() {
+        return breakingDriverContext();
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/OperatorTestCase.java
@@ -129,17 +129,17 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
         BlockFactory blockFactory = BlockFactory.getInstance(cranky.getBreaker(CircuitBreaker.REQUEST), bigArrays);
         DriverContext driverContext = new DriverContext(bigArrays, blockFactory);
 
-        boolean[] driverStarted = new boolean[1];
+        boolean driverStarted = false;
         try {
             Operator operator = simple(bigArrays).get(driverContext);
-            driverStarted[0] = true;
-            List<Page> result = drive(operator, input.iterator(), driverContext);
+            driverStarted = true;
+            drive(operator, input.iterator(), driverContext);
             // Either we get lucky and cranky doesn't throw and the test completes or we don't and it throws
         } catch (CircuitBreakingException e) {
             logger.info("broken", e);
             assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
         }
-        if (driverStarted[0] == false) {
+        if (driverStarted == false) {
             // if drive hasn't even started then we need to release the input pages
             Releasables.closeExpectNoException(Releasables.wrap(() -> Iterators.map(input.iterator(), p -> p::releaseBlocks)));
         }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Copy blocks on expand (#100778)