### PR TITLE
Clarify search application search API documentation

### DIFF
--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -59,6 +59,7 @@ The <<search-template,search template>> associated with this search application.
 (Required, object)
 The associated mustache template.
 
+[[put-search-application-dictionary-param]]
 `dictionary`::
 (Optional, object)
 The dictionary used to validate the parameters used with the <<search-application-search, search application search>> API. The dictionary must be a valid JSON schema.

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -57,7 +57,7 @@ Search Application `<name>` does not exist.
 ==== {api-examples-title}
 
 The following example generates a query for a search application called `my-app` that uses the search template from
-the <<search-application-api-bm25-template, text search example>>::
+the <<search-application-api-bm25-template, text search example>>:
 
 ////
 [source,console]

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -176,5 +176,5 @@ A sample response:
 ----
 // TEST[continued]
 
-In this case, the `from` and `size` parameters are not specified in the request, so default values are pulled from the
-search template.
+In this case, the `from` and `size` parameters are not specified in the request, so the default values specified in the
+search template are used.

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -8,10 +8,10 @@ preview::[]
 <titleabbrev>Render Search Application Query</titleabbrev>
 ++++
 
-Given specified query parameters, generates an Elasticsearch query using the search template associated with the search
+Given specified query parameters, generates an {es} query using the search template associated with the search
 application or a default template if none is specified.
 Unspecified template parameters will be assigned their default values (if applicable).
-Returns the specific Elasticsearch query that would be generated and executed by calling
+Returns the specific {es} query that would be generated and executed by calling
 <<search-application-search,search application search>>.
 
 [[search-application-render-query-request]]
@@ -29,8 +29,7 @@ Requires read privileges on the backing alias of the search application.
 
 `params`::
 (Optional, map of strings to objects)
-Query parameters used to generate the Elasticsearch query from the search template associated with the search
-application.
+Query parameters used to generate the {es} query from the search template associated with the search application.
 If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
 
 [NOTE]
@@ -57,7 +56,8 @@ Search Application `<name>` does not exist.
 [[search-application-render-query-example]]
 ==== {api-examples-title}
 
-The following example generates a query for a search application called `my-app` that uses the search template:
+The following example generates a query for a search application called `my-app` that uses the search template from
+the <<search-application-api-bm25-template, text search example>>::
 
 ////
 [source,console]
@@ -67,7 +67,6 @@ PUT /index1
 PUT _application/search_application/my-app
 {
   "indices": ["index1"],
-  "updated_at_millis": 1682105622204,
   "template": {
     "script": {
       "lang": "mustache",
@@ -76,16 +75,21 @@ PUT _application/search_application/my-app
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": ["title^{{title_boost}}", "description"]
+            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
           }
         },
+        "explain": "{{explain}}",
         "from": "{{from}}",
         "size": "{{size}}"
       }
       """,
       "params": {
         "query_string": "*",
-        "title_boost": 10,
+        "text_fields": [
+          {"name": "title", "boost": 10},
+          {"name": "description", "boost": 5}
+        ],
+        "explain": false,
         "from": 0,
         "size": 10
       }
@@ -108,50 +112,14 @@ DELETE index1
 
 [source,console]
 ----
-GET _application/search_application/my-app/
-----
-
-[source,console-result]
-----
-{
-  "name": "my-app",
-  "updated_at_millis": 1682105622204,
-  "indices": ["index1"],
-  "template": {
-    "script": {
-      "source": """
-      {
-        "query": {
-          "multi_match": {
-            "query": "{{query_string}}",
-            "fields": ["title^{{title_boost}}", "description"]
-          }
-        },
-        "from": "{{from}}",
-        "size": "{{size}}"
-      }
-      """,
-      "lang": "mustache",
-      "params": {
-        "title_boost": 10,
-        "from": 0,
-        "size": 10,
-        "query_string": "*"
-      }
-    }
-  }
-}
-----
-
-The following request will use the search template to generate an Elasticsearch query:
-
-[source,console]
-----
 POST _application/search_application/my-app/_render_query
 {
   "params": {
     "query_string": "my first query",
-    "title_boost": 5
+    "text_fields": [
+      {"name": "title", "boost": 5},
+      {"name": "description", "boost": 1}
+    ]
   }
 }
 ----
@@ -171,10 +139,11 @@ A sample response:
         "title^5.0"
       ]
     }
-  }
+  },
+  "explain": false
 }
 ----
 // TEST[continued]
 
-In this case, the `from` and `size` parameters are not specified in the request, so the default values specified in the
-search template are used.
+In this case, the `from`, `size`, and `explain` parameters are not specified in the request, so the default values
+specified in the search template are used.

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -8,9 +8,11 @@ preview::[]
 <titleabbrev>Render Search Application Query</titleabbrev>
 ++++
 
-Given specified query parameters, creates an Elasticsearch query to run. Any unspecified template parameters will be
-assigned their default values if applicable. Returns the specific Elasticsearch query that would be generated and
-run by calling <<search-application-search,search application search>>.
+Given specified query parameters, generates an Elasticsearch query using the search template associated with the search
+application.
+Any unspecified template parameters will be assigned their default values (if applicable).
+Returns the specific Elasticsearch query that would be generated and executed by calling
+<<search-application-search,search application search>>.
 
 [[search-application-render-query-request]]
 ==== {api-request-title}
@@ -27,7 +29,15 @@ Requires read privileges on the backing alias of the search application.
 
 `params`::
 (Optional, map of strings to objects)
-Query parameters specific to this request, which will override any defaults specified in the template.
+Query parameters used to generate the Elasticsearch query from the search template associated with the search
+application.
+If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
+
+[NOTE]
+====
+The search application can be configured to validate search template parameters.
+See the `dictionary` parameter in the <<put-search-application, put search application>> API for more information.
+====
 
 [[search-application-render-query-response-codes]]
 ==== {api-response-codes-title}
@@ -38,8 +48,7 @@ Search Application `<name>` does not exist.
 [[search-application-render-query-example]]
 ==== {api-examples-title}
 
-The following example renders a query for a search application called `my-app`. In this case, the `from` and `size`
-parameters are not specified, so default values are pulled from the search application template.
+The following example generates a query for a search application called `my-app` that uses the search template:
 
 ////
 [source,console]
@@ -49,6 +58,7 @@ PUT /index1
 PUT _application/search_application/my-app
 {
   "indices": ["index1"],
+  "updated_at_millis": 1682105622204,
   "template": {
     "script": {
       "lang": "mustache",
@@ -57,21 +67,16 @@ PUT _application/search_application/my-app
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
+            "fields": ["title^{{title_boost}}", "description"]
           }
         },
-        "explain": "{{explain}}",
         "from": "{{from}}",
         "size": "{{size}}"
       }
       """,
       "params": {
         "query_string": "*",
-        "text_fields": [
-          {"name": "title", "boost": 10},
-          {"name": "description", "boost": 5}
-        ],
-        "explain": false,
+        "title_boost": 10,
         "from": 0,
         "size": 10
       }
@@ -94,20 +99,50 @@ DELETE index1
 
 [source,console]
 ----
+GET _application/search_application/my-app/
+----
+
+[source,console-result]
+----
+{
+  "name": "my-app",
+  "updated_at_millis": 1682105622204,
+  "indices": ["index1"],
+  "template": {
+    "script": {
+      "source": """
+      {
+        "query": {
+          "multi_match": {
+            "query": "{{query_string}}",
+            "fields": ["title^{{title_boost}}", "description"]
+          }
+        },
+        "from": "{{from}}",
+        "size": "{{size}}"
+      }
+      """,
+      "lang": "mustache",
+      "params": {
+        "title_boost": 10,
+        "from": 0,
+        "size": 10,
+        "query_string": "*"
+      }
+    }
+  }
+}
+----
+
+The following request will use the search template to generate an Elasticsearch query:
+
+[source,console]
+----
 POST _application/search_application/my-app/_render_query
 {
   "params": {
     "query_string": "my first query",
-    "text_fields": [
-        {
-            "name": "title",
-            "boost": 10
-        },
-        {
-            "name": "text",
-            "boost": 1
-        }
-    ]
+    "title_boost": 5
   }
 }
 ----
@@ -117,19 +152,20 @@ A sample response:
 [source,console-result]
 ----
 {
-    "from": 0,
-    "size": 10,
-    "query": {
-        "multi_match": {
-            "query": "my first query",
-            "fields": [
-                "text^1.0",
-                "title^10.0"
-            ]
-        }
-    },
-    "explain": false
+  "from": 0,
+  "size": 10,
+  "query": {
+    "multi_match": {
+      "query": "my first query",
+      "fields": [
+        "description^1.0",
+        "title^5.0"
+      ]
+    }
+  }
 }
 ----
 // TEST[continued]
 
+In this case, the `from` and `size` parameters are not specified in the request, so default values are pulled from the
+search template.

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -36,7 +36,8 @@ If a parameter used in the search template is not specified in `params`, the par
 [NOTE]
 ====
 The search application can be configured to validate search template parameters.
-See the `dictionary` parameter in the <<put-search-application, put search application>> API for more information.
+See the `dictionary` parameter in the <<put-search-application-dictionary-param, put search application>> API for more
+information.
 ====
 
 [[search-application-render-query-response-codes]]

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -44,6 +44,11 @@ See the `dictionary` parameter in the <<put-search-application, put search appli
 
 `400`::
 Invalid parameter passed to search template.
+Examples include:
+
+- Missing required parameter
+- Invalid parameter data type
+- Invalid parameter value
 
 `404`::
 Search Application `<name>` does not exist.

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -10,7 +10,7 @@ preview::[]
 
 Given specified query parameters, generates an Elasticsearch query using the search template associated with the search
 application or a default template if none is specified.
-Any unspecified template parameters will be assigned their default values (if applicable).
+Unspecified template parameters will be assigned their default values (if applicable).
 Returns the specific Elasticsearch query that would be generated and executed by calling
 <<search-application-search,search application search>>.
 

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -42,6 +42,9 @@ See the `dictionary` parameter in the <<put-search-application, put search appli
 [[search-application-render-query-response-codes]]
 ==== {api-response-codes-title}
 
+`400`::
+Invalid parameter passed to search template.
+
 `404`::
 Search Application `<name>` does not exist.
 

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -9,7 +9,7 @@ preview::[]
 ++++
 
 Given specified query parameters, generates an Elasticsearch query using the search template associated with the search
-application.
+application or a default template if none is specified.
 Any unspecified template parameters will be assigned their default values (if applicable).
 Returns the specific Elasticsearch query that would be generated and executed by calling
 <<search-application-search,search application search>>.

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -138,6 +138,8 @@ GET _application/search_application/my-app/
   }
 }
 ----
+// TESTRESPONSE[skip:indices key mis-match]
+// TODO: fix test failure
 
 The following request will use the search template to generate & run an Elasticsearch query against the search
 application:
@@ -164,7 +166,7 @@ POST _application/search_application/my-app/_search
 
 The generated Elasticsearch query would look like:
 
-[source,console]
+[source,console-result]
 ----
 {
   "from": 0,
@@ -180,11 +182,12 @@ The generated Elasticsearch query would look like:
   }
 }
 ----
+// TESTRESPONSE[skip:result of request not run in this document]
 
 The expected response is the search results from the Elasticsearch query that was generated & run.
 The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>.
 
-[source,console]
+[source,console-result]
 ----
 {
   "took": 5,
@@ -207,3 +210,4 @@ The response format is the same as that used by the <<search-api-response-body,E
   }
 }
 ----
+// TESTRESPONSE[skip:index not populated with documents]

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -32,6 +32,12 @@ Query parameters used to generate the Elasticsearch query from the search templa
 application.
 If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
 
+[NOTE]
+====
+The search application can be configured to validate search template parameters.
+See the `dictionary` parameter in the <<put-search-application, put search application>> API for more information.
+====
+
 [[search-application-search-response-codes]]
 ==== {api-response-codes-title}
 

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -61,7 +61,7 @@ PUT _application/search_application/my-app
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
+            "fields": ["title^{{title_boost}}", "description"]
           }
         },
         "from": "{{from}}",
@@ -70,10 +70,7 @@ PUT _application/search_application/my-app
       """,
       "params": {
         "query_string": "*",
-        "text_fields": [
-          {"name": "title", "boost": 10},
-          {"name": "description", "boost": 5}
-        ],
+        "title_boost": 10,
         "from": 0,
         "size": 10
       }
@@ -112,7 +109,7 @@ GET _application/search_application/my-app/
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
+            "fields": ["title^{{title_boost}}", "description"]
           }
         },
         "from": "{{from}}",
@@ -121,19 +118,10 @@ GET _application/search_application/my-app/
       """,
       "lang": "mustache",
       "params": {
+        "title_boost": 10,
         "from": 0,
         "size": 10,
-        "query_string": "*",
-        "text_fields": [
-          {
-            "name": "title",
-            "boost": 10
-          },
-          {
-            "name": "description",
-            "boost": 5
-          }
-        ]
+        "query_string": "*"
       }
     }
   }
@@ -149,16 +137,7 @@ POST _application/search_application/my-app/_search
 {
   "params": {
     "query_string": "my first query",
-    "text_fields": [
-        {
-            "name": "title",
-            "boost": 10
-        },
-        {
-            "name": "text",
-            "boost": 1
-        }
-    ]
+    "title_boost": 5
   }
 }
 ----
@@ -174,8 +153,8 @@ The generated Elasticsearch query would look like:
     "multi_match": {
       "query": "my first query",
       "fields": [
-        "text^1.0",
-        "title^10.0"
+        "description^1.0",
+        "title^5.0"
       ]
     }
   }
@@ -184,7 +163,7 @@ The generated Elasticsearch query would look like:
 // TESTRESPONSE[skip:result of request not run in this document]
 
 The expected response is the search results from the Elasticsearch query that was generated & run.
-The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>.
+The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>:
 
 [source,console-result]
 ----

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -9,8 +9,8 @@ beta::[]
 ++++
 
 Given specified query parameters, generates and executes an Elasticsearch query using the search template associated
-with the search application.
-Any unspecified template parameters will be assigned their default values (if applicable).
+with the search application or a default template if none is specified.
+Unspecified template parameters will be assigned their default values (if applicable).
 
 [[search-application-search-request]]
 ==== {api-request-title}
@@ -177,8 +177,8 @@ The generated Elasticsearch query would look like:
 ----
 // TESTRESPONSE[skip:result of request not run in this document]
 
-In this case, the `from` and `size` parameters are not specified in the request, so default values are pulled from the
-search template.
+In this case, the `from` and `size` parameters are not specified in the request, so the default values specified in the
+search template are used.
 
 The expected response is the search results from the Elasticsearch query that was generated & executed.
 The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>:

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -64,6 +64,12 @@ The following example executes a search against a search application called `my-
 ----
 PUT /index1
 
+PUT /index1/_doc/1?refresh=true
+{
+  "title": "Sample document",
+  "description": "A sample document that matches my first query"
+}
+
 PUT _application/search_application/my-app
 {
   "indices": ["index1"],
@@ -196,14 +202,13 @@ The response format is the same as that used by the <<search-api-response-body,E
   },
   "hits": {
     "total": {
-      "value": 20,
+      "value": 1,
       "relation": "eq"
     },
-    "max_score": 1.3862942,
-    "hits": [
-      ...
-    ]
+    "max_score": 0.8630463,
+    "hits": ...
   }
 }
 ----
-// TESTRESPONSE[skip:index not populated with documents]
+// TESTRESPONSE[s/"took": 5/"took": $body.$_path/]
+// TESTRESPONSE[s/"hits": \.\.\./"hits": $body.$_path/]

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -8,8 +8,8 @@ beta::[]
 <titleabbrev>Search Application Search</titleabbrev>
 ++++
 
-Given specified query parameters, creates an Elasticsearch query to run. Any unspecified template parameters will be
-assigned their default values if applicable.
+Given specified query parameters, generates an Elasticsearch query to run using the search template associated with the
+search application. Any unspecified template parameters will be assigned their default values (if applicable).
 
 [[search-application-search-request]]
 ==== {api-request-title}
@@ -28,7 +28,9 @@ Requires read privileges on the backing alias of the search application.
 
 `params`::
 (Optional, map of strings to objects)
-Query parameters specific to this request, which will override any defaults specified in the template.
+Query parameters used to generate the Elasticsearch query from the search template associated with the search
+application.
+If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
 
 [[search-application-search-response-codes]]
 ==== {api-response-codes-title}
@@ -39,7 +41,8 @@ Search Application `<name>` does not exist.
 [[search-application-search-example]]
 ==== {api-examples-title}
 
-The following example performs a search against a search application called `my-app`:
+The following example performs a search against a search application called `my-app` that uses the search
+template:
 
 ////
 [source,console]
@@ -49,6 +52,7 @@ PUT /index1
 PUT _application/search_application/my-app
 {
   "indices": ["index1"],
+  "updated_at_millis": 1682105622204,
   "template": {
     "script": {
       "lang": "mustache",
@@ -57,10 +61,9 @@ PUT _application/search_application/my-app
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": [{{#text_fields}}"{{name}}^{{boost}}"{{^last}},{{/last}}{{/text_fields}}]
+            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
           }
         },
-        "explain": "{{explain}}",
         "from": "{{from}}",
         "size": "{{size}}"
       }
@@ -68,10 +71,9 @@ PUT _application/search_application/my-app
       "params": {
         "query_string": "*",
         "text_fields": [
-          {"name": "title", "boost": 10, "last": false},
-          {"name": "description", "boost": 5, "last": true}
+          {"name": "title", "boost": 10},
+          {"name": "description", "boost": 5}
         ],
-        "explain": false,
         "from": 0,
         "size": 10
       }
@@ -94,12 +96,58 @@ DELETE /index1
 
 [source,console]
 ----
+GET _application/search_application/my-app/
+----
+
+[source,console-result]
+----
+{
+  "name": "my-app",
+  "updated_at_millis": 1682105622204,
+  "template": {
+    "script": {
+      "source": """
+      {
+        "query": {
+          "multi_match": {
+            "query": "{{query_string}}",
+            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
+          }
+        },
+        "from": "{{from}}",
+        "size": "{{size}}"
+      }
+      """,
+      "lang": "mustache",
+      "params": {
+        "from": 0,
+        "size": 10,
+        "query_string": "*",
+        "text_fields": [
+          {
+            "name": "title",
+            "boost": 10
+          },
+          {
+            "name": "description",
+            "boost": 5
+          }
+        ]
+      }
+    }
+  }
+}
+----
+
+The following request will use the search template to generate & run an Elasticsearch query against the search
+application:
+
+[source,console]
+----
 POST _application/search_application/my-app/_search
 {
   "params": {
-    "value": "my first query",
-    "size": 10,
-    "from": 0,
+    "query_string": "my first query",
     "text_fields": [
         {
             "name": "title",
@@ -114,6 +162,48 @@ POST _application/search_application/my-app/_search
 }
 ----
 
-The expected results are search results from the query that was run.
+The generated Elasticsearch query would look like:
 
+[source,console]
+----
+{
+  "from": 0,
+  "size": 10,
+  "query": {
+    "multi_match": {
+      "query": "my first query",
+      "fields": [
+        "text^1.0",
+        "title^10.0"
+      ]
+    }
+  }
+}
+----
 
+The expected response is the search results from the Elasticsearch query that was generated & run.
+The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>.
+
+[source,console]
+----
+{
+  "took": 5,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 20,
+      "relation": "eq"
+    },
+    "max_score": 1.3862942,
+    "hits": [
+      ...
+    ]
+  }
+}
+----

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -36,7 +36,8 @@ If a parameter used in the search template is not specified in `params`, the par
 [NOTE]
 ====
 The search application can be configured to validate search template parameters.
-See the `dictionary` parameter in the <<put-search-application, put search application>> API for more information.
+See the `dictionary` parameter in the <<put-search-application-dictionary-param, put search application>> API for more
+information.
 ====
 
 [[search-application-search-response-codes]]

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -44,6 +44,11 @@ See the `dictionary` parameter in the <<put-search-application, put search appli
 
 `400`::
 Invalid parameter passed to search template.
+Examples include:
+
+- Missing required parameter
+- Invalid parameter data type
+- Invalid parameter value
 
 `404`::
 Search Application `<name>` does not exist.

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -8,8 +8,9 @@ beta::[]
 <titleabbrev>Search Application Search</titleabbrev>
 ++++
 
-Given specified query parameters, generates an Elasticsearch query to run using the search template associated with the
-search application. Any unspecified template parameters will be assigned their default values (if applicable).
+Given specified query parameters, generates and executes an Elasticsearch query using the search template associated
+with the search application.
+Any unspecified template parameters will be assigned their default values (if applicable).
 
 [[search-application-search-request]]
 ==== {api-request-title}
@@ -47,8 +48,7 @@ Search Application `<name>` does not exist.
 [[search-application-search-example]]
 ==== {api-examples-title}
 
-The following example performs a search against a search application called `my-app` that uses the search
-template:
+The following example executes a search against a search application called `my-app` that uses the search template:
 
 ////
 [source,console]
@@ -134,7 +134,7 @@ GET _application/search_application/my-app/
 }
 ----
 
-The following request will use the search template to generate & run an Elasticsearch query against the search
+The following request will use the search template to generate & execute an Elasticsearch query against the search
 application:
 
 [source,console]
@@ -168,7 +168,10 @@ The generated Elasticsearch query would look like:
 ----
 // TESTRESPONSE[skip:result of request not run in this document]
 
-The expected response is the search results from the Elasticsearch query that was generated & run.
+In this case, the `from` and `size` parameters are not specified in the request, so default values are pulled from the
+search template.
+
+The expected response is the search results from the Elasticsearch query that was generated & executed.
 The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>:
 
 [source,console-result]

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -8,7 +8,7 @@ beta::[]
 <titleabbrev>Search Application Search</titleabbrev>
 ++++
 
-Given specified query parameters, generates and executes an Elasticsearch query using the search template associated
+Given specified query parameters, generates and executes an {es} query using the search template associated
 with the search application or a default template if none is specified.
 Unspecified template parameters will be assigned their default values (if applicable).
 
@@ -29,8 +29,7 @@ Requires read privileges on the backing alias of the search application.
 
 `params`::
 (Optional, map of strings to objects)
-Query parameters used to generate the Elasticsearch query from the search template associated with the search
-application.
+Query parameters used to generate the {es} query from the search template associated with the search application.
 If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
 
 [NOTE]
@@ -57,7 +56,8 @@ Search Application `<name>` does not exist.
 [[search-application-search-example]]
 ==== {api-examples-title}
 
-The following example executes a search against a search application called `my-app` that uses the search template:
+The following example executes a search against a search application called `my-app` that uses the search template from
+the <<search-application-api-bm25-template, text search example>>:
 
 ////
 [source,console]
@@ -73,7 +73,6 @@ PUT /index1/_doc/1?refresh=true
 PUT _application/search_application/my-app
 {
   "indices": ["index1"],
-  "updated_at_millis": 1682105622204,
   "template": {
     "script": {
       "lang": "mustache",
@@ -82,16 +81,21 @@ PUT _application/search_application/my-app
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": ["title^{{title_boost}}", "description"]
+            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
           }
         },
+        "explain": "{{explain}}",
         "from": "{{from}}",
         "size": "{{size}}"
       }
       """,
       "params": {
         "query_string": "*",
-        "title_boost": 10,
+        "text_fields": [
+          {"name": "title", "boost": 10},
+          {"name": "description", "boost": 5}
+        ],
+        "explain": false,
         "from": 0,
         "size": 10
       }
@@ -114,56 +118,19 @@ DELETE /index1
 
 [source,console]
 ----
-GET _application/search_application/my-app/
-----
-
-[source,console-result]
-----
-{
-  "name": "my-app",
-  "updated_at_millis": 1682105622204,
-  "indices": ["index1"],
-  "template": {
-    "script": {
-      "source": """
-      {
-        "query": {
-          "multi_match": {
-            "query": "{{query_string}}",
-            "fields": ["title^{{title_boost}}", "description"]
-          }
-        },
-        "from": "{{from}}",
-        "size": "{{size}}"
-      }
-      """,
-      "lang": "mustache",
-      "params": {
-        "title_boost": 10,
-        "from": 0,
-        "size": 10,
-        "query_string": "*"
-      }
-    }
-  }
-}
-----
-
-The following request will use the search template to generate & execute an Elasticsearch query against the search
-application:
-
-[source,console]
-----
 POST _application/search_application/my-app/_search
 {
   "params": {
     "query_string": "my first query",
-    "title_boost": 5
+    "text_fields": [
+      {"name": "title", "boost": 5},
+      {"name": "description", "boost": 1}
+    ]
   }
 }
 ----
 
-The generated Elasticsearch query would look like:
+The generated {es} query would look like:
 
 [source,console-result]
 ----
@@ -178,16 +145,17 @@ The generated Elasticsearch query would look like:
         "title^5.0"
       ]
     }
-  }
+  },
+  "explain": false
 }
 ----
 // TESTRESPONSE[skip:result of request not run in this document]
 
-In this case, the `from` and `size` parameters are not specified in the request, so the default values specified in the
-search template are used.
+In this case, the `from`, `size`, and `explain` parameters are not specified in the request, so the default values
+specified in the search template are used.
 
-The expected response is the search results from the Elasticsearch query that was generated & executed.
-The response format is the same as that used by the <<search-api-response-body,Elasticsearch Search API>>:
+The expected response is the search results from the {es} query that was generated & executed.
+The response format is the same as that used by the <<search-api-response-body,{es} Search API>>:
 
 [source,console-result]
 ----

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -104,6 +104,7 @@ GET _application/search_application/my-app/
 {
   "name": "my-app",
   "updated_at_millis": 1682105622204,
+  "indices": ["index1"],
   "template": {
     "script": {
       "source": """
@@ -138,8 +139,6 @@ GET _application/search_application/my-app/
   }
 }
 ----
-// TESTRESPONSE[skip:indices key mis-match]
-// TODO: fix test failure
 
 The following request will use the search template to generate & run an Elasticsearch query against the search
 application:

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -42,6 +42,9 @@ See the `dictionary` parameter in the <<put-search-application, put search appli
 [[search-application-search-response-codes]]
 ==== {api-response-codes-title}
 
+`400`::
+Invalid parameter passed to search template.
+
 `404`::
 Search Application `<name>` does not exist.
 


### PR DESCRIPTION
- Simplify the search template used in the example
- Show the search template used to generate the example query
- Show via example how the search template is applied
- Add a note about the `dictionary` parameter
- Align language & examples used for Search Application Search and Render Search Application Query