### PR TITLE
[Profiling] Update how frame group IDs are created to match total expected frames

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -7,14 +7,11 @@
 
 package org.elasticsearch.xpack.profiling;
 
-import org.elasticsearch.core.SuppressForbidden;
-
 import java.util.Objects;
 
 public class FrameGroupID {
     private static final char UNIX_PATH_SEPARATOR = '/';
 
-    @SuppressForbidden(reason = "Using pathSeparator constant to extract the filename with low overhead")
     public static String getBasenameAndParent(String fullPath) {
         if (fullPath == null || fullPath.isEmpty()) {
             return fullPath;

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -13,12 +13,14 @@ import java.io.File;
 import java.util.Objects;
 
 public class FrameGroupID {
+    private static final String UNIX_PATH_SEPARATOR = "/";
+
     @SuppressForbidden(reason = "Using pathSeparator constant to extract the filename with low overhead")
     private static String getFilename(String fullPath) {
         if (fullPath == null || fullPath.isEmpty()) {
             return fullPath;
         }
-        int lastSeparatorIdx = fullPath.lastIndexOf(File.pathSeparator);
+        int lastSeparatorIdx = fullPath.lastIndexOf(UNIX_PATH_SEPARATOR);
         return lastSeparatorIdx == -1 ? fullPath : fullPath.substring(lastSeparatorIdx + 1);
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -9,19 +9,22 @@ package org.elasticsearch.xpack.profiling;
 
 import org.elasticsearch.core.SuppressForbidden;
 
-import java.io.File;
 import java.util.Objects;
 
 public class FrameGroupID {
-    private static final String UNIX_PATH_SEPARATOR = "/";
+    private static final char UNIX_PATH_SEPARATOR = '/';
 
     @SuppressForbidden(reason = "Using pathSeparator constant to extract the filename with low overhead")
-    private static String getFilename(String fullPath) {
+    public static String getBasenameAndParent(String fullPath) {
         if (fullPath == null || fullPath.isEmpty()) {
             return fullPath;
         }
         int lastSeparatorIdx = fullPath.lastIndexOf(UNIX_PATH_SEPARATOR);
-        return lastSeparatorIdx == -1 ? fullPath : fullPath.substring(lastSeparatorIdx + 1);
+        if (lastSeparatorIdx <= 0) {
+            return fullPath;
+        }
+        int nextSeparatorIdx = fullPath.lastIndexOf(UNIX_PATH_SEPARATOR, lastSeparatorIdx - 1);
+        return nextSeparatorIdx == -1 ? fullPath : fullPath.substring(nextSeparatorIdx + 1);
     }
 
     public static String create(
@@ -37,6 +40,6 @@ public class FrameGroupID {
         if (sourceFilename.isEmpty()) {
             return Integer.toString(Objects.hash(fileId, functionName));
         }
-        return Integer.toString(Objects.hash(exeFilename, functionName, getFilename(sourceFilename)));
+        return Integer.toString(Objects.hash(exeFilename, functionName, getBasenameAndParent(sourceFilename)));
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.profiling;
 
+import org.elasticsearch.common.Strings;
+
 import java.util.Objects;
 
 public final class FrameGroupID {
@@ -15,7 +17,7 @@ public final class FrameGroupID {
     private FrameGroupID() {}
 
     public static String getBasenameAndParent(String fullPath) {
-        if (fullPath == null || fullPath.isEmpty()) {
+        if (Strings.isEmpty(fullPath)) {
             return fullPath;
         }
         int lastSeparatorIdx = fullPath.lastIndexOf(UNIX_PATH_SEPARATOR);
@@ -27,10 +29,10 @@ public final class FrameGroupID {
     }
 
     public static String create(String fileId, Integer addressOrLine, String exeFilename, String sourceFilename, String functionName) {
-        if (functionName.isEmpty()) {
+        if (Strings.isEmpty(functionName)) {
             return Integer.toString(Objects.hash(fileId, addressOrLine));
         }
-        if (sourceFilename.isEmpty()) {
+        if (Strings.isEmpty(sourceFilename)) {
             return Integer.toString(Objects.hash(fileId, functionName));
         }
         return Integer.toString(Objects.hash(exeFilename, functionName, getBasenameAndParent(sourceFilename)));

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.File;
+import java.util.Objects;
+
+public class FrameGroupID {
+    @SuppressForbidden(reason = "Using pathSeparator constant to extract the filename with low overhead")
+    private static String getFilename(String fullPath) {
+        if (fullPath == null || fullPath.isEmpty()) {
+            return fullPath;
+        }
+        int lastSeparatorIdx = fullPath.lastIndexOf(File.pathSeparator);
+        return lastSeparatorIdx == -1 ? fullPath : fullPath.substring(lastSeparatorIdx + 1);
+    }
+
+    public static String create(
+        String fileId,
+        Integer addressOrLine,
+        String exeFilename,
+        String sourceFilename,
+        String functionName
+    ) {
+        StringBuilder sb = new StringBuilder();
+        if (functionName.isEmpty()) {
+            sb.append(fileId);
+            sb.append(addressOrLine);
+        } else {
+            sb.append(exeFilename);
+            sb.append(functionName);
+            sb.append(getFilename(sourceFilename));
+        }
+        return sb.toString();
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -24,13 +24,7 @@ public class FrameGroupID {
         return nextSeparatorIdx == -1 ? fullPath : fullPath.substring(nextSeparatorIdx + 1);
     }
 
-    public static String create(
-        String fileId,
-        Integer addressOrLine,
-        String exeFilename,
-        String sourceFilename,
-        String functionName
-    ) {
+    public static String create(String fileId, Integer addressOrLine, String exeFilename, String sourceFilename, String functionName) {
         if (functionName.isEmpty()) {
             return Integer.toString(Objects.hash(fileId, addressOrLine));
         }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.profiling;
 
 import java.util.Objects;
 
-public class FrameGroupID {
+public final class FrameGroupID {
     private static final char UNIX_PATH_SEPARATOR = '/';
+
+    private FrameGroupID() {}
 
     public static String getBasenameAndParent(String fullPath) {
         if (fullPath == null || fullPath.isEmpty()) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/FrameGroupID.java
@@ -31,15 +31,12 @@ public class FrameGroupID {
         String sourceFilename,
         String functionName
     ) {
-        StringBuilder sb = new StringBuilder();
         if (functionName.isEmpty()) {
-            sb.append(fileId);
-            sb.append(addressOrLine);
-        } else {
-            sb.append(exeFilename);
-            sb.append(functionName);
-            sb.append(getFilename(sourceFilename));
+            return Integer.toString(Objects.hash(fileId, addressOrLine));
         }
-        return sb.toString();
+        if (sourceFilename.isEmpty()) {
+            return Integer.toString(Objects.hash(fileId, functionName));
+        }
+        return Integer.toString(Objects.hash(exeFilename, functionName, getFilename(sourceFilename)));
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class FrameGroupIDTests extends ESTestCase {
+    public void testEmptyFunctionName() {
+        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 177863, "", "", "");
+	assertEquals("FEDCBA9876543210177863", frameGroupID);
+    }
+
+    public void testFunctionNameAndEmptySourceFilename() {
+        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 6694, "<main>", "", "void jdk.internal.misc.Unsafe.park(boolean, long)");
+	assertEquals("<main>void jdk.internal.misc.Unsafe.park(boolean, long)", frameGroupID);
+    }
+
+    public void testFunctionNameAndSourceFilenameWithAbsolutePath() {
+        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
+	assertEquals("mainfutex_wakelock_futex.go", frameGroupID);
+    }
+
+    public void testFunctionNameAndSourceFilenameWithoutAbsolutePath() {
+        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 29338, "<main>", "bootstrap.java", "void jdk.internal.misc.Unsafe.park(boolean, long)");
+	assertEquals("<main>void jdk.internal.misc.Unsafe.park(boolean, long)bootstrap.java", frameGroupID);
+    }
+}

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
@@ -12,21 +12,21 @@ import org.elasticsearch.test.ESTestCase;
 public class FrameGroupIDTests extends ESTestCase {
     public void testEmptyFunctionName() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 177863, "", "", "");
-	assertEquals("FEDCBA9876543210177863", frameGroupID);
+	    assertEquals("-226939920", frameGroupID);
     }
 
     public void testFunctionNameAndEmptySourceFilename() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 6694, "<main>", "", "void jdk.internal.misc.Unsafe.park(boolean, long)");
-	assertEquals("<main>void jdk.internal.misc.Unsafe.park(boolean, long)", frameGroupID);
+	    assertEquals("1523167754", frameGroupID);
     }
 
     public void testFunctionNameAndSourceFilenameWithAbsolutePath() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
-	assertEquals("mainfutex_wakelock_futex.go", frameGroupID);
+	    assertEquals("1582587615", frameGroupID);
     }
 
     public void testFunctionNameAndSourceFilenameWithoutAbsolutePath() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 29338, "<main>", "bootstrap.java", "void jdk.internal.misc.Unsafe.park(boolean, long)");
-	assertEquals("<main>void jdk.internal.misc.Unsafe.park(boolean, long)bootstrap.java", frameGroupID);
+	    assertEquals("-685957655", frameGroupID);
     }
 }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
@@ -41,17 +41,35 @@ public class FrameGroupIDTests extends ESTestCase {
     }
 
     public void testFunctionNameAndEmptySourceFilename() {
-        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 6694, "<main>", "", "void jdk.internal.misc.Unsafe.park(boolean, long)");
+        String frameGroupID = FrameGroupID.create(
+            "FEDCBA9876543210",
+            6694,
+            "<main>",
+            "",
+            "void jdk.internal.misc.Unsafe.park(boolean, long)"
+        );
         assertEquals("1523167754", frameGroupID);
     }
 
     public void testFunctionNameAndSourceFilenameWithAbsolutePath() {
-        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
+        String frameGroupID = FrameGroupID.create(
+            "FEDCBA9876543210",
+            64,
+            "main",
+            "/usr/local/go/src/runtime/lock_futex.go",
+            "futex_wake"
+        );
         assertEquals("1422498024", frameGroupID);
     }
 
     public void testFunctionNameAndSourceFilenameWithoutAbsolutePath() {
-        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 29338, "<main>", "bootstrap.java", "void jdk.internal.misc.Unsafe.park(boolean, long)");
+        String frameGroupID = FrameGroupID.create(
+            "FEDCBA9876543210",
+            29338,
+            "<main>",
+            "bootstrap.java",
+            "void jdk.internal.misc.Unsafe.park(boolean, long)"
+        );
         assertEquals("-685957655", frameGroupID);
     }
 }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
@@ -52,13 +52,7 @@ public class FrameGroupIDTests extends ESTestCase {
     }
 
     public void testFunctionNameAndSourceFilenameWithAbsolutePath() {
-        String frameGroupID = FrameGroupID.create(
-            "FEDCBA9876543210",
-            64,
-            "main",
-            "/usr/local/go/src/runtime/lock_futex.go",
-            "futex_wake"
-        );
+        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
         assertEquals("1422498024", frameGroupID);
     }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.profiling;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Objects;
+
 public class FrameGroupIDTests extends ESTestCase {
     public void testEmptySourceFilename() {
         String given = FrameGroupID.getBasenameAndParent("");
@@ -36,34 +38,36 @@ public class FrameGroupIDTests extends ESTestCase {
     }
 
     public void testEmptyFunctionName() {
-        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 177863, "", "", "");
-        assertEquals("-226939920", frameGroupID);
+        String expected = Integer.toString(Objects.hash("FEDCBA9876543210", 177863));
+        String given = FrameGroupID.create("FEDCBA9876543210", 177863, "", "", "");
+        assertEquals(expected, given);
     }
 
     public void testFunctionNameAndEmptySourceFilename() {
-        String frameGroupID = FrameGroupID.create(
-            "FEDCBA9876543210",
-            6694,
-            "<main>",
-            "",
-            "void jdk.internal.misc.Unsafe.park(boolean, long)"
-        );
-        assertEquals("1523167754", frameGroupID);
+        String expected = Integer.toString(Objects.hash("FEDCBA9876543210", "void jdk.internal.misc.Unsafe.park(boolean, long)"));
+        String given = FrameGroupID.create("FEDCBA9876543210", 6694, "<main>", "", "void jdk.internal.misc.Unsafe.park(boolean, long)");
+        assertEquals(expected, given);
     }
 
     public void testFunctionNameAndSourceFilenameWithAbsolutePath() {
-        String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
-        assertEquals("1422498024", frameGroupID);
+        String expected = Integer.toString(
+            Objects.hash("main", "futex_wake", FrameGroupID.getBasenameAndParent("/usr/local/go/src/runtime/lock_futex.go"))
+        );
+        String given = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
+        assertEquals(expected, given);
     }
 
     public void testFunctionNameAndSourceFilenameWithoutAbsolutePath() {
-        String frameGroupID = FrameGroupID.create(
+        String expected = Integer.toString(
+            Objects.hash("<main>", "void jdk.internal.misc.Unsafe.park(boolean, long)", FrameGroupID.getBasenameAndParent("bootstrap.java"))
+        );
+        String given = FrameGroupID.create(
             "FEDCBA9876543210",
             29338,
             "<main>",
             "bootstrap.java",
             "void jdk.internal.misc.Unsafe.park(boolean, long)"
         );
-        assertEquals("-685957655", frameGroupID);
+        assertEquals(expected, given);
     }
 }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/FrameGroupIDTests.java
@@ -10,23 +10,48 @@ package org.elasticsearch.xpack.profiling;
 import org.elasticsearch.test.ESTestCase;
 
 public class FrameGroupIDTests extends ESTestCase {
+    public void testEmptySourceFilename() {
+        String given = FrameGroupID.getBasenameAndParent("");
+        assertEquals("", given);
+    }
+
+    public void testNonPathSourceFilename() {
+        String given = FrameGroupID.getBasenameAndParent("void jdk.internal.misc.Unsafe.park(boolean, long)");
+        assertEquals("void jdk.internal.misc.Unsafe.park(boolean, long)", given);
+    }
+
+    public void testRootSourceFilename() {
+        String given = FrameGroupID.getBasenameAndParent("/");
+        assertEquals("/", given);
+    }
+
+    public void testRelativePathSourceFilename() {
+        String given = FrameGroupID.getBasenameAndParent("../src/main.c");
+        assertEquals("src/main.c", given);
+    }
+
+    public void testAbsolutePathSourceFilename() {
+        String given = FrameGroupID.getBasenameAndParent("/usr/local/go/src/runtime/lock_futex.go");
+        assertEquals("runtime/lock_futex.go", given);
+    }
+
     public void testEmptyFunctionName() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 177863, "", "", "");
-	    assertEquals("-226939920", frameGroupID);
+        assertEquals("-226939920", frameGroupID);
     }
 
     public void testFunctionNameAndEmptySourceFilename() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 6694, "<main>", "", "void jdk.internal.misc.Unsafe.park(boolean, long)");
-	    assertEquals("1523167754", frameGroupID);
+        assertEquals("1523167754", frameGroupID);
     }
 
     public void testFunctionNameAndSourceFilenameWithAbsolutePath() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 64, "main", "/usr/local/go/src/runtime/lock_futex.go", "futex_wake");
-	    assertEquals("1582587615", frameGroupID);
+        assertEquals("1422498024", frameGroupID);
     }
 
     public void testFunctionNameAndSourceFilenameWithoutAbsolutePath() {
         String frameGroupID = FrameGroupID.create("FEDCBA9876543210", 29338, "<main>", "bootstrap.java", "void jdk.internal.misc.Unsafe.park(boolean, long)");
-	    assertEquals("-685957655", frameGroupID);
+        assertEquals("-685957655", frameGroupID);
     }
 }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
@@ -58,15 +58,15 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 1), response.getCountExclusive());
         assertEquals(
             List.of(
-                Map.of("fr28zxcZ2UDasxYuu6dV-w12784352", 1),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w19334053", 2),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w19336161", 3),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w18795859", 4),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w18622708", 5),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w18619213", 6),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w12989721", 7),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w13658842", 8),
-                Map.of("fr28zxcZ2UDasxYuu6dV-w16339645", 9),
+                Map.of("174640828", 1),
+                Map.of("181190529", 2),
+                Map.of("181192637", 3),
+                Map.of("180652335", 4),
+                Map.of("180479184", 5),
+                Map.of("180475689", 6),
+                Map.of("174846197", 7),
+                Map.of("175515318", 8),
+                Map.of("178196121", 9),
                 Map.of()
             ),
             response.getEdges()


### PR DESCRIPTION
This PR addresses several issues identified after the port from Kibana in https://github.com/elastic/elasticsearch/pull/99091:

- refactor `createFrameGroupId` into its own class so other API actions can use it
- check if the source filename is empty and use `fileID`+`functionName` in ID instead of `exeFilename`+`functionName`
- create ID by hashing the respective metadata attributes
- trim the source filename so that only the basename and its parent directory is used if available