### PR TITLE
Perform enrich lookup with enrich_origin

### DIFF
--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql;
 
 import org.apache.http.HttpStatus;
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -17,6 +18,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.Before;
 
@@ -138,8 +140,14 @@ public class EsqlSecurityIT extends ESRestTestCase {
                 new Listen(8, "s3", 0.25),
                 new Listen(8, "s4", 1.25)
             );
-            for (int i = 0; i < listens.size(); i++) {
-                Listen listen = listens.get(i);
+            int numDocs = between(100, 1000);
+            for (int i = 0; i < numDocs; i++) {
+                final Listen listen;
+                if (i < listens.size()) {
+                    listen = listens.get(i);
+                } else {
+                    listen = new Listen(100 + i, "s" + between(1, 5), randomIntBetween(1, 10));
+                }
                 Request indexDoc = new Request("PUT", "/test-enrich/_doc/" + i);
                 String doc = Strings.toString(
                     JsonXContent.contentBuilder()
@@ -153,26 +161,38 @@ public class EsqlSecurityIT extends ESRestTestCase {
                 client().performRequest(indexDoc);
             }
             refresh("test-enrich");
-            for (String user : List.of("user1", "user4")) {
-                Response resp = runESQLCommand(
-                    user,
-                    "FROM test-enrich | ENRICH songs ON song_id | stats total_duration = sum(duration) by artist | sort artist"
-                );
-                Map<String, Object> respMap = entityAsMap(resp);
-                assertThat(
-                    respMap.get("values"),
-                    equalTo(List.of(List.of(2.75, "Disturbed"), List.of(10.5, "Eagles"), List.of(8.25, "Linkin Park")))
-                );
-            }
 
-            ResponseException resp = expectThrows(
-                ResponseException.class,
-                () -> runESQLCommand(
-                    "user5",
-                    "FROM test-enrich | ENRICH songs ON song_id | stats total_duration = sum(duration) by artist | sort artist"
-                )
+            var from = "FROM test-enrich ";
+            var stats = " | stats total_duration = sum(duration) by artist | sort artist ";
+            var enrich = " | ENRICH songs ON song_id ";
+            var topN = " | sort timestamp | limit " + listens.size() + " ";
+            var filter = " | where timestamp <= " + listens.size();
+
+            var commands = List.of(
+                from + enrich + filter + stats,
+                from + filter + enrich + stats,
+                from + topN + enrich + stats,
+                from + enrich + topN + stats
             );
-            assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            for (String command : commands) {
+                for (String user : List.of("user1", "user4")) {
+                    Response resp = runESQLCommand(user, command);
+                    Map<String, Object> respMap = entityAsMap(resp);
+                    assertThat(
+                        respMap.get("values"),
+                        equalTo(List.of(List.of(2.75, "Disturbed"), List.of(10.5, "Eagles"), List.of(8.25, "Linkin Park")))
+                    );
+                }
+
+                ResponseException resp = expectThrows(
+                    ResponseException.class,
+                    () -> runESQLCommand(
+                        "user5",
+                        "FROM test-enrich | ENRICH songs ON song_id | stats total_duration = sum(duration) by artist | sort artist"
+                    )
+                );
+                assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            }
         } finally {
             removeEnrichPolicy();
         }
@@ -227,6 +247,29 @@ public class EsqlSecurityIT extends ESRestTestCase {
     }
 
     private Response runESQLCommand(String user, String command) throws IOException {
+        Settings pragmas = Settings.EMPTY;
+        if (Build.current().isSnapshot()) {
+            Settings.Builder settings = Settings.builder();
+            if (randomBoolean()) {
+                settings.put("page_size", between(1, 5));
+            }
+            if (randomBoolean()) {
+                settings.put("exchange_buffer_size", between(1, 2));
+            }
+            if (randomBoolean()) {
+                settings.put("data_partitioning", randomFrom("shard", "segment", "doc"));
+            }
+            pragmas = settings.build();
+        }
+        XContentBuilder query = JsonXContent.contentBuilder();
+        query.startObject();
+        query.field("query", command);
+        if (pragmas != Settings.EMPTY) {
+            query.startObject("pragma");
+            query.value(pragmas);
+            query.endObject();
+        }
+        query.endObject();
         Request request = new Request("POST", "_query");
         request.setJsonEntity("{\"query\":\"" + command + "\"}");
         request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("es-security-runas-user", user));

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -118,6 +118,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         assertThat(respMap.get("values"), equalTo(List.of(List.of(2, 5))));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/100724/")
     public void testEnrich() throws Exception {
         createEnrichPolicy();
         try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -63,7 +63,6 @@ import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeResolver;
 import org.elasticsearch.xpack.core.security.support.Exceptions;
-import org.elasticsearch.xpack.core.security.user.InternalUsers;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.action.EsqlQueryAction;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -180,7 +180,6 @@ public class EnrichLookupService {
         final SecurityContext securityContext = new SecurityContext(Settings.EMPTY, threadContext);
         final User user = securityContext.getUser();
         if (user == null) {
-            assert false : "missing or unable to read authentication info on request";
             outListener.onFailure(new IllegalStateException("missing or unable to read authentication info on request"));
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -140,7 +140,7 @@ public class EnrichLookupService {
     ) {
         ThreadContext threadContext = transportService.getThreadPool().getThreadContext();
         ActionListener<Page> listener = ContextPreservingActionListener.wrapPreservingContext(outListener, threadContext);
-        hasEnrichPrivilege(ActionListener.wrap(user -> {
+        hasEnrichPrivilege(ActionListener.wrap(ignored -> {
             ClusterState clusterState = clusterService.state();
             GroupShardsIterator<ShardIterator> shardIterators = clusterService.operationRouting()
                 .searchShards(clusterState, new String[] { index }, Map.of(), "_local");
@@ -170,7 +170,7 @@ public class EnrichLookupService {
         }, listener::onFailure));
     }
 
-    private void hasEnrichPrivilege(ActionListener<User> outListener) {
+    private void hasEnrichPrivilege(ActionListener<Void> outListener) {
         final Settings settings = clusterService.getSettings();
         if (settings.hasValue(XPackSettings.SECURITY_ENABLED.getKey()) == false || XPackSettings.SECURITY_ENABLED.get(settings) == false) {
             outListener.onResponse(null);
@@ -191,7 +191,7 @@ public class EnrichLookupService {
         request.applicationPrivileges(new RoleDescriptor.ApplicationResourcePrivileges[0]);
         ActionListener<HasPrivilegesResponse> listener = outListener.delegateFailureAndWrap((l, resp) -> {
             if (resp.isCompleteMatch()) {
-                l.onResponse(user);
+                l.onResponse(null);
                 return;
             }
             String detailed = resp.getClusterPrivileges()


### PR DESCRIPTION
Direct access to the `.enrich-* indices`, which are restricted system indices, should not be granted to users. Instead, ESQL enrich lookup should access these indices using the `enrich_origin` on behalf of the user. With this change, the enrich lookup checks for the `monitor_enrich` cluster privilege before performing the actual lookup with the `enrich_origin`.

Spin-off from #100724