### PR TITLE
Use mapped action filter for api filtering

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
@@ -10,13 +10,13 @@ package org.elasticsearch.xpack.core.api.filtering;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.action.support.MappedActionFilter;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 
-public abstract class ApiFilteringActionFilter<Res extends ActionResponse> implements ActionFilter {
+public abstract class ApiFilteringActionFilter<Res extends ActionResponse> implements MappedActionFilter {
 
     private final ThreadContext threadContext;
     private final String actionName;
@@ -34,6 +34,11 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
     @Override
     public int order() {
         return 0;
+    }
+
+    @Override
+    public final String actionName() {
+        return actionName;
     }
 
     @Override


### PR DESCRIPTION
The MappedActionFilter was added to make filtering more efficient, but the api filtering action filter was not yet using it. This commit adjusts this shared action filter to implement MappedActionFilter.
