### PR TITLE
Ensure document order in enrich yaml test (#100863)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/single-node/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 restResources {
   restApi {
-    include '_common', 'bulk', 'indices', 'esql', 'xpack', 'enrich'
+    include '_common', 'bulk', 'indices', 'esql', 'xpack', 'enrich', 'cluster'
   }
 }
 

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/61_enrich_ip.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/61_enrich_ip.yml
@@ -4,6 +4,9 @@ setup:
       indices.create:
         index: networks
         body:
+          settings:
+            index.number_of_shards: 1
+            index.routing.rebalance.enable: "none"
           mappings:
             properties:
               range:
@@ -22,6 +25,10 @@ setup:
           - { "range": "10.100.0.0/16", "name": "Production", "department": "OPS" }
           - { "index": { } }
           - { "range": "10.101.0.0/16", "name": "QA", "department": "Engineering" }
+  - do:
+      cluster.health:
+        wait_for_no_initializing_shards: true
+        wait_for_events: languid
 
   - do:
       enrich.put_policy:
@@ -64,6 +71,7 @@ setup:
           - { "@timestamp": "2023-06-24", "ip": "13.101.0.114", "message": "authentication failed" }
 ---
 "IP strings":
+
   - do:
       esql.query:
         body:


### PR DESCRIPTION
Backport of #100863 to 8.11

The test fails due to out-of-order documents in the enrich index. This can occur when replicas are initializing during indexing. To avoid this, we just need to ensure there are no initializing shards before starting indexing and disable shard relocations.

Closes #99807