### PR TITLE
[8.11] Restore version skipping for position fields (#100817)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: "8.7.00 - 8.9.99"
-      reason: "Synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests"
+      version: " - 8.9.99"
+      reason: "position metric introduced in 8.8.0, synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -424,6 +424,10 @@ nested fields:
 
 ---
 "Synthetic source":
+  - skip:
+      version: " - 8.9.99"
+      reason: Synthetic source shows up in the mapping in 8.10
+
   - do:
       indices.create:
         index: tsdb-synthetic


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Restore version skipping for position fields (#100817)