### PR TITLE
[8.10] Fix synonyms documentation (#100916)

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -138,7 +138,7 @@ To apply synonyms, you will need to include a synonym graph token filter into an
         "my_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "filter": ["lowercase", "synonym_graph"]
+          "filter": ["stemmer", "synonym_graph"]
         }
       }
 ----
@@ -150,8 +150,8 @@ To apply synonyms, you will need to include a synonym graph token filter into an
 Order is important for your token filters.
 Text will be processed first through filters preceding the synonym filter before being processed by the synonym filter.
 
-In the above example, text will be lowercased by the `lowercase` filter before being processed by the `synonyms_filter`.
-This means that all the synonyms defined there needs to be in lowercase, or they won't be found by the synonyms filter.
+{es} will also use the token filters preceding the synonym filter in a tokenizer chain to parse the entries in a synonym file or synonym set.
+In the above example, the synonyms graph token filter is placed after a stemmer. The stemmer will also be applied to the synonym entries.
 
 The synonym rules should not contain words that are removed by a filter that appears later in the chain (like a `stop` filter).
 Removing a term from a synonym rule means there will be no matching for it at query time.

--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -128,7 +128,7 @@ To apply synonyms, you will need to include a synonym token filters into an anal
         "my_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "filter": ["lowercase", "synonym"]
+          "filter": ["stemmer", "synonym_graph"]
         }
       }
 ----
@@ -140,8 +140,8 @@ To apply synonyms, you will need to include a synonym token filters into an anal
 Order is important for your token filters.
 Text will be processed first through filters preceding the synonym filter before being processed by the synonym filter.
 
-In the above example, text will be lowercased by the `lowercase` filter before being processed by the `synonyms_filter`.
-This means that all the synonyms defined there needs to be in lowercase, or they won't be found by the synonyms filter.
+{es} will also use the token filters preceding the synonym filter in a tokenizer chain to parse the entries in a synonym file or synonym set.
+In the above example, the synonyms graph token filter is placed after a stemmer. The stemmer will also be applied to the synonym entries.
 
 The synonym rules should not contain words that are removed by a filter that appears later in the chain (like a `stop` filter).
 Removing a term from a synonym rule means there will be no matching for it at query time.


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Fix synonyms documentation (#100916)