### PR TITLE
Referenced the svgs of starts_with and trim in asciidoc for consistency.

### DIFF
--- a/docs/reference/esql/functions/starts_with.asciidoc
+++ b/docs/reference/esql/functions/starts_with.asciidoc
@@ -1,5 +1,8 @@
 [[esql-starts_with]]
 === `STARTS_WITH`
+[.text-center]
+image::esql/functions/signature/ends_with.svg[Embedded,opts=inline]
+
 Returns a boolean that indicates whether a keyword string starts with another
 string:
 
@@ -11,3 +14,7 @@ include::{esql-specs}/docs.csv-spec[tag=startsWith]
 |===
 include::{esql-specs}/docs.csv-spec[tag=startsWith-result]
 |===
+
+Supported types:
+
+include::types/starts_with.asciidoc[]

--- a/docs/reference/esql/functions/trim.asciidoc
+++ b/docs/reference/esql/functions/trim.asciidoc
@@ -1,5 +1,8 @@
 [[esql-trim]]
 === `TRIM`
+[.text-center]
+image::esql/functions/signature/trim.svg[Embedded,opts=inline]
+
 Removes leading and trailing whitespaces from strings.
 
 [source.merge.styled,esql]
@@ -10,3 +13,7 @@ include::{esql-specs}/string.csv-spec[tag=trim]
 |===
 include::{esql-specs}/string.csv-spec[tag=trim-result]
 |===
+
+Supported types:
+
+include::types/trim.asciidoc[]


### PR DESCRIPTION
Improved the ES|QL documentation by adding missing svgs for starts_with and trim functions.