### PR TITLE
[8.11] [TEST] Assert that both time-series indexes are created (#100885)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 8.0.99"
-      reason: introduced in 8.1.0
+      version: " - 8.0.99, 8.7.00 - 8.9.99"
+      reason: introduced in 8.1.0, synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests
 
   - do:
       indices.create:
@@ -175,6 +175,8 @@ setup:
       field_caps:
         index: tsdb_index1,tsdb_index2
         fields: [ "metricset", "non_tsdb_field", "k8s.pod.*" ]
+
+  - length: {indices: 2}
 
   - match: {fields.metricset.keyword.searchable: true}
   - match: {fields.metricset.keyword.aggregatable: true}


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [TEST] Assert that both time-series indexes are created (#100885)