### PR TITLE
Added metric for number of times there was a blob cache miss that triggered read from blob store

### DIFF
--- a/docs/changelog/100893.yaml
+++ b/docs/changelog/100893.yaml
@@ -1,0 +1,6 @@
+pr: 100893
+summary: Added metric for number of times there was a blob cache miss that triggered
+  read from blob store
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -427,7 +427,8 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                     context,
                     inputStats,
                     cacheService.getRangeSize(),
-                    cacheService.getRecoveryRangeSize()
+                    cacheService.getRecoveryRangeSize(),
+                    cacheMissCounter
                 );
             }
         } else {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
@@ -13,6 +13,7 @@ import org.apache.lucene.store.IOContext;
 import org.elasticsearch.blobcache.BlobCacheUtils;
 import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFile;
 import org.elasticsearch.xpack.searchablesnapshots.store.IndexInputStats;
 import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectory;
@@ -46,7 +47,8 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
         IOContext context,
         IndexInputStats stats,
         int rangeSize,
-        int recoveryRangeSize
+        int recoveryRangeSize,
+        LongCounter cacheMissCounter
     ) {
         this(
             name,
@@ -61,7 +63,8 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
             rangeSize,
             recoveryRangeSize,
             directory.getBlobCacheByteRange(name, fileInfo.length()),
-            ByteRange.EMPTY
+            ByteRange.EMPTY,
+            cacheMissCounter
         );
         stats.incrementOpenCount();
     }
@@ -79,7 +82,8 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
         int defaultRangeSize,
         int recoveryRangeSize,
         ByteRange headerBlobCacheByteRange,
-        ByteRange footerBlobCacheByteRange
+        ByteRange footerBlobCacheByteRange,
+        LongCounter cacheMissCounter
     ) {
         super(
             logger,
@@ -95,7 +99,8 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
             defaultRangeSize,
             recoveryRangeSize,
             headerBlobCacheByteRange,
-            footerBlobCacheByteRange
+            footerBlobCacheByteRange,
+            cacheMissCounter
         );
     }
 
@@ -272,7 +277,8 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
             defaultRangeSize,
             recoveryRangeSize,
             sliceHeaderByteRange,
-            sliceFooterByteRange
+            sliceFooterByteRange,
+            getCacheMissCounter()
         );
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -16,6 +16,7 @@ import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.blobcache.shared.SharedBytes;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
@@ -38,7 +39,8 @@ public final class FrozenIndexInput extends MetadataCachingIndexInput {
         IOContext context,
         IndexInputStats stats,
         int rangeSize,
-        int recoveryRangeSize
+        int recoveryRangeSize,
+        LongCounter cacheMissCounter
     ) {
         this(
             name,
@@ -54,7 +56,8 @@ public final class FrozenIndexInput extends MetadataCachingIndexInput {
             rangeSize,
             recoveryRangeSize,
             directory.getBlobCacheByteRange(name, fileInfo.length()),
-            ByteRange.EMPTY
+            ByteRange.EMPTY,
+            cacheMissCounter
         );
         stats.incrementOpenCount();
     }
@@ -73,7 +76,8 @@ public final class FrozenIndexInput extends MetadataCachingIndexInput {
         int defaultRangeSize,
         int recoveryRangeSize,
         ByteRange headerBlobCacheByteRange,
-        ByteRange footerBlobCacheByteRange
+        ByteRange footerBlobCacheByteRange,
+        LongCounter cacheMissCounter
     ) {
         super(
             logger,
@@ -89,7 +93,8 @@ public final class FrozenIndexInput extends MetadataCachingIndexInput {
             defaultRangeSize,
             recoveryRangeSize,
             headerBlobCacheByteRange,
-            footerBlobCacheByteRange
+            footerBlobCacheByteRange,
+            cacheMissCounter
         );
         this.cacheFile = cacheFile.copy();
     }
@@ -200,7 +205,8 @@ public final class FrozenIndexInput extends MetadataCachingIndexInput {
             defaultRangeSize,
             recoveryRangeSize,
             sliceHeaderByteRange,
-            sliceFooterByteRange
+            sliceFooterByteRange,
+            getCacheMissCounter()
         );
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -146,8 +146,8 @@ public abstract class MetadataCachingIndexInput extends BlobCacheBufferedIndexIn
         this.lastSeekPosition = offset;
         this.headerBlobCacheByteRange = Objects.requireNonNull(headerBlobCacheByteRange);
         this.footerBlobCacheByteRange = Objects.requireNonNull(footerBlobCacheByteRange);
-        assert offset >= compoundFileOffset;
         this.cacheMissCounter = cacheMissCounter;
+        assert offset >= compoundFileOffset;
         assert getBufferSize() <= BlobStoreCacheService.DEFAULT_CACHED_BLOB_SIZE; // must be able to cache at least one buffer's worth
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.telemetry.metric.Meter;
 import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.TestUtils;
@@ -666,7 +667,8 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
                 cacheDir,
                 shardPath,
                 threadPool,
-                sharedBlobCacheService
+                sharedBlobCacheService,
+                Meter.NOOP
             ) {
                 @Override
                 protected IndexInputStats createIndexInputStats(long numFiles, long totalSize, long minSize, long maxSize) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -88,6 +88,7 @@ import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.telemetry.metric.Meter;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -671,7 +672,8 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                         cacheDir,
                         shardPath,
                         threadPool,
-                        sharedBlobCacheService
+                        sharedBlobCacheService,
+                        Meter.NOOP
                     )
                 ) {
                     final PlainActionFuture<Void> f = PlainActionFuture.newFuture();
@@ -775,7 +777,8 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     cacheDir,
                     shardPath,
                     threadPool,
-                    sharedBlobCacheService
+                    sharedBlobCacheService,
+                    Meter.NOOP
                 )
             ) {
                 final RecoveryState recoveryState = createRecoveryState(randomBoolean());
@@ -834,7 +837,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
             final IndexSettings indexSettings = new IndexSettings(IndexMetadata.builder("test").settings(settings).build(), Settings.EMPTY);
             expectThrows(
                 IllegalArgumentException.class,
-                () -> SearchableSnapshotDirectory.create(null, null, indexSettings, null, null, null, null, null)
+                () -> SearchableSnapshotDirectory.create(null, null, indexSettings, null, null, null, null, null, Meter.NOOP)
             );
         }
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.telemetry.metric.Meter;
 import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.TestUtils.NoopBlobStoreCacheService;
@@ -122,7 +123,8 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                         cacheDir,
                         shardPath,
                         threadPool,
-                        sharedBlobCacheService
+                        sharedBlobCacheService,
+                        Meter.NOOP
                     )
                 ) {
                     RecoveryState recoveryState = createRecoveryState(recoveryFinalizedDone);
@@ -227,7 +229,8 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                     cacheDir,
                     shardPath,
                     threadPool,
-                    sharedBlobCacheService
+                    sharedBlobCacheService,
+                    Meter.NOOP
                 )
             ) {
                 RecoveryState recoveryState = createRecoveryState(randomBoolean());

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.telemetry.metric.Meter;
 import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
@@ -171,7 +172,8 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
                 cacheDir,
                 shardPath,
                 threadPool,
-                service
+                service,
+                Meter.NOOP
             );
         }
     }


### PR DESCRIPTION
The metric is called `elasticsearch.blob_cache.miss_that_triggered_read_from_blob_store` it's a `LongCounter` and is incremented if there is a cache miss reading from blob cache that triggers a read from blob store.
For tests we are passing a `Meter.NOOP` while in production code we are using the meter passed in the `TelemetryProvider` at `SearchableSnapshot::createComponents`.
We choose to prefix the metric name with `elasticsearch.blob_cache` to have it in line with this [PR](https://github.com/elastic/elasticsearch/pull/100570).