### PR TITLE
Avoid release expanded block twice

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 
@@ -151,7 +152,9 @@ public class BlockMultiValuedTests extends ESTestCase {
     }
 
     private void assertExpanded(Block orig) {
-        try (orig; Block expanded = orig.expand()) {
+        Block expanded = null;
+        try (orig) {
+            expanded = orig.expand();
             assertThat(expanded.getPositionCount(), equalTo(orig.getTotalValueCount() + orig.nullValuesCount()));
             assertThat(expanded.getTotalValueCount(), equalTo(orig.getTotalValueCount()));
 
@@ -168,6 +171,10 @@ public class BlockMultiValuedTests extends ESTestCase {
                     assertThat(expanded.getValueCount(np), equalTo(1));
                     assertThat(BasicBlockTests.valuesAtPositions(expanded, np, ++np).get(0), equalTo(List.of(ov)));
                 }
+            }
+        } finally {
+            if (expanded != orig) {
+                Releasables.close(expanded);
             }
         }
     }


### PR DESCRIPTION
The expanded block can be referred to the original block if the expanding block doesn't have multiple values. In this case, we should avoid closing it twice.

Closes #101000