### PR TITLE
[8.10] [DOCS] Remove the `coming[8.10.4]` from release notes (#100979)

### DIFF
--- a/docs/reference/release-notes/8.10.4.asciidoc
+++ b/docs/reference/release-notes/8.10.4.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.10.4]]
 == {es} version 8.10.4
 
-coming[8.10.4]
-
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
 [[bug-8.10.4]]


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOCS] Remove the `coming[8.10.4]` from release notes (#100979)