### PR TITLE
Mute `pre_filter_shard_size with shards that have no hit` test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -57,6 +57,9 @@ setup:
 
 ---
 "pre_filter_shard_size with shards that have no hit":
+  - skip:
+      version: all
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/92058"
   - do:
       index:
         index: index_1


### PR DESCRIPTION
Mutes https://github.com/elastic/elasticsearch/issues/92058

