### PR TITLE
[DOCS] Update 8.10.4.asciidoc

### DIFF
--- a/docs/reference/release-notes/8.10.4.asciidoc
+++ b/docs/reference/release-notes/8.10.4.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.10.4]]
 == {es} version 8.10.4
 
-coming[8.10.4]
-
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
 [[bug-8.10.4]]


### PR DESCRIPTION
Removes a "coming" tag from the 8.10.4 release notes.
