### PR TITLE
[ML] Use correct writable name for model assignment metadata in mixed cluster

### DIFF
--- a/docs/changelog/100886.yaml
+++ b/docs/changelog/100886.yaml
@@ -1,0 +1,5 @@
+pr: 100886
+summary: Always use correct writable name for `TrainedModelAssignmentMetadata`
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/100886.yaml
+++ b/docs/changelog/100886.yaml
@@ -1,5 +1,5 @@
 pr: 100886
-summary: Use the correct writable name for model assignment metadata in mixed version clusters. Prevents a node failure due to IllegalArgumentException: Unknown NamedWriteable [trained_model_assignment]
+summary: Use the correct writable name for model assignment metadata in mixed version clusters. Prevents a node failure due to IllegalArgumentException Unknown NamedWriteable [trained_model_assignment]
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/100886.yaml
+++ b/docs/changelog/100886.yaml
@@ -1,5 +1,5 @@
 pr: 100886
-summary: Always use correct writable name for `TrainedModelAssignmentMetadata`
+summary: Use the correct writable name for model assignment metadata in mixed version clusters. Prevents a node failure due to IllegalArgumentException: Unknown NamedWriteable [trained_model_assignment]
 area: Machine Learning
 type: bug
 issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -309,7 +309,8 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
             return new TrainedModelAssignmentMetadata(
-                new TreeMap<>(modelRoutingEntries.apply(((TrainedModelAssignmentMetadata) part).deploymentRoutingEntries))
+                new TreeMap<>(modelRoutingEntries.apply(((TrainedModelAssignmentMetadata) part).deploymentRoutingEntries)),
+                writeableName
             );
         }
 


### PR DESCRIPTION
`TrainedModelAssignmentMetadata` was introduced in version 8.3, in a mixed cluster there are many checks to ensure that the new named writable is not used before the cluster is fully upgraded. However, there is one case where the detail about whether to use the old or new named writable is forgotten and the new one used by default. As older nodes cannot read the new writable this can cause a node failure during a rolling upgrade with the error
```
java.lang.Exception: java.lang.AssertionError: java.lang.IllegalArgumentException: Unknown NamedWriteable [org.elasticsearch.cluster.metadata.Metadata$Custom][trained_model_assignment]
```

For #100371