### PR TITLE
[8.11][TEST] Accept fielddata memory size 0 in terms agg with global_ordinals execution hint

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/terms.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/terms.yml
@@ -723,7 +723,17 @@ setup:
   - do:
       search:
         index: test_1
-        body: { "size" : 0, "aggs" : { "str_terms" : { "terms" : { "field" : "str", "execution_hint" : "global_ordinals" } } } }
+        body: {
+          "size" : 0,
+          "aggs" : {
+            "str_terms" : {
+              "terms" : {
+                "field" : "str",
+                "execution_hint" : "global_ordinals"
+              }
+            }
+          }
+        }
 
   - match: { hits.total.value: 3}
   - length: { aggregations.str_terms.buckets: 2 }
@@ -734,7 +744,7 @@ setup:
         metric: fielddata
         fielddata_fields: str
 
-  - gt: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
+  - gte: { indices.test_1.total.fielddata.memory_size_in_bytes: 0}
 
 ---
 "No field or script":


### PR DESCRIPTION
Backports the following commits to 8.11:

* [TEST] Accept fielddata memory size 0 in terms agg with global_ordinals execution hint (#100756)