### PR TITLE
[8.10] Disable BWC tests in encryption at rest CI job (#100784)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -2,7 +2,7 @@ steps:
   - group: platform-support-unix
     steps:
       - label: "{{matrix.image}} / platform-support-unix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true platformSupportTests
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true functionalTests
         timeout_in_minutes: 420
         matrix:
           setup:

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
@@ -33,4 +33,4 @@
           ln -s "$PWD" "$WORKSPACE"
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
-          $WORKSPACE/.ci/scripts/run-gradle.sh -Dbwc.checkout.align=true check
+          $WORKSPACE/.ci/scripts/run-gradle.sh -Dbwc.checkout.align=true functionalTests

--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ if (bwc_tests_enabled == false) {
   println "See ${bwc_tests_disabled_issue}"
   println "==========================================================="
 }
-if (project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'platformSupportTests' }) {
+if (project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'functionalTests' }) {
   // Disable BWC tests for checkPart* tasks and platform support tests as it's expected that this will run on it's own check
   bwc_tests_enabled = false
 }
@@ -255,7 +255,7 @@ allprojects {
       tasks.register('checkPart1') { dependsOn 'check' }
     }
 
-    tasks.register('platformSupportTests') { dependsOn 'check'}
+    tasks.register('functionalTests') { dependsOn 'check'}
   }
 
   /*


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Disable BWC tests in encryption at rest CI job (#100784)