### PR TITLE
[8.11] Refresh indicies before checking disk usage (#100845)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -88,18 +88,14 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
         final XContentBuilder mapping = XContentFactory.jsonBuilder();
         mapping.startObject();
         {
-            mapping.startObject("_doc");
+            mapping.startObject("properties");
             {
-                mapping.startObject("properties");
-                {
-                    mapping.startObject("english_text");
-                    mapping.field("type", "text");
-                    mapping.endObject();
+                mapping.startObject("english_text");
+                mapping.field("type", "text");
+                mapping.endObject();
 
-                    mapping.startObject("value");
-                    mapping.field("type", "long");
-                    mapping.endObject();
-                }
+                mapping.startObject("value");
+                mapping.field("type", "long");
                 mapping.endObject();
             }
             mapping.endObject();
@@ -130,6 +126,8 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
                 .endObject();
             client().prepareIndex(index).setId("id").setSource(doc).get();
         }
+        // Force merge to ensure that there are more than one numeric value to justify doc value.
+        client().admin().indices().prepareForceMerge(index).setMaxNumSegments(1).get();
         PlainActionFuture<AnalyzeIndexDiskUsageResponse> future = PlainActionFuture.newFuture();
         client().execute(
             AnalyzeIndexDiskUsageAction.INSTANCE,


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Refresh indicies before checking disk usage (#100845)