### PR TITLE
ESQL: Preserve intermediate aggregation output in local relation

### DIFF
--- a/docs/changelog/100866.yaml
+++ b/docs/changelog/100866.yaml
@@ -1,0 +1,6 @@
+pr: 100866
+summary: "ESQL: Preserve intermediate aggregation output in local relation"
+area: ES|QL
+type: bug
+issues:
+ - 100807

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -207,8 +207,13 @@ public final class BlockUtils {
         if (val == null) {
             return Block.constantNullBlock(size);
         }
-        var type = fromJava(val.getClass());
+        return constantBlock(blockFactory, fromJava(val.getClass()), val, size);
+    }
+
+    // TODO: allow null values
+    private static Block constantBlock(BlockFactory blockFactory, ElementType type, Object val, int size) {
         return switch (type) {
+            case NULL -> Block.constantNullBlock(size);
             case LONG -> LongBlock.newConstantBlockWith((long) val, size, blockFactory);
             case INT -> IntBlock.newConstantBlockWith((int) val, size, blockFactory);
             case BYTES_REF -> BytesRefBlock.newConstantBlockWith(toBytesRef(val), size, blockFactory);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1237,7 +1237,11 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
                 .setMapping("field_2", "type=integer")
         );
         try (
-            var resp = run("from index-1,index-2 | where field_1 is not null | stats c = count(*), c1 = count(field_1), m = min(field_1)")
+
+            // this query fails:
+            // from index-1,index-2 | where field_1 is not null | stats c = count(*), c1 = count(field_1), m = min(field_1)"
+            // TODO: https://github.com/elastic/elasticsearch/issues/100928
+            var resp = run("from index-1,index-2 | where field_1 is not null | stats c = count(*), c1 = count(field_1), m = count()")
         ) {
             var valuesList = getValuesList(resp);
             assertEquals(3, resp.columns().size());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.analysis.VerificationException;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
-import org.junit.Assert;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -115,7 +114,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     private void testFromStatsGroupingAvgImpl(String command, String expectedGroupName, String expectedFieldName) {
         try (EsqlQueryResponse results = run(command)) {
             logger.info(results);
-            Assert.assertEquals(2, results.columns().size());
+            assertEquals(2, results.columns().size());
 
             // assert column metadata
             ColumnInfo valuesColumn = results.columns().get(0);
@@ -154,7 +153,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     private void testFromStatsGroupingCountImpl(String command, String expectedFieldName, String expectedGroupName) {
         try (EsqlQueryResponse results = run(command)) {
             logger.info(results);
-            Assert.assertEquals(2, results.columns().size());
+            assertEquals(2, results.columns().size());
 
             // assert column metadata
             ColumnInfo groupColumn = results.columns().get(0);
@@ -186,8 +185,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testFromStatsGroupingByDate() {
         try (EsqlQueryResponse results = run("from test | stats avg(count) by time")) {
             logger.info(results);
-            Assert.assertEquals(2, results.columns().size());
-            Assert.assertEquals(40, getValuesList(results).size());
+            assertEquals(2, results.columns().size());
+            assertEquals(40, getValuesList(results).size());
 
             // assert column metadata
             assertEquals("avg(count)", results.columns().get(0).name());
@@ -237,8 +236,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testFromStatsGroupingByKeyword() {
         try (EsqlQueryResponse results = run("from test | stats avg(count) by color")) {
             logger.info(results);
-            Assert.assertEquals(2, results.columns().size());
-            Assert.assertEquals(3, getValuesList(results).size());
+            assertEquals(2, results.columns().size());
+            assertEquals(3, getValuesList(results).size());
 
             // assert column metadata
             assertEquals("avg(count)", results.columns().get(0).name());
@@ -272,8 +271,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         for (String field : List.of("count", "count_d")) {
             try (EsqlQueryResponse results = run("from test | stats avg = avg(" + field + ") by color")) {
                 logger.info(results);
-                Assert.assertEquals(2, results.columns().size());
-                Assert.assertEquals(5, getValuesList(results).size());
+                assertEquals(2, results.columns().size());
+                assertEquals(5, getValuesList(results).size());
 
                 // assert column metadata
                 assertEquals("avg", results.columns().get(0).name());
@@ -306,8 +305,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
             )
         ) {
             logger.info(results);
-            Assert.assertEquals(6, results.columns().size());
-            Assert.assertEquals(3, getValuesList(results).size());
+            assertEquals(6, results.columns().size());
+            assertEquals(3, getValuesList(results).size());
 
             // assert column metadata
             assertEquals("a", results.columns().get(0).name());
@@ -458,8 +457,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testFromEvalStats() {
         try (EsqlQueryResponse results = run("from test | eval ratio = data_d / count_d | stats avg(ratio)")) {
             logger.info(results);
-            Assert.assertEquals(1, results.columns().size());
-            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals(1, results.columns().size());
+            assertEquals(1, getValuesList(results).size());
             assertEquals("avg(ratio)", results.columns().get(0).name());
             assertEquals("double", results.columns().get(0).type());
             assertEquals(1, getValuesList(results).get(0).size());
@@ -470,8 +469,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testUngroupedCountAll() {
         try (EsqlQueryResponse results = run("from test | stats count(*)")) {
             logger.info(results);
-            Assert.assertEquals(1, results.columns().size());
-            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals(1, results.columns().size());
+            assertEquals(1, getValuesList(results).size());
             assertEquals("count(*)", results.columns().get(0).name());
             assertEquals("long", results.columns().get(0).type());
             var values = getValuesList(results).get(0);
@@ -483,8 +482,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testUngroupedCountAllWithFilter() {
         try (EsqlQueryResponse results = run("from test | where data > 1 | stats count(*)")) {
             logger.info(results);
-            Assert.assertEquals(1, results.columns().size());
-            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals(1, results.columns().size());
+            assertEquals(1, getValuesList(results).size());
             assertEquals("count(*)", results.columns().get(0).name());
             assertEquals("long", results.columns().get(0).type());
             var values = getValuesList(results).get(0);
@@ -496,8 +495,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testGroupedCountAllWithFilter() {
         try (EsqlQueryResponse results = run("from test | where data > 1 | stats count(*) by data | sort data")) {
             logger.info(results);
-            Assert.assertEquals(2, results.columns().size());
-            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals(2, results.columns().size());
+            assertEquals(1, getValuesList(results).size());
             assertEquals("count(*)", results.columns().get(0).name());
             assertEquals("long", results.columns().get(0).type());
             assertEquals("data", results.columns().get(1).name());
@@ -513,7 +512,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         assumeTrue("pragmas only enabled on snapshot builds", Build.current().isSnapshot());
         try (EsqlQueryResponse results = run("from test | stats avg_count = avg(count) | eval x = avg_count + 7")) {
             logger.info(results);
-            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals(1, getValuesList(results).size());
             assertEquals(2, getValuesList(results).get(0).size());
             assertEquals(50, (double) getValuesList(results).get(0).get(results.columns().indexOf(new ColumnInfo("x", "double"))), 1d);
             assertEquals(
@@ -527,7 +526,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testWhere() {
         try (EsqlQueryResponse results = run("from test | where count > 40")) {
             logger.info(results);
-            Assert.assertEquals(30, getValuesList(results).size());
+            assertEquals(30, getValuesList(results).size());
             var countIndex = results.columns().indexOf(new ColumnInfo("count", "long"));
             for (List<Object> values : getValuesList(results)) {
                 assertThat((Long) values.get(countIndex), greaterThan(40L));
@@ -538,7 +537,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testProjectWhere() {
         try (EsqlQueryResponse results = run("from test | keep count | where count > 40")) {
             logger.info(results);
-            Assert.assertEquals(30, getValuesList(results).size());
+            assertEquals(30, getValuesList(results).size());
             int countIndex = results.columns().indexOf(new ColumnInfo("count", "long"));
             for (List<Object> values : getValuesList(results)) {
                 assertThat((Long) values.get(countIndex), greaterThan(40L));
@@ -549,7 +548,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testEvalWhere() {
         try (EsqlQueryResponse results = run("from test | eval x = count / 2 | where x > 20")) {
             logger.info(results);
-            Assert.assertEquals(30, getValuesList(results).size());
+            assertEquals(30, getValuesList(results).size());
             int countIndex = results.columns().indexOf(new ColumnInfo("x", "long"));
             for (List<Object> values : getValuesList(results)) {
                 assertThat((Long) values.get(countIndex), greaterThan(20L));
@@ -560,7 +559,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testFilterWithNullAndEval() {
         try (EsqlQueryResponse results = run("row a = 1 | eval b = a + null | where b > 1")) {
             logger.info(results);
-            Assert.assertEquals(0, getValuesList(results).size());
+            assertEquals(0, getValuesList(results).size());
         }
     }
 
@@ -582,11 +581,11 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         client().admin().indices().prepareRefresh("test").get();
         // sanity
         try (EsqlQueryResponse results = run("from test")) {
-            Assert.assertEquals(41, getValuesList(results).size());
+            assertEquals(41, getValuesList(results).size());
         }
         try (EsqlQueryResponse results = run("from test | eval newCount = count + 1 | where newCount > 1")) {
             logger.info(results);
-            Assert.assertEquals(40, getValuesList(results).size());
+            assertEquals(40, getValuesList(results).size());
             assertThat(results.columns(), hasItem(equalTo(new ColumnInfo("count", "long"))));
             assertThat(results.columns(), hasItem(equalTo(new ColumnInfo("count_d", "double"))));
             assertThat(results.columns(), hasItem(equalTo(new ColumnInfo("data", "long"))));
@@ -598,8 +597,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testMultiConditionalWhere() {
         try (var results = run("from test | eval abc = 1+2 | where (abc + count >= 44 or data_d == 2) and data == 1 | keep color, abc")) {
             logger.info(results);
-            Assert.assertEquals(10, getValuesList(results).size());
-            Assert.assertEquals(2, results.columns().size());
+            assertEquals(10, getValuesList(results).size());
+            assertEquals(2, results.columns().size());
             for (List<Object> values : getValuesList(results)) {
                 assertThat((String) values.get(0), equalTo("green"));
                 assertThat((Integer) values.get(1), equalTo(3));
@@ -610,8 +609,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testWhereNegatedCondition() {
         try (var results = run("from test | eval abc=1+2 | where abc + count > 45 and data != 1 | keep color, data")) {
             logger.info(results);
-            Assert.assertEquals(10, getValuesList(results).size());
-            Assert.assertEquals(2, results.columns().size());
+            assertEquals(10, getValuesList(results).size());
+            assertEquals(2, results.columns().size());
             for (List<Object> values : getValuesList(results)) {
                 assertThat((String) values.get(0), equalTo("red"));
                 assertThat((Long) values.get(1), equalTo(2L));
@@ -622,10 +621,10 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testEvalOverride() {
         try (var results = run("from test | eval count = count + 1 | eval count = count + 1")) {
             logger.info(results);
-            Assert.assertEquals(40, getValuesList(results).size());
-            Assert.assertEquals(1, results.columns().stream().filter(c -> c.name().equals("count")).count());
+            assertEquals(40, getValuesList(results).size());
+            assertEquals(1, results.columns().stream().filter(c -> c.name().equals("count")).count());
             int countIndex = results.columns().size() - 1;
-            Assert.assertEquals(new ColumnInfo("count", "long"), results.columns().get(countIndex));
+            assertEquals(new ColumnInfo("count", "long"), results.columns().get(countIndex));
             for (List<Object> values : getValuesList(results)) {
                 assertThat((Long) values.get(countIndex), greaterThanOrEqualTo(42L));
             }
@@ -635,7 +634,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testProjectRename() {
         try (var results = run("from test | eval y = count | rename count as x | keep x, y")) {
             logger.info(results);
-            Assert.assertEquals(40, getValuesList(results).size());
+            assertEquals(40, getValuesList(results).size());
             assertThat(results.columns(), contains(new ColumnInfo("x", "long"), new ColumnInfo("y", "long")));
             for (List<Object> values : getValuesList(results)) {
                 assertThat((Long) values.get(0), greaterThanOrEqualTo(40L));
@@ -647,7 +646,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testProjectRenameEval() {
         try (var results = run("from test | eval y = count | rename count as x | keep x, y | eval x2 = x + 1 | eval y2 = y + 2")) {
             logger.info(results);
-            Assert.assertEquals(40, getValuesList(results).size());
+            assertEquals(40, getValuesList(results).size());
             assertThat(
                 results.columns(),
                 contains(
@@ -669,7 +668,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testProjectRenameEvalProject() {
         try (var results = run("from test | eval y = count | rename count as x | keep x, y | eval z = x + y | keep x, y, z")) {
             logger.info(results);
-            Assert.assertEquals(40, getValuesList(results).size());
+            assertEquals(40, getValuesList(results).size());
             assertThat(results.columns(), contains(new ColumnInfo("x", "long"), new ColumnInfo("y", "long"), new ColumnInfo("z", "long")));
             for (List<Object> values : getValuesList(results)) {
                 assertThat((Long) values.get(0), greaterThanOrEqualTo(40L));
@@ -682,7 +681,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testProjectOverride() {
         try (var results = run("from test | eval cnt = count | rename count as data | keep cnt, data")) {
             logger.info(results);
-            Assert.assertEquals(40, getValuesList(results).size());
+            assertEquals(40, getValuesList(results).size());
             assertThat(results.columns(), contains(new ColumnInfo("cnt", "long"), new ColumnInfo("data", "long")));
             for (List<Object> values : getValuesList(results)) {
                 assertThat(values.get(1), is(values.get(0)));
@@ -845,8 +844,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testEvalWithNullAndAvg() {
         try (EsqlQueryResponse results = run("from test | eval nullsum = count_d + null | stats avg(nullsum)")) {
             logger.info(results);
-            Assert.assertEquals(1, results.columns().size());
-            Assert.assertEquals(1, getValuesList(results).size());
+            assertEquals(1, results.columns().size());
+            assertEquals(1, getValuesList(results).size());
             assertEquals("avg(nullsum)", results.columns().get(0).name());
             assertEquals("double", results.columns().get(0).type());
             assertEquals(1, getValuesList(results).get(0).size());
@@ -1058,8 +1057,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
                 | keep data, count, color
             """)) {
             logger.info(results);
-            Assert.assertEquals(3, results.columns().size());
-            Assert.assertEquals(10, getValuesList(results).size());
+            assertEquals(3, results.columns().size());
+            assertEquals(10, getValuesList(results).size());
 
             // assert column metadata
             assertEquals("data", results.columns().get(0).name());
@@ -1109,8 +1108,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         int limit = randomIntBetween(1, 5);
         try (EsqlQueryResponse results = run("from sorted_test_index | sort time " + sortOrder + " | limit " + limit + " | keep time")) {
             logger.info(results);
-            Assert.assertEquals(1, results.columns().size());
-            Assert.assertEquals(limit, getValuesList(results).size());
+            assertEquals(1, results.columns().size());
+            assertEquals(limit, getValuesList(results).size());
 
             // assert column metadata
             assertEquals("time", results.columns().get(0).name());
@@ -1217,6 +1216,32 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
                 }
                 assertThat(actual, equalTo(groups));
             }
+        }
+    }
+
+    public void testStatsNestFields() {
+        String node1 = internalCluster().startDataOnlyNode();
+        String node2 = internalCluster().startDataOnlyNode();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("index-1")
+                .setSettings(Settings.builder().put("index.routing.allocation.require._name", node1))
+                .setMapping("field_1", "type=keyword")
+        );
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("index-2")
+                .setSettings(Settings.builder().put("index.routing.allocation.require._name", node2))
+                .setMapping("field_2", "type=keyword")
+        );
+        try (var resp = run("from index-1,index-2 | where field_1 is not null | stats c = count(*), c1 = count(field_1)")) {
+            var valuesList = getValuesList(resp);
+            assertEquals(2, resp.columns().size());
+            assertEquals(1, valuesList.size());
+
+            assertThat(valuesList.get(0), contains(0L, 0L));
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1227,21 +1227,23 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
                 .indices()
                 .prepareCreate("index-1")
                 .setSettings(Settings.builder().put("index.routing.allocation.require._name", node1))
-                .setMapping("field_1", "type=keyword")
+                .setMapping("field_1", "type=integer")
         );
         assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("index-2")
                 .setSettings(Settings.builder().put("index.routing.allocation.require._name", node2))
-                .setMapping("field_2", "type=keyword")
+                .setMapping("field_2", "type=integer")
         );
-        try (var resp = run("from index-1,index-2 | where field_1 is not null | stats c = count(*), c1 = count(field_1)")) {
+        try (
+            var resp = run("from index-1,index-2 | where field_1 is not null | stats c = count(*), c1 = count(field_1), m = min(field_1)")
+        ) {
             var valuesList = getValuesList(resp);
-            assertEquals(2, resp.columns().size());
+            assertEquals(3, resp.columns().size());
             assertEquals(1, valuesList.size());
 
-            assertThat(valuesList.get(0), contains(0L, 0L));
+            assertThat(valuesList.get(0), contains(0L, 0L, nullValue()));
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1257,7 +1257,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
             assertEquals(3, resp.columns().size());
             assertEquals(1, valuesList.size());
 
-            assertThat(valuesList.get(0), contains(0L, 0L, nullValue()));
+            assertThat(valuesList.get(0), contains(0L, 0L, 0L));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -496,12 +496,13 @@ public final class PlanNamedTypes {
     }
 
     static ExchangeSinkExec readExchangeSinkExec(PlanStreamInput in) throws IOException {
-        return new ExchangeSinkExec(in.readSource(), readAttributes(in), in.readPhysicalPlanNode());
+        return new ExchangeSinkExec(in.readSource(), readAttributes(in), in.readBoolean(), in.readPhysicalPlanNode());
     }
 
     static void writeExchangeSinkExec(PlanStreamOutput out, ExchangeSinkExec exchangeSinkExec) throws IOException {
         out.writeNoSource();
         writeAttributes(out, exchangeSinkExec.output());
+        out.writeBoolean(exchangeSinkExec.isIntermediateAgg());
         out.writePhysicalPlanNode(exchangeSinkExec.child());
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
@@ -97,6 +98,8 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
     }
 
     protected List<Batch<PhysicalPlan>> rules(boolean optimizeForEsSource) {
+        var localSource = new Batch<>("Local execution", Limiter.ONCE, new AlignLocalOutputToExchange());
+
         List<Rule<?, PhysicalPlan>> esSourceRules = new ArrayList<>(4);
         esSourceRules.add(new ReplaceAttributeSourceWithDocId());
 
@@ -113,12 +116,31 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
         // add the field extraction in just one pass
         // add it at the end after all the other rules have ran
         var fieldExtraction = new Batch<>("Field extraction", Limiter.ONCE, new InsertFieldExtraction());
-        return asList(pushdown, fieldExtraction);
+        return asList(localSource, pushdown, fieldExtraction);
     }
 
     @Override
     protected List<Batch<PhysicalPlan>> batches() {
         return rules(true);
+    }
+
+    /**
+     * LocalSources, resulting from folding a query to no-op, can miss that they happen on a local node.
+     * This is fixed by this rule which aligns the two.
+     */
+    private static class AlignLocalOutputToExchange extends OptimizerRule<ExchangeExec> {
+
+        @Override
+        protected PhysicalPlan rule(ExchangeExec exchange) {
+            PhysicalPlan plan = exchange;
+            if (exchange.child() instanceof LocalSourceExec localExec) {
+                var output = exchange.output();
+                if (output.equals(localExec.output()) == false) {
+                    plan = exchange.replaceChild(new LocalSourceExec(localExec.source(), output, localExec.supplier()));
+                }
+            }
+            return plan;
+        }
     }
 
     private static class ReplaceAttributeSourceWithDocId extends OptimizerRule<EsSourceExec> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -509,8 +509,8 @@ public class LogicalPlanOptimizer extends RuleExecutor<LogicalPlan> {
             for (var agg : aggs) {
                 // there needs to be an alias
                 if (agg instanceof Alias a && a.child() instanceof AggregateFunction aggFunc) {
+                    // look for count(literal) with literal != null
                     Object value = aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null) ? 0L : null;
-                    //
                     var wrapper = BlockUtils.wrapperFor(blockFactory, LocalExecutionPlanner.toElementType(aggFunc.dataType()), 1);
                     wrapper.accept(value);
                     blocks[i++] = wrapper.builder().build();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -505,14 +505,16 @@ public class LogicalPlanOptimizer extends RuleExecutor<LogicalPlan> {
             for (var agg : aggs) {
                 // there needs to be an alias
                 if (agg instanceof Alias a && a.child() instanceof AggregateFunction aggFunc) {
-                    result.add(aggFunc instanceof Count ? 0L : null);
+                    result.add(aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null) ? 0L : null);
                 } else {
                     throw new EsqlIllegalArgumentException("Did not expect a non-aliased aggregation {}", agg);
                 }
             }
+
             var blocks = BlockUtils.fromListRow(BlockFactory.getNonBreakingInstance(), result);
             return LocalSupplier.of(blocks);
         }
+
     }
 
     private static LogicalPlan skipPlan(UnaryPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExec.java
@@ -46,10 +46,11 @@ public class ExchangeSinkExec extends UnaryExec {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ExchangeSinkExec that = (ExchangeSinkExec) o;
-        return Objects.equals(output, that.output) && intermediateAgg == that.intermediateAgg;
+        if (super.equals(o)) {
+            ExchangeSinkExec that = (ExchangeSinkExec) o;
+            return intermediateAgg == that.intermediateAgg && Objects.equals(output, that.output);
+        }
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExec.java
@@ -12,14 +12,17 @@ import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ExchangeSinkExec extends UnaryExec {
 
     private final List<Attribute> output;
+    private final boolean intermediateAgg;
 
-    public ExchangeSinkExec(Source source, List<Attribute> output, PhysicalPlan child) {
+    public ExchangeSinkExec(Source source, List<Attribute> output, boolean intermediateAgg, PhysicalPlan child) {
         super(source, child);
         this.output = output;
+        this.intermediateAgg = intermediateAgg;
     }
 
     @Override
@@ -27,13 +30,30 @@ public class ExchangeSinkExec extends UnaryExec {
         return output;
     }
 
+    public boolean isIntermediateAgg() {
+        return intermediateAgg;
+    }
+
     @Override
     protected NodeInfo<? extends ExchangeSinkExec> info() {
-        return NodeInfo.create(this, ExchangeSinkExec::new, output, child());
+        return NodeInfo.create(this, ExchangeSinkExec::new, output, intermediateAgg, child());
     }
 
     @Override
     public ExchangeSinkExec replaceChild(PhysicalPlan newChild) {
-        return new ExchangeSinkExec(source(), output, newChild);
+        return new ExchangeSinkExec(source(), output, intermediateAgg, newChild);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExchangeSinkExec that = (ExchangeSinkExec) o;
+        return Objects.equals(output, that.output) && intermediateAgg == that.intermediateAgg;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(output, intermediateAgg, child());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.DataPartitioning;
@@ -53,6 +54,7 @@ import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.evaluator.command.GrokEvaluatorExtracter;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -346,6 +348,31 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planExchangeSink(ExchangeSinkExec exchangeSink, LocalExecutionPlannerContext context) {
         Objects.requireNonNull(exchangeSinkHandler, "ExchangeSinkHandler wasn't provided");
         var child = exchangeSink.child();
+        // see https://github.com/elastic/elasticsearch/issues/100807 - handle case where the plan has been fully minimized
+        // to a local relation and the aggregate intermediate data erased. For this scenario, match the output the exchange output
+        // with that of the local relation
+
+        if (child instanceof LocalSourceExec localExec) {
+            var output = exchangeSink.output();
+            var localOutput = localExec.output();
+            if (output.equals(localOutput) == false) {
+                // the outputs are going to be similar except for the bool "seen" flags which are added in
+                List<Block> blocks = new ArrayList<>(asList(localExec.supplier().get()));
+                if (blocks.size() > 0) {
+                    Block boolBlock = BooleanBlock.newConstantBlockWith(true, 1);
+                    for (int i = 0, s = output.size(); i < s; i++) {
+                        var out = output.get(i);
+                        if (out.dataType() == DataTypes.BOOLEAN) {
+                            blocks.add(i, boolBlock);
+                        }
+                    }
+                }
+                var newSupplier = LocalSupplier.of(blocks.toArray(Block[]::new));
+
+                child = new LocalSourceExec(localExec.source(), output, newSupplier);
+            }
+        }
+
         PhysicalOperation source = plan(child, context);
 
         Function<Page, Page> transformer = exchangeSink.isIntermediateAgg()

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -348,8 +348,9 @@ public class LocalExecutionPlanner {
         var child = exchangeSink.child();
         PhysicalOperation source = plan(child, context);
 
-        boolean isAgg = child instanceof AggregateExec || child instanceof EsStatsQueryExec;
-        Function<Page, Page> transformer = isAgg ? Function.identity() : alignPageToAttributes(exchangeSink.output(), source.layout);
+        Function<Page, Page> transformer = exchangeSink.isIntermediateAgg()
+            ? Function.identity()
+            : alignPageToAttributes(exchangeSink.output(), source.layout);
 
         return source.withSink(new ExchangeSinkOperatorFactory(exchangeSinkHandler::createExchangeSink, transformer), source.layout);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -356,7 +356,7 @@ public class LocalExecutionPlanner {
             var output = exchangeSink.output();
             var localOutput = localExec.output();
             if (output.equals(localOutput) == false) {
-                // the outputs are going to be similar except for the bool "seen" flags which are added in
+                // the outputs are going to be similar except for the bool "seen" flags which are added in below
                 List<Block> blocks = new ArrayList<>(asList(localExec.supplier().get()));
                 if (blocks.size() > 0) {
                     Block boolBlock = BooleanBlock.newConstantBlockWith(true, 1);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -52,7 +52,7 @@ public class PlannerUtils {
         PhysicalPlan coordinatorPlan = plan.transformUp(ExchangeExec.class, e -> {
             // remember the datanode subplan and wire it to a sink
             var subplan = e.child();
-            dataNodePlan.set(new ExchangeSinkExec(e.source(), e.output(), subplan));
+            dataNodePlan.set(new ExchangeSinkExec(e.source(), e.output(), e.isInBetweenAggs(), subplan));
 
             return new ExchangeSourceExec(e.source(), e.output(), e.isInBetweenAggs());
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -117,7 +117,8 @@ public class PlannerUtils {
                     query -> new EsSourceExec(Source.EMPTY, query.index(), query.output(), filter)
                 );
             }
-            return EstimatesRowSize.estimateRowSize(f.estimatedRowSize(), physicalOptimizer.localOptimize(physicalFragment));
+            var localOptimized = physicalOptimizer.localOptimize(physicalFragment);
+            return EstimatesRowSize.estimateRowSize(f.estimatedRowSize(), localOptimized);
         });
         return isCoordPlan.get() ? plan : localPhysicalPlan;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.EsqlTestUtils.TestSearchStats;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
@@ -30,13 +31,13 @@ import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec.Stat;
 import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.planner.FilterTests;
 import org.elasticsearch.xpack.esql.planner.Mapper;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
-import org.elasticsearch.xpack.esql.stats.DisabledSearchStats;
 import org.elasticsearch.xpack.esql.stats.Metrics;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -63,6 +64,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+//@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE,org.elasticsearch.compute:TRACE", reason = "debug")
 public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     private static final String PARAM_FORMATTING = "%1$s";
@@ -81,7 +83,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
     private int allFieldRowSize;
 
     private final EsqlConfiguration config;
-    private final SearchStats IS_SV_STATS = new EsqlTestUtils.TestSearchStats() {
+    private final SearchStats IS_SV_STATS = new TestSearchStats() {
         @Override
         public boolean isSingleValue(String field) {
             return true;
@@ -325,6 +327,37 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(plan.anyMatch(EsQueryExec.class::isInstance), is(true));
     }
 
+    /**
+     * Expecting
+     * LimitExec[500[INTEGER]]
+     * \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS c],FINAL,null]
+     *   \_ExchangeExec[[count{r}#14, seen{r}#15],true]
+     *     \_LocalSourceExec[[c{r}#3],[LongVectorBlock[vector=ConstantLongVector[positions=1, value=0]]]]
+     */
+    public void testLocalAggOptimizedToLocalRelation() {
+        var stats = new TestSearchStats() {
+            @Override
+            public boolean exists(String field) {
+                return "emp_no".equals(field) == false;
+            }
+        };
+
+        var plan = plan("""
+            from test
+            | where emp_no > 10010
+            | stats c = count()
+            """, stats);
+
+        var limit = as(plan, LimitExec.class);
+        var agg = as(limit.child(), AggregateExec.class);
+        assertThat(agg.getMode(), is(FINAL));
+        assertThat(Expressions.names(agg.aggregates()), contains("c"));
+        var exchange = as(agg.child(), ExchangeExec.class);
+        assertThat(exchange.isInBetweenAggs(), is(true));
+        var localSource = as(exchange.child(), LocalSourceExec.class);
+        assertThat(Expressions.names(localSource.output()), contains("count", "seen"));
+    }
+
     private QueryBuilder wrapWithSingleQuery(QueryBuilder inner, String fieldName) {
         return FilterTests.singleValueQuery(inner, fieldName);
     }
@@ -357,9 +390,21 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         // this is of no use in the unit tests, which checks the plan as a whole instead of each
         // individually hence why here the plan is kept as is
 
-        var logicalTestOptimizer = new LocalLogicalPlanOptimizer(new LocalLogicalOptimizerContext(config, new DisabledSearchStats()));
+        var logicalTestOptimizer = new LocalLogicalPlanOptimizer(new LocalLogicalOptimizerContext(config, searchStats));
         var physicalTestOptimizer = new TestLocalPhysicalPlanOptimizer(new LocalPhysicalOptimizerContext(config, searchStats), true);
         var l = PlannerUtils.localPlan(plan, logicalTestOptimizer, physicalTestOptimizer);
+
+        // handle local reduction alignment
+        l = l.transformUp(ExchangeExec.class, exg -> {
+            PhysicalPlan pl = exg;
+            if (exg.isInBetweenAggs() && exg.child() instanceof LocalSourceExec lse) {
+                var output = exg.output();
+                if (lse.output().equals(output) == false) {
+                    pl = exg.replaceChild(new LocalSourceExec(lse.source(), output, lse.supplier()));
+                }
+            }
+            return pl;
+        });
 
         // System.out.println("* Localized DataNode Plan\n" + l);
         return l;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -395,16 +394,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         var l = PlannerUtils.localPlan(plan, logicalTestOptimizer, physicalTestOptimizer);
 
         // handle local reduction alignment
-        l = l.transformUp(ExchangeExec.class, exg -> {
-            PhysicalPlan pl = exg;
-            if (exg.isInBetweenAggs() && exg.child() instanceof LocalSourceExec lse) {
-                var output = exg.output();
-                if (lse.output().equals(output) == false) {
-                    pl = exg.replaceChild(new LocalSourceExec(lse.source(), output, lse.supplier()));
-                }
-            }
-            return pl;
-        });
+        l = PhysicalPlanOptimizerTests.localRelationshipAlignment(l);
 
         // System.out.println("* Localized DataNode Plan\n" + l);
         return l;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
@@ -1916,7 +1915,14 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         });
 
         // handle local reduction alignment
-        l = l.transformUp(ExchangeExec.class, exg -> {
+        l = localRelationshipAlignment(l);
+        // System.out.println("* Localized DataNode Plan\n" + l);
+        return l;
+    }
+
+    static PhysicalPlan localRelationshipAlignment(PhysicalPlan l) {
+        // handle local reduction alignment
+        return l.transformUp(ExchangeExec.class, exg -> {
             PhysicalPlan pl = exg;
             if (exg.isInBetweenAggs() && exg.child() instanceof LocalSourceExec lse) {
                 var output = exg.output();
@@ -1926,8 +1932,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             }
             return pl;
         });
-        // System.out.println("* Localized DataNode Plan\n" + l);
-        return l;
+
     }
 
     private PhysicalPlan physicalPlan(String query) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -103,7 +103,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-//@TestLogging(value = "org.elasticsearch.xpack.esql.optimizer:TRACE", reason = "debug")
+//@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class PhysicalPlanOptimizerTests extends ESTestCase {
 
     private static final String PARAM_FORMATTING = "%1$s";
@@ -1860,6 +1860,37 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(source.limit().fold(), equalTo(10));
     }
 
+    /**
+     * Expects
+     * LimitExec[500[INTEGER]]
+     * \_AggregateExec[[languages{f}#9],[MIN(salary{f}#11) AS m, languages{f}#9],FINAL,8]
+     *   \_ExchangeExec[[languages{f}#9, min{r}#16, seen{r}#17],true]
+     *     \_LocalSourceExec[[languages{f}#9, min{r}#16, seen{r}#17],EMPTY]
+     */
+    public void testAggToLocalRelationOnDataNode() {
+        var plan = physicalPlan("""
+            from test
+            | where first_name is not null
+            | stats m = min(salary) by languages
+            """);
+
+        var stats = new EsqlTestUtils.TestSearchStats() {
+            public boolean exists(String field) {
+                return "salary".equals(field);
+            }
+        };
+        var optimized = optimizedPlan(plan, stats);
+
+        var limit = as(optimized, LimitExec.class);
+        var aggregate = as(limit.child(), AggregateExec.class);
+        assertThat(aggregate.groupings(), hasSize(1));
+        assertThat(aggregate.estimatedRowSize(), equalTo(Long.BYTES));
+
+        var exchange = asRemoteExchange(aggregate.child());
+        var localSourceExec = as(exchange.child(), LocalSourceExec.class);
+        assertThat(Expressions.names(localSourceExec.output()), contains("languages", "min", "seen"));
+    }
+
     private static EsQueryExec source(PhysicalPlan plan) {
         if (plan instanceof ExchangeExec exchange) {
             plan = exchange.child();
@@ -1884,6 +1915,17 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             return EstimatesRowSize.estimateRowSize(fragment.estimatedRowSize(), localPlan);
         });
 
+        // handle local reduction alignment
+        l = l.transformUp(ExchangeExec.class, exg -> {
+            PhysicalPlan pl = exg;
+            if (exg.isInBetweenAggs() && exg.child() instanceof LocalSourceExec lse) {
+                var output = exg.output();
+                if (lse.output().equals(output) == false) {
+                    pl = exg.replaceChild(new LocalSourceExec(lse.source(), output, lse.supplier()));
+                }
+            }
+            return pl;
+        });
         // System.out.println("* Localized DataNode Plan\n" + l);
         return l;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
@@ -1108,6 +1108,13 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
             """, Set.of("*"));
     }
 
+    public void testWhereClauseNoProjection() {
+        assertFieldNames("""
+            from test
+            | where first_name is not null
+            """, Set.of("*"));
+    }
+
     private void assertFieldNames(String query, Set<String> expected) {
         Set<String> fieldNames = EsqlSession.fieldNames(parser.createStatement(query));
         assertThat(fieldNames, equalTo(expected));


### PR DESCRIPTION
Data nodes can fold a plan (typically for missing fields) to an empty, local relationship as a logical optimization.
However the context, such as whether the output is an aggregation or not gets lost which is problematic during physical execution since the upstream aggregation expects the intermediate states while the aggregation returns the final ones.

Consider the query: from index | where field is not null | stats c = count()

On shards where the field in the filter does not exist, the filter gets nullified which folds the whole _local_ plan to a LocalRelation returning c as 0.
However the data node should return the intermediate aggregation states (count and seen) - otherwise the query fails with an internal error (NPE) since the expected channel by the exchange is not found.

Fix #100807