### PR TITLE
[8.11] Fix manage/monitor_enrich documentation (#100781)

### DIFF
--- a/docs/reference/security/authorization/built-in-roles.asciidoc
+++ b/docs/reference/security/authorization/built-in-roles.asciidoc
@@ -141,11 +141,6 @@ read access to the `.ml-notifications` and `.ml-anomalies*` indices
 {ml-cap} users also need index privileges for source and destination
 indices and roles that grant access to {kib}. See {ml-docs-setup-privileges}.
 
-[[built-in-roles-manage-enrich]] `manage_enrich`::
-Grants privileges to access and use all of the {ref}/enrich-apis.html[enrich APIs].
-Users with this role can manage enrich policies that add data from your existing 
-indices to incoming documents during ingest.
-
 [[built-in-roles-monitoring-user]] `monitoring_user`::
 Grants the minimum privileges required for any user of {monitoring} other than those
 required to use {kib}. This role grants access to the monitoring indices and grants
@@ -171,10 +166,10 @@ Reporting users should also be assigned additional roles that grant
 access to the <<roles-indices-priv,indices>> that will be used to generate reports.
 
 [[built-in-roles-rollup-admin]] `rollup_admin`::
-Grants `manage_rollup` cluster privileges, which enable you to manage and execute all rollup actions. 
+Grants `manage_rollup` cluster privileges, which enable you to manage and execute all rollup actions.
 
 [[built-in-roles-rollup-user]] `rollup_user`::
-Grants `monitor_rollup` cluster privileges, which enable you to perform read-only operations related to rollups. 
+Grants `monitor_rollup` cluster privileges, which enable you to perform read-only operations related to rollups.
 
 [[built-in-roles-snapshot-user]] `snapshot_user`::
 Grants the necessary privileges to create snapshots of **all** the indices and

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -186,6 +186,9 @@ security roles of the user who created or updated them.
 All cluster read-only operations, like cluster health and state, hot threads,
 node info, node and cluster stats, and pending cluster tasks.
 
+`monitor_enrich`::
+All read-only operations related to managing and executing enrich policies.
+
 `monitor_ml`::
 All read-only {ml} operations, such as getting information about {dfeeds}, jobs,
 model snapshots, or results.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Fix manage/monitor_enrich documentation (#100781)](https://github.com/elastic/elasticsearch/pull/100781)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)