### PR TITLE
Updating testing and logging for dense_vector dynamic dims (#100546)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
@@ -3,6 +3,30 @@ setup:
       version: ' - 8.10.99'
       reason: 'Dynamic mapping of floats to dense_vector was added in 8.11'
 
+  # Additional logging for issue: https://github.com/elastic/elasticsearch/issues/100502
+  - do:
+      cluster.put_settings:
+        body: >
+          {
+            "persistent": {
+              "logger.org.elasticsearch.index": "TRACE"
+            }
+          }
+
+---
+teardown:
+  - skip:
+      version: ' - 8.10.99'
+      reason: 'Dynamic mapping of floats to dense_vector was added in 8.11'
+
+  - do:
+      cluster.put_settings:
+          body: >
+            {
+              "persistent": {
+                "logger.org.elasticsearch.index": null
+              }
+            }
 ---
 "Fields with float arrays below the threshold still map as float":
 


### PR DESCRIPTION
This adds a test for dynamic dims update mapping merges.

Also, this adds logging to help investigate a periodically failing test.

related to: https://github.com/elastic/elasticsearch/issues/100502