### PR TITLE
QL: Preserve subfields for invalid types

### DIFF
--- a/docs/changelog/100875.yaml
+++ b/docs/changelog/100875.yaml
@@ -1,0 +1,6 @@
+pr: 100875
+summary: Preserve subfields for unsupported types
+area: "SQL, EQL, ES|QL"
+type: bug
+issues:
+ - 100869

--- a/docs/changelog/100875.yaml
+++ b/docs/changelog/100875.yaml
@@ -1,6 +1,6 @@
 pr: 100875
 summary: Preserve subfields for unsupported types
-area: "SQL, EQL, ES|QL"
+area: "Query Languages"
 type: bug
 issues:
  - 100869

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1220,6 +1220,16 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    public void testFilterNestedFields() {
+        assertAcked(client().admin().indices().prepareCreate("index-1").setMapping("file.name", "type=keyword"));
+        assertAcked(client().admin().indices().prepareCreate("index-2").setMapping("file", "type=keyword"));
+        try (var resp = run("from index-1,index-2 | where file.name is not null")) {
+            var valuesList = getValuesList(resp);
+            assertEquals(2, resp.columns().size());
+            assertEquals(0, valuesList.size());
+        }
+    }
+
     private void createNestedMappingIndex(String indexName) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -956,12 +956,17 @@ public final class PlanNamedTypes {
     }
 
     static InvalidMappedField readInvalidMappedField(PlanStreamInput in) throws IOException {
-        return new InvalidMappedField(in.readString(), in.readString());
+        return new InvalidMappedField(
+            in.readString(),
+            in.readString(),
+            in.readImmutableMap(StreamInput::readString, readerFromPlanReader(PlanStreamInput::readEsFieldNamed))
+        );
     }
 
     static void writeInvalidMappedField(PlanStreamOutput out, InvalidMappedField field) throws IOException {
         out.writeString(field.getName());
         out.writeString(field.errorMessage());
+        out.writeMap(field.getProperties(), (o, v) -> out.writeNamed(EsField.class, v));
     }
 
     static KeywordEsField readKeywordEsField(PlanStreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -176,7 +176,15 @@ public class EsqlSession {
             TableInfo tableInfo = preAnalysis.indices.get(0);
             TableIdentifier table = tableInfo.id();
             var fieldNames = fieldNames(parsed);
-            indexResolver.resolveAsMergedMapping(table.index(), fieldNames, false, Map.of(), listener, EsqlSession::specificValidity);
+            indexResolver.resolveAsMergedMapping(
+                table.index(),
+                fieldNames,
+                false,
+                Map.of(),
+                listener,
+                EsqlSession::specificValidity,
+                IndexResolver.PRESERVE_PROPERTIES
+            );
         } else {
             try {
                 // occurs when dealing with local relations (row a = 1)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -56,7 +56,8 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
             EsqlDataTypeRegistry.INSTANCE,
             "idx-*",
             caps,
-            EsqlSession::specificValidity
+            EsqlSession::specificValidity,
+            IndexResolver.PRESERVE_PROPERTIES
         );
 
         EsField f = resolution.get().mapping().get(fieldCap.getName());

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -711,6 +711,16 @@ public class IndexResolver {
                         EsField field = indexFields.flattedMapping.get(fieldName);
                         if (field == null || (invalidField != null && (field instanceof InvalidMappedField) == false)) {
                             createField(typeRegistry, fieldName, indexFields, fieldCaps, invalidField, typeCap);
+                            // if there was a field before, copy its properties
+                            if (field != null) {
+                                EsField newField = indexFields.flattedMapping.get(fieldName);
+                                if (newField != field) {
+                                    if (newField.getProperties().size() > 0) {
+                                        throw new QlIllegalArgumentException("Expected new field to have no properties");
+                                    }
+                                    newField.getProperties().putAll(field.getProperties());
+                                }
+                            }
                         }
                     }
                 }
@@ -772,7 +782,7 @@ public class IndexResolver {
                     s,
                     typeCap.getType(),
                     typeCap.getMetricType(),
-                    emptyMap(),
+                    new TreeMap<>(),
                     typeCap.isAggregatable(),
                     isAliasFieldType.get()
                 )

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -358,7 +359,26 @@ public class IndexResolver {
         client.fieldCaps(
             fieldRequest,
             listener.delegateFailureAndWrap(
-                (l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response, specificValidityVerifier))
+                (l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response, specificValidityVerifier, null))
+            )
+        );
+    }
+
+    public void resolveAsMergedMapping(
+        String indexWildcard,
+        Set<String> fieldNames,
+        boolean includeFrozen,
+        Map<String, Object> runtimeMappings,
+        ActionListener<IndexResolution> listener,
+        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> specificValidityVerifier,
+        BiConsumer<EsField, InvalidMappedField> fieldUpdater
+
+    ) {
+        FieldCapabilitiesRequest fieldRequest = createFieldCapsRequest(indexWildcard, fieldNames, includeFrozen, runtimeMappings);
+        client.fieldCaps(
+            fieldRequest,
+            listener.delegateFailureAndWrap(
+                (l, response) -> l.onResponse(mergedMappings(typeRegistry, indexWildcard, response, specificValidityVerifier, fieldUpdater))
             )
         );
     }
@@ -369,13 +389,22 @@ public class IndexResolver {
         FieldCapabilitiesResponse fieldCapsResponse,
         BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> specificValidityVerifier
     ) {
+        return mergedMappings(typeRegistry, indexPattern, fieldCapsResponse, specificValidityVerifier, null);
+    }
+
+    public static IndexResolution mergedMappings(
+        DataTypeRegistry typeRegistry,
+        String indexPattern,
+        FieldCapabilitiesResponse fieldCapsResponse,
+        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> specificValidityVerifier,
+        BiConsumer<EsField, InvalidMappedField> fieldUpdater
+    ) {
 
         if (fieldCapsResponse.getIndices().length == 0) {
             return IndexResolution.notFound(indexPattern);
         }
 
-        // merge all indices onto the same one
-        List<EsIndex> indices = buildIndices(typeRegistry, null, fieldCapsResponse, null, i -> indexPattern, (fieldName, types) -> {
+        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> validityVerifier = (fieldName, types) -> {
             InvalidMappedField f = specificValidityVerifier.apply(fieldName, types);
             if (f != null) {
                 return f;
@@ -431,7 +460,18 @@ public class IndexResolver {
 
             // everything checks
             return null;
-        });
+        };
+
+        // merge all indices onto the same one
+        List<EsIndex> indices = buildIndices(
+            typeRegistry,
+            null,
+            fieldCapsResponse,
+            null,
+            i -> indexPattern,
+            validityVerifier,
+            fieldUpdater
+        );
 
         if (indices.size() > 1) {
             throw new QlIllegalArgumentException(
@@ -454,7 +494,7 @@ public class IndexResolver {
         String indexPattern,
         FieldCapabilitiesResponse fieldCapsResponse
     ) {
-        return mergedMappings(typeRegistry, indexPattern, fieldCapsResponse, (fieldName, types) -> null);
+        return mergedMappings(typeRegistry, indexPattern, fieldCapsResponse, (fieldName, types) -> null, null);
     }
 
     private static EsField createField(
@@ -509,7 +549,7 @@ public class IndexResolver {
 
         EsField esField = field.apply(fieldName);
 
-        if (parent != null && parent instanceof UnsupportedEsField unsupportedParent) {
+        if (parent instanceof UnsupportedEsField unsupportedParent) {
             String inherited = unsupportedParent.getInherited();
             String type = unsupportedParent.getOriginalType();
 
@@ -623,7 +663,7 @@ public class IndexResolver {
         FieldCapabilitiesResponse fieldCaps,
         Map<String, List<AliasMetadata>> aliases
     ) {
-        return buildIndices(typeRegistry, javaRegex, fieldCaps, aliases, Function.identity(), (s, cap) -> null);
+        return buildIndices(typeRegistry, javaRegex, fieldCaps, aliases, Function.identity(), (s, cap) -> null, null);
     }
 
     private static class Fields {
@@ -641,7 +681,8 @@ public class IndexResolver {
         FieldCapabilitiesResponse fieldCapsResponse,
         Map<String, List<AliasMetadata>> aliases,
         Function<String, String> indexNameProcessor,
-        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> validityVerifier
+        BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> validityVerifier,
+        BiConsumer<EsField, InvalidMappedField> fieldUpdater
     ) {
 
         if ((fieldCapsResponse.getIndices() == null || fieldCapsResponse.getIndices().length == 0)
@@ -711,14 +752,23 @@ public class IndexResolver {
                         EsField field = indexFields.flattedMapping.get(fieldName);
                         if (field == null || (invalidField != null && (field instanceof InvalidMappedField) == false)) {
                             createField(typeRegistry, fieldName, indexFields, fieldCaps, invalidField, typeCap);
-                            // if there was a field before, copy its properties
-                            if (field != null) {
+
+                            // In evolving mappings, it is possible for a field to be promoted to an object in new indices
+                            // meaning there are subfields associated with this *invalid* field.
+                            // index_A: file -> keyword
+                            // index_B: file -> object, file.name = keyword
+                            //
+                            // In the scenario above file is problematic but file.name is not. This scenario is addressed
+                            // below through the dedicated callback - copy the existing properties or drop them all together.
+                            // Note this applies for *invalid* fields (that have conflicts), not *unsupported* (those that cannot be read)
+                            // See https://github.com/elastic/elasticsearch/pull/100875
+
+                            // Postpone the call until is really needed
+                            if (fieldUpdater != null && field != null) {
                                 EsField newField = indexFields.flattedMapping.get(fieldName);
+
                                 if (newField != field) {
-                                    if (newField.getProperties().size() > 0) {
-                                        throw new QlIllegalArgumentException("Expected new field to have no properties");
-                                    }
-                                    newField.getProperties().putAll(field.getProperties());
+                                    fieldUpdater.accept(field, (InvalidMappedField) newField);
                                 }
                             }
                         }
@@ -925,4 +975,23 @@ public class IndexResolver {
         // everything checks
         return emptyMap();
     }
+
+    /**
+     * Callback interface used when transitioning an already discovered EsField to an InvalidMapped one.
+     * By default, this interface is not used, meaning when a field is marked as invalid all its subfields
+     * are removed (are dropped).
+     * For cases where this is not desired, a different strategy can be employed such as keeping the properties:
+     * @see IndexResolver#PRESERVE_PROPERTIES
+     */
+    public interface ExistingFieldInvalidCallback extends BiConsumer<EsField, InvalidMappedField> {};
+
+    /**
+     * Preserve the properties (sub fields) of an existing field even when marking it as invalid.
+     */
+    public static ExistingFieldInvalidCallback PRESERVE_PROPERTIES = (oldField, newField) -> {
+        var oldProps = oldField.getProperties();
+        if (oldProps.size() > 0) {
+            newField.getProperties().putAll(oldProps);
+        }
+    };
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/InvalidMappedField.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/InvalidMappedField.java
@@ -9,9 +9,9 @@ package org.elasticsearch.xpack.ql.type;
 
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 
+import java.util.Map;
 import java.util.Objects;
-
-import static java.util.Collections.emptyMap;
+import java.util.TreeMap;
 
 /**
  * Representation of field mapped differently across indices.
@@ -21,14 +21,17 @@ public class InvalidMappedField extends EsField {
 
     private final String errorMessage;
 
-    public InvalidMappedField(String name, String errorMessage) {
-        super(name, DataTypes.UNSUPPORTED, emptyMap(), false);
+    public InvalidMappedField(String name, String errorMessage, Map<String, EsField> properties) {
+        super(name, DataTypes.UNSUPPORTED, properties, false);
         this.errorMessage = errorMessage;
     }
 
+    public InvalidMappedField(String name, String errorMessage) {
+        this(name, errorMessage, new TreeMap<String, EsField>());
+    }
+
     public InvalidMappedField(String name) {
-        super(name, DataTypes.UNSUPPORTED, emptyMap(), false);
-        this.errorMessage = StringUtils.EMPTY;
+        this(name, StringUtils.EMPTY, new TreeMap<String, EsField>());
     }
 
     public String errorMessage() {

--- a/x-pack/plugin/ql/src/test/resources/fc-incompatible-object-compatible-subfields.json
+++ b/x-pack/plugin/ql/src/test/resources/fc-incompatible-object-compatible-subfields.json
@@ -1,0 +1,48 @@
+{
+  "indices": [
+    "index-1",
+    "index-2"
+  ],
+  "fields": {
+    "file": {
+      "keyword": {
+        "type": "keyword",
+        "metadata_field": false,
+        "searchable": true,
+        "aggregatable": true,
+        "indices": [
+          "index-2"
+        ]
+      },
+      "object": {
+        "type": "object",
+        "metadata_field": false,
+        "searchable": false,
+        "aggregatable": false,
+        "indices": [
+          "index-1"
+        ]
+      }
+    },
+    "file.name": {
+      "keyword": {
+        "type": "keyword",
+        "metadata_field": false,
+        "searchable": true,
+        "aggregatable": true,
+        "indices": [
+          "index-1"
+        ]
+      },
+      "unmapped": {
+        "type": "unmapped",
+        "metadata_field": false,
+        "searchable": false,
+        "aggregatable": false,
+        "indices": [
+          "index-2"
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -407,7 +407,14 @@ public class IndexResolverTests extends ESTestCase {
     public void testMergeObjectIncompatibleTypes() throws Exception {
         var response = readFieldCapsResponse("fc-incompatible-object-compatible-subfields.json");
 
-        IndexResolution resolution = mergedMappings("*", response);
+        IndexResolution resolution = IndexResolver.mergedMappings(
+            SqlDataTypeRegistry.INSTANCE,
+            "*",
+            response,
+            (fieldName, types) -> null,
+            IndexResolver.PRESERVE_PROPERTIES
+
+        );
 
         assertTrue(resolution.isValid());
         EsIndex esIndex = resolution.get();
@@ -575,10 +582,6 @@ public class IndexResolverTests extends ESTestCase {
             indexPattern,
             new FieldCapabilitiesResponse(indexNames, fieldCaps)
         );
-    }
-
-    private static IndexResolution mergedMappings(String indexPattern, FieldCapabilitiesResponse response) {
-        return IndexResolver.mergedMappings(SqlDataTypeRegistry.INSTANCE, indexPattern, response);
     }
 
     private static List<EsIndex> separateMappings(


### PR DESCRIPTION
In certain scenarios, a field can be mapped both as a primitive and
 object, causing it to be marked as unsupported, losing any potential
 subfields that might have been discovered before.
This commit preserve them to avoid subfields from being incorrectly
 reported as missing.

Fix #100869