### PR TITLE
Use pooled Netty allocator in tests by default

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -323,10 +323,9 @@ public abstract class ESTestCase extends LuceneTestCase {
 
         // Enable Netty leak detection and monitor logger for logged leak errors
         System.setProperty("io.netty.leakDetection.level", "paranoid");
-        if (usually() && System.getProperty("es.use_unpooled_allocator") == null) {
-            // Unless explicitly forced to unpooled, always test with the pooled allocator to get the best possible coverage from Netty's
-            // leak detection which does not cover simple unpooled heap buffer.
-            // Skip this sometimes to get some coverage for the unpooled case.
+        if (System.getProperty("es.use_unpooled_allocator") == null) {
+            // unless explicitly forced to unpooled, always test with the pooled allocator to get the best possible coverage from Netty's
+            // leak detection which does not cover simple unpooled heap buffers
             System.setProperty("es.use_unpooled_allocator", "false");
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -323,9 +323,10 @@ public abstract class ESTestCase extends LuceneTestCase {
 
         // Enable Netty leak detection and monitor logger for logged leak errors
         System.setProperty("io.netty.leakDetection.level", "paranoid");
-        if (System.getProperty("es.use_unpooled_allocator") == null) {
-            // unless explicitly forced to unpooled, always test with the pooled allocator to get the best possible coverage from Netty's
-            // leak detection which does not cover simple unpooled heap buffers
+        if (usually() && System.getProperty("es.use_unpooled_allocator") == null) {
+            // Unless explicitly forced to unpooled, always test with the pooled allocator to get the best possible coverage from Netty's
+            // leak detection which does not cover simple unpooled heap buffer.
+            // Skip this sometimes to get some coverage for the unpooled case.
             System.setProperty("es.use_unpooled_allocator", "false");
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -323,6 +323,11 @@ public abstract class ESTestCase extends LuceneTestCase {
 
         // Enable Netty leak detection and monitor logger for logged leak errors
         System.setProperty("io.netty.leakDetection.level", "paranoid");
+        if (System.getProperty("es.use_unpooled_allocator") == null) {
+            // unless explicitly forced to unpooled, always test with the pooled allocator to get the best possible coverage from Netty's
+            // leak detection which does not cover simple unpooled heap buffers
+            System.setProperty("es.use_unpooled_allocator", "false");
+        }
 
         // We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
         // other if we allow them to set the number of available processors as it's set-once in Netty.


### PR DESCRIPTION
We mostly run our tests with less than 1G of heap per JVM. This means that we will use the unpooled Netty allocator in most tests, losing us a lot of leak coverage in internal cluster tests (mostly for inbound buffers). Unless otherwise specified by tests, we should force the use of our standard allocator by default to get a higher chance of catching leaks in internalClusterTests in particular.

Noticed this when testing pooling `SearchHit` source bytes and not getting any failures on obvious leaks.