### PR TITLE
Updating core enrich rest tests to run in new test framework

### DIFF
--- a/x-pack/plugin/enrich/qa/common/build.gradle
+++ b/x-pack/plugin/enrich/qa/common/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'elasticsearch.java'
 
+
 dependencies {
   api project(':test:framework')
+}
+
+dependencies {
+  api project(path: ':test:test-clusters')
 }

--- a/x-pack/plugin/enrich/qa/common/build.gradle
+++ b/x-pack/plugin/enrich/qa/common/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'elasticsearch.java'
 
-
 dependencies {
   api project(':test:framework')
 }

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'elasticsearch.legacy-java-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-test-artifact'
 
 
 import org.elasticsearch.gradle.Version
@@ -17,6 +18,13 @@ restResources {
 
 dependencies {
   javaRestTestImplementation project(path: xpackModule('enrich:qa:common'))
+}
+
+tasks.named('yamlRestTest') {
+  usesDefaultDistribution()
+}
+tasks.named('javaRestTest') {
+  usesDefaultDistribution()
 }
 
 if (BuildParams.inFipsJvm){

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 restResources {
@@ -31,12 +30,4 @@ if (BuildParams.inFipsJvm){
   // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
   tasks.named("javaRestTest").configure{enabled = false }
   tasks.named("yamlRestTest").configure{enabled = false }
-}
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.license.self_generated.type', 'basic'
-  setting 'xpack.monitoring.collection.enabled', 'true'
-  setting 'xpack.security.enabled', 'false'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.4.0")
 }

--- a/x-pack/plugin/enrich/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/enrich/EnrichRestIT.java
+++ b/x-pack/plugin/enrich/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/enrich/EnrichRestIT.java
@@ -9,8 +9,14 @@ package org.elasticsearch.xpack.enrich;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 public class EnrichRestIT extends ESClientYamlSuiteTestCase {
 
@@ -21,6 +27,25 @@ public class EnrichRestIT extends ESClientYamlSuiteTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return createParameters();
+    }
+
+    private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue("x_pack_rest_user", new SecureString("x-pack-test-password"));
+
+    @Override
+    protected Settings restClientSettings() {
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE).build();
+    }
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "true")
+        .user("x_pack_rest_user", "x-pack-test-password")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 
 }


### PR DESCRIPTION
This change updates the core enrich java and yaml rests to run in the newer rest test framework.