### PR TITLE
Add getter to GetSettingsResponse

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -53,6 +53,14 @@ public class GetSettingsResponse extends ActionResponse implements ChunkedToXCon
     }
 
     /**
+     * Returns a map of index name to {@link Settings} object.  The returned {@link Settings}
+     * objects contain only the default settings
+     */
+    public Map<String, Settings> getIndexToDefaultSettings() {
+        return indexToDefaultSettings;
+    }
+
+    /**
      * Returns the string value for the specified index and setting.  If the includeDefaults
      * flag was not set or set to false on the GetSettingsRequest, this method will only
      * return a value where the setting was explicitly set on the index.  If the includeDefaults


### PR DESCRIPTION
This commit addes a getter on GetSettingsResponse
to allow the recreation of GetSettingsResponse during response filtering.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
