### PR TITLE
[ML] Rename the ELSER service

### DIFF
--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -24,10 +24,10 @@ Retrieves {infer} model information.
 [[get-inference-api-desc]]
 ==== {api-description-title}
 
-You can get information in a single API request for: 
+You can get information in a single API request for:
 
 * a single {infer} model by providing the task type and the model ID,
-* all of the {infer} models for a certain task type by providing the task type 
+* all of the {infer} models for a certain task type by providing the task type
 and a wildcard expression,
 * all of the {infer} models by using a wildcard expression.
 
@@ -50,7 +50,7 @@ The type of {infer} task that the model performs.
 [[get-inference-api-example]]
 ==== {api-examples-title}
 
-The following API call retrives information about the `my-elser-model` {infer} 
+The following API call retrives information about the `my-elser-model` {infer}
 model that can perform `sparse_embedding` tasks.
 
 
@@ -68,7 +68,7 @@ The API returns the following response:
 {
   "model_id": "my-elser-model",
   "task_type": "sparse_embedding",
-  "service": "elser_mlnode",
+  "service": "elser",
   "service_settings": {
     "num_allocations": 1,
     "num_threads": 1

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -22,8 +22,8 @@ Creates a model to perform an {infer} task.
 [[put-inference-api-desc]]
 ==== {api-description-title}
 
-The create {infer} API enables you to create and configure an {infer} model to 
-perform a specific {infer} task. 
+The create {infer} API enables you to create and configure an {infer} model to
+perform a specific {infer} task.
 
 
 [discrete]
@@ -50,17 +50,16 @@ The type of the {infer} task that the model will perform. Available task types:
 (Required, string)
 The type of service supported for the specified task type.
 Available services:
-* `elser`,
-* `elser_mlnode`.
+* `elser`
 
 `service_settings`::
 (Required, object)
-Settings used to install the {infer} model. These settings are specific to the 
+Settings used to install the {infer} model. These settings are specific to the
 `service` you specified.
 
 `task_settings`::
 (Optional, object)
-Settings to configure the {infer} task. These settings are specific to the 
+Settings to configure the {infer} task. These settings are specific to the
 `<task_type>` you specified.
 
 
@@ -68,14 +67,14 @@ Settings to configure the {infer} task. These settings are specific to the
 [[put-inference-api-example]]
 ==== {api-examples-title}
 
-The following example shows how to create an {infer} model called 
+The following example shows how to create an {infer} model called
 `my-elser-model` to perform a `sparse_embedding` task type.
 
 [source,console]
 ------------------------------------------------------------
 PUT _inference/sparse_embedding/my-elser-model
 {
-  "service": "elser_mlnode",
+  "service": "elser",
   "service_settings": {
     "num_allocations": 1,
     "num_threads": 1
@@ -93,7 +92,7 @@ Example response:
 {
   "model_id": "my-elser-model",
   "task_type": "sparse_embedding",
-  "service": "elser_mlnode",
+  "service": "elser",
   "service_settings": {
     "num_allocations": 1,
     "num_threads": 1

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeService.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.xpack.inference.services.MapParsingUtils.throwIf
 
 public class ElserMlNodeService implements InferenceService {
 
-    public static final String NAME = "elser_mlnode";
+    public static final String NAME = "elser";
 
     static final String ELSER_V1_MODEL = ".elser_model_1";
     // Default non platform specific v2 model

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeServiceTests.java
@@ -124,7 +124,7 @@ public class ElserMlNodeServiceTests extends ESTestCase {
                     );
                     assertThat(
                         e.getMessage(),
-                        containsString("Model configuration contains settings [{foo=bar}] unknown to the [elser_mlnode] service")
+                        containsString("Model configuration contains settings [{foo=bar}] unknown to the [elser] service")
                     );
                 } else {
                     var parsed = service.parsePersistedConfig("foo", TaskType.SPARSE_EMBEDDING, settings, Collections.emptyMap());
@@ -155,7 +155,7 @@ public class ElserMlNodeServiceTests extends ESTestCase {
                     );
                     assertThat(
                         e.getMessage(),
-                        containsString("Model configuration contains settings [{foo=bar}] unknown to the [elser_mlnode] service")
+                        containsString("Model configuration contains settings [{foo=bar}] unknown to the [elser] service")
                     );
                 } else {
                     var parsed = service.parsePersistedConfig("foo", TaskType.SPARSE_EMBEDDING, settings, Collections.emptyMap());
@@ -187,7 +187,7 @@ public class ElserMlNodeServiceTests extends ESTestCase {
                     );
                     assertThat(
                         e.getMessage(),
-                        containsString("Model configuration contains settings [{foo=bar}] unknown to the [elser_mlnode] service")
+                        containsString("Model configuration contains settings [{foo=bar}] unknown to the [elser] service")
                     );
                 } else {
                     var parsed = service.parsePersistedConfig("foo", TaskType.SPARSE_EMBEDDING, settings, Collections.emptyMap());

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/inference/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/inference/inference_crud.yml
@@ -17,7 +17,7 @@
         model_id: elser_model
         body: >
           {
-            "service": "elser_mlnode",
+            "service": "elser",
             "service_settings": {
               "num_allocations": 1,
               "num_threads": 1


### PR DESCRIPTION
Rename from `elser_mlnode` -which was only a placeholder name- to `elser`