### PR TITLE
[TEST] Assert that both time-series indexes are created

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -176,6 +176,8 @@ setup:
         index: tsdb_index1,tsdb_index2
         fields: [ "metricset", "non_tsdb_field", "k8s.pod.*" ]
 
+  - length: {indices: 2}
+
   - match: {fields.metricset.keyword.searchable: true}
   - match: {fields.metricset.keyword.aggregatable: true}
   - is_false: fields.metricset.keyword.time_series_dimension

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -176,6 +176,10 @@ setup:
         index: tsdb_index1,tsdb_index2
         fields: [ "metricset", "non_tsdb_field", "k8s.pod.*" ]
 
+  - length: { indices: 2 }
+  - match: { indices.0: tsdb_index1 }
+  - match: { indices.1: tsdb_index2 }
+
   - match: {fields.metricset.keyword.searchable: true}
   - match: {fields.metricset.keyword.aggregatable: true}
   - is_false: fields.metricset.keyword.time_series_dimension

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 8.0.99"
-      reason: introduced in 8.1.0
+      version: " - 8.0.99, 8.7.00 - 8.9.99"
+      reason: introduced in 8.1.0, synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -176,6 +176,10 @@ setup:
         index: tsdb_index1,tsdb_index2
         fields: [ "metricset", "non_tsdb_field", "k8s.pod.*" ]
 
+  - length: {indices: 2}
+  - match: {indices.0: tsdb_index1}
+  - match: {indices.1: tsdb_index2}
+
   - match: {fields.metricset.keyword.searchable: true}
   - match: {fields.metricset.keyword.aggregatable: true}
   - is_false: fields.metricset.keyword.time_series_dimension


### PR DESCRIPTION
Verify that there are no failures to create the expected indexes in field_caps/time_series tests.

This is also affected by the fix for showing the synthetic source, #98808. This can trigger an assert in older versions as the mapping they produce (without synthetic source) doesn't match the one they may get from the master, if the latter is in version 8.10+.

Fixes #100882