### PR TITLE
Add method BytesReference#deepCopy

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -93,7 +93,7 @@ public final class BytesArray extends AbstractBytesReference {
     }
 
     @Override
-    public BytesReference copy(int from, int length) {
+    public BytesReference deepCopy(int from, int length) {
         Objects.checkFromIndexSize(from, length, this.length);
         final byte[] copy = new byte[length];
         System.arraycopy(bytes, offset + from, copy, 0, length);

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -93,6 +93,14 @@ public final class BytesArray extends AbstractBytesReference {
     }
 
     @Override
+    public BytesReference copy(int from, int length) {
+        Objects.checkFromIndexSize(from, length, this.length);
+        final byte[] copy = new byte[length];
+        System.arraycopy(bytes, offset + from, copy, 0, length);
+        return new BytesArray(copy);
+    }
+
+    @Override
     public boolean hasArray() {
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -105,13 +105,20 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
      * that backing array directly.
      */
     static BytesReference fromByteArray(ByteArray byteArray, int length) {
+        return fromByteArray(byteArray, 0, length);
+    }
+
+    /**
+     * Similar to {@link #fromByteArray(ByteArray, int)} but allows to specify an offset into the ByteArray.
+     */
+    static BytesReference fromByteArray(ByteArray byteArray, int offset, int length) {
         if (length == 0) {
             return BytesArray.EMPTY;
         }
         if (byteArray.hasArray()) {
-            return new BytesArray(byteArray.array(), 0, length);
+            return new BytesArray(byteArray.array(), offset, length);
         }
-        return new PagedBytesReference(byteArray, 0, length);
+        return new PagedBytesReference(byteArray, offset, length);
     }
 
     /**
@@ -153,9 +160,16 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
     int length();
 
     /**
-     * Slice the bytes from the {@code from} index up to {@code length}.
+     * Slice the bytes from the {@code from} index up to {@code length}. The slice contains
+     * a direct reference to the internal pages.
      */
     BytesReference slice(int from, int length);
+
+    /**
+     * Make a copy the bytes from the {@code from} index up to {@code length}. The copy does not
+     * contain a direct reference to the internal pages.
+     */
+    BytesReference copy(int from, int length);
 
     /**
      * The amount of memory used by this BytesReference

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -166,10 +166,10 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
     BytesReference slice(int from, int length);
 
     /**
-     * Make a copy the bytes from the {@code from} index up to {@code length}. The copy does not
+     * Make a copy of the bytes from the {@code from} index up to {@code length}. The copy does not
      * contain a direct reference to the internal pages.
      */
-    BytesReference copy(int from, int length);
+    BytesReference deepCopy(int from, int length) throws IOException;
 
     /**
      * The amount of memory used by this BytesReference

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -165,7 +165,7 @@ public final class CompositeBytesReference extends AbstractBytesReference {
     }
 
     @Override
-    public BytesReference copy(int from, int length) {
+    public BytesReference deepCopy(int from, int length) throws IOException {
         Objects.checkFromIndexSize(from, length, this.length);
         final int to = from + length;
         final int limit = getOffsetIndex(to - 1);
@@ -173,14 +173,14 @@ public final class CompositeBytesReference extends AbstractBytesReference {
         final int numCopies = 1 + (limit - start);
         final int inCopyOffset = from - offsets[start];
         if (numCopies == 1) {
-            return references[start].copy(inCopyOffset, length);
+            return references[start].deepCopy(inCopyOffset, length);
         }
         final BytesReference[] inCopy = new BytesReference[numCopies];
-        inCopy[0] = references[start].copy(inCopyOffset, references[start].length() - inCopyOffset);
+        inCopy[0] = references[start].deepCopy(inCopyOffset, references[start].length() - inCopyOffset);
         for (int i = 1, j = start + 1; i < inCopy.length - 1; i++, j++) {
-            inCopy[i] = references[j].copy(0, references[j].length());
+            inCopy[i] = references[j].deepCopy(0, references[j].length());
         }
-        inCopy[inCopy.length - 1] = references[limit].copy(0, to - offsets[limit]);
+        inCopy[inCopy.length - 1] = references[limit].deepCopy(0, to - offsets[limit]);
         return CompositeBytesReference.ofMultiple(inCopy);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.bytes;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.PageCacheRecycler;
 
@@ -46,6 +47,29 @@ public class PagedBytesReference extends AbstractBytesReference {
         }
         Objects.checkFromIndexSize(from, length, this.length);
         return new PagedBytesReference(byteArray, offset + from, length);
+    }
+
+    @Override
+    public BytesReference copy(int from, int length) {
+        Objects.checkFromIndexSize(from, length, this.length);
+        final int offsetFirstPage = (Math.addExact(offset, from)) % PAGE_SIZE;
+        // adjust offset and length for doing aligned page copies
+        final int adjustedFrom = from - offsetFirstPage;
+        final int adjustedLength = Math.addExact(length, offsetFirstPage);
+        final ByteArray byteArray = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(adjustedLength);
+        final long offset = this.offset + adjustedFrom;
+        final BytesRef slice = new BytesRef();
+        int nextFragmentSize = Math.min(adjustedLength, PAGE_SIZE);
+        int position = 0;
+        while (nextFragmentSize != 0) {
+            final boolean materialized = this.byteArray.get(offset + position, nextFragmentSize, slice);
+            assert materialized == false : "iteration should be page aligned but array got materialized";
+            assert slice.offset == 0 : "iteration should be page aligned but it did not copy the start of the page";
+            byteArray.set(position, slice.bytes, slice.offset, slice.length);
+            position += nextFragmentSize;
+            nextFragmentSize = Math.min(adjustedLength - position, PAGE_SIZE);
+        }
+        return BytesReference.fromByteArray(byteArray, offsetFirstPage, length);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -140,6 +140,12 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     }
 
     @Override
+    public BytesReference copy(int from, int length) {
+        assert hasReferences();
+        return delegate.copy(from, length);
+    }
+
+    @Override
     public long ramBytesUsed() {
         return delegate.ramBytesUsed();
     }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -140,9 +140,9 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     }
 
     @Override
-    public BytesReference copy(int from, int length) {
+    public BytesReference deepCopy(int from, int length) throws IOException {
         assert hasReferences();
-        return delegate.copy(from, length);
+        return delegate.deepCopy(from, length);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1084,8 +1084,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 reader.indexShard().shardId(),
                 request.getClusterAlias()
             );
-            // ExecutorService executor = this.enableSearchWorkerThreads ? threadPool.executor(Names.SEARCH_WORKER) : null;
-            ExecutorService executor = threadPool.executor(Names.SEARCH_WORKER);
+            ExecutorService executor = this.enableSearchWorkerThreads ? threadPool.executor(Names.SEARCH_WORKER) : null;
             int maximumNumberOfSlices = determineMaximumNumberOfSlices(executor, request, resultsType);
             searchContext = new DefaultSearchContext(
                 reader,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1084,7 +1084,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 reader.indexShard().shardId(),
                 request.getClusterAlias()
             );
-            ExecutorService executor = this.enableSearchWorkerThreads ? threadPool.executor(Names.SEARCH_WORKER) : null;
+            // ExecutorService executor = this.enableSearchWorkerThreads ? threadPool.executor(Names.SEARCH_WORKER) : null;
+            ExecutorService executor = threadPool.executor(Names.SEARCH_WORKER);
             int maximumNumberOfSlices = determineMaximumNumberOfSlices(executor, request, resultsType);
             searchContext = new DefaultSearchContext(
                 reader,

--- a/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
@@ -47,6 +47,11 @@ public class ZeroBytesReference extends AbstractBytesReference {
     }
 
     @Override
+    public BytesReference copy(int from, int length) {
+        return slice(from, length);
+    }
+
+    @Override
     public long ramBytesUsed() {
         return 0;
     }

--- a/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
@@ -47,7 +47,7 @@ public class ZeroBytesReference extends AbstractBytesReference {
     }
 
     @Override
-    public BytesReference copy(int from, int length) {
+    public BytesReference deepCopy(int from, int length) {
         return slice(from, length);
     }
 

--- a/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReferenceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReferenceTests.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.common.bytes;
 
-import java.io.IOException;
-
 import static org.hamcrest.Matchers.containsString;
 
 public class ZeroBytesReferenceTests extends AbstractBytesReferenceTestCase {
@@ -39,9 +37,20 @@ public class ZeroBytesReferenceTests extends AbstractBytesReferenceTestCase {
         // ZeroBytesReference shifts offsets
     }
 
-    public void testWriteWithIterator() throws IOException {
-        AssertionError error = expectThrows(AssertionError.class, () -> super.testWriteWithIterator());
+    @Override
+    public void testSlice() {
+        AssertionError error = expectThrows(AssertionError.class, super::testSlice);
         assertThat(error.getMessage(), containsString("Internal pages from ZeroBytesReference must be zero"));
     }
 
+    @Override
+    public void testCopy() {
+        AssertionError error = expectThrows(AssertionError.class, super::testCopy);
+        assertThat(error.getMessage(), containsString("Internal pages from ZeroBytesReference must be zero"));
+    }
+
+    public void testWriteWithIterator() {
+        AssertionError error = expectThrows(AssertionError.class, super::testWriteWithIterator);
+        assertThat(error.getMessage(), containsString("Internal pages from ZeroBytesReference must be zero"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -595,7 +595,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         }
 
         @Override
-        public BytesReference copy(int from, int length) {
+        public BytesReference deepCopy(int from, int length) {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -595,6 +595,11 @@ public class IndicesRequestCacheTests extends ESTestCase {
         }
 
         @Override
+        public BytesReference copy(int from, int length) {
+            return null;
+        }
+
+        @Override
         public BytesRef toBytesRef() {
             return null;
         }

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -100,7 +100,7 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
             BytesReference pbr = newBytesReference(length);
             int sliceOffset = randomIntBetween(0, length / 2);
             int copyLength = Math.max(0, length - sliceOffset - 1);
-            BytesReference slice = pbr.copy(sliceOffset, copyLength);
+            BytesReference slice = pbr.deepCopy(sliceOffset, copyLength);
             assertEquals(copyLength, slice.length());
             for (int i = 0; i < copyLength; i++) {
                 assertEquals(pbr.get(i + sliceOffset), slice.get(i));

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReference.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReference.java
@@ -41,6 +41,12 @@ class RandomBlobContentBytesReference extends AbstractBytesReference {
     }
 
     @Override
+    public BytesReference copy(int from, int length) {
+        assert false : "must not copy a RandomBlobContentBytesReference";
+        throw new UnsupportedOperationException("RandomBlobContentBytesReference#copy(int, int) is unsupported");
+    }
+
+    @Override
     public long ramBytesUsed() {
         // no need for accurate accounting of the overhead since we don't really account for these things anyway
         return randomBlobContent.buffer.length;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReference.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReference.java
@@ -41,7 +41,7 @@ class RandomBlobContentBytesReference extends AbstractBytesReference {
     }
 
     @Override
-    public BytesReference copy(int from, int length) {
+    public BytesReference deepCopy(int from, int length) {
         assert false : "must not copy a RandomBlobContentBytesReference";
         throw new UnsupportedOperationException("RandomBlobContentBytesReference#copy(int, int) is unsupported");
     }


### PR DESCRIPTION
Introduce new method in BytesReference to copy a subset of the underlying bytes:

```
    /**
     * Make a copy the bytes from the {@code from} index up to {@code length}. The copy does not
     * contain a direct reference to the internal pages.
     */
    BytesReference deepCopy(int from, int length);
```

The output is the same as the slice method but instead of having a reference to the underlying pages, this method creates totally new pages to hold the result.

Note that you can do the same by copying a BytesReference into another using the internal iterator for accessing the pages but this method should be much faster as it copy pages using aligned boundaries.
