### PR TITLE
Check if the index belongs to the SLM policy before deleting

### DIFF
--- a/docs/changelog/100816.yaml
+++ b/docs/changelog/100816.yaml
@@ -1,0 +1,5 @@
+pr: 100816
+summary: Check if the index belongs to the SLM policy before deleting
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -19,10 +19,12 @@ import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicyMetadata;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapshotStep> {
 
@@ -126,6 +128,38 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             () -> instance.isConditionMet(indexMetadata.getIndex(), clusterState)
         );
         assertThat(e.getMessage(), containsString("does not apply to index"));
+    }
+
+    public void testWaitForSlmPolicyAfterChange() throws IOException {
+        long phaseTime = randomLongBetween(100, 100000);
+        long actionTime = phaseTime + randomLongBetween(100, 100000);
+        String indexName = randomAlphaOfLength(10);
+        WaitForSnapshotStep instance = createRandomInstance();
+        long modifiedDate = actionTime + 1000;
+        SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
+            .setModifiedDate(randomLong())
+            .setPolicy(new SnapshotLifecyclePolicy("", "", "", "", Map.of("indices", List.of("*")), null))
+            .setLastSuccess(new SnapshotInvocationRecord("", actionTime + 10, actionTime + 100, ""))
+            .setModifiedDate(modifiedDate)
+            .build();
+        SnapshotLifecycleMetadata smlMetadata = new SnapshotLifecycleMetadata(
+            Map.of(instance.getPolicy(), slmPolicy),
+            OperationMode.RUNNING,
+            null
+        );
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Map.of("action_time", Long.toString(actionTime)))
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5))
+            .build();
+        Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
+        ClusterStateWaitStep.Result conditionMet = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
+        assertThat(conditionMet.isComplete(), is(false));
+        assertThat(getMessage(conditionMet), containsString("to be executed since " + new Date(modifiedDate)));
     }
 
     public void testSlmPolicyExecutedBeforeStep() throws IOException {


### PR DESCRIPTION
With this PR we propose to address #57809 by checking if the policy that we are waiting for applies to the index that we are going to delete.

We also introduce a new safety check, namely, the last successful run of the SLM policy needs to have happened after the latest modification time. From fixing the index pattern but then SLM's last successful run was before this modification meaning this index is still not included.

Fixes: #57809 