### PR TITLE
Increase security test timeout to 30s

### DIFF
--- a/x-pack/plugin/security/qa/basic-enable-security/src/javaRestTest/java/org/elasticsearch/xpack/security/EnableSecurityOnBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/basic-enable-security/src/javaRestTest/java/org/elasticsearch/xpack/security/EnableSecurityOnBasicLicenseIT.java
@@ -10,7 +10,6 @@ import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
 
 import org.apache.http.HttpHost;
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -36,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 @TestCaseOrdering(AnnotationTestOrdering.class)
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97487")
 public class EnableSecurityOnBasicLicenseIT extends ESRestTestCase {
     private static MutableSettingsProvider clusterSettings = new MutableSettingsProvider() {
         {
@@ -171,7 +170,7 @@ public class EnableSecurityOnBasicLicenseIT extends ESRestTestCase {
             } catch (ResponseException e) {
                 throw new AssertionError(e);
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     private void checkSecurityStatus(boolean expectEnabled) throws IOException {


### PR DESCRIPTION
In some cases it takes more than 10s for the test cluster to move from "yellow" health to having a valid basic license.

This is clearly ridiculous, however it's not a problem with the test itself - it's related to the number of templates being installed and the performance on the CI worker.

There are 3 possible options:
- Leave the test running and failing due to something outside of its control
- Mute the test indefinitely
- Increase the timeout when waiting for the license to be generated

Of those options, the last one is the least-worst.

Relates: #97487
