### PR TITLE
[8.11] Fix NullPointerException in RotableSecret (#100779)

### DIFF
--- a/docs/changelog/100779.yaml
+++ b/docs/changelog/100779.yaml
@@ -1,0 +1,6 @@
+pr: 100779
+summary: Fix NullPointerException in RotableSecret
+area: Security
+type: bug
+issues:
+ - 99759

--- a/server/src/test/java/org/elasticsearch/common/settings/RotatableSecretTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/RotatableSecretTests.java
@@ -27,7 +27,6 @@ public class RotatableSecretTests extends ESTestCase {
     private final SecureString secret2 = new SecureString(randomAlphaOfLength(10));
     private final SecureString secret3 = new SecureString(randomAlphaOfLength(10));
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99759")
     public void testBasicRotation() throws Exception {
         // initial state
         RotatableSecret rotatableSecret = new RotatableSecret(secret1);


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix NullPointerException in RotableSecret (#100779)