### PR TITLE
Fixing AsyncStatusResponseTests#testGetStatusFromStoredSearchWithNonEmptyClustersStillRunning

### DIFF
--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -414,7 +414,6 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98706")
     public void testGetStatusFromStoredSearchWithNonEmptyClustersStillRunning() {
         String searchId = randomSearchId();
 
@@ -426,6 +425,16 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         int successful = randomInt(10);
         int partial = randomInt(10);
         int skipped = randomInt(10);
+
+        if (successful + partial + skipped == 0) {
+            int val = randomIntBetween(1, 10);
+            switch (randomInt(2)) {
+                case 0 -> successful = val;
+                case 1 -> partial = val;
+                case 2 -> skipped = val;
+                default -> throw new UnsupportedOperationException();
+            }
+        }
         SearchResponse.Clusters clusters = AsyncSearchResponseTests.createCCSClusterObjects(100, 99, true, successful, skipped, partial);
 
         SearchResponse searchResponse = new SearchResponse(


### PR DESCRIPTION
The issue with the failing test was that we're having an assertion within the test suite that relies on 3 randomly generated integers. The assertion states that the sum should be a strictly positive number, whereas the integers are drawn from the `[0, 10]` range. 

Since this seems to be only test-related, and IIUC is not an actual issue that we might have to deal with, in this PR we are adding small variance to one of the int variables in case all of them are 0 (+unmuting the test itself). 

Closes https://github.com/elastic/elasticsearch/issues/98706