### PR TITLE
Remove ~600 references to SearchResponse in tests

### DIFF
--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/QueryStringWithAnalyzersIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/QueryStringWithAnalyzersIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.plugins.Plugin;
@@ -53,9 +52,10 @@ public class QueryStringWithAnalyzersIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", "foo bar baz", "field2", "not needed").get();
         refresh();
 
-        SearchResponse response = client().prepareSearch("test")
-            .setQuery(queryStringQuery("foo.baz").defaultOperator(Operator.AND).field("field1").field("field2"))
-            .get();
-        assertHitCount(response, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(queryStringQuery("foo.baz").defaultOperator(Operator.AND).field("field1").field("field2")),
+            1L
+        );
     }
 }

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadAnalyzerTests.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadAnalyzerTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction.Response;
 import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzerAction;
 import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersRequest;
 import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
@@ -56,10 +55,8 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
 
         checkAnalyzerTokens(List.of("foo", "baz", "buzz"));
 
-        SearchResponse response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-        assertHitCount(response, 1L);
-        response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
-        assertHitCount(response, 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 1L);
     }
 
     public void testSynonymsAreNotUpdatedOnPreview() throws IOException {
@@ -69,10 +66,8 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
 
         checkAnalyzerTokens(List.of("foo", "baz"));
 
-        SearchResponse response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-        assertHitCount(response, 1L);
-        response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
-        assertHitCount(response, 0L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);
     }
 
     private Path setupSynonyms() throws IOException {
@@ -99,10 +94,8 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
         client().prepareIndex(INDEX_NAME).setId("1").setSource("field", "Foo").get();
         assertNoFailures(indicesAdmin().prepareRefresh(INDEX_NAME).execute().actionGet());
 
-        SearchResponse response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-        assertHitCount(response, 1L);
-        response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
-        assertHitCount(response, 0L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);
 
         {
             for (String analyzerName : new String[] { SYNONYM_ANALYZER_NAME, SYNONYM_GRAPH_ANALYZER_NAME }) {
@@ -171,10 +164,8 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
         client().prepareIndex(INDEX_NAME).setId("1").setSource("field", "foo").get();
         assertNoFailures(indicesAdmin().prepareRefresh(INDEX_NAME).execute().actionGet());
 
-        SearchResponse response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-        assertHitCount(response, 1L);
-        response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
-        assertHitCount(response, 0L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);
 
         Response analyzeResponse = indicesAdmin().prepareAnalyze(INDEX_NAME, "foo").setAnalyzer(SYNONYM_ANALYZER_NAME).get();
         assertEquals(2, analyzeResponse.getTokens().size());
@@ -208,10 +199,8 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
         assertTrue(tokens.contains("baz"));
         assertTrue(tokens.contains("buzz"));
 
-        response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-        assertHitCount(response, 1L);
-        response = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
-        assertHitCount(response, 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 1L);
     }
 
     public void testUpdateableSynonymsRejectedAtIndexTime() throws FileNotFoundException, IOException {

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction.Response;
 import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzerAction;
 import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersRequest;
 import org.elasticsearch.action.admin.indices.analyze.ReloadAnalyzersResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
@@ -84,10 +83,8 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field", "foo").get();
         assertNoFailures(indicesAdmin().prepareRefresh("test").execute().actionGet());
 
-        SearchResponse response = client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-        assertHitCount(response, 1L);
-        response = client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
-        assertHitCount(response, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);
         Response analyzeResponse = indicesAdmin().prepareAnalyze("test", "foo").setAnalyzer("my_synonym_analyzer").get();
         assertEquals(2, analyzeResponse.getTokens().size());
         assertEquals("foo", analyzeResponse.getTokens().get(0).getTerm());
@@ -127,11 +124,9 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
                 assertTrue(tokens.contains(testTerm));
             }
 
-            response = client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "baz")).get();
-            assertHitCount(response, 1L);
+            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
             long expectedHitCount = preview ? 0L : 1L;
-            response = client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", testTerm)).get();
-            assertHitCount(response, expectedHitCount);
+            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", testTerm)), expectedHitCount);
         }
     }
 }

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1894,7 +1894,7 @@ public class DataStreamIT extends ESIntegTestCase {
             }
         } else {
             if (requestBuilder instanceof SearchRequestBuilder searchRequestBuilder) {
-                assertHitCount(searchRequestBuilder.get(), expectedCount);
+                assertHitCount(searchRequestBuilder, expectedCount);
             } else if (requestBuilder instanceof MultiSearchRequestBuilder) {
                 MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
                 assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(false));

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
@@ -517,26 +517,26 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("test", "child", "c1", parentId, "c_field", "1").get();
         refresh();
 
-        SearchResponse countResponse = client().prepareSearch("test")
-            .setSize(0)
-            .setQuery(hasChildQuery("child", termQuery("c_field", "1"), ScoreMode.Max))
-            .get();
-        assertHitCount(countResponse, 1L);
+        assertHitCount(
+            client().prepareSearch("test").setSize(0).setQuery(hasChildQuery("child", termQuery("c_field", "1"), ScoreMode.Max)),
+            1L
+        );
 
-        countResponse = client().prepareSearch("test").setSize(0).setQuery(hasParentQuery("parent", termQuery("p_field", "1"), true)).get();
-        assertHitCount(countResponse, 1L);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(hasParentQuery("parent", termQuery("p_field", "1"), true)), 1L);
 
-        countResponse = client().prepareSearch("test")
-            .setSize(0)
-            .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "1"), ScoreMode.None)))
-            .get();
-        assertHitCount(countResponse, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setSize(0)
+                .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "1"), ScoreMode.None))),
+            1L
+        );
 
-        countResponse = client().prepareSearch("test")
-            .setSize(0)
-            .setQuery(constantScoreQuery(hasParentQuery("parent", termQuery("p_field", "1"), false)))
-            .get();
-        assertHitCount(countResponse, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setSize(0)
+                .setQuery(constantScoreQuery(hasParentQuery("parent", termQuery("p_field", "1"), false))),
+            1L
+        );
     }
 
     public void testExplainUsage() throws Exception {
@@ -975,29 +975,31 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         );
         ensureGreen();
 
-        SearchResponse response = client().prepareSearch("test")
-            .setQuery(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
-            .get();
-        assertHitCount(response, 0L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child"))),
+            0L
+        );
 
         createIndexRequest("test", "child", "c1", "p1").get();
         refresh();
 
-        response = client().prepareSearch("test")
-            .setQuery(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
-            .get();
-        assertHitCount(response, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child"))),
+            1L
+        );
 
         createIndexRequest("test", "child", "c2", "p2").get();
         refresh();
-
-        response = client().prepareSearch("test")
-            .setQuery(
-                boolQuery().should(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
-                    .should(boolQuery().filter(termQuery("join_field#parent", "p2")).filter(termQuery("join_field", "child")))
-            )
-            .get();
-        assertHitCount(response, 2L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    boolQuery().should(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
+                        .should(boolQuery().filter(termQuery("join_field#parent", "p2")).filter(termQuery("join_field", "child")))
+                ),
+            2L
+        );
     }
 
     public void testParentIdQuery() throws Exception {
@@ -1010,16 +1012,15 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("test", "child", "c1", "p1").get();
         refresh();
 
-        SearchResponse response = client().prepareSearch("test").setQuery(parentId("child", "p1")).get();
-        assertHitCount(response, 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(parentId("child", "p1")), 1L);
 
         createIndexRequest("test", "child", "c2", "p2").get();
         refresh();
 
-        response = client().prepareSearch("test")
-            .setQuery(boolQuery().should(parentId("child", "p1")).should(parentId("child", "p2")))
-            .get();
-        assertHitCount(response, 2L);
+        assertHitCount(
+            client().prepareSearch("test").setQuery(boolQuery().should(parentId("child", "p1")).should(parentId("child", "p2"))),
+            2L
+        );
     }
 
     public void testHasChildNotBeingCached() throws IOException {
@@ -1107,35 +1108,37 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("grandissue", "child_type_two", "4", "2", "name", "Kate").setRouting("1").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("grandissue")
-            .setQuery(
-                boolQuery().must(
-                    hasChildQuery(
-                        "parent",
-                        boolQuery().must(
-                            hasChildQuery("child_type_one", boolQuery().must(queryStringQuery("name:William*")), ScoreMode.None)
-                        ),
-                        ScoreMode.None
+        assertHitCount(
+            client().prepareSearch("grandissue")
+                .setQuery(
+                    boolQuery().must(
+                        hasChildQuery(
+                            "parent",
+                            boolQuery().must(
+                                hasChildQuery("child_type_one", boolQuery().must(queryStringQuery("name:William*")), ScoreMode.None)
+                            ),
+                            ScoreMode.None
+                        )
                     )
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 1L);
+                ),
+            1L
+        );
 
-        searchResponse = client().prepareSearch("grandissue")
-            .setQuery(
-                boolQuery().must(
-                    hasChildQuery(
-                        "parent",
-                        boolQuery().must(
-                            hasChildQuery("child_type_two", boolQuery().must(queryStringQuery("name:William*")), ScoreMode.None)
-                        ),
-                        ScoreMode.None
+        assertHitCount(
+            client().prepareSearch("grandissue")
+                .setQuery(
+                    boolQuery().must(
+                        hasChildQuery(
+                            "parent",
+                            boolQuery().must(
+                                hasChildQuery("child_type_two", boolQuery().must(queryStringQuery("name:William*")), ScoreMode.None)
+                            ),
+                            ScoreMode.None
+                        )
                     )
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 0L);
+                ),
+            0L
+        );
     }
 
     public void testHasChildQueryWithNestedInnerObjects() throws Exception {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
@@ -145,32 +145,33 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
         indicesAdmin().prepareRefresh().get();
 
         for (int i = 0; i < 32; i++) {
-            SearchResponse response = client().prepareSearch()
-                .setQuery(
-                    new PercolateQueryBuilder(
-                        "query",
-                        BytesReference.bytes(
-                            XContentFactory.jsonBuilder()
-                                .startObject()
-                                .field("companyname", "stark")
-                                .startArray("employee")
-                                .startObject()
-                                .field("name", "virginia potts")
-                                .endObject()
-                                .startObject()
-                                .field("name", "tony stark")
-                                .endObject()
-                                .endArray()
-                                .endObject()
-                        ),
-                        XContentType.JSON
+            assertHitCount(
+                client().prepareSearch()
+                    .setQuery(
+                        new PercolateQueryBuilder(
+                            "query",
+                            BytesReference.bytes(
+                                XContentFactory.jsonBuilder()
+                                    .startObject()
+                                    .field("companyname", "stark")
+                                    .startArray("employee")
+                                    .startObject()
+                                    .field("name", "virginia potts")
+                                    .endObject()
+                                    .startObject()
+                                    .field("name", "tony stark")
+                                    .endObject()
+                                    .endArray()
+                                    .endObject()
+                            ),
+                            XContentType.JSON
+                        )
                     )
-                )
-                .addSort("_doc", SortOrder.ASC)
-                // size 0, because other wise load bitsets for normal document in FetchPhase#findRootDocumentIfNested(...)
-                .setSize(0)
-                .get();
-            assertHitCount(response, 1);
+                    .addSort("_doc", SortOrder.ASC)
+                    // size 0, because other wise load bitsets for normal document in FetchPhase#findRootDocumentIfNested(...)
+                    .setSize(0),
+                1
+            );
         }
 
         // We can't check via api... because BitsetCacheListener requires that it can extract shardId from index reader
@@ -243,11 +244,12 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
         }
         doc.endObject();
         for (int i = 0; i < 32; i++) {
-            SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", BytesReference.bytes(doc), XContentType.JSON))
-                .addSort("_doc", SortOrder.ASC)
-                .get();
-            assertHitCount(response, 1);
+            assertHitCount(
+                client().prepareSearch()
+                    .setQuery(new PercolateQueryBuilder("query", BytesReference.bytes(doc), XContentType.JSON))
+                    .addSort("_doc", SortOrder.ASC),
+                1
+            );
         }
 
         long fieldDataSize = clusterAdmin().prepareClusterStats().get().getIndicesStats().getFieldData().getMemorySizeInBytes();

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
@@ -283,7 +283,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         );
 
         // Checks that the all documents have been indexed and correctly counted
-        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0), numDocs);
         assertThat(ALLOWED_OPERATIONS.drainPermits(), equalTo(0));
 
         ReindexRequestBuilder builder = new ReindexRequestBuilder(client, ReindexAction.INSTANCE).source(INDEX_NAME)

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/CancelTests.java
@@ -102,7 +102,7 @@ public class CancelTests extends ReindexTestCase {
         );
 
         // Checks that the all documents have been indexed and correctly counted
-        assertHitCount(client().prepareSearch(INDEX).setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch(INDEX).setSize(0), numDocs);
         assertThat(ALLOWED_OPERATIONS.drainPermits(), equalTo(0));
 
         // Scroll by 1 so that cancellation is easier to control
@@ -225,7 +225,7 @@ public class CancelTests extends ReindexTestCase {
             assertThat(response, matcher().created(modified).reasonCancelled(equalTo("by user request")));
 
             refresh("dest");
-            assertHitCount(client().prepareSearch("dest").setSize(0).get(), modified);
+            assertHitCount(client().prepareSearch("dest").setSize(0), modified);
         }, equalTo("reindex from [" + INDEX + "] to [dest]"));
     }
 
@@ -241,7 +241,7 @@ public class CancelTests extends ReindexTestCase {
 
         testCancel(UpdateByQueryAction.NAME, updateByQuery().setPipeline("set-processed").source(INDEX), (response, total, modified) -> {
             assertThat(response, matcher().updated(modified).reasonCancelled(equalTo("by user request")));
-            assertHitCount(client().prepareSearch(INDEX).setSize(0).setQuery(termQuery("processed", true)).get(), modified);
+            assertHitCount(client().prepareSearch(INDEX).setSize(0).setQuery(termQuery("processed", true)), modified);
         }, equalTo("update-by-query [" + INDEX + "]"));
 
         assertAcked(clusterAdmin().deletePipeline(new DeletePipelineRequest("set-processed")).get());
@@ -253,7 +253,7 @@ public class CancelTests extends ReindexTestCase {
             deleteByQuery().source(INDEX).filter(QueryBuilders.matchAllQuery()),
             (response, total, modified) -> {
                 assertThat(response, matcher().deleted(modified).reasonCancelled(equalTo("by user request")));
-                assertHitCount(client().prepareSearch(INDEX).setSize(0).get(), total - modified);
+                assertHitCount(client().prepareSearch(INDEX).setSize(0), total - modified);
             },
             equalTo("delete-by-query [" + INDEX + "]")
         );
@@ -266,7 +266,7 @@ public class CancelTests extends ReindexTestCase {
             (response, total, modified) -> {
                 assertThat(response, matcher().created(modified).reasonCancelled(equalTo("by user request")).slices(hasSize(5)));
                 refresh("dest");
-                assertHitCount(client().prepareSearch("dest").setSize(0).get(), modified);
+                assertHitCount(client().prepareSearch("dest").setSize(0), modified);
             },
             equalTo("reindex from [" + INDEX + "] to [dest]")
         );
@@ -287,7 +287,7 @@ public class CancelTests extends ReindexTestCase {
             updateByQuery().setPipeline("set-processed").source(INDEX).setSlices(5),
             (response, total, modified) -> {
                 assertThat(response, matcher().updated(modified).reasonCancelled(equalTo("by user request")).slices(hasSize(5)));
-                assertHitCount(client().prepareSearch(INDEX).setSize(0).setQuery(termQuery("processed", true)).get(), modified);
+                assertHitCount(client().prepareSearch(INDEX).setSize(0).setQuery(termQuery("processed", true)), modified);
             },
             equalTo("update-by-query [" + INDEX + "]")
         );
@@ -301,7 +301,7 @@ public class CancelTests extends ReindexTestCase {
             deleteByQuery().source(INDEX).filter(QueryBuilders.matchAllQuery()).setSlices(5),
             (response, total, modified) -> {
                 assertThat(response, matcher().deleted(modified).reasonCancelled(equalTo("by user request")).slices(hasSize(5)));
-                assertHitCount(client().prepareSearch(INDEX).setSize(0).get(), total - modified);
+                assertHitCount(client().prepareSearch(INDEX).setSize(0), total - modified);
             },
             equalTo("delete-by-query [" + INDEX + "]")
         );

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryBasicTests.java
@@ -61,25 +61,25 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             client().prepareIndex("test").setId("7").setSource("foo", "f")
         );
 
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 7);
+        assertHitCount(client().prepareSearch("test").setSize(0), 7);
 
         // Deletes two docs that matches "foo:a"
         assertThat(deleteByQuery().source("test").filter(termQuery("foo", "a")).refresh(true).get(), matcher().deleted(2));
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 5);
+        assertHitCount(client().prepareSearch("test").setSize(0), 5);
 
         // Deletes the two first docs with limit by size
         DeleteByQueryRequestBuilder request = deleteByQuery().source("test").filter(QueryBuilders.matchAllQuery()).size(2).refresh(true);
         request.source().addSort("foo.keyword", SortOrder.ASC);
         assertThat(request.get(), matcher().deleted(2));
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 3);
+        assertHitCount(client().prepareSearch("test").setSize(0), 3);
 
         // Deletes but match no docs
         assertThat(deleteByQuery().source("test").filter(termQuery("foo", "no_match")).refresh(true).get(), matcher().deleted(0));
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 3);
+        assertHitCount(client().prepareSearch("test").setSize(0), 3);
 
         // Deletes all remaining docs
         assertThat(deleteByQuery().source("test").filter(QueryBuilders.matchAllQuery()).refresh(true).get(), matcher().deleted(3));
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
+        assertHitCount(client().prepareSearch("test").setSize(0), 0);
     }
 
     public void testDeleteByQueryWithOneIndex() throws Exception {
@@ -92,7 +92,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         indexRandom(true, true, true, builders);
 
         assertThat(deleteByQuery().source("t*").filter(QueryBuilders.matchAllQuery()).refresh(true).get(), matcher().deleted(docs));
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
+        assertHitCount(client().prepareSearch("test").setSize(0), 0);
     }
 
     public void testDeleteByQueryWithMultipleIndices() throws Exception {
@@ -122,15 +122,15 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
 
         for (int i = 0; i < indices; i++) {
             long remaining = docs - candidates[i];
-            assertHitCount(client().prepareSearch("test-" + i).setSize(0).get(), remaining);
+            assertHitCount(client().prepareSearch("test-" + i).setSize(0), remaining);
         }
 
-        assertHitCount(client().prepareSearch().setSize(0).get(), (indices * docs) - deletions);
+        assertHitCount(client().prepareSearch().setSize(0), (indices * docs) - deletions);
     }
 
     public void testDeleteByQueryWithMissingIndex() throws Exception {
         indexRandom(true, client().prepareIndex("test").setId("1").setSource("foo", "a"));
-        assertHitCount(client().prepareSearch().setSize(0).get(), 1);
+        assertHitCount(client().prepareSearch().setSize(0), 1);
 
         try {
             deleteByQuery().source("missing").filter(QueryBuilders.matchAllQuery()).get();
@@ -154,7 +154,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         indexRandom(true, true, true, builders);
 
         logger.info("--> counting documents with no routing, should be equal to [{}]", docs);
-        assertHitCount(client().prepareSearch().setSize(0).get(), docs);
+        assertHitCount(client().prepareSearch().setSize(0), docs);
 
         String routing = String.valueOf(randomIntBetween(2, docs));
 
@@ -166,7 +166,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         delete.source().setRouting(routing);
         assertThat(delete.refresh(true).get(), matcher().deleted(expected));
 
-        assertHitCount(client().prepareSearch().setSize(0).get(), docs - expected);
+        assertHitCount(client().prepareSearch().setSize(0), docs - expected);
     }
 
     public void testDeleteByMatchQuery() throws Exception {
@@ -186,13 +186,13 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         indexRandom(true, true, true, builders);
 
         int n = between(0, docs - 1);
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(matchQuery("_id", Integer.toString(n))).get(), 1);
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get(), docs);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(matchQuery("_id", Integer.toString(n))), 1);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.matchAllQuery()), docs);
 
         DeleteByQueryRequestBuilder delete = deleteByQuery().source("alias").filter(matchQuery("_id", Integer.toString(n)));
         assertThat(delete.refresh(true).get(), matcher().deleted(1L));
 
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get(), docs - 1);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.matchAllQuery()), docs - 1);
     }
 
     public void testDeleteByQueryWithDateMath() throws Exception {
@@ -201,7 +201,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         DeleteByQueryRequestBuilder delete = deleteByQuery().source("test").filter(rangeQuery("d").to("now-1h"));
         assertThat(delete.refresh(true).get(), matcher().deleted(1L));
 
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
+        assertHitCount(client().prepareSearch("test").setSize(0), 0);
     }
 
     public void testDeleteByQueryOnReadOnlyIndex() throws Exception {
@@ -224,7 +224,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             disableIndexBlock("test", SETTING_READ_ONLY);
         }
 
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), docs);
+        assertHitCount(client().prepareSearch("test").setSize(0), docs);
     }
 
     public void testDeleteByQueryOnReadOnlyAllowDeleteIndex() throws Exception {
@@ -280,9 +280,9 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             }
         }
         if (diskAllocationDeciderEnabled) {
-            assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
+            assertHitCount(client().prepareSearch("test").setSize(0), 0);
         } else {
-            assertHitCount(client().prepareSearch("test").setSize(0).get(), docs);
+            assertHitCount(client().prepareSearch("test").setSize(0), docs);
         }
     }
 
@@ -297,7 +297,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             client().prepareIndex("test").setId("6").setSource("foo", "e"),
             client().prepareIndex("test").setId("7").setSource("foo", "f")
         );
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 7);
+        assertHitCount(client().prepareSearch("test").setSize(0), 7);
 
         int slices = randomSlices();
         int expectedSlices = expectedSliceStatuses(slices, "test");
@@ -307,14 +307,14 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             deleteByQuery().source("test").filter(termQuery("foo", "a")).refresh(true).setSlices(slices).get(),
             matcher().deleted(2).slices(hasSize(expectedSlices))
         );
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 5);
+        assertHitCount(client().prepareSearch("test").setSize(0), 5);
 
         // Delete remaining docs
         assertThat(
             deleteByQuery().source("test").filter(QueryBuilders.matchAllQuery()).refresh(true).setSlices(slices).get(),
             matcher().deleted(5).slices(hasSize(expectedSlices))
         );
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
+        assertHitCount(client().prepareSearch("test").setSize(0), 0);
     }
 
     public void testMultipleSources() throws Exception {
@@ -333,7 +333,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> allDocs = docs.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
         indexRandom(true, allDocs);
         for (Map.Entry<String, List<IndexRequestBuilder>> entry : docs.entrySet()) {
-            assertHitCount(client().prepareSearch(entry.getKey()).setSize(0).get(), entry.getValue().size());
+            assertHitCount(client().prepareSearch(entry.getKey()).setSize(0), entry.getValue().size());
         }
 
         int slices = randomSlices(1, 10);
@@ -347,7 +347,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         );
 
         for (String index : docs.keySet()) {
-            assertHitCount(client().prepareSearch(index).setSize(0).get(), 0);
+            assertHitCount(client().prepareSearch(index).setSize(0), 0);
         }
 
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryConcurrentTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/DeleteByQueryConcurrentTests.java
@@ -40,7 +40,7 @@ public class DeleteByQueryConcurrentTests extends ReindexTestCase {
         final CountDownLatch start = new CountDownLatch(1);
         for (int t = 0; t < threads.length; t++) {
             final int threadNum = t;
-            assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.termQuery("field", threadNum)).get(), docs);
+            assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.termQuery("field", threadNum)), docs);
 
             Runnable r = () -> {
                 try {
@@ -64,7 +64,7 @@ public class DeleteByQueryConcurrentTests extends ReindexTestCase {
         }
 
         for (int t = 0; t < threads.length; t++) {
-            assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.termQuery("field", t)).get(), 0);
+            assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.termQuery("field", t)), 0);
         }
     }
 
@@ -105,7 +105,7 @@ public class DeleteByQueryConcurrentTests extends ReindexTestCase {
             thread.join();
         }
 
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 0L);
+        assertHitCount(client().prepareSearch("test").setSize(0), 0L);
         assertThat(deleted.get(), equalTo(docs));
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
@@ -35,28 +35,28 @@ public class ReindexBasicTests extends ReindexTestCase {
             client().prepareIndex("source").setId("3").setSource("foo", "b"),
             client().prepareIndex("source").setId("4").setSource("foo", "c")
         );
-        assertHitCount(client().prepareSearch("source").setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch("source").setSize(0), 4);
 
         // Copy all the docs
         ReindexRequestBuilder copy = reindex().source("source").destination("dest").refresh(true);
         assertThat(copy.get(), matcher().created(4));
-        assertHitCount(client().prepareSearch("dest").setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch("dest").setSize(0), 4);
 
         // Now none of them
         createIndex("none");
         copy = reindex().source("source").destination("none").filter(termQuery("foo", "no_match")).refresh(true);
         assertThat(copy.get(), matcher().created(0));
-        assertHitCount(client().prepareSearch("none").setSize(0).get(), 0);
+        assertHitCount(client().prepareSearch("none").setSize(0), 0);
 
         // Now half of them
         copy = reindex().source("source").destination("dest_half").filter(termQuery("foo", "a")).refresh(true);
         assertThat(copy.get(), matcher().created(2));
-        assertHitCount(client().prepareSearch("dest_half").setSize(0).get(), 2);
+        assertHitCount(client().prepareSearch("dest_half").setSize(0), 2);
 
         // Limit with maxDocs
         copy = reindex().source("source").destination("dest_size_one").maxDocs(1).refresh(true);
         assertThat(copy.get(), matcher().created(1));
-        assertHitCount(client().prepareSearch("dest_size_one").setSize(0).get(), 1);
+        assertHitCount(client().prepareSearch("dest_size_one").setSize(0), 1);
     }
 
     public void testCopyMany() throws Exception {
@@ -67,14 +67,14 @@ public class ReindexBasicTests extends ReindexTestCase {
         }
 
         indexRandom(true, docs);
-        assertHitCount(client().prepareSearch("source").setSize(0).get(), max);
+        assertHitCount(client().prepareSearch("source").setSize(0), max);
 
         // Copy all the docs
         ReindexRequestBuilder copy = reindex().source("source").destination("dest").refresh(true);
         // Use a small batch size so we have to use more than one batch
         copy.source().setSize(5);
         assertThat(copy.get(), matcher().created(max).batches(max, 5));
-        assertHitCount(client().prepareSearch("dest").setSize(0).get(), max);
+        assertHitCount(client().prepareSearch("dest").setSize(0), max);
 
         // Copy some of the docs
         int half = max / 2;
@@ -83,7 +83,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         copy.source().setSize(5);
         copy.maxDocs(half);
         assertThat(copy.get(), matcher().created(half).batches(half, 5));
-        assertHitCount(client().prepareSearch("dest_half").setSize(0).get(), half);
+        assertHitCount(client().prepareSearch("dest_half").setSize(0), half);
     }
 
     public void testCopyManyWithSlices() throws Exception {
@@ -94,7 +94,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         }
 
         indexRandom(true, docs);
-        assertHitCount(client().prepareSearch("source").setSize(0).get(), max);
+        assertHitCount(client().prepareSearch("source").setSize(0), max);
 
         int slices = randomSlices();
         int expectedSlices = expectedSliceStatuses(slices, "source");
@@ -104,7 +104,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         // Use a small batch size so we have to use more than one batch
         copy.source().setSize(5);
         assertThat(copy.get(), matcher().created(max).batches(greaterThanOrEqualTo(max / 5)).slices(hasSize(expectedSlices)));
-        assertHitCount(client().prepareSearch("dest").setSize(0).get(), max);
+        assertHitCount(client().prepareSearch("dest").setSize(0), max);
 
         // Copy some of the docs
         int half = max / 2;
@@ -114,7 +114,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         copy.maxDocs(half);
         BulkByScrollResponse response = copy.get();
         assertThat(response, matcher().created(lessThanOrEqualTo((long) half)).slices(hasSize(expectedSlices)));
-        assertHitCount(client().prepareSearch("dest_half").setSize(0).get(), response.getCreated());
+        assertHitCount(client().prepareSearch("dest_half").setSize(0), response.getCreated());
     }
 
     public void testMultipleSources() throws Exception {
@@ -134,7 +134,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> allDocs = docs.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
         indexRandom(true, allDocs);
         for (Map.Entry<String, List<IndexRequestBuilder>> entry : docs.entrySet()) {
-            assertHitCount(client().prepareSearch(entry.getKey()).setSize(0).get(), entry.getValue().size());
+            assertHitCount(client().prepareSearch(entry.getKey()).setSize(0), entry.getValue().size());
         }
 
         int slices = randomSlices(1, 10);
@@ -145,7 +145,7 @@ public class ReindexBasicTests extends ReindexTestCase {
 
         BulkByScrollResponse response = request.get();
         assertThat(response, matcher().created(allDocs.size()).slices(hasSize(expectedSlices)));
-        assertHitCount(client().prepareSearch("dest").setSize(0).get(), allDocs.size());
+        assertHitCount(client().prepareSearch("dest").setSize(0), allDocs.size());
     }
 
     public void testMissingSources() {
@@ -166,12 +166,12 @@ public class ReindexBasicTests extends ReindexTestCase {
             client().prepareIndex(sourceIndexName).setId("3").setSource("foo", "b"),
             client().prepareIndex(sourceIndexName).setId("4").setSource("foo", "c")
         );
-        assertHitCount(client().prepareSearch(sourceIndexName).setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch(sourceIndexName).setSize(0), 4);
 
         // Copy all the docs
         ReindexRequestBuilder copy = reindex().source(sourceIndexName).destination(destIndexName).refresh(true);
         assertThat(copy.get(), matcher().created(4));
-        assertHitCount(client().prepareSearch(destIndexName).setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch(destIndexName).setSize(0), 4);
     }
 
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFailureTests.java
@@ -128,7 +128,7 @@ public class ReindexFailureTests extends ReindexTestCase {
             client().prepareIndex(sourceIndexName).setId("3").setSource("foo", "b"),
             client().prepareIndex(sourceIndexName).setId("4").setSource("foo", "c")
         );
-        assertHitCount(client().prepareSearch(sourceIndexName).setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch(sourceIndexName).setSize(0), 4);
 
         ActionRequestValidationException e = expectThrows(
             ActionRequestValidationException.class,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSingleNodeTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSingleNodeTests.java
@@ -34,7 +34,7 @@ public class ReindexSingleNodeTests extends ESSingleNodeTestCase {
         }
 
         indicesAdmin().prepareRefresh("source").get();
-        assertHitCount(client().prepareSearch("source").setSize(0).get(), max);
+        assertHitCount(client().prepareSearch("source").setSize(0), max);
 
         // Copy a subset of the docs sorted
         int subsetSize = randomIntBetween(1, max - 1);
@@ -45,8 +45,8 @@ public class ReindexSingleNodeTests extends ESSingleNodeTestCase {
         copy.request().addSortField("foo", SortOrder.DESC);
         assertThat(copy.get(), matcher().created(subsetSize));
 
-        assertHitCount(client().prepareSearch("dest").setSize(0).get(), subsetSize);
-        assertHitCount(client().prepareSearch("dest").setQuery(new RangeQueryBuilder("foo").gte(0).lt(max - subsetSize)).get(), 0);
+        assertHitCount(client().prepareSearch("dest").setSize(0), subsetSize);
+        assertHitCount(client().prepareSearch("dest").setQuery(new RangeQueryBuilder("foo").gte(0).lt(max - subsetSize)), 0);
         assertWarnings(ReindexValidator.SORT_DEPRECATED_MESSAGE);
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryBasicTests.java
@@ -34,7 +34,7 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
             client().prepareIndex("test").setId("3").setSource("foo", "b"),
             client().prepareIndex("test").setId("4").setSource("foo", "c")
         );
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch("test").setSize(0), 4);
         assertEquals(1, client().prepareGet("test", "1").get().getVersion());
         assertEquals(1, client().prepareGet("test", "4").get().getVersion());
 
@@ -74,7 +74,7 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
             client().prepareIndex("test").setId("3").setSource("foo", "b"),
             client().prepareIndex("test").setId("4").setSource("foo", "c")
         );
-        assertHitCount(client().prepareSearch("test").setSize(0).get(), 4);
+        assertHitCount(client().prepareSearch("test").setSize(0), 4);
         assertEquals(1, client().prepareGet("test", "1").get().getVersion());
         assertEquals(1, client().prepareGet("test", "4").get().getVersion());
 
@@ -124,7 +124,7 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> allDocs = docs.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
         indexRandom(true, allDocs);
         for (Map.Entry<String, List<IndexRequestBuilder>> entry : docs.entrySet()) {
-            assertHitCount(client().prepareSearch(entry.getKey()).setSize(0).get(), entry.getValue().size());
+            assertHitCount(client().prepareSearch(entry.getKey()).setSize(0), entry.getValue().size());
         }
 
         int slices = randomSlices(1, 10);

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -198,7 +198,7 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
         flushAndRefresh(index);
         ForceMergeResponse forceMerge = client().admin().indices().prepareForceMerge(index).setFlush(true).setMaxNumSegments(1).get();
         assertThat(forceMerge.getSuccessfulShards(), equalTo(1));
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
 
         // Intentionally fail snapshot to trigger abortMultipartUpload requests
         shouldFailCompleteMultipartUploadRequest.set(true);
@@ -240,14 +240,14 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
         flushAndRefresh(index);
         ForceMergeResponse forceMerge = client().admin().indices().prepareForceMerge(index).setFlush(true).setMaxNumSegments(1).get();
         assertThat(forceMerge.getSuccessfulShards(), equalTo(1));
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
 
         final String snapshot = "snapshot";
         assertSuccessfulSnapshot(clusterAdmin().prepareCreateSnapshot(repository, snapshot).setWaitForCompletion(true).setIndices(index));
         assertAcked(client().admin().indices().prepareDelete(index));
         assertSuccessfulRestore(clusterAdmin().prepareRestoreSnapshot(repository, snapshot).setWaitForCompletion(true));
         ensureGreen(index);
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
         assertAcked(clusterAdmin().prepareDeleteSnapshot(repository, snapshot).get());
 
         final Map<String, Long> aggregatedMetrics = new HashMap<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -112,8 +112,7 @@ public class HotThreadsIT extends ESIntegTestCase {
                         .setPostFilter(
                             boolQuery().must(matchAllQuery())
                                 .mustNot(boolQuery().must(termQuery("field1", "value1")).must(termQuery("field1", "value2")))
-                        )
-                        .get(),
+                        ),
                     3L
                 );
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CloneIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CloneIndexIT.java
@@ -80,24 +80,21 @@ public class CloneIndexIT extends ESIntegTestCase {
             }
 
             final int size = docs > 0 ? 2 * docs : 1;
-            assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+            assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
 
             if (createWithReplicas == false) {
                 // bump replicas
                 setReplicaCount(1, "target");
                 ensureGreen();
-                assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+                assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
             }
 
             for (int i = docs; i < 2 * docs; i++) {
                 client().prepareIndex("target").setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON).get();
             }
             flushAndRefresh();
-            assertHitCount(
-                client().prepareSearch("target").setSize(2 * size).setQuery(new TermsQueryBuilder("foo", "bar")).get(),
-                2 * docs
-            );
-            assertHitCount(client().prepareSearch("source").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+            assertHitCount(client().prepareSearch("target").setSize(2 * size).setQuery(new TermsQueryBuilder("foo", "bar")), 2 * docs);
+            assertHitCount(client().prepareSearch("source").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
             GetSettingsResponse target = indicesAdmin().prepareGetSettings("target").get();
             assertThat(
                 target.getIndexToSettings().get("target").getAsVersionId("index.version.created", IndexVersion::fromId),

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -107,7 +107,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
                 .get()
         );
         ensureGreen();
-        assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
+        assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
 
         for (int i = 0; i < 20; i++) { // now update
             client().prepareIndex("first_shrink")
@@ -116,8 +116,8 @@ public class ShrinkIndexIT extends ESIntegTestCase {
                 .get();
         }
         flushAndRefresh();
-        assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
-        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
+        assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
+        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
 
         // relocate all shards to one node such that we can merge it.
         updateIndexSettings(
@@ -134,14 +134,14 @@ public class ShrinkIndexIT extends ESIntegTestCase {
                 .get()
         );
         ensureGreen();
-        assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
+        assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
         // let it be allocated anywhere and bump replicas
         updateIndexSettings(
             Settings.builder().putNull("index.routing.allocation.include._id").put("index.number_of_replicas", 1),
             "second_shrink"
         );
         ensureGreen();
-        assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
+        assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
 
         for (int i = 0; i < 20; i++) { // now update
             client().prepareIndex("second_shrink")
@@ -150,9 +150,9 @@ public class ShrinkIndexIT extends ESIntegTestCase {
                 .get();
         }
         flushAndRefresh();
-        assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
-        assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
-        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
+        assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
+        assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
+        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
 
         assertNoResizeSourceIndexSettings("first_shrink");
         assertNoResizeSourceIndexSettings("second_shrink");
@@ -311,21 +311,21 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         }
 
         final int size = docs > 0 ? 2 * docs : 1;
-        assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+        assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
 
         if (createWithReplicas == false) {
             // bump replicas
             setReplicaCount(1, "target");
             ensureGreen();
-            assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+            assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
         }
 
         for (int i = docs; i < 2 * docs; i++) {
             client().prepareIndex("target").setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON).get();
         }
         flushAndRefresh();
-        assertHitCount(client().prepareSearch("target").setSize(2 * size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 2 * docs);
-        assertHitCount(client().prepareSearch("source").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+        assertHitCount(client().prepareSearch("target").setSize(2 * size).setQuery(new TermsQueryBuilder("foo", "bar")), 2 * docs);
+        assertHitCount(client().prepareSearch("source").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
         GetSettingsResponse target = indicesAdmin().prepareGetSettings("target").get();
         assertThat(
             target.getIndexToSettings().get("target").getAsVersionId("index.version.created", IndexVersion::fromId),
@@ -409,7 +409,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         // we support the expected shard size in the allocator to sum up over the source index shards
         assertTrue("expected shard size must be set but wasn't: " + expectedShardSize, expectedShardSize > 0);
         ensureGreen();
-        assertHitCount(client().prepareSearch("target").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
+        assertHitCount(client().prepareSearch("target").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), 20);
         assertNoResizeSourceIndexSettings("target");
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -189,7 +189,7 @@ public class SplitIndexIT extends ESIntegTestCase {
                 .get()
         );
         ensureGreen();
-        assertHitCount(client().prepareSearch("first_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
+        assertHitCount(client().prepareSearch("first_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
         assertNoResizeSourceIndexSettings("first_split");
 
         for (int i = 0; i < numDocs; i++) { // now update
@@ -200,8 +200,8 @@ public class SplitIndexIT extends ESIntegTestCase {
             builder.get();
         }
         flushAndRefresh();
-        assertHitCount(client().prepareSearch("first_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
-        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
+        assertHitCount(client().prepareSearch("first_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
+        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
         for (int i = 0; i < numDocs; i++) {
             GetResponse getResponse = client().prepareGet("first_split", Integer.toString(i)).setRouting(routingValue[i]).get();
             assertTrue(getResponse.isExists());
@@ -217,13 +217,13 @@ public class SplitIndexIT extends ESIntegTestCase {
                 .get()
         );
         ensureGreen();
-        assertHitCount(client().prepareSearch("second_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
+        assertHitCount(client().prepareSearch("second_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
         assertNoResizeSourceIndexSettings("second_split");
 
         // let it be allocated anywhere and bump replicas
         setReplicaCount(1, "second_split");
         ensureGreen();
-        assertHitCount(client().prepareSearch("second_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
+        assertHitCount(client().prepareSearch("second_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
 
         for (int i = 0; i < numDocs; i++) { // now update
             IndexRequestBuilder builder = indexFunc.apply("second_split", i);
@@ -237,9 +237,9 @@ public class SplitIndexIT extends ESIntegTestCase {
             GetResponse getResponse = client().prepareGet("second_split", Integer.toString(i)).setRouting(routingValue[i]).get();
             assertTrue(getResponse.isExists());
         }
-        assertHitCount(client().prepareSearch("second_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
-        assertHitCount(client().prepareSearch("first_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
-        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), numDocs);
+        assertHitCount(client().prepareSearch("second_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
+        assertHitCount(client().prepareSearch("first_split").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
+        assertHitCount(client().prepareSearch("source").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")), numDocs);
         if (useNested) {
             assertNested("source", numDocs);
             assertNested("first_split", numDocs);
@@ -410,24 +410,21 @@ public class SplitIndexIT extends ESIntegTestCase {
             }
 
             final int size = docs > 0 ? 2 * docs : 1;
-            assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+            assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
 
             if (createWithReplicas == false) {
                 // bump replicas
                 setReplicaCount(1, "target");
                 ensureGreen();
-                assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+                assertHitCount(client().prepareSearch("target").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
             }
 
             for (int i = docs; i < 2 * docs; i++) {
                 client().prepareIndex("target").setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON).get();
             }
             flushAndRefresh();
-            assertHitCount(
-                client().prepareSearch("target").setSize(2 * size).setQuery(new TermsQueryBuilder("foo", "bar")).get(),
-                2 * docs
-            );
-            assertHitCount(client().prepareSearch("source").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")).get(), docs);
+            assertHitCount(client().prepareSearch("target").setSize(2 * size).setQuery(new TermsQueryBuilder("foo", "bar")), 2 * docs);
+            assertHitCount(client().prepareSearch("source").setSize(size).setQuery(new TermsQueryBuilder("foo", "bar")), docs);
             GetSettingsResponse target = indicesAdmin().prepareGetSettings("target").get();
             assertThat(
                 target.getIndexToSettings().get("target").getAsVersionId("index.version.created", IndexVersion::fromId),

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
@@ -515,8 +514,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
 
         refresh();
 
-        SearchResponse countResponse = client().prepareSearch().setSize(0).get();
-        assertHitCount(countResponse, numDocs);
+        assertHitCount(client().prepareSearch().setSize(0), numDocs);
     }
 
     public void testFailingVersionedUpdatedOnBulk() throws Exception {
@@ -636,8 +634,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE);
 
         client().bulk(bulkRequest).get();
-        SearchResponse searchResponse = client().prepareSearch("bulkindex*").get();
-        assertHitCount(searchResponse, 3);
+        assertHitCount(client().prepareSearch("bulkindex*"), 3);
 
         assertBusy(() -> assertAcked(indicesAdmin().prepareClose("bulkindex2")));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -1141,11 +1141,8 @@ public class IndexAliasesIT extends ESIntegTestCase {
             client().prepareIndex("my-index").setSource("timestamp", "2016-12-12").get();
             if (i % 2 == 0) {
                 refresh();
-                SearchResponse response = client().prepareSearch("filter1").get();
-                assertHitCount(response, i);
-
-                response = client().prepareSearch("filter2").get();
-                assertHitCount(response, i);
+                assertHitCount(client().prepareSearch("filter1"), i);
+                assertHitCount(client().prepareSearch("filter2"), i);
             }
         }
     }
@@ -1242,7 +1239,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             "test_2",
             () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test_2", "test").removeIndex("test"))
         );
-        assertHitCount(client().prepareSearch("test").get(), 1);
+        assertHitCount(client().prepareSearch("test"), 1);
     }
 
     public void testHiddenAliasesMustBeConsistent() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -265,7 +265,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
         }
 
         indicesAdmin().prepareRefresh(indexName).get();
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), nbDocs);
+        assertHitCount(client().prepareSearch(indexName).setSize(0), nbDocs);
     }
 
     public void testSameBlockTwice() throws Exception {
@@ -390,7 +390,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
             disableIndexBlock(indexName, block);
         }
         refresh(indexName);
-        assertHitCount(client().prepareSearch(indexName).setSize(0).setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE).get(), nbDocs);
+        assertHitCount(client().prepareSearch(indexName).setSize(0).setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE), nbDocs);
     }
 
     public void testAddBlockWhileDeletingIndices() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -161,7 +161,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> verify we get the data back after cluster reform");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet(), 100);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
         }
 
         logger.info("--> clearing voting config exclusions");
@@ -208,7 +208,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> verify we the data back");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet(), 100);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
         }
     }
 
@@ -261,7 +261,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         refresh();
         logger.info("--> verify we get the data back");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet(), 100);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
         }
 
         List<String> nonMasterNodes = new ArrayList<>(
@@ -290,7 +290,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> verify we the data back");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet(), 100);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -250,14 +250,12 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         GetResponse getResponse = clientToMasterlessNode.prepareGet("test1", "1").get();
         assertExists(getResponse);
 
-        SearchResponse countResponse = clientToMasterlessNode.prepareSearch("test1").setAllowPartialSearchResults(true).setSize(0).get();
-        assertHitCount(countResponse, 1L);
+        assertHitCount(clientToMasterlessNode.prepareSearch("test1").setAllowPartialSearchResults(true).setSize(0), 1L);
 
         logger.info("--> here 3");
-        SearchResponse searchResponse = clientToMasterlessNode.prepareSearch("test1").setAllowPartialSearchResults(true).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(clientToMasterlessNode.prepareSearch("test1").setAllowPartialSearchResults(true), 1L);
 
-        countResponse = clientToMasterlessNode.prepareSearch("test2").setAllowPartialSearchResults(true).setSize(0).get();
+        SearchResponse countResponse = clientToMasterlessNode.prepareSearch("test2").setAllowPartialSearchResults(true).setSize(0).get();
         assertThat(countResponse.getTotalShards(), equalTo(3));
         assertThat(countResponse.getSuccessfulShards(), equalTo(1));
 
@@ -347,11 +345,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
 
         expectThrows(Exception.class, () -> client(partitionedNode).prepareGet("test1", "1").get());
 
-        SearchResponse countResponse = client(randomFrom(nodesWithShards)).prepareSearch("test1")
-            .setAllowPartialSearchResults(true)
-            .setSize(0)
-            .get();
-        assertHitCount(countResponse, 1L);
+        assertHitCount(client(randomFrom(nodesWithShards)).prepareSearch("test1").setAllowPartialSearchResults(true).setSize(0), 1L);
 
         expectThrows(
             Exception.class,

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -213,7 +213,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
             long dataClusterStateVersion = internalCluster().clusterService(dataNode).state().version();
             assertThat(masterClusterStateVersion, equalTo(dataClusterStateVersion));
         });
-        assertHitCount(client().prepareSearch("test").get(), 0);
+        assertHitCount(client().prepareSearch("test"), 0);
     }
 
     public void testDelayedMappingPropagationOnPrimary() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
@@ -93,7 +93,7 @@ public class AllocationIdIT extends ESIntegTestCase {
 
         // index more docs to node2 that marks node1 as stale
         int numExtraDocs = indexDocs(indexName, "foo", "bar2");
-        assertHitCount(client(node2).prepareSearch(indexName).setQuery(matchAllQuery()).get(), numDocs + numExtraDocs);
+        assertHitCount(client(node2).prepareSearch(indexName).setQuery(matchAllQuery()), numDocs + numExtraDocs);
 
         internalCluster().stopNode(node2);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -177,7 +177,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         logger.info("--> check that the up-to-date primary shard gets promoted and that documents are available");
         ensureYellow("test");
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2L);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2L);
     }
 
     public void testFailedAllocationOfStalePrimaryToDataNodeWithNoData() throws Exception {
@@ -475,7 +475,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         internalCluster().restartRandomDataNode();
         logger.info("--> checking that index still gets allocated with only 1 shard copy being available");
         ensureYellow("test");
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 1L);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 1L);
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -238,7 +238,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         assertEquals(nodeId, clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId());
         assertTrue(indexExists("test"));
         ensureYellow("test");
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 1L);
     }
 
     public void testFailsToStartOnDataPathsFromMultipleNodes() throws IOException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -283,7 +283,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> verify 1 doc in the index");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 1L);
         }
 
         logger.info("--> closing test index...");
@@ -306,9 +306,9 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify 1 doc in the index");
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 1L);
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 1L);
         }
     }
 
@@ -548,7 +548,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         assertNull(
             state.metadata().persistentSettings().get("archived." + ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey())
         );
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 1L);
     }
 
     public void testHalfDeletedIndexImport() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/QuorumGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/QuorumGatewayIT.java
@@ -50,7 +50,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
         refresh();
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2L);
         }
         logger.info("--> restart all nodes");
         internalCluster().fullRestart(new RestartCallback() {
@@ -79,7 +79,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
                         .get();
                     assertNoFailures(activeClient.admin().indices().prepareRefresh().get());
                     for (int i = 0; i < 10; i++) {
-                        assertHitCount(activeClient.prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 3L);
+                        assertHitCount(activeClient.prepareSearch().setSize(0).setQuery(matchAllQuery()), 3L);
                     }
                 }
             }
@@ -90,7 +90,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 3L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 3L);
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -123,7 +123,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             .actionGet();
 
         refresh();
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)).execute().actionGet(), 2);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)), 2);
         ensureYellow("test"); // wait for primary allocations here otherwise if we have a lot of shards we might have a
         // shard that is still in post recovery when we restart and the ensureYellow() below will timeout
 
@@ -135,7 +135,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         indicesAdmin().prepareRefresh().execute().actionGet();
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)).execute().actionGet(), 2);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)), 2);
 
         internalCluster().fullRestart();
 
@@ -144,7 +144,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         indicesAdmin().prepareRefresh().execute().actionGet();
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)).execute().actionGet(), 2);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)), 2);
     }
 
     private Map<String, long[]> assertAndCapturePrimaryTerms(Map<String, long[]> previousTerms) {
@@ -233,10 +233,10 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         refresh();
 
         for (int i = 0; i <= randomInt(10); i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), value1Docs + value2Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value1")).get(), value1Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")).get(), value2Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)).get(), value1Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), value1Docs + value2Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value1")), value1Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")), value2Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)), value1Docs);
         }
         if (indexToAllShards == false) {
             // we have to verify primaries are started for them to be restored
@@ -253,10 +253,10 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         for (int i = 0; i <= randomInt(10); i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), value1Docs + value2Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value1")).get(), value1Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")).get(), value2Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)).get(), value1Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), value1Docs + value2Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value1")), value1Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")), value2Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)), value1Docs);
         }
 
         internalCluster().fullRestart();
@@ -266,10 +266,10 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         for (int i = 0; i <= randomInt(10); i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), value1Docs + value2Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value1")).get(), value1Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")).get(), value2Docs);
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)).get(), value1Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), value1Docs + value2Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value1")), value1Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("field", "value2")), value2Docs);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(termQuery("num", 179)), value1Docs);
         }
     }
 
@@ -288,7 +288,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             .actionGet();
         refresh();
 
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
 
         ensureYellow("test"); // wait for primary allocations here otherwise if we have a lot of shards we might have a
         // shard that is still in post recovery when we restart and the ensureYellow() below will timeout
@@ -302,7 +302,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
         }
 
         internalCluster().fullRestart();
@@ -312,7 +312,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
         }
     }
 
@@ -337,7 +337,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
         }
 
         Map<String, long[]> primaryTerms = assertAndCapturePrimaryTerms(null);
@@ -365,7 +365,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
         }
 
         client().execute(ClearVotingConfigExclusionsAction.INSTANCE, new ClearVotingConfigExclusionsRequest()).get();
@@ -395,7 +395,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
         }
 
         String metadataUuid = clusterAdmin().prepareState().execute().get().getState().getMetadata().clusterUUID();
@@ -418,7 +418,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
 
         logger.info("--> checking if documents exist, there should be 3");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 3);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 3);
         }
 
         logger.info("--> add some metadata and additional template");
@@ -462,7 +462,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         assertThat(clusterAdmin().prepareState().execute().get().getState().getMetadata().clusterUUID(), equalTo(metadataUuid));
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 3);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 3);
         }
 
         ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexRequestBuilderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexRequestBuilderIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -37,8 +36,10 @@ public class IndexRequestBuilderIT extends ESIntegTestCase {
                 .setSource(BytesReference.toBytes(new BytesArray("{\"test_field\" : \"foobar\"}")), XContentType.JSON),
             client().prepareIndex("test").setSource(map) };
         indexRandom(true, builders);
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.termQuery("test_field", "foobar")).get();
-        ElasticsearchAssertions.assertHitCount(searchResponse, builders.length);
+        ElasticsearchAssertions.assertHitCount(
+            client().prepareSearch("test").setQuery(QueryBuilders.termQuery("test_field", "foobar")),
+            builders.length
+        );
     }
 
     public void testOddNumberOfSourceObjects() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/query/plugin/CustomQueryParserIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/query/plugin/CustomQueryParserIT.java
@@ -42,10 +42,10 @@ public class CustomQueryParserIT extends ESIntegTestCase {
     }
 
     public void testCustomDummyQuery() {
-        assertHitCount(client().prepareSearch("index").setQuery(new DummyQueryBuilder()).get(), 1L);
+        assertHitCount(client().prepareSearch("index").setQuery(new DummyQueryBuilder()), 1L);
     }
 
     public void testCustomDummyQueryWithinBooleanQuery() {
-        assertHitCount(client().prepareSearch("index").setQuery(new BoolQueryBuilder().must(new DummyQueryBuilder())).get(), 1L);
+        assertHitCount(client().prepareSearch("index").setQuery(new BoolQueryBuilder().must(new DummyQueryBuilder())), 1L);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/search/MatchPhraseQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/search/MatchPhraseQueryIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.search;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.ZeroTermsQueryOption;
@@ -48,12 +47,10 @@ public class MatchPhraseQueryIT extends ESIntegTestCase {
         MatchPhraseQueryBuilder baseQuery = matchPhraseQuery("name", "the who").analyzer("standard_stopwords");
 
         MatchPhraseQueryBuilder matchNoneQuery = baseQuery.zeroTermsQuery(ZeroTermsQueryOption.NONE);
-        SearchResponse matchNoneResponse = client().prepareSearch(INDEX).setQuery(matchNoneQuery).get();
-        assertHitCount(matchNoneResponse, 0L);
+        assertHitCount(client().prepareSearch(INDEX).setQuery(matchNoneQuery), 0L);
 
         MatchPhraseQueryBuilder matchAllQuery = baseQuery.zeroTermsQuery(ZeroTermsQueryOption.ALL);
-        SearchResponse matchAllResponse = client().prepareSearch(INDEX).setQuery(matchAllQuery).get();
-        assertHitCount(matchAllResponse, 2L);
+        assertHitCount(client().prepareSearch(INDEX).setQuery(matchAllQuery), 2L);
     }
 
     private List<IndexRequestBuilder> getIndexRequests() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterInfoServiceUtils;
@@ -222,8 +221,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         createIndex("test", idxSettings);
         ensureGreen("test");
         client().prepareIndex("test").setId("1").setSource("{}", XContentType.JSON).setRefreshPolicy(IMMEDIATE).get();
-        SearchResponse response = client().prepareSearch("test").get();
-        assertHitCount(response, 1L);
+        assertHitCount(client().prepareSearch("test"), 1L);
         indicesAdmin().prepareDelete("test").get();
         assertAllIndicesRemovedAndDeletionCompleted(Collections.singleton(getInstanceFromNode(IndicesService.class)));
         assertPathHasBeenCleared(idxPath);
@@ -258,7 +256,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         client().prepareIndex(index).setId("1").setSource("foo", "bar").setRefreshPolicy(IMMEDIATE).get();
         ensureGreen(index);
 
-        assertHitCount(client().prepareSearch(index).setSize(0).get(), 1L);
+        assertHitCount(client().prepareSearch(index).setSize(0), 1L);
 
         logger.info("--> closing the index [{}]", index);
         assertAcked(indicesAdmin().prepareClose(index));
@@ -267,7 +265,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         logger.info("--> index re-opened");
         ensureGreen(index);
 
-        assertHitCount(client().prepareSearch(index).setSize(0).get(), 1L);
+        assertHitCount(client().prepareSearch(index).setSize(0), 1L);
 
         // Now, try closing and changing the settings
         logger.info("--> closing the index [{}] before updating data_path", index);
@@ -303,7 +301,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         logger.info("--> index re-opened");
         ensureGreen(index);
 
-        assertHitCount(client().prepareSearch(index).setSize(0).get(), 1L);
+        assertHitCount(client().prepareSearch(index).setSize(0), 1L);
 
         assertAcked(indicesAdmin().prepareDelete(index));
         assertAllIndicesRemovedAndDeletionCompleted(Collections.singleton(getInstanceFromNode(IndicesService.class)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -255,7 +255,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
 
         ensureGreen(indexName);
 
-        assertHitCount(client().prepareSearch(indexName).setQuery(matchAllQuery()).get(), expectedNumDocs);
+        assertHitCount(client().prepareSearch(indexName).setQuery(matchAllQuery()), expectedNumDocs);
     }
 
     public void testCorruptTranslogTruncation() throws Exception {
@@ -424,14 +424,14 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         ensureYellow(indexName);
 
         // Run a search and make sure it succeeds
-        assertHitCount(client().prepareSearch(indexName).setQuery(matchAllQuery()).get(), numDocsToKeep);
+        assertHitCount(client().prepareSearch(indexName).setQuery(matchAllQuery()), numDocsToKeep);
 
         logger.info("--> starting the replica node to test recovery");
         internalCluster().startNode(node2PathSettings);
         ensureGreen(indexName);
         for (String node : internalCluster().nodesInclude(indexName)) {
             SearchRequestBuilder q = client().prepareSearch(indexName).setPreference("_only_nodes:" + node).setQuery(matchAllQuery());
-            assertHitCount(q.get(), numDocsToKeep);
+            assertHitCount(q, numDocsToKeep);
         }
         final RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).setActiveOnly(false).get();
         final RecoveryState replicaRecoveryState = recoveryResponse.shardRecoveryStates()
@@ -513,7 +513,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         ensureYellow();
 
         // Run a search and make sure it succeeds
-        assertHitCount(client().prepareSearch(indexName).setQuery(matchAllQuery()).get(), totalDocs);
+        assertHitCount(client().prepareSearch(indexName).setQuery(matchAllQuery()), totalDocs);
 
         // check replica corruption
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
@@ -534,10 +534,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         internalCluster().startNode(node2PathSettings);
         ensureGreen(indexName);
         for (String node : internalCluster().nodesInclude(indexName)) {
-            assertHitCount(
-                client().prepareSearch(indexName).setPreference("_only_nodes:" + node).setQuery(matchAllQuery()).get(),
-                totalDocs
-            );
+            assertHitCount(client().prepareSearch(indexName).setPreference("_only_nodes:" + node).setQuery(matchAllQuery()), totalDocs);
         }
 
         final RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).setActiveOnly(false).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -161,7 +161,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         CountDownLatch refreshLatch = new CountDownLatch(1);
         // async on purpose to make sure it happens concurrently
         indicesAdmin().prepareRefresh().execute(ActionListener.running(refreshLatch::countDown));
-        assertHitCount(client().prepareSearch().get(), 1);
+        assertHitCount(client().prepareSearch(), 1);
         client().prepareIndex("test").setId("1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         scheduleRefresh(shard, false);
         assertTrue(shard.hasRefreshPending());
@@ -171,7 +171,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1).build())
             .execute(ActionListener.running(updateSettingsLatch::countDown));
-        assertHitCount(client().prepareSearch().get(), 2);
+        assertHitCount(client().prepareSearch(), 2);
         // wait for both to ensure we don't have in-flight operations
         updateSettingsLatch.await();
         refreshLatch.await();
@@ -183,7 +183,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         scheduleRefresh(shard, true);
         assertFalse(shard.hasRefreshPending());
         assertTrue(shard.isSearchIdle());
-        assertHitCount(client().prepareSearch().get(), 3);
+        assertHitCount(client().prepareSearch(), 3);
         final IndicesStatsResponse statsResponse = indicesAdmin().stats(new IndicesStatsRequest()).actionGet();
         for (ShardStats shardStats : statsResponse.getShards()) {
             if (shardStats.isSearchIdle()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -166,7 +166,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
-        assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch().setSize(0), numDocs);
 
         final int numShards = numShards("test");
         ShardRouting corruptedShardRouting = corruptRandomPrimaryFile();
@@ -192,7 +192,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         assertThat(health.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         final int numIterations = scaledRandomIntBetween(5, 20);
         for (int i = 0; i < numIterations; i++) {
-            assertHitCount(client().prepareSearch().setSize(numDocs).get(), numDocs);
+            assertHitCount(client().prepareSearch().setSize(numDocs), numDocs);
         }
 
         /*
@@ -277,7 +277,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
-        assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch().setSize(0), numDocs);
 
         ShardRouting shardRouting = corruptRandomPrimaryFile();
         /*
@@ -411,7 +411,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         ensureGreen();
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
         // we have to flush at least once here since we don't corrupt the translog
-        assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch().setSize(0), numDocs);
 
         var source = (MockTransportService) internalCluster().getInstance(TransportService.class, primariesNode.getName());
         var target = internalCluster().getInstance(TransportService.class, unluckyNode.getName());
@@ -509,7 +509,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
         final int numIterations = scaledRandomIntBetween(5, 20);
         for (int i = 0; i < numIterations; i++) {
-            assertHitCount(client().prepareSearch().setSize(numDocs).get(), numDocs);
+            assertHitCount(client().prepareSearch().setSize(numDocs), numDocs);
         }
     }
 
@@ -550,7 +550,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         ensureGreen();
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
         // we have to flush at least once here since we don't corrupt the translog
-        assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch().setSize(0), numDocs);
 
         ShardRouting shardRouting = corruptRandomPrimaryFile(false);
         logger.info("--> shard {} has a corrupted file", shardRouting);
@@ -617,7 +617,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         ensureGreen();
         assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
         // we have to flush at least once here since we don't corrupt the translog
-        assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
+        assertHitCount(client().prepareSearch().setSize(0), numDocs);
 
         // disable allocations of replicas post restart (the restart will change replicas to primaries, so we have
         // to capture replicas post restart)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/ConcurrentDynamicTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/ConcurrentDynamicTemplateIT.java
@@ -77,8 +77,8 @@ public class ConcurrentDynamicTemplateIT extends ESIntegTestCase {
             latch.await();
             assertThat(throwable, emptyIterable());
             refresh();
-            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery(fieldName, "test-user")).get(), numDocs);
-            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery(fieldName, "test user")).get(), 0);
+            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery(fieldName, "test-user")), numDocs);
+            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.matchQuery(fieldName, "test user")), 0);
 
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/MalformedDynamicTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/MalformedDynamicTemplateIT.java
@@ -59,7 +59,7 @@ public class MalformedDynamicTemplateIT extends ESIntegTestCase {
         );
         client().prepareIndex(indexName).setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         assertNoFailures((indicesAdmin().prepareRefresh(indexName)).get());
-        assertHitCount(client().prepareSearch(indexName).get(), 1);
+        assertHitCount(client().prepareSearch(indexName), 1);
 
         MapperParsingException ex = expectThrows(
             MapperParsingException.class,

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -105,12 +105,11 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
         finished.set(true);
         indexingThread.join();
         refresh("test");
-        ElasticsearchAssertions.assertHitCount(client().prepareSearch("test").setTrackTotalHits(true).get(), numAutoGenDocs.get());
+        ElasticsearchAssertions.assertHitCount(client().prepareSearch("test").setTrackTotalHits(true), numAutoGenDocs.get());
         ElasticsearchAssertions.assertHitCount(
             client().prepareSearch("test")
                 .setTrackTotalHits(true)// extra paranoia ;)
-                .setQuery(QueryBuilders.termQuery("auto", true))
-                .get(),
+                .setQuery(QueryBuilders.termQuery("auto", true)),
             numAutoGenDocs.get()
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -394,7 +394,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
 
         refresh(INDEX_NAME);
-        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), numOfDocs);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0), numOfDocs);
 
         final boolean closedIndex = randomBoolean();
         if (closedIndex) {
@@ -439,7 +439,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         if (closedIndex) {
             assertAcked(indicesAdmin().prepareOpen(INDEX_NAME));
         }
-        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), numOfDocs);
+        assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0), numOfDocs);
     }
 
     public void testCancelNewShardRecoveryAndUsesExistingShardCopy() throws Exception {
@@ -1076,7 +1076,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
 
         indicesAdmin().prepareRefresh("test").get();
-        assertHitCount(client().prepareSearch().get(), numDocs);
+        assertHitCount(client().prepareSearch(), numDocs);
     }
 
     /** Makes sure the new master does not repeatedly fetch index metadata from recovering replicas */

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
@@ -43,7 +43,7 @@ public class ReplicaToPrimaryPromotionIT extends ESIntegTestCase {
             refresh(indexName);
         }
 
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), numOfDocs);
+        assertHitCount(client().prepareSearch(indexName).setSize(0), numOfDocs);
         ensureGreen(indexName);
 
         // sometimes test with a closed index
@@ -76,6 +76,6 @@ public class ReplicaToPrimaryPromotionIT extends ESIntegTestCase {
             assertAcked(indicesAdmin().prepareOpen(indexName));
             ensureYellowAndNoInitializingShards(indexName);
         }
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), numOfDocs);
+        assertHitCount(client().prepareSearch(indexName).setSize(0), numOfDocs);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.indices.settings;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -63,8 +62,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         refresh();
 
         for (int i = 0; i < 10; i++) {
-            SearchResponse countResponse = client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get();
-            assertHitCount(countResponse, 10L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 10L);
         }
 
         final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
@@ -120,8 +118,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
         for (int i = 0; i < 10; i++) {
-            SearchResponse countResponse = client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get();
-            assertHitCount(countResponse, 10L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 10L);
         }
 
         logger.info("Decreasing number of replicas from 2 to 0");
@@ -144,7 +141,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries));
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 10);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 10);
         }
 
         final long afterReplicaDecreaseSettingsVersion = clusterAdmin().prepareState()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -132,7 +132,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         assertIndexIsClosed(indexName);
 
         assertAcked(indicesAdmin().prepareOpen(indexName));
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), nbDocs);
+        assertHitCount(client().prepareSearch(indexName).setSize(0), nbDocs);
     }
 
     public void testCloseAlreadyClosedIndex() throws Exception {
@@ -244,7 +244,7 @@ public class CloseIndexIT extends ESIntegTestCase {
 
         assertIndexIsClosed(indexName);
         assertAcked(indicesAdmin().prepareOpen(indexName));
-        assertHitCount(client().prepareSearch(indexName).setSize(0).setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE).get(), nbDocs);
+        assertHitCount(client().prepareSearch(indexName).setSize(0).setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE), nbDocs);
     }
 
     public void testCloseWhileDeletingIndices() throws Exception {
@@ -349,7 +349,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         refresh(indexName);
         assertIndexIsOpened(indexName);
         assertHitCount(
-            client().prepareSearch(indexName).setSize(0).setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE).get(),
+            client().prepareSearch(indexName).setSize(0).setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE),
             indexer.totalIndexedDocs()
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -512,16 +512,11 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
 
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test_index").get();
-        assertHitCount(searchResponse, 5L);
+        assertHitCount(client().prepareSearch("test_index"), 5L);
+        assertHitCount(client().prepareSearch("simple_alias"), 5L);
+        assertHitCount(client().prepareSearch("templated_alias-test_index"), 5L);
 
-        searchResponse = client().prepareSearch("simple_alias").get();
-        assertHitCount(searchResponse, 5L);
-
-        searchResponse = client().prepareSearch("templated_alias-test_index").get();
-        assertHitCount(searchResponse, 5L);
-
-        searchResponse = client().prepareSearch("filtered_alias").get();
+        SearchResponse searchResponse = client().prepareSearch("filtered_alias").get();
         assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getSourceAsMap().get("type"), equalTo("type2"));
 
@@ -563,10 +558,9 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         client().prepareIndex("test_index").setId("2").setSource("field", "value2").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test_index").get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(client().prepareSearch("test_index"), 2L);
 
-        searchResponse = client().prepareSearch("my_alias").get();
+        SearchResponse searchResponse = client().prepareSearch("my_alias").get();
         assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value2"));
     }
@@ -599,13 +593,10 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         client().prepareIndex("test_index").setId("2").setSource("field", "value2").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test_index").get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(client().prepareSearch("test_index"), 2L);
+        assertHitCount(client().prepareSearch("alias1"), 2L);
 
-        searchResponse = client().prepareSearch("alias1").get();
-        assertHitCount(searchResponse, 2L);
-
-        searchResponse = client().prepareSearch("alias2").get();
+        SearchResponse searchResponse = client().prepareSearch("alias2").get();
         assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value2"));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -95,7 +95,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         logger.info("--> refreshing and checking data");
         refresh();
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2000L);
         }
 
         // now start shutting nodes down
@@ -124,7 +124,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         logger.info("--> stopped two nodes, verifying data");
         refresh();
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2000L);
         }
 
         // closing the 3rd node
@@ -154,7 +154,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         logger.info("--> one node left, verifying data");
         refresh();
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000L);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()), 2000L);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -500,8 +500,7 @@ public class RelocationIT extends ESIntegTestCase {
             docs[i] = client().prepareIndex("test").setId(id).setSource("field1", English.intToEnglish(i));
         }
         indexRandom(true, docs);
-        SearchResponse countResponse = client().prepareSearch("test").get();
-        assertHitCount(countResponse, numDocs);
+        assertHitCount(client().prepareSearch("test"), numDocs);
 
         logger.info(" --> moving index to new nodes");
         updateIndexSettings(

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
@@ -93,7 +93,7 @@ public class TruncatedRecoveryIT extends ESIntegTestCase {
         indexRandom(true, builder);
         for (int i = 0; i < numDocs; i++) {
             String id = Integer.toString(i);
-            assertHitCount(client().prepareSearch().setQuery(QueryBuilders.termQuery("the_id", id)).get(), 1);
+            assertHitCount(client().prepareSearch().setQuery(QueryBuilders.termQuery("the_id", id)), 1);
         }
         ensureGreen();
         // ensure we have flushed segments and make them a big one via optimize
@@ -143,7 +143,7 @@ public class TruncatedRecoveryIT extends ESIntegTestCase {
         ensureGreen("test");
         for (int i = 0; i < numDocs; i++) {
             String id = Integer.toString(i);
-            assertHitCount(client().prepareSearch().setQuery(QueryBuilders.termQuery("the_id", id)).get(), 1);
+            assertHitCount(client().prepareSearch().setQuery(QueryBuilders.termQuery("the_id", id)), 1);
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -46,8 +46,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
             client().prepareSearch()
                 .setIndices("alias-*")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-                .setQuery(queryStringQuery("quick"))
-                .get(),
+                .setQuery(queryStringQuery("quick")),
             3L
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexIT.java
@@ -64,10 +64,9 @@ public class SearchWhileCreatingIndexIT extends ESIntegTestCase {
         ClusterHealthStatus status = clusterAdmin().prepareHealth("test").get().getStatus();
         while (status != ClusterHealthStatus.GREEN) {
             // first, verify that search normal search works
-            SearchResponse searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field", "test")).get();
-            assertHitCount(searchResponse, 1);
+            assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field", "test")), 1);
             Client client = client();
-            searchResponse = client.prepareSearch("test")
+            SearchResponse searchResponse = client.prepareSearch("test")
                 .setPreference(preference + Integer.toString(counter++))
                 .setQuery(QueryBuilders.termQuery("field", "test"))
                 .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
@@ -61,7 +61,7 @@ public class SearchWhileRelocatingIT extends ESIntegTestCase {
             );
         }
         indexRandom(true, indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]));
-        assertHitCount(client().prepareSearch().get(), (numDocs));
+        assertHitCount(client().prepareSearch(), (numDocs));
         final int numIters = scaledRandomIntBetween(5, 20);
         for (int i = 0; i < numIters; i++) {
             final AtomicBoolean stop = new AtomicBoolean(false);
@@ -134,7 +134,7 @@ public class SearchWhileRelocatingIT extends ESIntegTestCase {
             if (nonCriticalExceptions.isEmpty() == false) {
                 logger.info("non-critical exceptions: {}", nonCriticalExceptions);
                 for (int j = 0; j < 10; j++) {
-                    assertHitCount(client().prepareSearch().get(), numDocs);
+                    assertHitCount(client().prepareSearch(), numDocs);
                 }
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -1842,15 +1842,22 @@ public class HighlighterSearchIT extends ESIntegTestCase {
             .get();
         refresh();
 
-        SearchResponse response = client().prepareSearch("test")
-            .setQuery(QueryBuilders.matchQuery("text", "test"))
-            .highlighter(
-                new HighlightBuilder().field("text").field("byte").field("short").field("int").field("long").field("float").field("double")
-            )
-            .get();
         // Highlighting of numeric fields is not supported, but it should not raise errors
         // (this behavior is consistent with version 0.20)
-        assertHitCount(response, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(QueryBuilders.matchQuery("text", "test"))
+                .highlighter(
+                    new HighlightBuilder().field("text")
+                        .field("byte")
+                        .field("short")
+                        .field("int")
+                        .field("long")
+                        .field("float")
+                        .field("double")
+                ),
+            1L
+        );
     }
 
     // Issue #3200
@@ -1864,12 +1871,13 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("text", "elasticsearch test").get();
         refresh();
 
-        SearchResponse response = client().prepareSearch("test")
-            .setQuery(QueryBuilders.matchQuery("text", "test"))
-            .highlighter(new HighlightBuilder().field("text"))
-            .get();
         // Mock tokenizer will throw an exception if it is resetted twice
-        assertHitCount(response, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(QueryBuilders.matchQuery("text", "test"))
+                .highlighter(new HighlightBuilder().field("text")),
+            1L
+        );
     }
 
     public void testHighlightUsesHighlightQuery() throws IOException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoPolygonIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoPolygonIT.java
@@ -175,9 +175,10 @@ public class GeoPolygonIT extends ESIntegTestCase {
         points.add(new GeoPoint(40.8, -74.1));
         points.add(new GeoPoint(40.8, -74.0));
         points.add(new GeoPoint(40.7, -74.0));
-        SearchResponse searchResponse = client().prepareSearch("test") // from NY
-            .setQuery(boolQuery().must(geoPolygonQuery("alias", points)))
-            .get();
-        assertHitCount(searchResponse, 4);
+        assertHitCount(
+            client().prepareSearch("test") // from NY
+                .setQuery(boolQuery().must(geoPolygonQuery("alias", points))),
+            4
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
@@ -83,10 +83,11 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis");
-        SearchResponse response = client().prepareSearch()
-            .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1))
-            .get();
-        assertHitCount(response, 1L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1)),
+            1L
+        );
     }
 
     public void testSimpleMoreLikeThisWithTypes() throws Exception {
@@ -116,10 +117,11 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis");
-        SearchResponse response = client().prepareSearch()
-            .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1))
-            .get();
-        assertHitCount(response, 1L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1)),
+            1L
+        );
     }
 
     // Issue #30148
@@ -152,14 +154,14 @@ public class MoreLikeThisIT extends ESIntegTestCase {
 
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(
-                moreLikeThisQuery(new String[] { "myField", "empty" }, null, new Item[] { new Item("test", "1") }).minTermFreq(1)
-                    .minDocFreq(1)
-            )
-            .get();
-
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    moreLikeThisQuery(new String[] { "myField", "empty" }, null, new Item[] { new Item("test", "1") }).minTermFreq(1)
+                        .minDocFreq(1)
+                ),
+            1L
+        );
     }
 
     public void testSimpleMoreLikeOnLongField() throws Exception {
@@ -178,10 +180,11 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis");
-        SearchResponse response = client().prepareSearch()
-            .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1))
-            .get();
-        assertHitCount(response, 0L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1)),
+            0L
+        );
     }
 
     public void testMoreLikeThisWithAliases() throws Exception {
@@ -221,13 +224,14 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis on index");
-        SearchResponse response = client().prepareSearch()
-            .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1))
-            .get();
-        assertHitCount(response, 2L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1)),
+            2L
+        );
 
         logger.info("Running moreLikeThis on beta shard");
-        response = client().prepareSearch("beta")
+        SearchResponse response = client().prepareSearch("beta")
             .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1))
             .get();
         assertHitCount(response, 1L);
@@ -362,10 +366,11 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         refresh();
 
         // Implicit list of fields -> ignore numeric fields
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1))
-            .get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("test", "1") }).minTermFreq(1).minDocFreq(1)),
+            1L
+        );
 
         // Explicit list of fields including numeric fields -> fail
         assertRequestBuilderThrows(
@@ -385,10 +390,11 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         );
 
         // mlt query with string fields
-        searchResponse = client().prepareSearch()
-            .setQuery(moreLikeThisQuery(new String[] { "string_value" }, new String[] { "index" }, null).minTermFreq(1).minDocFreq(1))
-            .get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(moreLikeThisQuery(new String[] { "string_value" }, new String[] { "index" }, null).minTermFreq(1).minDocFreq(1)),
+            2L
+        );
 
         // mlt query with at least a numeric field -> fail by default
         assertRequestBuilderThrows(
@@ -409,14 +415,15 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         );
 
         // mlt query with at least a numeric field but fail_on_unsupported_field set to false
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                moreLikeThisQuery(new String[] { "string_value", "int_value" }, new String[] { "index" }, null).minTermFreq(1)
-                    .minDocFreq(1)
-                    .failOnUnsupportedField(false)
-            )
-            .get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    moreLikeThisQuery(new String[] { "string_value", "int_value" }, new String[] { "index" }, null).minTermFreq(1)
+                        .minDocFreq(1)
+                        .failOnUnsupportedField(false)
+                ),
+            2L
+        );
 
         // mlt field query on a numeric field -> failure by default
         assertRequestBuilderThrows(
@@ -437,14 +444,15 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         );
 
         // mlt field query on a numeric field but fail_on_unsupported_field set to false
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                moreLikeThisQuery(new String[] { "int_value" }, new String[] { "42" }, null).minTermFreq(1)
-                    .minDocFreq(1)
-                    .failOnUnsupportedField(false)
-            )
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    moreLikeThisQuery(new String[] { "int_value" }, new String[] { "42" }, null).minTermFreq(1)
+                        .minDocFreq(1)
+                        .failOnUnsupportedField(false)
+                ),
+            0L
+        );
     }
 
     public void testMoreLikeThisWithFieldAlias() throws Exception {
@@ -474,8 +482,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         QueryBuilder query = QueryBuilders.moreLikeThisQuery(new String[] { "alias" }, null, new Item[] { item })
             .minTermFreq(1)
             .minDocFreq(1);
-        SearchResponse response = client().prepareSearch().setQuery(query).get();
-        assertHitCount(response, 1L);
+        assertHitCount(client().prepareSearch().setQuery(query), 1L);
     }
 
     public void testSimpleMoreLikeInclude() throws Exception {
@@ -576,8 +583,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .include(true)
             .minTermFreq(1)
             .minDocFreq(1);
-        SearchResponse mltResponse = client().prepareSearch().setQuery(queryBuilder).get();
-        assertHitCount(mltResponse, 3L);
+        assertHitCount(client().prepareSearch().setQuery(queryBuilder), 3L);
     }
 
     public void testMoreLikeThisMultiValueFields() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -750,28 +750,30 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
         // counter example
-        searchResponse = client().prepareSearch("test")
-            .setQuery(
-                randomizeType(
-                    multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category").type(
-                        randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : MultiMatchQueryBuilder.DEFAULT_TYPE
-                    ).operator(Operator.AND)
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    randomizeType(
+                        multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category").type(
+                            randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : MultiMatchQueryBuilder.DEFAULT_TYPE
+                        ).operator(Operator.AND)
+                    )
+                ),
+            0L
+        );
 
         // counter example
-        searchResponse = client().prepareSearch("test")
-            .setQuery(
-                randomizeType(
-                    multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category").type(
-                        randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : MultiMatchQueryBuilder.DEFAULT_TYPE
-                    ).operator(Operator.AND)
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    randomizeType(
+                        multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category").type(
+                            randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : MultiMatchQueryBuilder.DEFAULT_TYPE
+                        ).operator(Operator.AND)
+                    )
+                ),
+            0L
+        );
 
         // test if boosts work
         searchResponse = client().prepareSearch("test")
@@ -839,13 +841,12 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                 )
             )
             .get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("ultimate1"));
         /*
-         * Doesn't find theone because "alpha 15" isn't a number and we don't
+         * Doesn't find the one because "alpha 15" isn't a number and we don't
          * break on spaces.
          */
-        assertHitCount(searchResponse, 1);
+        assertHitCount(searchResponse, 1L);
+        assertFirstHit(searchResponse, hasId("ultimate1"));
 
         // Lenient wasn't always properly lenient with two numeric fields
         searchResponse = client().prepareSearch("test")

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -180,12 +180,11 @@ public class QueryStringIT extends ESIntegTestCase {
         reqs.add(client().prepareIndex("test_1").setId("1").setSource("f1", "foo", "f2", "eggplant"));
         indexRandom(true, false, reqs);
 
-        SearchResponse resp = client().prepareSearch("test_1")
-            .setQuery(queryStringQuery("foo eggplant").defaultOperator(Operator.AND))
-            .get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test_1").setQuery(queryStringQuery("foo eggplant").defaultOperator(Operator.AND)), 0L);
 
-        resp = client().prepareSearch("test_1").setQuery(queryStringQuery("foo eggplant").defaultOperator(Operator.OR)).get();
+        SearchResponse resp = client().prepareSearch("test_1")
+            .setQuery(queryStringQuery("foo eggplant").defaultOperator(Operator.OR))
+            .get();
         assertHits(resp.getHits(), "1");
         assertHitCount(resp, 1L);
     }
@@ -196,8 +195,7 @@ public class QueryStringIT extends ESIntegTestCase {
         reqs.add(client().prepareIndex("test").setId("2").setSource("f1", "foo bar", "f4", "chicken parmesan"));
         indexRandom(true, false, reqs);
 
-        SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("\"eggplant parmesan\"").lenient(true)).get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("\"eggplant parmesan\"").lenient(true)), 0L);
 
         Exception exc = expectThrows(
             Exception.class,

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -145,8 +145,8 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("3").setSource("field1", "quick")
         );
 
-        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("quick")).get(), 3L);
-        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("")).get(), 0L); // return no docs
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("quick")), 3L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("")), 0L); // return no docs
     }
 
     // see https://github.com/elastic/elasticsearch/issues/3177
@@ -165,8 +165,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .setPostFilter(
                     boolQuery().must(matchAllQuery())
                         .must(boolQuery().mustNot(boolQuery().must(termQuery("field1", "value1")).must(termQuery("field1", "value2"))))
-                )
-                .get(),
+                ),
             3L
         );
         assertHitCount(
@@ -177,12 +176,11 @@ public class SearchQueryIT extends ESIntegTestCase {
                             .should(termQuery("field1", "value2"))
                             .should(termQuery("field1", "value3"))
                     ).filter(boolQuery().mustNot(boolQuery().must(termQuery("field1", "value1")).must(termQuery("field1", "value2"))))
-                )
-                .get(),
+                ),
             3L
         );
         assertHitCount(
-            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(boolQuery().mustNot(termQuery("field1", "value3"))).get(),
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(boolQuery().mustNot(termQuery("field1", "value3"))),
             2L
         );
     }
@@ -195,8 +193,7 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("2").setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox")
         );
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(matchPhraseQuery("field2", "quick brown").slop(0)).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchPhraseQuery("field2", "quick brown").slop(0)), 1L);
 
         assertFailures(
             client().prepareSearch().setQuery(matchPhraseQuery("field1", "quick brown").slop(0)),
@@ -297,10 +294,9 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         int iters = scaledRandomIntBetween(100, 200);
         for (int i = 0; i < iters; i++) {
-            SearchResponse searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("*:*^10.0").boost(10.0f)).get();
-            assertHitCount(searchResponse, 2L);
+            assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("*:*^10.0").boost(10.0f)), 2L);
 
-            searchResponse = client().prepareSearch("test")
+            SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).must(constantScoreQuery(matchAllQuery())))
                 .get();
             assertHitCount(searchResponse, 2L);
@@ -315,20 +311,11 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", "value_1", "field2", "value_2").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("value*")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("*ue*")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("*ue_1")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("val*e_1")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("v?l*e?1")).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("value*")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("*ue*")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("*ue_1")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("val*e_1")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("v?l*e?1")), 1L);
     }
 
     public void testLowercaseExpandedTerms() {
@@ -337,14 +324,10 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", "value_1", "field2", "value_2").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("VALUE_3~1")).get();
-        assertHitCount(searchResponse, 1L);
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("ValUE_*")).get();
-        assertHitCount(searchResponse, 1L);
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("vAl*E_1")).get();
-        assertHitCount(searchResponse, 1L);
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("[VALUE_1 TO VALUE_3]")).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("VALUE_3~1")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("ValUE_*")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("vAl*E_1")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("[VALUE_1 TO VALUE_3]")), 1L);
     }
 
     // Issue #3540
@@ -359,11 +342,8 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("past:[now-2M/d TO now/d]")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("future:[now/d TO now+2M/d]")).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("past:[now-2M/d TO now/d]")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("future:[now/d TO now+2M/d]")), 1L);
 
         SearchPhaseExecutionException e = expectThrows(
             SearchPhaseExecutionException.class,
@@ -385,10 +365,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("past", now).get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(queryStringQuery("past:[now-1m/m TO now+1m/m]").timeZone(timeZone.getId()))
-            .get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("past:[now-1m/m TO now+1m/m]").timeZone(timeZone.getId())), 1L);
     }
 
     // Issue #10477
@@ -402,28 +379,29 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         // Timezone set with dates
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(queryStringQuery("past:[2015-04-06T00:00:00+0200 TO 2015-04-06T23:00:00+0200]"))
-            .get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(
+            client().prepareSearch().setQuery(queryStringQuery("past:[2015-04-06T00:00:00+0200 TO 2015-04-06T23:00:00+0200]")),
+            2L
+        );
 
         // Same timezone set with time_zone
-        searchResponse = client().prepareSearch()
-            .setQuery(queryStringQuery("past:[2015-04-06T00:00:00 TO 2015-04-06T23:00:00]").timeZone("+0200"))
-            .get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(
+            client().prepareSearch().setQuery(queryStringQuery("past:[2015-04-06T00:00:00 TO 2015-04-06T23:00:00]").timeZone("+0200")),
+            2L
+        );
 
         // We set a timezone which will give no result
-        searchResponse = client().prepareSearch()
-            .setQuery(queryStringQuery("past:[2015-04-06T00:00:00-0200 TO 2015-04-06T23:00:00-0200]"))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch().setQuery(queryStringQuery("past:[2015-04-06T00:00:00-0200 TO 2015-04-06T23:00:00-0200]")),
+            0L
+        );
 
         // Same timezone set with time_zone but another timezone is set directly within dates which has the precedence
-        searchResponse = client().prepareSearch()
-            .setQuery(queryStringQuery("past:[2015-04-06T00:00:00-0200 TO 2015-04-06T23:00:00-0200]").timeZone("+0200"))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(queryStringQuery("past:[2015-04-06T00:00:00-0200 TO 2015-04-06T23:00:00-0200]").timeZone("+0200")),
+            0L
+        );
     }
 
     public void testIdsQueryTestsIdIndexed() throws Exception {
@@ -444,8 +422,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
-        searchResponse = client().prepareSearch().setQuery(idsQuery().addIds("7", "10")).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(idsQuery().addIds("7", "10")), 0L);
 
         // repeat..., with terms
         searchResponse = client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_id", "1", "3"))).get();
@@ -576,13 +553,13 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", "value1_1", "field2", "value2_1").setRefreshPolicy(IMMEDIATE).get();
 
         WrapperQueryBuilder wrapper = new WrapperQueryBuilder("{ \"term\" : { \"field1\" : \"value1_1\" } }");
-        assertHitCount(client().prepareSearch().setQuery(wrapper).get(), 1L);
+        assertHitCount(client().prepareSearch().setQuery(wrapper), 1L);
 
         BoolQueryBuilder bool = boolQuery().must(wrapper).must(new TermQueryBuilder("field2", "value2_1"));
-        assertHitCount(client().prepareSearch().setQuery(bool).get(), 1L);
+        assertHitCount(client().prepareSearch().setQuery(bool), 1L);
 
         WrapperQueryBuilder wrapperFilter = wrapperQuery("{ \"term\" : { \"field1\" : \"value1_1\" } }");
-        assertHitCount(client().prepareSearch().setPostFilter(wrapperFilter).get(), 1L);
+        assertHitCount(client().prepareSearch().setPostFilter(wrapperFilter), 1L);
     }
 
     public void testFiltersWithCustomCacheKey() throws Exception {
@@ -590,17 +567,10 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         refresh();
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))), 1L);
     }
 
     public void testMatchQueryNumeric() throws Exception {
@@ -631,13 +601,11 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("1").setSource("text", "Unit"),
             client().prepareIndex("test").setId("2").setSource("text", "Unity")
         );
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(0))), 0L);
 
         SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(0)))
+            .setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(1)))
             .get();
-        assertHitCount(searchResponse, 0L);
-
-        searchResponse = client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(1))).get();
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
@@ -645,8 +613,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
-        searchResponse = client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromString("AUTO:5,7"))).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromString("AUTO:5,7"))), 0L);
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("text", "unify").fuzziness(Fuzziness.fromString("AUTO:5,7"))).get();
         assertHitCount(searchResponse, 1L);
@@ -739,17 +706,14 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         BoolQueryBuilder boolQuery = boolQuery().must(matchQuery("field1", "a").zeroTermsQuery(ZeroTermsQueryOption.NONE))
             .must(matchQuery("field1", "value1").zeroTermsQuery(ZeroTermsQueryOption.NONE));
-        SearchResponse searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 0L);
 
         boolQuery = boolQuery().must(matchQuery("field1", "a").zeroTermsQuery(ZeroTermsQueryOption.ALL))
             .must(matchQuery("field1", "value1").zeroTermsQuery(ZeroTermsQueryOption.ALL));
-        searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 1L);
 
         boolQuery = boolQuery().must(matchQuery("field1", "a").zeroTermsQuery(ZeroTermsQueryOption.ALL));
-        searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 2L);
     }
 
     public void testMultiMatchQueryZeroTermsQuery() {
@@ -761,17 +725,14 @@ public class SearchQueryIT extends ESIntegTestCase {
         BoolQueryBuilder boolQuery = boolQuery().must(multiMatchQuery("a", "field1", "field2").zeroTermsQuery(ZeroTermsQueryOption.NONE))
             // Fields are ORed together
             .must(multiMatchQuery("value1", "field1", "field2").zeroTermsQuery(ZeroTermsQueryOption.NONE));
-        SearchResponse searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 0L);
 
         boolQuery = boolQuery().must(multiMatchQuery("a", "field1", "field2").zeroTermsQuery(ZeroTermsQueryOption.ALL))
             .must(multiMatchQuery("value4", "field1", "field2").zeroTermsQuery(ZeroTermsQueryOption.ALL));
-        searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 1L);
 
         boolQuery = boolQuery().must(multiMatchQuery("a", "field1").zeroTermsQuery(ZeroTermsQueryOption.ALL));
-        searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 2L);
     }
 
     public void testMultiMatchQueryMinShouldMatch() {
@@ -806,8 +767,7 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         multiMatchQuery = multiMatchQuery("value1 value2 bar", "field1");
         multiMatchQuery.minimumShouldMatch("100%");
-        searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(multiMatchQuery), 0L);
 
         multiMatchQuery.minimumShouldMatch("70%");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
@@ -816,8 +776,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         // Min should match > # optional clauses returns no docs.
         multiMatchQuery = multiMatchQuery("value1 value2 value3", "field1", "field2");
         multiMatchQuery.minimumShouldMatch("4");
-        searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(multiMatchQuery), 0L);
     }
 
     public void testBoolQueryMinShouldMatchBiggerThanNumberOfShouldClauses() throws IOException {
@@ -836,8 +795,7 @@ public class SearchQueryIT extends ESIntegTestCase {
             .should(boolQuery().should(termQuery("field1", "value1")).should(termQuery("field1", "value2")).minimumShouldMatch(1))
             // Only one should clause is defined, returns no docs.
             .minimumShouldMatch(2);
-        searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 0L);
 
         boolQuery = boolQuery().should(termQuery("field1", "value1"))
             .should(boolQuery().should(termQuery("field1", "value1")).should(termQuery("field1", "value2")).minimumShouldMatch(3))
@@ -848,8 +806,7 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         boolQuery = boolQuery().must(termQuery("field1", "value1"))
             .must(boolQuery().should(termQuery("field1", "value1")).should(termQuery("field1", "value2")).minimumShouldMatch(3));
-        searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(boolQuery), 0L);
     }
 
     public void testFuzzyQueryString() {
@@ -901,24 +858,16 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>20")).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("num:>20")), 0L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>=20")).get();
         assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>11")).get();
-        assertHitCount(searchResponse, 2L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:<20")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:<=20")).get();
-        assertHitCount(searchResponse, 2L);
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("+num:>11 +num:<20")).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("num:>11")), 2L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("num:<20")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("num:<=20")), 2L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("+num:>11 +num:<20")), 1L);
     }
 
     public void testEmptytermsQuery() throws Exception {
@@ -931,14 +880,8 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("3").setSource("term", "3"),
             client().prepareIndex("test").setId("4").setSource("term", "4")
         );
-
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(constantScoreQuery(termsQuery("term", new String[0])))
-            .get();
-        assertHitCount(searchResponse, 0L);
-
-        searchResponse = client().prepareSearch("test").setQuery(idsQuery()).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("term", new String[0]))), 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(idsQuery()), 0L);
     }
 
     public void testTermsQuery() throws Exception {
@@ -989,14 +932,10 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertFirstHit(searchResponse, hasId("2"));
 
         // test valid type, but no matching terms
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "5", "6"))).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "5", "6"))), 0L);
 
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 5, 6 }))).get();
-        assertHitCount(searchResponse, 0L);
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 5, 6 }))).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 5, 6 }))), 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 5, 6 }))), 0L);
     }
 
     public void testTermsLookupFilter() throws Exception {
@@ -1100,8 +1039,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "4");
 
-        searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "4", "terms"))).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "4", "terms"))), 0L);
 
         searchResponse = client().prepareSearch("test")
             .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "1", "arr.term")))
@@ -1121,20 +1059,19 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "4");
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(termsLookupQuery("not_exists", new TermsLookup("lookup2", "3", "arr.term")))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch("test").setQuery(termsLookupQuery("not_exists", new TermsLookup("lookup2", "3", "arr.term"))),
+            0L
+        );
 
         // index "lookup" id "missing" document does not exist: ignore the lookup terms
-        searchResponse = client().prepareSearch("test")
-            .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "missing", "terms")))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "missing", "terms"))),
+            0L
+        );
 
         // index "lookup3" has the source disabled: ignore the lookup terms
-        searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup3", "1", "terms"))).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup3", "1", "terms"))), 0L);
     }
 
     public void testBasicQueryById() throws Exception {
@@ -1404,13 +1341,12 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("4").setSource("description", "foo")
         );
 
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(spanOrQuery(spanTermQuery("description", "bar"))).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test")
-            .setQuery(spanNearQuery(spanTermQuery("description", "foo"), 3).addClause(spanTermQuery("description", "other")))
-            .get();
-        assertHitCount(searchResponse, 3L);
+        assertHitCount(client().prepareSearch("test").setQuery(spanOrQuery(spanTermQuery("description", "bar"))), 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(spanNearQuery(spanTermQuery("description", "foo"), 3).addClause(spanTermQuery("description", "other"))),
+            3L
+        );
     }
 
     public void testSpanMultiTermQuery() throws IOException {
@@ -1422,28 +1358,27 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("4").setSource("description", "fop", "count", 4).get();
         refresh();
 
-        SearchResponse response = client().prepareSearch("test")
-            .setQuery(spanOrQuery(spanMultiTermQueryBuilder(fuzzyQuery("description", "fop"))))
-            .get();
-        assertHitCount(response, 4);
-
-        response = client().prepareSearch("test").setQuery(spanOrQuery(spanMultiTermQueryBuilder(prefixQuery("description", "fo")))).get();
-        assertHitCount(response, 4);
-
-        response = client().prepareSearch("test")
-            .setQuery(spanOrQuery(spanMultiTermQueryBuilder(wildcardQuery("description", "oth*"))))
-            .get();
-        assertHitCount(response, 3);
-
-        response = client().prepareSearch("test")
-            .setQuery(spanOrQuery(spanMultiTermQueryBuilder(QueryBuilders.rangeQuery("description").from("ffa").to("foo"))))
-            .get();
-        assertHitCount(response, 3);
-
-        response = client().prepareSearch("test")
-            .setQuery(spanOrQuery(spanMultiTermQueryBuilder(regexpQuery("description", "fo{2}"))))
-            .get();
-        assertHitCount(response, 3);
+        assertHitCount(
+            client().prepareSearch("test").setQuery(spanOrQuery(spanMultiTermQueryBuilder(fuzzyQuery("description", "fop")))),
+            4
+        );
+        assertHitCount(
+            client().prepareSearch("test").setQuery(spanOrQuery(spanMultiTermQueryBuilder(prefixQuery("description", "fo")))),
+            4
+        );
+        assertHitCount(
+            client().prepareSearch("test").setQuery(spanOrQuery(spanMultiTermQueryBuilder(wildcardQuery("description", "oth*")))),
+            3
+        );
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(spanOrQuery(spanMultiTermQueryBuilder(QueryBuilders.rangeQuery("description").from("ffa").to("foo")))),
+            3
+        );
+        assertHitCount(
+            client().prepareSearch("test").setQuery(spanOrQuery(spanMultiTermQueryBuilder(regexpQuery("description", "fo{2}")))),
+            3
+        );
     }
 
     public void testSpanNot() throws IOException, ExecutionException, InterruptedException {
@@ -1453,41 +1388,42 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("2").setSource("description", "the quick black fox leaped over the sleeping dog").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(
-                spanNotQuery(
-                    spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1).addClause(
-                        QueryBuilders.spanTermQuery("description", "fox")
-                    ),
-                    spanTermQuery("description", "brown")
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test")
-            .setQuery(
-                spanNotQuery(
-                    spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1).addClause(
-                        QueryBuilders.spanTermQuery("description", "fox")
-                    ),
-                    spanTermQuery("description", "sleeping")
-                ).dist(5)
-            )
-            .get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test")
-            .setQuery(
-                spanNotQuery(
-                    spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1).addClause(
-                        QueryBuilders.spanTermQuery("description", "fox")
-                    ),
-                    spanTermQuery("description", "jumped")
-                ).pre(1).post(1)
-            )
-            .get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    spanNotQuery(
+                        spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1).addClause(
+                            QueryBuilders.spanTermQuery("description", "fox")
+                        ),
+                        spanTermQuery("description", "brown")
+                    )
+                ),
+            1L
+        );
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    spanNotQuery(
+                        spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1).addClause(
+                            QueryBuilders.spanTermQuery("description", "fox")
+                        ),
+                        spanTermQuery("description", "sleeping")
+                    ).dist(5)
+                ),
+            1L
+        );
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    spanNotQuery(
+                        spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1).addClause(
+                            QueryBuilders.spanTermQuery("description", "fox")
+                        ),
+                        spanTermQuery("description", "jumped")
+                    ).pre(1).post(1)
+                ),
+            1L
+        );
     }
 
     public void testSimpleDFSQuery() throws IOException {
@@ -1563,20 +1499,20 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
         logger.info("regular");
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value1").field("field1").field("field2")).get(), 1);
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:value1")).get(), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value1").field("field1").field("field2")), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:value1")), 1);
         logger.info("prefix");
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value*").field("field1").field("field2")).get(), 1);
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:value*")).get(), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value*").field("field1").field("field2")), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:value*")), 1);
         logger.info("wildcard");
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("v?lue*").field("field1").field("field2")).get(), 1);
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:v?lue*")).get(), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("v?lue*").field("field1").field("field2")), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:v?lue*")), 1);
         logger.info("fuzzy");
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value~").field("field1").field("field2")).get(), 1);
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:value~")).get(), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value~").field("field1").field("field2")), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:value~")), 1);
         logger.info("regexp");
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("/value[01]/").field("field1").field("field2")).get(), 1);
-        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:/value[01]/")).get(), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("/value[01]/").field("field1").field("field2")), 1);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("field\\*:/value[01]/")), 1);
     }
 
     // see #3797
@@ -1586,18 +1522,9 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", 123, "field2", "value2").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(multiMatchQuery("value2", "field2").field("field1", 2).lenient(true))
-            .get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test")
-            .setQuery(multiMatchQuery("value2", "field2").field("field1", 2).lenient(true))
-            .get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test").setQuery(multiMatchQuery("value2").field("field2", 2).lenient(true)).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(multiMatchQuery("value2", "field2").field("field1", 2).lenient(true)), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(multiMatchQuery("value2", "field2").field("field1", 2).lenient(true)), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(multiMatchQuery("value2").field("field2", 2).lenient(true)), 1L);
     }
 
     public void testMinScore() throws ExecutionException, InterruptedException {
@@ -1623,40 +1550,32 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("desc", "one two three", "type", "customer").get();
         client().prepareIndex("test").setId("2").setSource("desc", "one two three", "type", "product").get();
         refresh();
-        {
-            SearchResponse searchResponse = client().prepareSearch("test")
-                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").defaultField("desc"))
-                .get();
-            assertHitCount(searchResponse, 2);
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch("test")
+
+        assertHitCount(client().prepareSearch("test").setQuery(QueryBuilders.queryStringQuery("\"one two\"").defaultField("desc")), 2);
+        assertHitCount(
+            client().prepareSearch("test")
                 .setPostFilter(QueryBuilders.termQuery("type", "customer"))
-                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").field("desc"))
-                .get();
-            assertHitCount(searchResponse, 1);
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch("test")
+                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").field("desc")),
+            1
+        );
+        assertHitCount(
+            client().prepareSearch("test")
                 .setPostFilter(QueryBuilders.termQuery("type", "product"))
-                .setQuery(QueryBuilders.queryStringQuery("\"one three\"~5").field("desc"))
-                .get();
-            assertHitCount(searchResponse, 1);
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch("test")
+                .setQuery(QueryBuilders.queryStringQuery("\"one three\"~5").field("desc")),
+            1
+        );
+        assertHitCount(
+            client().prepareSearch("test")
                 .setPostFilter(QueryBuilders.termQuery("type", "customer"))
-                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").defaultField("desc"))
-                .get();
-            assertHitCount(searchResponse, 1);
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch("test")
+                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").defaultField("desc")),
+            1
+        );
+        assertHitCount(
+            client().prepareSearch("test")
                 .setPostFilter(QueryBuilders.termQuery("type", "customer"))
-                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").defaultField("desc"))
-                .get();
-            assertHitCount(searchResponse, 1);
-        }
+                .setQuery(QueryBuilders.queryStringQuery("\"one two\"").defaultField("desc")),
+            1
+        );
     }
 
     public void testDateProvidedAsNumber() throws InterruptedException {
@@ -1672,8 +1591,8 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("6").setSource("field", 999999999999L)
         );
 
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").gte(1000000000000L)).get(), 4);
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").gte(999999999999L)).get(), 6);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").gte(1000000000000L)), 4);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").gte(999999999999L)), 6);
     }
 
     public void testRangeQueryWithTimeZone() throws Exception {
@@ -1785,22 +1704,27 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("2").setSource("date_field", "Do, 07 Dez 2000 02:55:00 -0800")
         );
 
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Do, 07 Dez 2000 00:00:00 -0800"))
-            .get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Fr, 08 Dez 2000 00:00:00 -0800"))
-            .get();
-        assertHitCount(searchResponse, 2L);
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Do, 07 Dez 2000 00:00:00 -0800")
+                ),
+            1L
+        );
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(
+                    QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Fr, 08 Dez 2000 00:00:00 -0800")
+                ),
+            2L
+        );
     }
 
     public void testSearchEmptyDoc() {
         client().prepareIndex("test").setId("1").setSource("{}", XContentType.JSON).get();
 
         refresh();
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), 1L);
     }
 
     public void testMatchPhrasePrefixQuery() throws ExecutionException, InterruptedException {
@@ -1900,8 +1824,7 @@ public class SearchQueryIT extends ESIntegTestCase {
             QueryBuilders.termQuery("section.route_length_miles", 42),
             ScoreMode.Max
         );
-        SearchResponse searchResponse = client().prepareSearch("index").setQuery(nestedQuery).get();
-        assertHitCount(searchResponse, 1);
+        assertHitCount(client().prepareSearch("index").setQuery(nestedQuery), 1);
     }
 
     public void testFieldAliasesForMetaFields() throws Exception {
@@ -1962,12 +1885,10 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         {
             WildcardQueryBuilder wildCardQuery = wildcardQuery("field1", "Bb*");
-            SearchResponse searchResponse = client().prepareSearch().setQuery(wildCardQuery).get();
-            assertHitCount(searchResponse, 1L);
+            assertHitCount(client().prepareSearch().setQuery(wildCardQuery), 1L);
 
             wildCardQuery = wildcardQuery("field1", "bb*");
-            searchResponse = client().prepareSearch().setQuery(wildCardQuery).get();
-            assertHitCount(searchResponse, 1L);
+            assertHitCount(client().prepareSearch().setQuery(wildCardQuery), 1L);
         }
     }
 
@@ -2076,8 +1997,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         BoolQueryBuilder query = boolQuery().filter(spanMultiTermQueryBuilder(fuzzyQuery("field", "foobarbiz").rewrite("constant_score")));
-        SearchResponse response = client().prepareSearch("test").setQuery(query).get();
-        assertHitCount(response, 1);
+        assertHitCount(client().prepareSearch("test").setQuery(query), 1);
     }
 
     public void testFetchIdFieldQuery() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -258,19 +258,21 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("3"));
 
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("baz | egg*").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.NONE))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(simpleQueryStringQuery("baz | egg*").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.NONE)),
+            0L
+        );
 
-        searchResponse = client().prepareSearch()
-            .setSource(
-                new SearchSourceBuilder().query(
-                    QueryBuilders.simpleQueryStringQuery("foo|bar").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.NONE)
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(
+            client().prepareSearch()
+                .setSource(
+                    new SearchSourceBuilder().query(
+                        QueryBuilders.simpleQueryStringQuery("foo|bar").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.NONE)
+                    )
+                ),
+            1L
+        );
 
         searchResponse = client().prepareSearch()
             .setQuery(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/GeoDistanceIT.java
@@ -583,12 +583,12 @@ public class GeoDistanceIT extends ESIntegTestCase {
         refresh();
         client().prepareGet("locations", "1").get();
 
-        SearchResponse result = client().prepareSearch("locations")
-            .setQuery(QueryBuilders.matchAllQuery())
-            .setPostFilter(QueryBuilders.geoDistanceQuery("pin").geoDistance(GeoDistance.ARC).point(lat, lon).distance("1m"))
-            .get();
-
-        assertHitCount(result, 1);
+        assertHitCount(
+            client().prepareSearch("locations")
+                .setQuery(QueryBuilders.matchAllQuery())
+                .setPostFilter(QueryBuilders.geoDistanceQuery("pin").geoDistance(GeoDistance.ARC).point(lat, lon).distance("1m")),
+            1
+        );
     }
 
     public void testDistanceSortingWithUnmappedField() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -691,9 +691,9 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         indexRandom(true, builders);
         flushAndRefresh();
 
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "foo")).get(), numdocs);
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")).get(), 0);
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")).get(), numdocs);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "foo")), numdocs);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")), 0);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")), numdocs);
 
         createSnapshot("test-repo", "test-snap", Collections.singletonList("test-idx"));
 
@@ -754,8 +754,8 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(getSettingsResponse.getSetting("test-idx", SETTING_NUMBER_OF_SHARDS), equalTo("" + numberOfShards));
         assertThat(getSettingsResponse.getSetting("test-idx", "index.analysis.analyzer.my_analyzer.type"), equalTo("standard"));
 
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")).get(), numdocs);
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")).get(), numdocs);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")), numdocs);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")), numdocs);
 
         logger.info("--> delete the index and recreate it while deleting all index settings");
         cluster().wipeIndices("test-idx");
@@ -777,8 +777,8 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         // Make sure that number of shards didn't change
         assertThat(getSettingsResponse.getSetting("test-idx", SETTING_NUMBER_OF_SHARDS), equalTo("" + numberOfShards));
 
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")).get(), numdocs);
-        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")).get(), numdocs);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "Foo")), numdocs);
+        assertHitCount(client.prepareSearch("test-idx").setSize(0).setQuery(matchQuery("field1", "bar")), numdocs);
     }
 
     public void testRecreateBlocksOnRestore() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1615,7 +1615,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards(), equalTo(snapshotInfo.successfulShards()));
 
         ensureGreen("test-idx-1", "test-idx-2");
-        assertHitCount(client().prepareSearch("test-idx-*").setSize(0).get(), 3);
+        assertHitCount(client().prepareSearch("test-idx-*").setSize(0), 3);
     }
 
     /**
@@ -1684,7 +1684,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         ensureGreen();
         for (Map.Entry<String, Integer> entry : nbDocsPerIndex.entrySet()) {
             if (isRestorableIndex.test(entry.getKey())) {
-                assertHitCount(client().prepareSearch(entry.getKey()).setSize(0).get(), entry.getValue().longValue());
+                assertHitCount(client().prepareSearch(entry.getKey()).setSize(0), entry.getValue().longValue());
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
@@ -72,7 +72,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
         assertHitCount(response, 19);
         assertEquals(10, response.getHits().getHits().length);
         // Make sure we still have 20 docs
-        assertHitCount(client().prepareSearch("index").setSize(0).setTrackTotalHits(true).get(), 20);
+        assertHitCount(client().prepareSearch("index").setSize(0).setTrackTotalHits(true), 20);
     }
 
     public void testKnnWithQuery() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSearchTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSearchTests.java
@@ -88,15 +88,11 @@ public class FlattenedFieldSearchTests extends ESSingleNodeTestCase {
             )
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("headers", "application/json")).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("headers", "application/json")), 1L);
 
         // Check that queries are split on whitespace.
-        searchResponse = client().prepareSearch().setQuery(matchQuery("headers.content-type", "application/json text/plain")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(matchQuery("headers.origin", "application/json")).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("headers.content-type", "application/json text/plain")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("headers.origin", "application/json")), 0L);
     }
 
     public void testMultiMatchQuery() throws Exception {
@@ -114,19 +110,10 @@ public class FlattenedFieldSearchTests extends ESSingleNodeTestCase {
             )
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(multiMatchQuery("application/json", "headers")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(multiMatchQuery("application/json text/plain", "headers.content-type")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(multiMatchQuery("application/json", "headers.origin")).get();
-        assertHitCount(searchResponse, 0L);
-
-        searchResponse = client().prepareSearch()
-            .setQuery(multiMatchQuery("application/json", "headers.origin", "headers.contentType"))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(multiMatchQuery("application/json", "headers")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(multiMatchQuery("application/json text/plain", "headers.content-type")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(multiMatchQuery("application/json", "headers.origin")), 0L);
+        assertHitCount(client().prepareSearch().setQuery(multiMatchQuery("application/json", "headers.origin", "headers.contentType")), 0L);
     }
 
     public void testQueryStringQuery() throws Exception {
@@ -199,14 +186,9 @@ public class FlattenedFieldSearchTests extends ESSingleNodeTestCase {
             )
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(existsQuery("headers")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(existsQuery("headers.content-type")).get();
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch().setQuery(existsQuery("headers.nonexistent")).get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(client().prepareSearch().setQuery(existsQuery("headers")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(existsQuery("headers.content-type")), 1L);
+        assertHitCount(client().prepareSearch().setQuery(existsQuery("headers.nonexistent")), 0L);
     }
 
     public void testCardinalityAggregation() throws IOException {

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -270,7 +270,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         test = createIndex("test");
         client().prepareIndex("test").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         client().admin().indices().prepareFlush("test").get();
-        assertHitCount(client().prepareSearch("test").get(), 1);
+        assertHitCount(client().prepareSearch("test"), 1);
         IndexMetadata secondMetadata = clusterService.state().metadata().index("test");
         assertAcked(client().admin().indices().prepareClose("test"));
         ShardPath secondPath = ShardPath.loadShardPath(

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -1211,8 +1211,8 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         ).actionGet();
 
         client().prepareIndex("throttled_threadpool_index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
-        assertHitCount(client().prepareSearch().get(), 1L);
-        assertHitCount(client().prepareSearch().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED).get(), 1L);
+        assertHitCount(client().prepareSearch(), 1L);
+        assertHitCount(client().prepareSearch().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED), 1L);
     }
 
     public void testExpandSearchFrozen() {
@@ -1224,8 +1224,8 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         ).actionGet();
 
         client().prepareIndex(indexName).setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
-        assertHitCount(client().prepareSearch().get(), 0L);
-        assertHitCount(client().prepareSearch().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED).get(), 1L);
+        assertHitCount(client().prepareSearch(), 0L);
+        assertHitCount(client().prepareSearch().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED), 1L);
         assertWarnings(TransportSearchAction.FROZEN_INDICES_DEPRECATION_MESSAGE.replace("{}", indexName));
     }
 
@@ -1850,11 +1850,13 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         final List<ShardSearchRequest> shardRequests = new CopyOnWriteArrayList<>();
         searchService.setOnCreateSearchContext(ctx -> shardRequests.add(ctx.request()));
         try {
-            SearchRequest searchRequest = new SearchRequest().source(
-                new SearchSourceBuilder().size(between(numDocs, numDocs * 2)).pointInTimeBuilder(new PointInTimeBuilder(pitId))
+            assertHitCount(
+                client().prepareSearch()
+                    .setSource(
+                        new SearchSourceBuilder().size(between(numDocs, numDocs * 2)).pointInTimeBuilder(new PointInTimeBuilder(pitId))
+                    ),
+                numDocs
             );
-            final SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertHitCount(searchResponse, numDocs);
         } finally {
             client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest(pitId)).actionGet();
         }

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -140,8 +139,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
 
         assertFalse(stateResponse.getState().getRoutingNodes().node(blueNodeId).isEmpty());
 
-        SearchResponse searchResponse = client().prepareSearch(indexName).get();
-        assertHitCount(searchResponse, numDocs);
+        assertHitCount(client().prepareSearch(indexName), numDocs);
 
         logger.info("--> will temporarily interrupt recovery action between blue & red on [{}]", recoveryActionToBlock);
 
@@ -196,8 +194,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
             if (recoveryActionToBlock.equals(PeerRecoveryTargetService.Actions.RESTORE_FILE_FROM_SNAPSHOT)) {
                 assertThat(handlingBehavior.blocksRemaining.get(), is(equalTo(0)));
             }
-            searchResponse = client(redNodeName).prepareSearch(indexName).setPreference("_local").get();
-            assertHitCount(searchResponse, numDocs);
+            assertHitCount(client(redNodeName).prepareSearch(indexName).setPreference("_local"), numDocs);
         } finally {
             blueTransportService.clearAllRules();
             redTransportService.clearAllRules();
@@ -244,8 +241,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
 
         assertFalse(stateResponse.getState().getRoutingNodes().node(blueNodeId).isEmpty());
 
-        SearchResponse searchResponse = client().prepareSearch(indexName).get();
-        assertHitCount(searchResponse, numDocs);
+        assertHitCount(client().prepareSearch(indexName), numDocs);
 
         final boolean dropRequests = randomBoolean();
         logger.info("--> will {} between blue & red on [{}]", dropRequests ? "drop requests" : "break connection", recoveryActionToBlock);
@@ -309,8 +305,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         redMockTransportService.clearAllRules();
 
         ensureGreen();
-        searchResponse = client(redNodeName).prepareSearch(indexName).setPreference("_local").get();
-        assertHitCount(searchResponse, numDocs);
+        assertHitCount(client(redNodeName).prepareSearch(indexName).setPreference("_local"), numDocs);
     }
 
     public void checkDisconnectsDuringRecovery(boolean useSnapshotBasedRecoveries) throws Exception {
@@ -347,7 +342,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         }
         indexRandom(true, requests);
         ensureSearchable(indexName);
-        assertHitCount(client().prepareSearch(indexName).get(), numDocs);
+        assertHitCount(client().prepareSearch(indexName), numDocs);
 
         if (useSnapshotBasedRecoveries) {
             createSnapshotThatCanBeUsedDuringRecovery(indexName);
@@ -462,7 +457,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         }
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch(indexName).get(), numDocs);
+            assertHitCount(client().prepareSearch(indexName), numDocs);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -295,7 +295,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
             docCounts[i] = iterations(10, 1000);
             logger.info("-->  create random index {} with {} records", indexNames[i], docCounts[i]);
             addRandomDocuments(indexNames[i], docCounts[i]);
-            assertHitCount(client().prepareSearch(indexNames[i]).setSize(0).get(), docCounts[i]);
+            assertHitCount(client().prepareSearch(indexNames[i]).setSize(0), docCounts[i]);
         }
 
         final String snapshotName = randomName();
@@ -348,7 +348,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
         ensureGreen(TimeValue.timeValueSeconds(120));
 
         for (int i = 0; i < indexCount; i++) {
-            assertHitCount(client().prepareSearch(indexNames[i]).setSize(0).get(), docCounts[i]);
+            assertHitCount(client().prepareSearch(indexNames[i]).setSize(0), docCounts[i]);
         }
 
         logger.info("-->  delete snapshot {}:{}", repoName, snapshotName);
@@ -415,7 +415,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
             );
 
             ensureGreen();
-            assertHitCount(client().prepareSearch(indexName).setSize(0).get(), docCounts[iterationToRestore]);
+            assertHitCount(client().prepareSearch(indexName).setSize(0), docCounts[iterationToRestore]);
         }
 
         for (int i = 0; i < iterationCount; i++) {

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESFsBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESFsBasedRepositoryIntegTestCase.java
@@ -46,7 +46,7 @@ public abstract class ESFsBasedRepositoryIntegTestCase extends ESBlobStoreReposi
         int docCount = iterations(10, 1000);
         logger.info("-->  create random index {} with {} records", indexName, docCount);
         addRandomDocuments(indexName, docCount);
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), docCount);
+        assertHitCount(client().prepareSearch(indexName).setSize(0), docCount);
 
         final String snapshotName = randomName();
         logger.info("-->  create snapshot {}:{}", repoName, snapshotName);

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -166,7 +166,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
         flushAndRefresh(index);
         ForceMergeResponse forceMerge = client().admin().indices().prepareForceMerge(index).setFlush(true).setMaxNumSegments(1).get();
         assertThat(forceMerge.getSuccessfulShards(), equalTo(1));
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
 
         final String snapshot = "snapshot";
         assertSuccessfulSnapshot(clusterAdmin().prepareCreateSnapshot(repository, snapshot).setWaitForCompletion(true).setIndices(index));
@@ -175,7 +175,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
 
         assertSuccessfulRestore(clusterAdmin().prepareRestoreSnapshot(repository, snapshot).setWaitForCompletion(true));
         ensureGreen(index);
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
 
         assertAcked(clusterAdmin().prepareDeleteSnapshot(repository, snapshot).get());
     }
@@ -193,7 +193,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
         flushAndRefresh(index);
         ForceMergeResponse forceMerge = client().admin().indices().prepareForceMerge(index).setFlush(true).setMaxNumSegments(1).get();
         assertThat(forceMerge.getSuccessfulShards(), equalTo(1));
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
 
         final String snapshot = "snapshot";
         assertSuccessfulSnapshot(clusterAdmin().prepareCreateSnapshot(repository, snapshot).setWaitForCompletion(true).setIndices(index));
@@ -202,7 +202,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
 
         assertSuccessfulRestore(clusterAdmin().prepareRestoreSnapshot(repository, snapshot).setWaitForCompletion(true));
         ensureGreen(index);
-        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true).get(), nbDocs);
+        assertHitCount(client().prepareSearch(index).setSize(0).setTrackTotalHits(true), nbDocs);
 
         assertAcked(clusterAdmin().prepareDeleteSnapshot(repository, snapshot).get());
 

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
@@ -312,11 +312,10 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         assertFirstHit(result, hasId("1"));
 
         // Point in polygon hole
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(4.5, 4.5)))
-            .get();
-        assertHitCount(result, 0);
+        assertHitCount(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(4.5, 4.5))),
+            0
+        );
 
         // by definition the border of a polygon belongs to the inner
         // so the border of a polygons hole also belongs to the inner
@@ -339,11 +338,10 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         assertFirstHit(result, hasId("1"));
 
         // Point not in polygon
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().disjointQuery("area", new Point(3, 3)))
-            .get();
-        assertHitCount(result, 0);
+        assertHitCount(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().disjointQuery("area", new Point(3, 3))),
+            0
+        );
 
         // Point in polygon hole
         result = client().prepareSearch()
@@ -374,8 +372,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         // Polygon WithIn Polygon
         Polygon WithIn = new Polygon(new LinearRing(new double[] { -30, -30, 30, 30, -30 }, new double[] { -30, 30, 30, -30, -30 }));
 
-        result = client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().withinQuery("area", WithIn)).get();
-        assertHitCount(result, 2);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().withinQuery("area", WithIn)), 2);
 
         // Create a polygon crossing longitude 180.
         Polygon crossing = new Polygon(new LinearRing(new double[] { 170, 190, 190, 170, 170 }, new double[] { -10, -10, 10, 10, -10 }));
@@ -394,31 +391,27 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         client().prepareIndex("shapes").setId("1").setSource(data, XContentType.JSON).get();
         client().admin().indices().prepareRefresh().get();
 
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(174, -4)))
-            .get();
-        assertHitCount(result, 1);
+        assertHitCount(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(174, -4))),
+            1
+        );
 
         // In geo coordinates the polygon wraps the dateline, so we need to search within valid longitude ranges
         double xWrapped = getFieldTypeName().contains("geo") ? -174 : 186;
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(xWrapped, -4)))
-            .get();
-        assertHitCount(result, 1);
-
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(180, -4)))
-            .get();
-        assertHitCount(result, 0);
-
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(180, -6)))
-            .get();
-        assertHitCount(result, 1);
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(matchAllQuery())
+                .setPostFilter(queryBuilder().intersectionQuery("area", new Point(xWrapped, -4))),
+            1
+        );
+        assertHitCount(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(180, -4))),
+            0
+        );
+        assertHitCount(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(180, -6))),
+            1
+        );
     }
 
     public void testBulk() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
@@ -72,12 +72,10 @@ public abstract class GeoShapeIntegTestCase extends BaseShapeIntegTestCase<GeoSh
 
     /** The testBulk method uses this only for Geo-specific tests */
     protected void doDistanceAndBoundingBoxTest(String key) {
-        SearchResponse world = client().prepareSearch()
-            .addStoredField("pin")
-            .setQuery(geoBoundingBoxQuery("pin").setCorners(90, -179.99999, -90, 179.99999))
-            .get();
-
-        assertHitCount(world, 53);
+        assertHitCount(
+            client().prepareSearch().addStoredField("pin").setQuery(geoBoundingBoxQuery("pin").setCorners(90, -179.99999, -90, 179.99999)),
+            53
+        );
 
         SearchResponse distance = client().prepareSearch()
             .addStoredField("pin")

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -253,6 +253,15 @@ public class ElasticsearchAssertions {
         );
     }
 
+    public static void assertHitCount(SearchRequestBuilder searchRequestBuilder, long expectedHitCount) {
+        var res = searchRequestBuilder.get();
+        try {
+            assertHitCount(res, expectedHitCount);
+        } finally {
+            res.decRef();
+        }
+    }
+
     public static void assertHitCount(SearchResponse countResponse, long expectedHitCount) {
         final TotalHits totalHits = countResponse.getHits().getTotalHits();
         if (totalHits.relation != TotalHits.Relation.EQUAL_TO || totalHits.value != expectedHitCount) {

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -598,7 +598,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
             );
         }
 
-        assertHitCount(followerClient().prepareSearch(followerIndex).setSize(0).get(), numDocs);
+        assertHitCount(followerClient().prepareSearch(followerIndex).setSize(0), numDocs);
         assertAcked(followerClient().admin().indices().prepareDelete(followerIndex).setMasterNodeTimeout(TimeValue.MAX_VALUE));
     }
 

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotIT.java
@@ -348,7 +348,7 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
         }
         indexRandom(true, builders);
         flushAndRefresh();
-        assertHitCount(client().prepareSearch(sourceIdx).setQuery(QueryBuilders.idsQuery().addIds("0")).get(), 1);
+        assertHitCount(client().prepareSearch(sourceIdx).setQuery(QueryBuilders.idsQuery().addIds("0")), 1);
 
         createSnapshot(repo, snapshot, Collections.singletonList(sourceIdx));
 

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1039,7 +1039,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         }
         int docsIndexed = docCount - duplicates;
         logger.info("Indexed [{}] documents. Dropped [{}] duplicates.", docsIndexed, duplicates);
-        assertHitCount(client().prepareSearch(indexName).setSize(0).get(), docsIndexed);
+        assertHitCount(client().prepareSearch(indexName).setSize(0), docsIndexed);
     }
 
     private void prepareSourceIndex(final String sourceIndex, boolean blockWrite) {

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
@@ -111,8 +111,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         assertHitCount(
             client().prepareSearch()
                 .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED)
-                .setSearchType(useDFS ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH)
-                .get(),
+                .setSearchType(useDFS ? SearchType.DFS_QUERY_THEN_FETCH : SearchType.QUERY_THEN_FETCH),
             3
         );
         assertThat(engine, Matchers.instanceOf(FrozenEngine.class));
@@ -293,7 +292,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
         assertEquals(IndexMetadata.State.CLOSE, stateResponse.getState().getMetadata().index("idx-closed").getState());
         assertEquals(IndexMetadata.State.OPEN, stateResponse.getState().getMetadata().index("idx").getState());
-        assertHitCount(client().prepareSearch().get(), 1L);
+        assertHitCount(client().prepareSearch(), 1L);
     }
 
     public void testFreezePattern() {
@@ -307,7 +306,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
 
         IndicesStatsResponse index = indicesAdmin().prepareStats(indexName).clear().setRefresh(true).get();
         assertEquals(0, index.getTotal().refresh.getTotal());
-        assertHitCount(client().prepareSearch(indexName).setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED).get(), 1);
+        assertHitCount(client().prepareSearch(indexName).setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED), 1);
         index = indicesAdmin().prepareStats(indexName).clear().setRefresh(true).get();
         assertEquals(1, index.getTotal().refresh.getTotal());
 

--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -109,7 +109,7 @@ public class GraphTests extends ESSingleNodeTestCase {
             }
         }
 
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), numDocs);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()), numDocs);
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -478,7 +478,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         assertThat(restore.getRestoreInfo().failedShards(), equalTo(0));
         ensureGreen(restoredIndexName);
 
-        assertHitCount(client().prepareSearch(restoredIndexName).setSize(0).get(), nbDocs);
+        assertHitCount(client().prepareSearch(restoredIndexName).setSize(0), nbDocs);
 
         final Index restoredIndex = resolveIndex(restoredIndexName);
         for (String node : internalCluster().getNodeNames()) {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
@@ -87,7 +87,7 @@ public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearch
 
         ensureGreen(restoredIndexName);
 
-        assertHitCount(client().prepareSearch(restoredIndexName).setTrackTotalHits(true).get(), totalHits.value);
+        assertHitCount(client().prepareSearch(restoredIndexName).setTrackTotalHits(true), totalHits.value);
 
         mockAppender.assertAllExpectationsMatched();
         Loggers.removeAppender(logger, mockAppender);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
@@ -68,7 +68,7 @@ public class SearchableSnapshotsRepositoryIntegTests extends BaseFrozenSearchabl
             Storage storage = randomFrom(Storage.values());
             String restoredIndexName = (storage == Storage.FULL_COPY ? "fully-mounted-" : "partially-mounted-") + indexName + '-' + i;
             mountSnapshot(repositoryName, snapshotName, indexName, restoredIndexName, Settings.EMPTY, storage);
-            assertHitCount(client().prepareSearch(restoredIndexName).setTrackTotalHits(true).get(), totalHits.value);
+            assertHitCount(client().prepareSearch(restoredIndexName).setTrackTotalHits(true), totalHits.value);
             mountedIndices[i] = restoredIndexName;
         }
 
@@ -182,7 +182,7 @@ public class SearchableSnapshotsRepositoryIntegTests extends BaseFrozenSearchabl
                 ? equalTo(Boolean.toString(deleteSnapshot))
                 : nullValue()
         );
-        assertHitCount(client().prepareSearch(mounted).setTrackTotalHits(true).get(), totalHits.value);
+        assertHitCount(client().prepareSearch(mounted).setTrackTotalHits(true), totalHits.value);
 
         final String mountedAgain = randomValueOtherThan(mounted, () -> randomAlphaOfLength(10).toLowerCase(Locale.ROOT));
         final SnapshotRestoreException exception = expectThrows(
@@ -207,7 +207,7 @@ public class SearchableSnapshotsRepositoryIntegTests extends BaseFrozenSearchabl
                 ? equalTo(Boolean.toString(deleteSnapshot))
                 : nullValue()
         );
-        assertHitCount(client().prepareSearch(mountedAgain).setTrackTotalHits(true).get(), totalHits.value);
+        assertHitCount(client().prepareSearch(mountedAgain).setTrackTotalHits(true), totalHits.value);
 
         assertAcked(indicesAdmin().prepareDelete(mountedAgain));
         assertAcked(indicesAdmin().prepareDelete(mounted));
@@ -237,7 +237,7 @@ public class SearchableSnapshotsRepositoryIntegTests extends BaseFrozenSearchabl
                 ? equalTo(Boolean.toString(deleteSnapshot))
                 : nullValue()
         );
-        assertHitCount(client().prepareSearch(mounted).setTrackTotalHits(true).get(), totalHits.value);
+        assertHitCount(client().prepareSearch(mounted).setTrackTotalHits(true), totalHits.value);
 
         if (randomBoolean()) {
             assertAcked(indicesAdmin().prepareClose(mounted));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -225,7 +225,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
         final long numberOfCacheWrites = indexingStats != null ? indexingStats.getTotal().getIndexCount() : 0L;
 
         logger.info("--> verifying number of documents in index [{}]", restoredIndex);
-        assertHitCount(client().prepareSearch(restoredIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
+        assertHitCount(client().prepareSearch(restoredIndex).setSize(0).setTrackTotalHits(true), numberOfDocs);
 
         for (IndicesService indicesService : internalCluster().getDataNodeInstances(IndicesService.class)) {
             for (IndexService indexService : indicesService) {
@@ -266,12 +266,12 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
         checkNoBlobStoreAccess();
 
         logger.info("--> verifying number of documents in index [{}]", restoredAgainIndex);
-        assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
+        assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true), numberOfDocs);
 
         logger.info("--> verifying that no extra cached blobs were indexed [{}]", SNAPSHOT_BLOB_CACHE_INDEX);
         refreshSystemIndex();
         assertHitCount(
-            systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0).get(),
+            systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0),
             numberOfCachedBlobs
         );
         indexingStats = systemClient().admin()
@@ -307,7 +307,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
 
         logger.info("--> verifying that no cached blobs were indexed in system index [{}] after restart", SNAPSHOT_BLOB_CACHE_INDEX);
         assertHitCount(
-            systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0).get(),
+            systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0),
             numberOfCachedBlobs
         );
         indexingStats = systemClient().admin()
@@ -322,7 +322,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
         assertThat(indexingStats != null ? indexingStats.getTotal().getIndexCount() : 0L, equalTo(0L));
 
         logger.info("--> verifying number of documents in index [{}]", restoredAgainIndex);
-        assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
+        assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true), numberOfDocs);
 
         logger.info("--> deleting indices, maintenance service should clean up [{}] docs in system index", numberOfCachedBlobs);
         assertAcked(indicesAdmin().prepareDelete("restored-*"));
@@ -330,10 +330,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
         assertBusy(() -> {
             refreshSystemIndex();
             assertHitCount(
-                systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX)
-                    .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
-                    .setSize(0)
-                    .get(),
+                systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN).setSize(0),
                 0L
             );
         }, 30L, TimeUnit.SECONDS);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
@@ -114,8 +114,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
                                 SNAPSHOT_INDEX_ID_SETTING.get(indexSettings)
                             )
                         )
-                        .setSize(0)
-                        .get(),
+                        .setSize(0),
                     indicesToDelete.contains(mountedIndex) ? 0L : mountedIndices.get(mountedIndex).v2()
                 );
             }
@@ -197,7 +196,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
         assertAcked(indicesAdmin().prepareDelete("mounted-*"));
         assertBusy(() -> {
             refreshSystemIndex(true);
-            assertHitCount(systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setSize(0).get(), 0L);
+            assertHitCount(systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setSize(0), 0L);
         });
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
@@ -230,7 +230,7 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
                     assertThat(restoreSnapshotResponse.status(), is(RestStatus.OK));
                     assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards(), equalTo(shardsPerIndex.get(indexName)));
                     assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
-                    assertHitCount(client().prepareSearch(indexName).setSize(0).setTrackTotalHits(true).get(), docsPerIndex.get(indexName));
+                    assertHitCount(client().prepareSearch(indexName).setSize(0).setTrackTotalHits(true), docsPerIndex.get(indexName));
 
                     final GetSettingsResponse getSettingsResponse = indicesAdmin().prepareGetSettings(indexName).get();
                     assertThat(getSettingsResponse.getSetting(indexName, SNAPSHOT_CACHE_ENABLED_SETTING.getKey()), equalTo("true"));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
@@ -189,11 +189,12 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
         assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
         assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value2"));
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(QueryBuilders.termQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(QueryBuilders.termQuery("field1", "value1")),
+            0
+        );
     }
 
     public void testQueryCache() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -681,11 +681,13 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         ).prepareSearch("search_index").setQuery(lookup).get();
         assertHitCount(response, 3);
         assertSearchHits(response, "1", "2", "3");
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(lookup)
-            .get();
-        assertHitCount(response, 0);
+
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(lookup),
+            0
+        );
 
         response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
             .prepareSearch("search_index")
@@ -695,11 +697,13 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         assertSearchHits(response, "1", "2", "3", "4", "5");
         // Lookup doc#2 is: hidden from user1, visible to user2 and user3
         lookup = QueryBuilders.termsLookupQuery("search_field", new TermsLookup("lookup_index", "2", "lookup_field"));
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(lookup)
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(lookup)
+                .get(),
+            0
+        );
 
         response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
             .prepareSearch("search_index")
@@ -1031,29 +1035,33 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         assertThat(searchResponse.getHits().getAt(2).getId(), equalTo("c3"));
 
         // Both user1 and user2 can't see field1 and field2, no parent/child query should yield results:
-        searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(hasChildQuery("child", matchAllQuery(), ScoreMode.None))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(hasChildQuery("child", matchAllQuery(), ScoreMode.None)),
+            0L
+        );
 
-        searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(hasChildQuery("child", matchAllQuery(), ScoreMode.None))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(hasChildQuery("child", matchAllQuery(), ScoreMode.None)),
+            0L
+        );
 
-        searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(hasParentQuery("parent", matchAllQuery(), false))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(hasParentQuery("parent", matchAllQuery(), false)),
+            0L
+        );
 
-        searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(hasParentQuery("parent", matchAllQuery(), false))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(hasParentQuery("parent", matchAllQuery(), false)),
+            0L
+        );
 
         // user 3 can see them but not c3
         searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityFeatureUsageTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityFeatureUsageTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.integration;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
@@ -77,12 +76,13 @@ public class FieldLevelSecurityFeatureUsageTests extends AbstractDocumentAndFiel
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field1", "value2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
-        SearchResponse response = internalCluster().coordOnlyNodeClient()
-            .filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(QueryBuilders.termQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            internalCluster().coordOnlyNodeClient()
+                .filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(QueryBuilders.termQuery("field1", "value1")),
+            1
+        );
 
         // coordinating only node should not tack DLS/FLS feature usage
         assertDlsFlsNotTrackedOnCoordOnlyNode();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
@@ -161,17 +161,21 @@ public class FieldLevelSecurityRandomTests extends SecurityIntegTestCase {
 
         for (String allowedField : allowedFields) {
             logger.info("Checking allowed field [{}]", allowedField);
-            SearchResponse response = client().filterWithHeader(
-                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-            ).prepareSearch("test").setQuery(matchQuery(allowedField, "value")).get();
-            assertHitCount(response, 1);
+            assertHitCount(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                    .prepareSearch("test")
+                    .setQuery(matchQuery(allowedField, "value")),
+                1
+            );
         }
         for (String disallowedField : disAllowedFields) {
             logger.info("Checking disallowed field [{}]", disallowedField);
-            SearchResponse response = client().filterWithHeader(
-                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-            ).prepareSearch("test").setQuery(matchQuery(disallowedField, "value")).get();
-            assertHitCount(response, 0);
+            assertHitCount(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                    .prepareSearch("test")
+                    .setQuery(matchQuery(disallowedField, "value")),
+                0
+            );
         }
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -237,145 +237,169 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             .get();
 
         // user1 has access to field1, so the query should match with the document:
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        ).prepareSearch("test").setQuery(matchQuery("field1", "value1")).get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            1
+        );
         // user2 has no access to field1, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            0
+        );
         // user3 has access to field1 and field2, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            1
+        );
         // user4 has access to no fields, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            0
+        );
         // user5 has no field level security configured, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            1
+        );
         // user7 has roles with field level security configured and without field level security
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user7", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user7", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            1
+        );
         // user8 has roles with field level security configured for field1 and field2
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field1", "value1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field1", "value1")),
+            1
+        );
 
         // user1 has no access to field2, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            0
+        );
         // user2 has access to field1, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            1
+        );
         // user3 has access to field1 and field2, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            1
+        );
         // user4 has access to no fields, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            0
+        );
         // user5 has no field level security configured, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            1
+        );
         // user7 has role with field level security and without field level security
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            1
+        );
         // user8 has roles with field level security configured for field1 and field2
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field2", "value2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field2", "value2")),
+            1
+        );
 
         // user1 has access to field3, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            0
+        );
         // user2 has no access to field3, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            0
+        );
         // user3 has access to field1 and field2 but not field3, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            0
+        );
         // user4 has access to no fields, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            0
+        );
         // user5 has no field level security configured, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            1
+        );
         // user7 has roles with field level security and without field level security
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            1
+        );
         // user8 has roles with field level security configured for field1 and field2
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("field3", "value3"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("field3", "value3")),
+            0
+        );
 
         // user1 has access to field1, so a query on its field alias should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("alias", "value1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("alias", "value1")),
+            1
+        );
         // user2 has no access to field1, so a query on its field alias should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(matchQuery("alias", "value1"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(matchQuery("alias", "value1")),
+            0
+        );
     }
 
     public void testKnnSearch() throws IOException {
@@ -410,12 +434,13 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         assertNotNull(response.getHits().getAt(0).field("vector"));
 
         // user2 has no access to vector field, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(query)
-            .addFetchField("vector")
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(query)
+                .addFetchField("vector"),
+            0
+        );
 
         // check user2 cannot see the vector field, even when their search matches the document
         response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
@@ -429,21 +454,23 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         KnnVectorQueryBuilder filterQuery1 = new KnnVectorQueryBuilder("vector", queryVector, 10, null).addFilterQuery(
             QueryBuilders.matchQuery("field1", "value1")
         );
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(filterQuery1)
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(filterQuery1),
+            1
+        );
 
         // user1 cannot access field2, so the filtered query should not match with the document:
         KnnVectorQueryBuilder filterQuery2 = new KnnVectorQueryBuilder("vector", queryVector, 10, null).addFilterQuery(
             QueryBuilders.matchQuery("field2", "value2")
         );
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(filterQuery2)
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(filterQuery2),
+            0
+        );
     }
 
     public void testPercolateQueryWithIndexedDocWithFLS() {
@@ -621,17 +648,19 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         assertHitCount(response, 1);
         assertSearchHits(response, "1");
         // user does not see the terms doc field
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(QueryBuilders.termsLookupQuery("field", new TermsLookup("lookup_index", "2", "other")))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(QueryBuilders.termsLookupQuery("field", new TermsLookup("lookup_index", "2", "other"))),
+            0
+        );
         // user does not see the queried field
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(QueryBuilders.termsLookupQuery("other", new TermsLookup("lookup_index", "1", "field")))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(QueryBuilders.termsLookupQuery("other", new TermsLookup("lookup_index", "1", "field"))),
+            0
+        );
     }
 
     public void testGetApi() throws Exception {
@@ -1878,11 +1907,12 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("p1"));
 
-        searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(hasChildQuery("child", termQuery("field1", "yellow"), ScoreMode.None))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(hasChildQuery("child", termQuery("field1", "yellow"), ScoreMode.None)),
+            0L
+        );
 
         // Perform the same checks, but using an alias for field1.
         searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
@@ -1893,11 +1923,12 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("p1"));
 
-        searchResponse = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(hasChildQuery("child", termQuery("alias", "yellow"), ScoreMode.None))
-            .get();
-        assertHitCount(searchResponse, 0L);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(hasChildQuery("child", termQuery("alias", "yellow"), ScoreMode.None)),
+            0L
+        );
     }
 
     public void testUpdateApiIsBlocked() throws Exception {
@@ -1978,65 +2009,76 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             .get();
 
         // user1 has access to field1, so the query should match with the document:
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        ).prepareSearch("test").setQuery(existsQuery("field1")).get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field1")),
+            1
+        );
         // user1 has no access to field2, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field2"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field2")),
+            0
+        );
         // user2 has no access to field1, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field1"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field1")),
+            0
+        );
         // user2 has access to field2, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field2")),
+            1
+        );
         // user3 has access to field1 and field2, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field1"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field1")),
+            1
+        );
         // user3 has access to field1 and field2, so the query should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field2"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field2")),
+            1
+        );
         // user4 has access to no fields, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field1"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field1")),
+            0
+        );
         // user4 has access to no fields, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("field2"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("field2")),
+            0
+        );
 
         // user1 has access to field1, so a query on its alias should match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("alias"))
-            .get();
-        assertHitCount(response, 1);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("alias")),
+            1
+        );
         // user2 has no access to field1, so the query should not match with the document:
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(existsQuery("alias"))
-            .get();
-        assertHitCount(response, 0);
+        assertHitCount(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(existsQuery("alias")),
+            0
+        );
     }
 
     public void testLookupRuntimeFields() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ShrinkIndexWithSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ShrinkIndexWithSecurityTests.java
@@ -56,7 +56,7 @@ public class ShrinkIndexWithSecurityTests extends SecurityIntegTestCase {
         // verify all docs
         ensureGreen();
         assertHitCount(
-            client().prepareSearch("shrunk_bigindex").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(),
+            client().prepareSearch("shrunk_bigindex").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")),
             randomNumberOfDocs
         );
     }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -220,7 +220,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
      * Test that ignore_malformed on GeoShapeFieldMapper does not fail the entire document
      */
     public void testIgnoreMalformed() {
-        assertHitCount(client().prepareSearch(IGNORE_MALFORMED_INDEX).setQuery(matchAllQuery()).get(), numDocs);
+        assertHitCount(client().prepareSearch(IGNORE_MALFORMED_INDEX).setQuery(matchAllQuery()), numDocs);
     }
 
     /**

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/SpatialQueryStringIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/SpatialQueryStringIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.spatial.search;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentType;
@@ -64,17 +63,13 @@ public class SpatialQueryStringIT extends ESIntegTestCase {
         );
         // nothing matches
         indexRandom(true, false, reqs);
-        SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("foo")).get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("foo")), 0L);
 
-        resp = client().prepareSearch("test").setQuery(queryStringQuery("\"2015/09/02\"")).get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("\"2015/09/02\"")), 0L);
 
-        resp = client().prepareSearch("test").setQuery(queryStringQuery("127.0.0.1 OR 1.8")).get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("127.0.0.1 OR 1.8")), 0L);
 
-        resp = client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)")).get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)")), 0L);
 
         Exception e = expectThrows(
             Exception.class,
@@ -94,7 +89,6 @@ public class SpatialQueryStringIT extends ESIntegTestCase {
         );
         assertThat(e.getCause().getMessage(), containsString("Field [point] of type [point] does not support match queries"));
 
-        resp = client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)").field("*shape")).get();
-        assertHitCount(resp, 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)").field("*shape")), 0L);
     }
 }

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateHttpMappingsTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateHttpMappingsTests.java
@@ -166,10 +166,10 @@ public class HistoryTemplateHttpMappingsTests extends AbstractWatcherIntegration
         assertBusy(() -> {
             // ensure watcher history index has been written with this id
             flushAndRefresh(HistoryStoreField.INDEX_PREFIX + "*");
-            SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.INDEX_PREFIX + "*")
-                .setQuery(QueryBuilders.termQuery("watch_id", id))
-                .get();
-            assertHitCount(searchResponse, 1L);
+            assertHitCount(
+                client().prepareSearch(HistoryStoreField.INDEX_PREFIX + "*").setQuery(QueryBuilders.termQuery("watch_id", id)),
+                1L
+            );
         });
 
         // ensure that enabled is set to false

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
@@ -134,7 +134,7 @@ public class BasicWatcherTests extends AbstractWatcherIntegrationTestCase {
         assertThat(deleteWatchResponse.isFound(), is(true));
 
         refresh();
-        assertHitCount(client().prepareSearch(Watch.INDEX).setSize(0).get(), 0L);
+        assertHitCount(client().prepareSearch(Watch.INDEX).setSize(0), 0L);
 
         // Deleting the same watch for the second time
         deleteWatchResponse = new DeleteWatchRequestBuilder(client()).setId("_name").get();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
@@ -193,7 +193,7 @@ public class BootStrapTests extends AbstractWatcherIntegrationTestCase {
             );
         }
         bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
-        assertHitCount(client().prepareSearch(Watch.INDEX).setSize(0).get(), numWatches);
+        assertHitCount(client().prepareSearch(Watch.INDEX).setSize(0), numWatches);
 
         startWatcher();
 

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -73,8 +73,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         assertBusy(() -> {
             flushAndRefresh(".watcher-history-*");
-            SearchResponse searchResponse = client().prepareSearch(".watcher-history-*").get();
-            assertHitCount(searchResponse, 1);
+            assertHitCount(client().prepareSearch(".watcher-history-*"), 1);
         });
     }
 
@@ -107,8 +106,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         assertBusy(() -> {
             refresh(".watcher-history*");
-            SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
-            assertHitCount(searchResponse, 1);
+            assertHitCount(client().prepareSearch(".watcher-history*").setSize(0), 1);
         });
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
@@ -153,8 +151,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         assertBusy(() -> {
             refresh(".watcher-history*");
-            SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
-            assertHitCount(searchResponse, 1);
+            assertHitCount(client().prepareSearch(".watcher-history*").setSize(0), 1);
         });
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition


### PR DESCRIPTION
We'd like to make `SearchResponse` reference counted and pooled but there are around 6k instances of tests that create a `SearchResponse` local variable that would need to be released manually to avoid leaks in the tests.
This does away with about 10% of these spots by adding an override for `assertHitCount` that handles the actual execution of the search request and its release automatically and making use of it in all spots where the `.get()` on the request build could be inlined semi-automatically and in a straight-forward fashion without other code changes.
