### PR TITLE
Removed flaky test for unsupported metric type position

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -575,37 +575,6 @@ source include/exclude:
                         time_series_dimension: true
 
 ---
-Unsupported metric type position:
-  - skip:
-      version: "all, - 8.0.99, 8.8.0 -"
-      reason: AwaitsFix https://github.com/elastic/elasticsearch/issues/94239, index.mode and routing_path introduced in 8.1.0 and time series metric position introduced in 8.8.0
-
-  - do:
-      catch: '/unknown parameter \[time_series_metric\] on mapper \[location\] of type \[geo_point\]/'
-      indices.create:
-        index: test_position
-        body:
-          settings:
-            number_of_shards: 1
-            number_of_replicas: 0
-            index:
-              mode: time_series
-              routing_path: [metricset]
-              time_series:
-                start_time: 2021-04-28T00:00:00Z
-                end_time: 2021-04-29T00:00:00Z
-          mappings:
-            properties:
-              "@timestamp":
-                type: date
-              metricset:
-                type: keyword
-                time_series_dimension: true
-              location:
-                type: geo_point
-                time_series_metric: position
-
----
 Supported metric type position:
   - skip:
       version: " - 8.7.99"


### PR DESCRIPTION
This test failed about 1% of the time in mixed clusters. We never figured out why, but since it was a test that really only needed to be run a few times to verify that the correct error is raised in mixed clusters, it was seen as very low priority, and considered better to just delete it.

Fixes #94239