### PR TITLE
Revert "Making yaml tests version selector parser compatible with versions returned by Build"

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -10,7 +10,6 @@ package org.elasticsearch.test.rest.yaml.section;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.HasAttributeNodeSelector;
 import org.elasticsearch.client.Node;
@@ -39,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
@@ -628,47 +626,24 @@ public class DoSection implements ExecutableSection {
         return result;
     }
 
-    private static boolean matchWithRange(String nodeVersionString, List<VersionRange> acceptedVersionRanges, XContentLocation location) {
-        var unqualifiedNodeVersionString = nodeVersionString.replace("-SNAPSHOT", "");
-        try {
-            Version version = Version.fromString(unqualifiedNodeVersionString);
-            return acceptedVersionRanges.stream().anyMatch(v -> v.contains(version));
-        } catch (IllegalArgumentException e) {
-            throw new XContentParseException(
-                location,
-                "[version] range node selector expects a semantic version format (x.y.z), but found " + unqualifiedNodeVersionString,
-                e
-            );
-        }
-    }
-
     private static NodeSelector parseVersionSelector(XContentParser parser) throws IOException {
         if (false == parser.currentToken().isValue()) {
             throw new XContentParseException(parser.getTokenLocation(), "expected [version] to be a value");
         }
-
-        final Predicate<String> nodeMatcher;
-        final String versionSelectorString;
-        if (parser.text().equals("current")) {
-            var currentUnqualified = Build.current().version().replace("-SNAPSHOT", "");
-            nodeMatcher = nodeVersion -> currentUnqualified.equals(nodeVersion.replace("-SNAPSHOT", ""));
-            versionSelectorString = "version is " + currentUnqualified + " (current)";
-        } else {
-            var acceptedVersionRange = SkipSection.parseVersionRanges(parser.text());
-            nodeMatcher = nodeVersion -> matchWithRange(nodeVersion, acceptedVersionRange, parser.getTokenLocation());
-            versionSelectorString = "version ranges " + acceptedVersionRange;
-        }
-
+        List<VersionRange> skipVersionRanges = parser.text().equals("current")
+            ? List.of(new VersionRange(Version.CURRENT, Version.CURRENT))
+            : SkipSection.parseVersionRanges(parser.text());
         return new NodeSelector() {
             @Override
             public void select(Iterable<Node> nodes) {
                 for (Iterator<Node> itr = nodes.iterator(); itr.hasNext();) {
                     Node node = itr.next();
-                    String versionString = node.getVersion();
-                    if (versionString == null) {
+                    if (node.getVersion() == null) {
                         throw new IllegalStateException("expected [version] metadata to be set but got " + node);
                     }
-                    if (nodeMatcher.test(versionString) == false) {
+                    Version version = Version.fromString(node.getVersion());
+                    boolean skip = skipVersionRanges.stream().anyMatch(v -> v.contains(version));
+                    if (false == skip) {
                         itr.remove();
                     }
                 }
@@ -676,7 +651,7 @@ public class DoSection implements ExecutableSection {
 
             @Override
             public String toString() {
-                return versionSelectorString;
+                return "version ranges " + skipVersionRanges;
             }
         };
     }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.test.rest.yaml.section;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.NodeSelector;
@@ -20,7 +19,6 @@ import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
 import org.elasticsearch.xcontent.XContentLocation;
-import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
 import org.hamcrest.MatcherAssert;
@@ -38,7 +36,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -579,7 +576,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(e.getMessage(), equalTo("the warning [foo] was both allowed and expected"));
     }
 
-    public void testNodeSelectorByVersionRange() throws IOException {
+    public void testNodeSelectorByVersion() throws IOException {
         parser = createParser(YamlXContent.yamlXContent, """
             node_selector:
                 version: 5.2.0-6.0.0
@@ -629,28 +626,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         }
     }
 
-    public void testNodeSelectorByVersionRangeFailsWithNonSemanticVersion() throws IOException {
-        parser = createParser(YamlXContent.yamlXContent, """
-            node_selector:
-                version: 5.2.0-6.0.0
-            indices.get_field_mapping:
-                index: test_index""");
-
-        DoSection doSection = DoSection.parse(parser);
-        assertNotSame(NodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
-        Node nonSemantic = nodeWithVersion("abddef");
-        List<Node> nodes = new ArrayList<>();
-
-        var exception = expectThrows(
-            XContentParseException.class,
-            () -> doSection.getApiCallSection().getNodeSelector().select(List.of(nonSemantic))
-        );
-        assertThat(
-            exception.getMessage(),
-            endsWith("[version] range node selector expects a semantic version format (x.y.z), but found abddef")
-        );
-    }
-
     public void testNodeSelectorCurrentVersion() throws IOException {
         parser = createParser(YamlXContent.yamlXContent, """
             node_selector:
@@ -663,16 +638,14 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         Node v170 = nodeWithVersion("1.7.0");
         Node v521 = nodeWithVersion("5.2.1");
         Node v550 = nodeWithVersion("5.5.0");
-        Node oldCurrent = nodeWithVersion(Version.CURRENT.toString());
-        Node newCurrent = nodeWithVersion(Build.current().version());
+        Node current = nodeWithVersion(Version.CURRENT.toString());
         List<Node> nodes = new ArrayList<>();
         nodes.add(v170);
         nodes.add(v521);
         nodes.add(v550);
-        nodes.add(oldCurrent);
-        nodes.add(newCurrent);
+        nodes.add(current);
         doSection.getApiCallSection().getNodeSelector().select(nodes);
-        assertEquals(List.of(oldCurrent, newCurrent), nodes);
+        assertEquals(List.of(current), nodes);
     }
 
     private static Node nodeWithVersion(String version) {


### PR DESCRIPTION
Reverts elastic/elasticsearch#100794

The current matcher fails in serverless because the YAML framework uses NodeInfo - and that still returns Version.CURRENT,

In order for this to work, we need to merge:
- https://github.com/elastic/elasticsearch/pull/100868 (to make es tests pass without too many issues due to Version.CURRENT -> Build.current().version() change).
- https://github.com/elastic/elasticsearch/pull/100746 (to make NodeInfo return the "current" version - Build.current().version() - that will make the matcher correct on serverless)

Will re-apply this PR once this chain of merges happen.