### PR TITLE
Execute local action via client in RemoteClusterNodesAction

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -10,7 +10,10 @@ package org.elasticsearch.action.admin.cluster.remote;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoMetrics;
@@ -18,6 +21,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.internal.support.AbstractClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -42,9 +46,6 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,11 +55,6 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
         final ThreadPool threadPool = mock(ThreadPool.class);
         final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-
-        final TransportService transportService = mock(TransportService.class);
-        final DiscoveryNode localNode = mock(DiscoveryNode.class);
-        when(transportService.getLocalNode()).thenReturn(localNode);
-        when(transportService.getThreadPool()).thenReturn(threadPool);
 
         // Prepare nodesInfo response
         final int numberOfNodes = randomIntBetween(1, 6);
@@ -107,17 +103,28 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
             List.of()
         );
 
-        doAnswer(invocation -> {
-            final NodesInfoRequest nodesInfoRequest = invocation.getArgument(2);
-            assertThat(nodesInfoRequest.requestedMetrics(), containsInAnyOrder(NodesInfoMetrics.Metric.REMOTE_CLUSTER_SERVER.metricName()));
-            final ActionListenerResponseHandler<NodesInfoResponse> handler = invocation.getArgument(3);
-            handler.handleResponse(nodesInfoResponse);
-            return null;
-        }).when(transportService).sendRequest(eq(localNode), eq(NodesInfoAction.NAME), any(NodesInfoRequest.class), any());
-
         final RemoteClusterNodesAction.TransportAction action = new RemoteClusterNodesAction.TransportAction(
-            transportService,
-            mock(ActionFilters.class)
+            mock(TransportService.class),
+            new ActionFilters(Set.of()),
+            new AbstractClient(Settings.EMPTY, threadPool) {
+                @SuppressWarnings("unchecked")
+                @Override
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertSame(NodesInfoAction.INSTANCE, action);
+                    assertThat(
+                        asInstanceOf(NodesInfoRequest.class, request).requestedMetrics(),
+                        containsInAnyOrder(NodesInfoMetrics.Metric.REMOTE_CLUSTER_SERVER.metricName())
+                    );
+                    listener.onResponse((Response) nodesInfoResponse);
+                }
+
+                @Override
+                public void close() {}
+            }
         );
 
         final PlainActionFuture<RemoteClusterNodesAction.Response> future = new PlainActionFuture<>();
@@ -135,11 +142,6 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
         final ThreadPool threadPool = mock(ThreadPool.class);
         final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-
-        final TransportService transportService = mock(TransportService.class);
-        final DiscoveryNode localNode = mock(DiscoveryNode.class);
-        when(transportService.getLocalNode()).thenReturn(localNode);
-        when(transportService.getThreadPool()).thenReturn(threadPool);
 
         // Prepare nodesInfo response
         final int numberOfNodes = randomIntBetween(1, 6);
@@ -178,17 +180,25 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
             List.of()
         );
 
-        doAnswer(invocation -> {
-            final NodesInfoRequest nodesInfoRequest = invocation.getArgument(2);
-            assertThat(nodesInfoRequest.requestedMetrics(), empty());
-            final ActionListenerResponseHandler<NodesInfoResponse> handler = invocation.getArgument(3);
-            handler.handleResponse(nodesInfoResponse);
-            return null;
-        }).when(transportService).sendRequest(eq(localNode), eq(NodesInfoAction.NAME), any(NodesInfoRequest.class), any());
-
         final RemoteClusterNodesAction.TransportAction action = new RemoteClusterNodesAction.TransportAction(
-            transportService,
-            mock(ActionFilters.class)
+            mock(TransportService.class),
+            new ActionFilters(Set.of()),
+            new AbstractClient(Settings.EMPTY, threadPool) {
+                @SuppressWarnings("unchecked")
+                @Override
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertSame(NodesInfoAction.INSTANCE, action);
+                    assertThat(asInstanceOf(NodesInfoRequest.class, request).requestedMetrics(), empty());
+                    listener.onResponse((Response) nodesInfoResponse);
+                }
+
+                @Override
+                public void close() {}
+            }
         );
 
         final PlainActionFuture<RemoteClusterNodesAction.Response> future = new PlainActionFuture<>();


### PR DESCRIPTION
Rather than sending a nodes-info request to the local node via its
transport service, we should use the `Client` to invoke the action
directly.