### PR TITLE
[7.17] Add tolerance to ExtendedStatsAggregatorTests#testSummationAccuracy (#100917)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
@@ -203,7 +203,7 @@ public class ExtendedStatsAggregatorTests extends AggregatorTestCase {
 
     public void testSummationAccuracy() throws IOException {
         double[] values = new double[] { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7 };
-        verifyStatsOfDoubles(values, 13.5, 16.21, 0d);
+        verifyStatsOfDoubles(values, 13.5, 16.21, TOLERANCE);
 
         // Summing up an array which contains NaN and infinities and expect a result same as naive summation
         int n = randomIntBetween(5, 10);


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Add tolerance to ExtendedStatsAggregatorTests#testSummationAccuracy (#100917)