### PR TITLE
[8.10] [Query Rules] clarify query rules API documentation (#100732)

### DIFF
--- a/docs/reference/query-rules/apis/get-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/get-query-ruleset.asciidoc
@@ -52,9 +52,9 @@ PUT _query_rules/my-ruleset
             "type": "pinned",
             "criteria": [
                 {
-                    "type": "exact",
+                    "type": "contains",
                     "metadata": "query_string",
-                    "values": [ "marvel" ]
+                    "values": [ "pugs", "puggles" ]
                 }
             ],
             "actions": {
@@ -69,9 +69,9 @@ PUT _query_rules/my-ruleset
             "type": "pinned",
             "criteria": [
                 {
-                    "type": "exact",
+                    "type": "fuzzy",
                     "metadata": "query_string",
-                    "values": [ "dc" ]
+                    "values": [ "rescue dogs" ]
                 }
             ],
             "actions": {
@@ -117,9 +117,9 @@ A sample response:
             "type": "pinned",
             "criteria": [
                 {
-                    "type": "exact",
+                    "type": "contains",
                     "metadata": "query_string",
-                    "values": [ "marvel" ]
+                    "values": [ "pugs", "puggles" ]
                 }
             ],
             "actions": {
@@ -134,9 +134,9 @@ A sample response:
             "type": "pinned",
             "criteria": [
                 {
-                    "type": "exact",
+                    "type": "fuzzy",
                     "metadata": "query_string",
-                    "values": [ "dc" ]
+                    "values": [ "rescue dogs" ]
                 }
             ],
             "actions": {

--- a/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
@@ -22,29 +22,27 @@ Requires the `manage_search_query_rules` privilege.
 
 [role="child_attributes"]
 [[put-query-ruleset-request-body]]
-(Required, object)
-Contains parameters for a query ruleset:
+(Required, object) Contains parameters for a query ruleset:
 
 ==== {api-request-body-title}
+
 `rules`::
-(Required, array of objects)
-The specific rules included in this query ruleset.
+(Required, array of objects) The specific rules included in this query ruleset.
 
 Each rule must have the following information:
 
-- `rule_id` (Required, string)
-  A unique identifier for this rule.
-- `type` (Required, string)
-  The type of rule. At this time only `pinned` query rule types are allowed.
-- `criteria` (Required, array of objects)
-  The criteria that must be met for the rule to be applied. If multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.
-- `actions` (Required, object)
-  The actions to take when the rule is matched. The format of this action depends on the rule type.
+- `rule_id` (Required, string) A unique identifier for this rule.
+- `type` (Required, string) The type of rule.
+At this time only `pinned` query rule types are allowed.
+- `criteria` (Required, array of objects) The criteria that must be met for the rule to be applied.
+If multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.
+- `actions` (Required, object) The actions to take when the rule is matched.
+The format of this action depends on the rule type.
 
 Criteria must have the following information:
 
-- `type` (Required, string)
-  The type of criteria. The following criteria types are supported:
+- `type` (Required, string) The type of criteria.
+The following criteria types are supported:
 +
 --
 - `exact`
@@ -77,30 +75,32 @@ Only applicable for numerical values.
 - `always`
 Matches all queries, regardless of input.
 --
-- `metadata` (Optional, string)
-  The metadata field to match against. Required for all criteria types except `global`.
-- `values` (Optional, array of strings)
-  The values to match against the metadata field. Only one value must match for the criteria to be met. Required for all criteria types except `global`.
+- `metadata` (Optional, string) The metadata field to match against.
+This metadata will be used to match against `match_criteria` sent in the <<query-dsl-rule-query>>.
+Required for all criteria types except `global`.
+- `values` (Optional, array of strings) The values to match against the metadata field.
+Only one value must match for the criteria to be met.
+Required for all criteria types except `global`.
 
 Actions depend on the rule type.
 For `pinned` rules, actions follow the format specified by the <<query-dsl-pinned-query,Pinned Query>>.
 The following actions are allowed:
 
-- `ids` (Optional, array of strings)
-  The The unique <<mapping-id-field, document IDs>> of the documents to pin.
-  Only one of `ids` or `docs` may be specified, and at least one must be specified.
-- `docs` (Optional, array of objects)
-  The documents to pin. Only one of `ids` or `docs` may be specified, and at least one must be specified.
-  You can specify the following attributes for each document:
+- `ids` (Optional, array of strings) The unique <<mapping-id-field, document IDs>> of the documents to pin.
+Only one of `ids` or `docs` may be specified, and at least one must be specified.
+- `docs` (Optional, array of objects) The documents to pin.
+Only one of `ids` or `docs` may be specified, and at least one must be specified.
+You can specify the following attributes for each document:
 +
 --
-- `_index` (Required, string)
-  The index of the document to pin.
-- `_id` (Required, string)
-  The unique <<mapping-id-field, document ID>>.
+- `_index` (Required, string) The index of the document to pin.
+- `_id` (Required, string) The unique <<mapping-id-field, document ID>>.
 --
 
-IMPORTANT: Due to limitations within <<query-dsl-pinned-query,Pinned queries>>, you can only pin documents using `ids` or `docs`, but cannot use both in single rule. It is advised to use one or the other in query rulesets, to avoid errors. Additionally, pinned queries have a maximum limit of 100 pinned hits. If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.
+IMPORTANT: Due to limitations within <<query-dsl-pinned-query,Pinned queries>>, you can only pin documents using `ids` or `docs`, but cannot use both in single rule.
+It is advised to use one or the other in query rulesets, to avoid errors.
+Additionally, pinned queries have a maximum limit of 100 pinned hits.
+If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.
 
 [[put-query-ruleset-example]]
 ==== {api-examples-title}
@@ -109,8 +109,8 @@ The following example creates a new query ruleset called `my-ruleset`.
 
 Two rules are associated with `my-ruleset`:
 
-- `my-rule1` will pin documents with IDs `id1` and `id2` when `user.query` exactly matches `marvel` _or_ `dc` **and** `user.country` exactly matches `us`.
-- `my-rule2` will pin documents from different, specified indices with IDs `id3` and `id4` when the `query_string` fuzzily matches `comic`.
+- `my-rule1` will pin documents with IDs `id1` and `id2` when `user_query` contains `pugs` _or_ `puggles` **and** `user_country` exactly matches `us`.
+- `my-rule2` will pin documents from different, specified indices with IDs `id3` and `id4` when the `query_string` fuzzily matches `rescue dogs`.
 
 [source,console]
 ----
@@ -123,12 +123,12 @@ PUT _query_rules/my-ruleset
             "criteria": [
                 {
                     "type": "contains",
-                    "metadata": "user.query",
-                    "values": [ "marvel", "dc" ]
+                    "metadata": "user_query",
+                    "values": [ "pugs", "puggles" ]
                 },
                 {
                     "type": "exact",
-                    "metadata": "user.country",
+                    "metadata": "user_country",
                     "values": [ "us" ]
                 }
             ],
@@ -145,8 +145,8 @@ PUT _query_rules/my-ruleset
             "criteria": [
                 {
                     "type": "fuzzy",
-                    "metadata": "query_string",
-                    "values": [ "comic" ]
+                    "metadata": "user_query",
+                    "values": [ "rescue dogs" ]
                 }
             ],
             "actions": {


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [Query Rules] clarify query rules API documentation (#100732)