### PR TITLE
Remove unneeded node selector from YAML aggregation tests

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/adjacency_matrix.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/adjacency_matrix.yml
@@ -66,8 +66,6 @@ setup:
   - skip:
       version: " - 7.8.99"
       reason:  fixed in 7.9.0
-      features: node_selector
-
   - do:
       indices.create:
           index: lookup
@@ -91,8 +89,6 @@ setup:
           { "num": [4] }
 
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test
         preference: hit-same-shard-copy
@@ -145,8 +141,6 @@ setup:
 
   # The second request should hit the cache
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test
         preference: hit-same-shard-copy

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/filter.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/filter.yml
@@ -24,12 +24,7 @@ setup:
 
 ---
 "Terms lookup gets cached":
-  - skip:
-      features: node_selector
-
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0
@@ -63,8 +58,6 @@ setup:
   - match: { indices.test.total.request_cache.miss_count: 1 }
 
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0
@@ -99,12 +92,7 @@ setup:
 
 ---
 "Standard queries get cached":
-  - skip:
-      features: node_selector
-
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0
@@ -137,8 +125,6 @@ setup:
 
   # Try again - it'll cache
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/filters_bucket.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/filters_bucket.yml
@@ -393,7 +393,6 @@ null meta:
   - skip:
       version: " - 7.10.99"
       reason:  cache fixed in 7.11.0
-      features: node_selector
 
   - do:
       bulk:
@@ -407,8 +406,6 @@ null meta:
             string_field: foo bar
 
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test_1
         body:
@@ -440,8 +437,6 @@ null meta:
 
   # This should be entirely fresh because updating the mapping busted the cache.
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test_1
         body:
@@ -512,9 +507,6 @@ nested:
 
 ---
 "cache hits":
-  - skip:
-      features: node_selector
-
   - do:
       indices.create:
           index: test
@@ -539,8 +531,6 @@ nested:
           {"mentions" : ["abc"]}
 
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0
@@ -579,8 +569,6 @@ nested:
   - match: { indices.test.total.request_cache.miss_count: 1 }
 
   - do:
-      node_selector:
-        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0


### PR DESCRIPTION
We reverted https://github.com/elastic/elasticsearch/pull/100794 (through https://github.com/elastic/elasticsearch/pull/100889) as some YAML tests were not passing on serverless (see https://gradle-enterprise.elastic.co/s/i6ntwjhsxtray).

However, by submitting https://github.com/elastic/elasticsearch/pull/100746, we will break it again - the NodeInfo rest API will be updated to return Build.version(), but the YAML tests will not. There is no "safe" order to submit https://github.com/elastic/elasticsearch/pull/100746 and https://github.com/elastic/elasticsearch/pull/100794, change needs to happen on both sides.

However, it is also true that the `node_selector` used in broken tests is a no-op: these tests do not run on a mixed cluster or during a rolling upgrade test, so `node_selector: current` will always return the whole set of nodes. 
Removing the selector will make submitting https://github.com/elastic/elasticsearch/pull/100794 safe again - then, after https://github.com/elastic/elasticsearch/pull/100746, `node_selector: current` will also work for serverless under the new version scheme (if we need or want to introduce mixed cluster or rolling upgrade tests in the future).
