### PR TITLE
Add/fix known issue docs for 8.10.4

### DIFF
--- a/docs/reference/release-notes/8.10.0.asciidoc
+++ b/docs/reference/release-notes/8.10.0.asciidoc
@@ -28,9 +28,11 @@ first. If you cannot repair the repository in this way, first delete all the
 snapshots in the repository taken with version 8.9.0 or later. To do this will
 require using a cluster running version 8.10.0 or later.
 +
-If you wish to downgrade to a version in the 8.9 series, you must take or
-delete a snapshot using a cluster running version 8.11.0 or later to repair the
-repository format first.
+If you wish to downgrade to a version in the 8.9 series, you must take or delete
+a snapshot using a cluster running version 8.11.0 or later to repair the
+repository format first. If you cannot repair the repository in this way, first
+delete all the snapshots in the repository taken with version 8.10.0 or later
+using a cluster running version 8.10.4.
 // end::repositorydata-format-change[]
 
 [[breaking-8.10.0]]

--- a/docs/reference/release-notes/8.10.4.asciidoc
+++ b/docs/reference/release-notes/8.10.4.asciidoc
@@ -1,6 +1,30 @@
 [[release-notes-8.10.4]]
 == {es} version 8.10.4
 
+[[known-issues-8.10.4]]
+[float]
+=== Known issues
+
+* Snapshot-based downgrades
++
+The snapshot repository format changed in a manner that prevents earlier
+versions of Elasticsearch from reading the repository contents if it contains
+snapshots from this version and the last cluster to write to this repository was
+in the 8.10 series. This will prevent you from reverting an upgrade to the 8.10
+series by restoring a snapshot taken before the upgrade.
++
+Snapshot repositories written by clusters running versions 8.11.0 and later are
+compatible with all earlier versions. Moreover, clusters running version 8.11.0
+or later will also automatically repair the repository format the first time
+they write to the repository to take or delete a snapshot, making it so that all
+earlier versions can read its contents again.
++
+If you wish to downgrade to a version prior to 8.10.0, take or delete a snapshot
+using a cluster running version 8.11.0 or later to repair the repository format
+first. If you cannot repair the repository in this way, first delete all the
+snapshots in the repository taken with version 8.10.0 or later using a cluster
+running version 8.10.4.
+
 Also see <<breaking-changes-8.10,Breaking changes in 8.10>>.
 
 [[bug-8.10.4]]


### PR DESCRIPTION
8.10.4 includes a partial mitigation for the snapshots downgrades bug
introduced in 8.10.0. This commit adds known-issue docs for 8.10.4, and
adjusts the known-issue docs for earlier 8.10.x issues.