### PR TITLE
[8.11] [ML] Use correct writable name for model assignment metadata in mixed cluster (#100886)

### DIFF
--- a/docs/changelog/100886.yaml
+++ b/docs/changelog/100886.yaml
@@ -1,0 +1,5 @@
+pr: 100886
+summary: Use the correct writable name for model assignment metadata in mixed version clusters. Prevents a node failure due to IllegalArgumentException Unknown NamedWriteable [trained_model_assignment]
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -309,7 +309,8 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
             return new TrainedModelAssignmentMetadata(
-                new TreeMap<>(modelRoutingEntries.apply(((TrainedModelAssignmentMetadata) part).deploymentRoutingEntries))
+                new TreeMap<>(modelRoutingEntries.apply(((TrainedModelAssignmentMetadata) part).deploymentRoutingEntries)),
+                writeableName
             );
         }
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [ML] Use correct writable name for model assignment metadata in mixed cluster (#100886)