### PR TITLE
[TEST] Skip cat tsdb test for versions 8.7-8-10

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -173,8 +173,8 @@
 ---
 tsdb:
   - skip:
-      version: " - 8.4.99"
-      reason: Serialization for segment stats fixed in 8.5.0
+      version: " - 8.4.99, 8.7.00 - 8.9.99"
+      reason: Serialization for segment stats fixed in 8.5.0, synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests
 
   - do:
       indices.create:


### PR DESCRIPTION
Yet another test affected by the fix for showing the synthetic source, #98808. This can trigger an assert in older versions as the mapping they produce (without synthetic source) doesn't match the one they may get from the master, if the latter is in version 8.10+.

Fixes #100913