### PR TITLE
Separate version qualifier from version in build

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -298,7 +298,7 @@ public class InstallPluginActionTests extends ESTestCase {
                 "version",
                 "1.0",
                 "elasticsearch.version",
-                InstallPluginAction.getSemanticVersion(Build.current().version()),
+                Build.current().version(),
                 "java.version",
                 System.getProperty("java.specification.version")
 
@@ -1110,8 +1110,8 @@ public class InstallPluginActionTests extends ESTestCase {
         String url = String.format(
             Locale.ROOT,
             "https://snapshots.elastic.co/%s-abc123/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-%s.zip",
-            InstallPluginAction.getSemanticVersion(Build.current().version()),
-            Build.current().version()
+            Build.current().version(),
+            Build.current().qualifiedVersion()
         );
         assertInstallPluginFromUrl("analysis-icu", url, "abc123", true);
     }
@@ -1120,8 +1120,8 @@ public class InstallPluginActionTests extends ESTestCase {
         String url = String.format(
             Locale.ROOT,
             "https://snapshots.elastic.co/%s-abc123/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-%s.zip",
-            InstallPluginAction.getSemanticVersion(Build.current().version()),
-            Build.current().version()
+            Build.current().version(),
+            Build.current().qualifiedVersion()
         );
         // attempting to install a release build of a plugin (no staging ID) on a snapshot build should throw a user exception
         final UserException e = expectThrows(
@@ -1137,9 +1137,9 @@ public class InstallPluginActionTests extends ESTestCase {
 
     public void testOfficialPluginStaging() throws Exception {
         String url = "https://staging.elastic.co/"
-            + InstallPluginAction.getSemanticVersion(Build.current().version())
-            + "-abc123/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-"
             + Build.current().version()
+            + "-abc123/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-"
+            + Build.current().qualifiedVersion()
             + ".zip";
         assertInstallPluginFromUrl("analysis-icu", url, "abc123", false);
     }
@@ -1148,7 +1148,7 @@ public class InstallPluginActionTests extends ESTestCase {
         String url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-"
             + Platforms.PLATFORM_NAME
             + "-"
-            + Build.current().version()
+            + Build.current().qualifiedVersion()
             + ".zip";
         assertInstallPluginFromUrl("analysis-icu", url, null, false);
     }
@@ -1157,16 +1157,16 @@ public class InstallPluginActionTests extends ESTestCase {
         String url = String.format(
             Locale.ROOT,
             "https://snapshots.elastic.co/%s-abc123/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-%s-%s.zip",
-            InstallPluginAction.getSemanticVersion(Build.current().version()),
+            Build.current().version(),
             Platforms.PLATFORM_NAME,
-            Build.current().version()
+            Build.current().qualifiedVersion()
         );
         assertInstallPluginFromUrl("analysis-icu", url, "abc123", true);
     }
 
     public void testOfficialPlatformPluginStaging() throws Exception {
         String url = "https://staging.elastic.co/"
-            + InstallPluginAction.getSemanticVersion(Build.current().version())
+            + Build.current().version()
             + "-abc123/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-"
             + Platforms.PLATFORM_NAME
             + "-"

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -19,9 +19,11 @@ import org.elasticsearch.plugins.ExtensionLoader;
 import java.io.IOException;
 import java.net.URL;
 import java.security.CodeSource;
+import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
+import java.util.regex.Pattern;
 
 /**
  * Information about a build of Elasticsearch.
@@ -31,8 +33,9 @@ public record Build(
     Type type,
     String hash,
     String date,
-    boolean isSnapshot,
     String version,
+    String qualifier,
+    boolean isSnapshot,
     String minWireCompatVersion,
     String minIndexCompatVersion,
     String displayString
@@ -48,6 +51,8 @@ public record Build(
         }
     }
 
+    private static final Pattern qualfiedVersionRegex = Pattern.compile("([^-]+)(?:-((:?alpha|beta|rc)[0-9]+))?(?:-SNAPSHOT)?");
+
     /**
      * Finds build info scanned from the server jar.
      */
@@ -56,6 +61,7 @@ public record Build(
         final String hash;
         final String date;
         final boolean isSnapshot;
+        final String qualifier;
         final String version;
 
         // these are parsed at startup, and we require that we are able to recognize the values passed in by the startup scripts
@@ -71,7 +77,13 @@ public record Build(
                 hash = manifest.getMainAttributes().getValue("Change");
                 date = manifest.getMainAttributes().getValue("Build-Date");
                 isSnapshot = "true".equals(manifest.getMainAttributes().getValue("X-Compile-Elasticsearch-Snapshot"));
-                version = manifest.getMainAttributes().getValue("X-Compile-Elasticsearch-Version");
+                String rawVersion = manifest.getMainAttributes().getValue("X-Compile-Elasticsearch-Version");
+                var versionMatcher = qualfiedVersionRegex.matcher(rawVersion);
+                if (versionMatcher.matches() == false) {
+                    throw new IllegalStateException(String.format(Locale.ROOT, "Malformed elasticsearch compile version: %s", rawVersion));
+                }
+                version = versionMatcher.group(1);
+                qualifier = versionMatcher.group(2);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -92,6 +104,7 @@ public record Build(
             } else {
                 isSnapshot = true;
             }
+            qualifier = System.getProperty("build.version_qualifier");
         }
         if (hash == null) {
             throw new IllegalStateException(
@@ -115,9 +128,9 @@ public record Build(
         final String flavor = "default";
         String minWireCompat = Version.CURRENT.minimumCompatibilityVersion().toString();
         String minIndexCompat = minimumCompatString(IndexVersion.MINIMUM_COMPATIBLE);
-        String displayString = defaultDisplayString(type, hash, date, version);
+        String displayString = defaultDisplayString(type, hash, date, qualifiedVersionString(version, qualifier, isSnapshot));
 
-        return new Build(flavor, type, hash, date, isSnapshot, version, minWireCompat, minIndexCompat, displayString);
+        return new Build(flavor, type, hash, date, version, qualifier, isSnapshot, minWireCompat, minIndexCompat, displayString);
     }
 
     public static String minimumCompatString(IndexVersion minimumCompatible) {
@@ -199,11 +212,27 @@ public record Build(
         final Type type = Type.fromDisplayName(in.readString(), false);
         String hash = in.readString();
         String date = in.readString();
-        boolean snapshot = in.readBoolean();
-        final String version = in.readString();
+        final String version;
+        final String qualifier;
+        final boolean snapshot;
         final String minWireVersion;
         final String minIndexVersion;
         final String displayString;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.BUILD_QUALIFIER_SEPARATED)) {
+            version = in.readString();
+            qualifier = in.readOptionalString();
+            snapshot = in.readBoolean();
+        } else {
+            snapshot = in.readBoolean();
+            String rawVersion = in.readString();
+            // need to separate out qualifiers from older nodes
+            var versionMatcher = qualfiedVersionRegex.matcher(rawVersion);
+            if (versionMatcher.matches() == false) {
+                throw new IllegalStateException(String.format(Locale.ROOT, "Malformed elasticsearch compile version: %s", rawVersion));
+            }
+            version = versionMatcher.group(1);
+            qualifier = versionMatcher.group(2);
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_500_041)) {
             minWireVersion = in.readString();
             minIndexVersion = in.readString();
@@ -214,9 +243,9 @@ public record Build(
             var versionConstant = Version.fromString(dashNdx == -1 ? version : version.substring(0, dashNdx));
             minWireVersion = versionConstant.minimumCompatibilityVersion().toString();
             minIndexVersion = minimumCompatString(IndexVersion.getMinimumCompatibleIndexVersion(versionConstant.id()));
-            displayString = defaultDisplayString(type, hash, date, version);
+            displayString = defaultDisplayString(type, hash, date, qualifiedVersionString(version, qualifier, snapshot));
         }
-        return new Build(flavor, type, hash, date, snapshot, version, minWireVersion, minIndexVersion, displayString);
+        return new Build(flavor, type, hash, date, version, qualifier, snapshot, minWireVersion, minIndexVersion, displayString);
     }
 
     public static void writeBuild(Build build, StreamOutput out) throws IOException {
@@ -227,8 +256,14 @@ public record Build(
         out.writeString(build.type().displayName());
         out.writeString(build.hash());
         out.writeString(build.date());
-        out.writeBoolean(build.isSnapshot());
-        out.writeString(build.qualifiedVersion());
+        if (out.getTransportVersion().onOrAfter(TransportVersions.BUILD_QUALIFIER_SEPARATED)) {
+            out.writeString(build.version());
+            out.writeOptionalString(build.qualifier());
+            out.writeBoolean(build.isSnapshot());
+        } else {
+            out.writeBoolean(build.isSnapshot());
+            out.writeString(build.qualifiedVersion());
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_500_041)) {
             out.writeString(build.minWireCompatVersion());
             out.writeString(build.minIndexCompatVersion());
@@ -246,19 +281,30 @@ public record Build(
      * @return the fully qualified build
      */
     public String qualifiedVersion() {
-        return version;
+        return qualifiedVersionString(version, qualifier, isSnapshot);
+    }
+
+    private static String qualifiedVersionString(String version, String qualifier, boolean isSnapshot) {
+        String versionString = version;
+        if (qualifier != null) {
+            versionString += "-" + qualifier;
+        }
+        if (isSnapshot) {
+            versionString += "-SNAPSHOT";
+        }
+        return versionString;
     }
 
     public boolean isProductionRelease() {
-        return isSnapshot() == false && version.matches(".*(-alpha\\d+)|(-beta\\d+)|(-rc\\d+)") == false;
+        return isSnapshot == false && qualifier == null;
     }
 
     public static String defaultDisplayString(Type type, String hash, String date, String version) {
         return "[" + type.displayName + "][" + hash + "][" + date + "][" + version + "]";
     }
 
-    @Override
+    /*@Override
     public String toString() {
         return displayString();
-    }
+    }*/
 }

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -303,8 +303,8 @@ public record Build(
         return "[" + type.displayName + "][" + hash + "][" + date + "][" + version + "]";
     }
 
-    /*@Override
+    @Override
     public String toString() {
         return displayString();
-    }*/
+    }
 }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -140,6 +140,7 @@ public class TransportVersions {
     public static final TransportVersion ELSER_SERVICE_MODEL_VERSION_ADDED = def(8_515_00_0);
     public static final TransportVersion NODE_STATS_HTTP_ROUTE_STATS_ADDED = def(8_516_00_0);
     public static final TransportVersion INCLUDE_SHARDS_STATS_ADDED = def(8_517_00_0);
+    public static final TransportVersion BUILD_QUALIFIER_SEPARATED = def(8_518_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.TransportVersionUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,54 +45,24 @@ public class BuildTests extends ESTestCase {
         String version = Math.abs(randomInt()) + "." + Math.abs(randomInt()) + "." + Math.abs(randomInt());
         Build build = Build.current();
         assertTrue(newBuild(build, Map.of("version", version, "isSnapshot", false)).isProductionRelease());
-        assertFalse(newBuild(build, Map.of("version", "7.0.0-SNAPSHOT", "isSnapshot", true)).isProductionRelease());
-        assertFalse(newBuild(build, Map.of("version", "7.0.0-alpha1", "isSnapshot", false)).isProductionRelease());
+        assertFalse(newBuild(build, Map.of("version", "7.0.0", "isSnapshot", true)).isProductionRelease());
+        assertFalse(newBuild(build, Map.of("version", "7.0.0", "qualifier", "alpha1", "isSnapshot", false)).isProductionRelease());
     }
 
-    private static class WriteableBuild implements Writeable {
-        private final Build build;
+    private record WriteableBuild(Build build) implements Writeable {
 
         WriteableBuild(StreamInput in) throws IOException {
-            build = Build.readBuild(in);
-        }
-
-        WriteableBuild(Build build) {
-            this.build = build;
+            this(Build.readBuild(in));
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             Build.writeBuild(build, out);
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            WriteableBuild that = (WriteableBuild) o;
-            return build.equals(that.build);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(build);
-        }
     }
 
     public void testSerialization() {
-        var randomBuild = new WriteableBuild(
-            new Build(
-                randomAlphaOfLength(6),
-                randomFrom(Build.Type.values()),
-                randomAlphaOfLength(6),
-                randomAlphaOfLength(6),
-                randomBoolean(),
-                randomAlphaOfLength(6),
-                randomAlphaOfLength(6),
-                randomAlphaOfLength(6),
-                randomAlphaOfLength(6)
-            )
-        );
+        var randomBuild = new WriteableBuild(randomBuild());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             randomBuild,
             // Note: the cast of the Copy- and MutateFunction is needed for some IDE (specifically Eclipse 4.10.0) to infer the right type
@@ -119,4 +90,29 @@ public class BuildTests extends ESTestCase {
         assertThat(e, hasToString(containsString("unexpected distribution type [" + displayName + "]; your distribution is broken")));
     }
 
+    public void testSerializationQualifierBwc() throws IOException {
+        var randomBuild = new WriteableBuild(randomBuild());
+        var combinedQualifierVersion = TransportVersionUtils.getPreviousVersion(TransportVersions.BUILD_QUALIFIER_SEPARATED);
+        var serializationVersion = TransportVersionUtils.randomVersionBetween(random(), null, combinedQualifierVersion);
+        var roundtrip = copyWriteable(randomBuild, writableRegistry(), WriteableBuild::new, serializationVersion);
+        assertThat(roundtrip.build.version(), equalTo(randomBuild.build.version()));
+        assertThat(roundtrip.build.qualifier(), equalTo(randomBuild.build.qualifier()));
+        assertThat(roundtrip.build.isSnapshot(), equalTo(randomBuild.build.isSnapshot()));
+        assertThat(roundtrip.build.displayString(), equalTo(randomBuild.build.displayString()));
+    }
+
+    private static Build randomBuild() {
+        return new Build(
+            randomAlphaOfLength(6),
+            randomFrom(Build.Type.values()),
+            randomAlphaOfLength(6),
+            randomAlphaOfLength(6),
+            randomAlphaOfLength(6),
+            randomFrom(random(), null, "alpha1", "beta1", "rc2"),
+            randomBoolean(),
+            randomAlphaOfLength(6),
+            randomAlphaOfLength(6),
+            randomAlphaOfLength(6)
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -91,8 +91,7 @@ public class BuildTests extends ESTestCase {
 
     public void testSerializationQualifierBwc() throws IOException {
         var randomBuild = new WriteableBuild(randomBuild());
-        var combinedQualifierVersion = TransportVersionUtils.getPreviousVersion(TransportVersions.BUILD_QUALIFIER_SEPARATED);
-        var serializationVersion = TransportVersionUtils.randomVersionBetween(random(), null, combinedQualifierVersion);
+        var serializationVersion = TransportVersionUtils.getPreviousVersion(TransportVersions.BUILD_QUALIFIER_SEPARATED);
         var roundtrip = copyWriteable(randomBuild, writableRegistry(), WriteableBuild::new, serializationVersion);
         assertThat(roundtrip.build.version(), equalTo(randomBuild.build.version()));
         assertThat(roundtrip.build.qualifier(), equalTo(randomBuild.build.qualifier()));

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.elasticsearch.test.BuildUtils.mutateBuild;
 import static org.elasticsearch.test.BuildUtils.newBuild;

--- a/server/src/test/java/org/elasticsearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/FeatureFlagTests.java
@@ -81,8 +81,9 @@ public class FeatureFlagTests extends ESTestCase {
             randomFrom(Build.Type.values()),
             Hex.encodeHexString(randomByteArrayOfLength(20)),
             Instant.now().toString(),
-            isSnapshot,
             VersionUtils.randomVersion(random()).toString(),
+            randomFrom(random(), null, "alpha1", "beta1", "rc2"),
+            isSnapshot,
             VersionUtils.randomVersion(random()).toString(),
             VersionUtils.randomVersion(random()).toString(),
             randomAlphaOfLength(10)

--- a/test/framework/src/main/java/org/elasticsearch/test/BuildUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BuildUtils.java
@@ -53,11 +53,9 @@ public class BuildUtils {
             int i = 0;
             for (var argComponent : argsComponents) {
                 Object value = argsOverrides.remove(argComponent.getName());
-                boolean containedValue = value != null;
                 if (value == null) {
                     value = argComponent.getAccessor().invoke(existing);
                 }
-                System.out.println(argComponent.getName() + " = " + value + (containedValue ? "" : " (original)"));
                 args[i++] = value;
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/BuildUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BuildUtils.java
@@ -53,9 +53,11 @@ public class BuildUtils {
             int i = 0;
             for (var argComponent : argsComponents) {
                 Object value = argsOverrides.remove(argComponent.getName());
+                boolean containedValue = value != null;
                 if (value == null) {
                     value = argComponent.getAccessor().invoke(existing);
                 }
+                System.out.println(argComponent.getName() + " = " + value + (containedValue ? "" : " (original)"));
                 args[i++] = value;
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/EqualsHashCodeTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/EqualsHashCodeTestUtils.java
@@ -104,7 +104,7 @@ public class EqualsHashCodeTestUtils {
             T copy = copyFunction.copy(original);
             try {
                 assertTrue(objectName + " copy is not equal to self", copy.equals(copy));
-                assertTrue(objectName + " is not equal to its copy", original.equals(copy));
+                assertThat(objectName + " is not equal to its copy", original, equalTo(copy));
                 assertTrue("equals is not symmetric", copy.equals(original));
                 assertThat(objectName + " hashcode is different from copies hashcode", copy.hashCode(), equalTo(original.hashCode()));
 


### PR DESCRIPTION
The build version is made up of a few parts in non-release builds. Both the snapshot and pre-release qualifiers are appended to it. These qualifiers used to be part of Version, but in 7.0 the qualifiers were made to be found only in the build info. The Build class retains these qualifiers through the compile ES version extracted from the server jar at runtime.

Build.qualifiedVersion() is suppose to provide the fully qualified version, including snapshot and pre-release qualifiers. Yet Build.version() also includes this information; there is no distinction since the qualifier was moved to be only in the build info.

This commit separates the pre-release qualifier from the version. It maintains bwc in talking to older nodes, passing the fully qualified version there, but in current nodes splits out the pre-release qualifier into a new member of Build.