### PR TITLE
[8.11] [CI] Disable jenkins platform-support jobs, and re-enable all Buildkite periodic pipelines (#100630)

### DIFF
--- a/.buildkite/scripts/periodic.trigger.sh
+++ b/.buildkite/scripts/periodic.trigger.sh
@@ -12,6 +12,18 @@ for BRANCH in "${BRANCHES[@]}"; do
   LAST_GOOD_COMMIT=$(echo "${BUILD_JSON}" | jq -r '.commit')
 
   cat <<EOF
+  - trigger: elasticsearch-periodic
+    label: Trigger periodic pipeline for $BRANCH
+    async: true
+    build:
+      branch: "$BRANCH"
+      commit: "$LAST_GOOD_COMMIT"
+  - trigger: elasticsearch-periodic-packaging
+    label: Trigger periodic-packaging pipeline for $BRANCH
+    async: true
+    build:
+      branch: "$BRANCH"
+      commit: "$LAST_GOOD_COMMIT"
   - trigger: elasticsearch-periodic-platform-support
     label: Trigger periodic-platform-support pipeline for $BRANCH
     async: true
@@ -19,26 +31,4 @@ for BRANCH in "${BRANCHES[@]}"; do
       branch: "$BRANCH"
       commit: "$LAST_GOOD_COMMIT"
 EOF
-
-### Only platform-support enabled for right now
-#   cat <<EOF
-#   - trigger: elasticsearch-periodic
-#     label: Trigger periodic pipeline for $BRANCH
-#     async: true
-#     build:
-#       branch: "$BRANCH"
-#       commit: "$LAST_GOOD_COMMIT"
-#   - trigger: elasticsearch-periodic-packaging
-#     label: Trigger periodic-packaging pipeline for $BRANCH
-#     async: true
-#     build:
-#       branch: "$BRANCH"
-#       commit: "$LAST_GOOD_COMMIT"
-#   - trigger: elasticsearch-periodic-platform-support
-#     label: Trigger periodic-platform-support pipeline for $BRANCH
-#     async: true
-#     build:
-#       branch: "$BRANCH"
-#       commit: "$LAST_GOOD_COMMIT"
-# EOF
 done

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+multijob+platform-support-arm
     display-name: "elastic / elasticsearch # %BRANCH% - arm compatibility"
-    description: "Elasticsearch %BRANCH% ARM (aarch64) compatibility testing.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     child-workspace: "/dev/shm/elastic+elasticsearch+%BRANCH%+multijob+platform-support-arm"
     project-type: matrix
     node: master
@@ -20,14 +21,14 @@
           type: user-defined
           name: GRADLE_TASK
           values:
-            - 'checkPart1'
-            - 'checkPart2'
-            - 'checkPart3'
-            - 'bwcTestSnapshots'
-            - 'checkRestCompat'
+            - "checkPart1"
+            - "checkPart2"
+            - "checkPart3"
+            - "bwcTestSnapshots"
+            - "checkRestCompat"
     builders:
       - inject:
-          properties-file: '.ci/java-versions-aarch64.properties'
+          properties-file: ".ci/java-versions-aarch64.properties"
           properties-content: |
             COMPOSE_HTTP_TIMEOUT=120
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+multijob+platform-support-unix
     display-name: "elastic / elasticsearch # %BRANCH% - unix compatibility"
-    description: "Elasticsearch %BRANCH% unix compatibility testing.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     project-type: matrix
     node: master
     child-workspace: "/var/lib/jenkins/workspace/elastic+elasticsearch+%BRANCH%+multijob+platform-support-unix"
@@ -34,7 +35,7 @@
             - "almalinux-8&&immutable"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA11_HOME=$HOME/.java/java11

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-windows.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+multijob+platform-support-windows
     display-name: "elastic / elasticsearch # %BRANCH% - windows compatibility"
-    description: "Elasticsearch %BRANCH% Windows compatibility testing.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     project-type: matrix
     node: master
     # Use a hard-coded workspace directory to avoid hitting file path limits with auto-generated workspace path
@@ -25,14 +26,14 @@
           type: user-defined
           name: GRADLE_TASK
           values:
-            - 'checkPart1'
-            - 'checkPart2'
-            - 'checkPart3'
-            - 'bwcTestSnapshots'
-            - 'checkRestCompat'
+            - "checkPart1"
+            - "checkPart2"
+            - "checkPart3"
+            - "bwcTestSnapshots"
+            - "checkRestCompat"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+platform-support-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+platform-support-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+platform-support
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/12 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+platform-support.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+platform-support.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+periodic+platform-support
     display-name: "elastic / elasticsearch # %BRANCH% - platform support"
-    description: "Testing of the Elasticsearch %BRANCH% branch platform support tests.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     project-type: multijob
     node: master
     vault: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[CI] Disable jenkins platform-support jobs, and re-enable all Buildkite periodic pipelines (#100630)](https://github.com/elastic/elasticsearch/pull/100630)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)