### PR TITLE
Add tolerance to ExtendedStatsAggregatorTests#testSummationAccuracy

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
@@ -202,7 +202,7 @@ public class ExtendedStatsAggregatorTests extends AggregatorTestCase {
 
     public void testSummationAccuracy() throws IOException {
         double[] values = new double[] { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7 };
-        verifyStatsOfDoubles(values, 13.5, 16.21, 0d);
+        verifyStatsOfDoubles(values, 13.5, 16.21, TOLERANCE);
 
         // Summing up an array which contains NaN and infinities and expect a result same as naive summation
         int n = randomIntBetween(5, 10);


### PR DESCRIPTION
There was a test failure reported in 7.17 but I could reproduce it in main with the following seed:

```
./gradlew ':server:test' --tests "org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregatorTests.testSummationAccuracy" -Dtests.seed=6B6E3126F645B5CB:44D44F56A999020D
```

There are just some combinations on how the data is indexed that can result in some precision loss. Let's add some tolerance into the test.

fixes https://github.com/elastic/elasticsearch/issues/99465