### PR TITLE
Avoid eagerly creating spotless task in esql:compute project

### DIFF
--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -19,7 +19,7 @@ tasks.named('checkstyleMain').configure {
   excludes = [ "**/*.java.st" ]
 }
 
-spotlessJava.dependsOn stringTemplates
+tasks.named("spotlessJava") { dependsOn stringTemplates }
 
 spotless {
   java {


### PR DESCRIPTION
Turns out creating spotless tasks is actually quite costly. It requires reaching out to public P2 repositories and eagerly resolving dependencies. We should avoid doing so by using lazy-task configuration APIs here.

Closes https://github.com/elastic/elasticsearch/issues/100753