### PR TITLE
Synchronize Coordinator#onClusterStateApplied

### DIFF
--- a/docs/changelog/100986.yaml
+++ b/docs/changelog/100986.yaml
@@ -1,0 +1,6 @@
+pr: 100986
+summary: Synchronize Coordinator#onClusterStateApplied
+area: Cluster Coordination
+type: bug
+issues:
+ - 99023

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -414,13 +414,15 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
     private void onClusterStateApplied() {
         assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
-        if (getMode() != Mode.CANDIDATE) {
-            joinHelper.onClusterStateApplied();
-            closeElectionScheduler();
-            peerFinder.closePeers();
-        }
-        if (getLocalNode().isMasterNode()) {
-            joinReasonService.onClusterStateApplied(applierState.nodes());
+        synchronized (mutex) {
+            if (getMode() != Mode.CANDIDATE) {
+                joinHelper.onClusterStateApplied();
+                closeElectionScheduler();
+                peerFinder.closePeers();
+            }
+            if (getLocalNode().isMasterNode()) {
+                joinReasonService.onClusterStateApplied(applierState.nodes());
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -415,14 +415,14 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     private void onClusterStateApplied() {
         assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
         synchronized (mutex) {
-            if (getMode() != Mode.CANDIDATE) {
+            if (mode != Mode.CANDIDATE) {
                 joinHelper.onClusterStateApplied();
                 closeElectionScheduler();
                 peerFinder.closePeers();
             }
-            if (getLocalNode().isMasterNode()) {
-                joinReasonService.onClusterStateApplied(applierState.nodes());
-            }
+        }
+        if (getLocalNode().isMasterNode()) {
+            joinReasonService.onClusterStateApplied(applierState.nodes());
         }
     }
 


### PR DESCRIPTION
When a cluster state has been applied and right after the node becomes a candidate, there's a small race condition where the the thread scheduling can lead to closing the PeerFinder while the node is a Candidate.

Closes #99023

The issue can be reproduced in `CoordinatorTests` with this change:
```
diff --git a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
index cccc1b903ab..8cb21bfec54 100644
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -417,7 +417,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         if (getMode() != Mode.CANDIDATE) {
             joinHelper.onClusterStateApplied();
             closeElectionScheduler();
-            peerFinder.closePeers();
+            clusterCoordinationExecutor.execute(peerFinder::closePeers);
         }
         if (getLocalNode().isMasterNode()) {
             joinReasonService.onClusterStateApplied(applierState.nodes());
```
