### PR TITLE
Set replica to 1 in 130_geo_shape_runtime.yaml

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/130_geo_shape_runtime.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/130_geo_shape_runtime.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               geometry_from_doc_value:


### PR DESCRIPTION
Set number of replicas to 1 so the test can run against serverless.