### PR TITLE
Fix manage/monitor_enrich documentation

### DIFF
--- a/docs/reference/security/authorization/built-in-roles.asciidoc
+++ b/docs/reference/security/authorization/built-in-roles.asciidoc
@@ -141,11 +141,6 @@ read access to the `.ml-notifications` and `.ml-anomalies*` indices
 {ml-cap} users also need index privileges for source and destination
 indices and roles that grant access to {kib}. See {ml-docs-setup-privileges}.
 
-[[built-in-roles-manage-enrich]] `manage_enrich`::
-Grants privileges to access and use all of the {ref}/enrich-apis.html[enrich APIs].
-Users with this role can manage enrich policies that add data from your existing 
-indices to incoming documents during ingest.
-
 [[built-in-roles-monitoring-user]] `monitoring_user`::
 Grants the minimum privileges required for any user of {monitoring} other than those
 required to use {kib}. This role grants access to the monitoring indices and grants
@@ -171,10 +166,10 @@ Reporting users should also be assigned additional roles that grant
 access to the <<roles-indices-priv,indices>> that will be used to generate reports.
 
 [[built-in-roles-rollup-admin]] `rollup_admin`::
-Grants `manage_rollup` cluster privileges, which enable you to manage and execute all rollup actions. 
+Grants `manage_rollup` cluster privileges, which enable you to manage and execute all rollup actions.
 
 [[built-in-roles-rollup-user]] `rollup_user`::
-Grants `monitor_rollup` cluster privileges, which enable you to perform read-only operations related to rollups. 
+Grants `monitor_rollup` cluster privileges, which enable you to perform read-only operations related to rollups.
 
 [[built-in-roles-snapshot-user]] `snapshot_user`::
 Grants the necessary privileges to create snapshots of **all** the indices and

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -79,6 +79,11 @@ patterns. It also includes the authority to grant the privileges necessary to
 manage follower indices and auto-follow patterns. This privilege is necessary
 only on clusters that contain follower indices.
 
+`manage_enrich`::
+Grants access and use all of the {ref}/enrich-apis.html[enrich APIs].
+Users with this privilege can manage enrich policies that add data from your existing
+indices to incoming documents during ingest.
+
 `manage_ilm`::
 All {Ilm} operations related to managing policies.
 

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -79,11 +79,6 @@ patterns. It also includes the authority to grant the privileges necessary to
 manage follower indices and auto-follow patterns. This privilege is necessary
 only on clusters that contain follower indices.
 
-`manage_enrich`::
-Grants access and use all of the {ref}/enrich-apis.html[enrich APIs].
-Users with this privilege can manage enrich policies that add data from your existing
-indices to incoming documents during ingest.
-
 `manage_ilm`::
 All {Ilm} operations related to managing policies.
 
@@ -190,6 +185,9 @@ security roles of the user who created or updated them.
 `monitor`::
 All cluster read-only operations, like cluster health and state, hot threads,
 node info, node and cluster stats, and pending cluster tasks.
+
+`monitor_enrich`::
+All read-only operations related to managing and executing enrich policies.
 
 `monitor_ml`::
 All read-only {ml} operations, such as getting information about {dfeeds}, jobs,


### PR DESCRIPTION
`manage_enrich` is a cluster privilege, not a built in role. This commit remove `manage_enrich` from the role documentation. 
`manage_enrich` is already documented as a cluster privilege. 
This commit also makes mention of the `monitor_enrich` introduced in https://github.com/elastic/elasticsearch/pull/99646.

related: https://github.com/elastic/elasticsearch/pull/85877