### PR TITLE
Metrics: Synchronous gauges respect attributes

### DIFF
--- a/docs/changelog/101018.yaml
+++ b/docs/changelog/101018.yaml
@@ -1,0 +1,5 @@
+pr: 101018
+summary: "Metrics: Synchronous gauges respect attributes"
+area: Infra/Core
+type: bug
+issues: []

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/AbstractGaugeAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/AbstractGaugeAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * AbstractGaugeAdapter records the latest measurement for the given {@link Attributes} for each
+ * time period.  This is a locking implementation.
+ * T is the Otel instrument
+ * N is the value of measurement
+ */
+public abstract class AbstractGaugeAdapter<T, N extends Number> extends AbstractInstrument<T> {
+
+    private ConcurrentHashMap<Attributes, N> records = new ConcurrentHashMap<>();
+    private final ReentrantReadWriteLock.ReadLock addRecordLock;
+    private final ReentrantReadWriteLock.WriteLock popRecordsLock;
+
+    public AbstractGaugeAdapter(Meter meter, String name, String description, String unit) {
+        super(meter, name, description, unit);
+        ReentrantReadWriteLock recordsLock = new ReentrantReadWriteLock();
+        addRecordLock = recordsLock.readLock();
+        popRecordsLock = recordsLock.writeLock();
+    }
+
+    protected ConcurrentHashMap<Attributes, N> popRecords() {
+        ConcurrentHashMap<Attributes, N> currentRecords;
+        ConcurrentHashMap<Attributes, N> newRecords = new ConcurrentHashMap<>();
+        try {
+            popRecordsLock.lock();
+            currentRecords = records;
+            records = newRecords;
+        } finally {
+            popRecordsLock.unlock();
+        }
+        return currentRecords;
+    }
+
+    protected void record(N value, Attributes attributes) {
+        try {
+            addRecordLock.lock();
+            records.put(attributes, value);
+        } finally {
+            addRecordLock.unlock();
+        }
+    }
+}

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/MeterRecorder.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/MeterRecorder.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.telemetry.metric.DoubleCounter;
+import org.elasticsearch.telemetry.metric.DoubleGauge;
+import org.elasticsearch.telemetry.metric.DoubleHistogram;
+import org.elasticsearch.telemetry.metric.DoubleUpDownCounter;
+import org.elasticsearch.telemetry.metric.Instrument;
+import org.elasticsearch.telemetry.metric.LongCounter;
+import org.elasticsearch.telemetry.metric.LongGauge;
+import org.elasticsearch.telemetry.metric.LongHistogram;
+import org.elasticsearch.telemetry.metric.LongUpDownCounter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class MeterRecorder {
+    enum INSTRUMENT {
+        COUNTER,
+        UP_DOWN_COUNTER,
+        HISTOGRAM,
+        GAUGE,
+        GAUGE_OBSERVER
+    }
+
+    private record Registration(String name, String description, String unit) {
+        Registration {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(description);
+            Objects.requireNonNull(unit);
+        }
+    };
+
+    private record RegisteredMetric(Map<String, Registration> registered, Map<String, List<TestMetric>> called) {
+        void register(String name, String description, String unit) {
+            assert registered.containsKey(name) == false
+                : Strings.format("unexpected [{}]: [{}][{}], already registered[{}]", name, description, unit, registered.get(name));
+            registered.put(name, new Registration(name, description, unit));
+        }
+
+        void call(String name, TestMetric call) {
+            assert registered.containsKey(name) : Strings.format("call for unregistered metric [{}]: [{}]", name, call);
+            called.computeIfAbsent(Objects.requireNonNull(name), k -> new ArrayList<>()).add(call);
+        }
+    }
+
+    private final Map<INSTRUMENT, RegisteredMetric> doubles;
+    private final Map<INSTRUMENT, RegisteredMetric> longs;
+
+    MeterRecorder() {
+        doubles = new HashMap<>(INSTRUMENT.values().length);
+        longs = new HashMap<>(INSTRUMENT.values().length);
+        for (var instrument : INSTRUMENT.values()) {
+            doubles.put(instrument, new RegisteredMetric(new HashMap<>(), new HashMap<>()));
+            longs.put(instrument, new RegisteredMetric(new HashMap<>(), new HashMap<>()));
+        }
+    }
+
+    public void clearCalls() {
+        doubles.forEach((inst, rm) -> rm.called.clear());
+        longs.forEach((inst, rm) -> rm.called.clear());
+    }
+
+    void registerDouble(INSTRUMENT instrument, String name, String description, String unit) {
+        doubles.get(Objects.requireNonNull(instrument)).register(name, description, unit);
+    }
+
+    void registerLong(INSTRUMENT instrument, String name, String description, String unit) {
+        longs.get(Objects.requireNonNull(instrument)).register(name, description, unit);
+    }
+
+    void call(INSTRUMENT instrument, String name, double value, Map<String, Object> attributes) {
+        doubles.get(Objects.requireNonNull(instrument)).call(name, new TestMetric(value, attributes));
+    }
+
+    void call(INSTRUMENT instrument, String name, long value, Map<String, Object> attributes) {
+        longs.get(Objects.requireNonNull(instrument)).call(name, new TestMetric(value, attributes));
+    }
+
+    List<TestMetric> getDouble(INSTRUMENT instrument, String name) {
+        return doubles.get(Objects.requireNonNull(instrument)).called.getOrDefault(Objects.requireNonNull(name), Collections.emptyList());
+    }
+
+    List<TestMetric> getLong(INSTRUMENT instrument, String name) {
+        return longs.get(Objects.requireNonNull(instrument)).called.getOrDefault(Objects.requireNonNull(name), Collections.emptyList());
+    }
+
+    List<TestMetric> get(Instrument instrument) {
+        Objects.requireNonNull(instrument);
+        if (instrument instanceof DoubleCounter) {
+            return getDouble(MeterRecorder.INSTRUMENT.COUNTER, instrument.getName());
+        } else if (instrument instanceof LongCounter) {
+            return getLong(MeterRecorder.INSTRUMENT.COUNTER, instrument.getName());
+        } else if (instrument instanceof DoubleUpDownCounter) {
+            return getDouble(MeterRecorder.INSTRUMENT.UP_DOWN_COUNTER, instrument.getName());
+        } else if (instrument instanceof LongUpDownCounter) {
+            return getLong(MeterRecorder.INSTRUMENT.UP_DOWN_COUNTER, instrument.getName());
+        } else if (instrument instanceof DoubleHistogram) {
+            return getDouble(MeterRecorder.INSTRUMENT.HISTOGRAM, instrument.getName());
+        } else if (instrument instanceof LongHistogram) {
+            return getLong(MeterRecorder.INSTRUMENT.HISTOGRAM, instrument.getName());
+        } else if (instrument instanceof DoubleGauge) {
+            return getDouble(MeterRecorder.INSTRUMENT.GAUGE_OBSERVER, instrument.getName());
+        } else if (instrument instanceof LongGauge) {
+            return getLong(MeterRecorder.INSTRUMENT.GAUGE_OBSERVER, instrument.getName());
+        } else {
+            throw new IllegalArgumentException("unknown instrument [" + instrument.getClass().getName() + "]");
+        }
+    }
+}

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/RecordingMeterProvider.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/RecordingMeterProvider.java
@@ -1,0 +1,645 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.LongGaugeBuilder;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableDoubleCounter;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableDoubleUpDownCounter;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+import io.opentelemetry.context.Context;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+
+public class RecordingMeterProvider implements Meter {
+
+    Queue<DoubleGaugeRecorder> doubleCallbacks = new ConcurrentLinkedQueue<>();
+    Queue<LongGaugeRecorder> longCallbacks = new ConcurrentLinkedQueue<>();
+
+    public void collectMetrics() {
+        doubleCallbacks.forEach(DoubleGaugeRecorder::doCall);
+        longCallbacks.forEach(LongGaugeRecorder::doCall);
+    }
+
+    public void clearCalls() {
+        recorder.clearCalls();
+    }
+
+    public MeterRecorder getRecorder() {
+        return recorder;
+    }
+
+    private MeterRecorder recorder = new MeterRecorder();
+
+    @Override
+    public LongCounterBuilder counterBuilder(String name) {
+        return new RecordingLongCounterBuilder(name);
+    }
+
+    @Override
+    public LongUpDownCounterBuilder upDownCounterBuilder(String name) {
+        return new RecordingLongUpDownBuilder(name);
+    }
+
+    @Override
+    public DoubleHistogramBuilder histogramBuilder(String name) {
+        return new RecordingDoubleHistogramBuilder(name);
+    }
+
+    @Override
+    public DoubleGaugeBuilder gaugeBuilder(String name) {
+        return new RecordingDoubleGaugeBuilder(name);
+    }
+
+    // Counter
+    private class RecordingLongCounterBuilder extends AbstractBuilder implements LongCounterBuilder {
+        RecordingLongCounterBuilder(String name) {
+            super(name);
+        }
+
+        @Override
+        public LongCounterBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public LongCounterBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public DoubleCounterBuilder ofDoubles() {
+            return new RecordingDoubleCounterBuilder(this);
+        }
+
+        @Override
+        public LongCounter build() {
+            LongRecorder counter = new LongRecorder(name);
+            recorder.registerLong(counter.getInstrument(), name, description, unit);
+            return counter;
+        }
+
+        @Override
+        public ObservableLongCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            unimplemented();
+            return null;
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            unimplemented();
+            return null;
+        }
+    }
+
+    private class LongRecorder extends LongUpDownRecorder implements LongCounter {
+        LongRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.COUNTER);
+        }
+
+        @Override
+        public void add(long value) {
+            assert value >= 0;
+            super.add(value);
+        }
+
+        @Override
+        public void add(long value, Attributes attributes) {
+            assert value >= 0;
+            super.add(value, attributes);
+        }
+
+        @Override
+        public void add(long value, Attributes attributes, Context context) {
+            assert value >= 0;
+            super.add(value, attributes, context);
+        }
+    }
+
+    private class RecordingDoubleCounterBuilder extends AbstractBuilder implements DoubleCounterBuilder {
+
+        RecordingDoubleCounterBuilder(AbstractBuilder other) {
+            super(other);
+        }
+
+        @Override
+        public DoubleCounterBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public DoubleCounterBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public DoubleCounter build() {
+            DoubleRecorder counter = new DoubleRecorder(name);
+            recorder.registerDouble(counter.getInstrument(), name, description, unit);
+            return counter;
+        }
+
+        @Override
+        public ObservableDoubleCounter buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            unimplemented();
+            return null;
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            unimplemented();
+            return null;
+        }
+    }
+
+    private class DoubleRecorder extends DoubleUpDownRecorder implements DoubleCounter {
+        DoubleRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.COUNTER);
+        }
+
+        @Override
+        public void add(double value) {
+            assert value >= 0;
+            super.add(value);
+        }
+
+        @Override
+        public void add(double value, Attributes attributes) {
+            assert value >= 0;
+            super.add(value, attributes);
+        }
+
+        @Override
+        public void add(double value, Attributes attributes, Context context) {
+            assert value >= 0;
+            super.add(value, attributes, context);
+        }
+    }
+
+    private class RecordingLongUpDownBuilder extends AbstractBuilder implements LongUpDownCounterBuilder {
+        RecordingLongUpDownBuilder(String name) {
+            super(name);
+        }
+
+        @Override
+        public LongUpDownCounterBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public LongUpDownCounterBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public DoubleUpDownCounterBuilder ofDoubles() {
+            return new RecordingDoubleUpDownBuilder(this);
+        }
+
+        @Override
+        public LongUpDownCounter build() {
+            LongUpDownRecorder counter = new LongUpDownRecorder(name);
+            recorder.registerLong(counter.getInstrument(), name, description, unit);
+            return counter;
+        }
+
+        @Override
+        public ObservableLongUpDownCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            unimplemented();
+            return null;
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            unimplemented();
+            return null;
+        }
+    }
+
+    private class LongUpDownRecorder extends AbstractInstrument implements LongUpDownCounter {
+        LongUpDownRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.UP_DOWN_COUNTER);
+        }
+
+        protected LongUpDownRecorder(String name, MeterRecorder.INSTRUMENT instrument) {
+            // used by LongRecorder
+            super(name, instrument);
+        }
+
+        @Override
+        public void add(long value) {
+            recorder.call(instrument, name, value, null);
+        }
+
+        @Override
+        public void add(long value, Attributes attributes) {
+            recorder.call(instrument, name, value, toMap(attributes));
+        }
+
+        @Override
+        public void add(long value, Attributes attributes, Context context) {
+            unimplemented();
+        }
+    }
+
+    private class RecordingDoubleUpDownBuilder extends AbstractBuilder implements DoubleUpDownCounterBuilder {
+
+        RecordingDoubleUpDownBuilder(AbstractBuilder other) {
+            super(other);
+        }
+
+        @Override
+        public DoubleUpDownCounterBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public DoubleUpDownCounterBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public DoubleUpDownCounter build() {
+            DoubleUpDownRecorder counter = new DoubleUpDownRecorder(name);
+            recorder.registerDouble(counter.getInstrument(), name, description, unit);
+            return counter;
+        }
+
+        @Override
+        public ObservableDoubleUpDownCounter buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            unimplemented();
+            return null;
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            unimplemented();
+            return null;
+        }
+    }
+
+    private class DoubleUpDownRecorder extends AbstractInstrument implements DoubleUpDownCounter {
+        DoubleUpDownRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.UP_DOWN_COUNTER);
+        }
+
+        protected DoubleUpDownRecorder(String name, MeterRecorder.INSTRUMENT instrument) {
+            // used by DoubleRecorder
+            super(name, instrument);
+        }
+
+        @Override
+        public void add(double value) {
+            recorder.call(instrument, name, value, null);
+        }
+
+        @Override
+        public void add(double value, Attributes attributes) {
+            recorder.call(instrument, name, value, toMap(attributes));
+        }
+
+        @Override
+        public void add(double value, Attributes attributes, Context context) {
+            unimplemented();
+        }
+    }
+
+    abstract static class AbstractInstrument {
+        protected final String name;
+        protected final MeterRecorder.INSTRUMENT instrument;
+
+        AbstractInstrument(String name, MeterRecorder.INSTRUMENT instrument) {
+            this.name = name;
+            this.instrument = instrument;
+        }
+
+        public MeterRecorder.INSTRUMENT getInstrument() {
+            return instrument;
+        }
+
+        protected void unimplemented() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        Map<String, Object> toMap(Attributes attributes) {
+            if (attributes == null) {
+                return null;
+            }
+            if (attributes.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            Map<String, Object> map = new HashMap<>(attributes.size());
+            attributes.forEach((k, v) -> map.put(k.getKey(), v));
+            return map;
+        }
+    }
+
+    // Gauges
+    private class RecordingDoubleGaugeBuilder extends AbstractBuilder implements DoubleGaugeBuilder {
+        RecordingDoubleGaugeBuilder(String name) {
+            super(name);
+        }
+
+        @Override
+        public DoubleGaugeBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public DoubleGaugeBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public LongGaugeBuilder ofLongs() {
+            return new RecordingLongGaugeBuilder(this);
+        }
+
+        @Override
+        public ObservableDoubleGauge buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
+            DoubleGaugeRecorder gauge = new DoubleGaugeRecorder(name, callback);
+            recorder.registerDouble(gauge.getInstrument(), name, description, unit);
+            doubleCallbacks.add(gauge);
+            return gauge;
+        }
+
+        @Override
+        public ObservableDoubleMeasurement buildObserver() {
+            DoubleMeasurementRecorder measurement = new DoubleMeasurementRecorder(name);
+            recorder.registerDouble(measurement.getInstrument(), name, description, unit);
+            return measurement;
+        }
+    }
+
+    private class DoubleGaugeRecorder extends AbstractInstrument implements ObservableDoubleGauge {
+        final Consumer<ObservableDoubleMeasurement> callback;
+
+        DoubleGaugeRecorder(String name, Consumer<ObservableDoubleMeasurement> callback) {
+            super(name, MeterRecorder.INSTRUMENT.GAUGE_OBSERVER);
+            this.callback = callback;
+        }
+
+        @Override
+        public void close() {
+            doubleCallbacks.remove(this);
+        }
+
+        void doCall() {
+            callback.accept(new DoubleMeasurementRecorder(name, instrument));
+        }
+    }
+
+    private class DoubleMeasurementRecorder extends AbstractInstrument implements ObservableDoubleMeasurement {
+        DoubleMeasurementRecorder(String name, MeterRecorder.INSTRUMENT instrument) {
+            super(name, instrument);
+        }
+
+        DoubleMeasurementRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.GAUGE);
+        }
+
+        @Override
+        public void record(double value) {
+            recorder.call(instrument, name, value, null);
+        }
+
+        @Override
+        public void record(double value, Attributes attributes) {
+            recorder.call(instrument, name, value, toMap(attributes));
+        }
+    }
+
+    private class RecordingLongGaugeBuilder extends AbstractBuilder implements LongGaugeBuilder {
+        RecordingLongGaugeBuilder(AbstractBuilder other) {
+            super(other);
+        }
+
+        @Override
+        public LongGaugeBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public LongGaugeBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public ObservableLongGauge buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
+            LongGaugeRecorder gauge = new LongGaugeRecorder(name, callback);
+            recorder.registerLong(gauge.getInstrument(), name, description, unit);
+            longCallbacks.add(gauge);
+            return gauge;
+        }
+
+        @Override
+        public ObservableLongMeasurement buildObserver() {
+            LongMeasurementRecorder measurement = new LongMeasurementRecorder(name);
+            recorder.registerLong(measurement.getInstrument(), name, description, unit);
+            return measurement;
+        }
+    }
+
+    private class LongGaugeRecorder extends AbstractInstrument implements ObservableLongGauge {
+        final Consumer<ObservableLongMeasurement> callback;
+
+        LongGaugeRecorder(String name, Consumer<ObservableLongMeasurement> callback) {
+            super(name, MeterRecorder.INSTRUMENT.GAUGE_OBSERVER);
+            this.callback = callback;
+        }
+
+        @Override
+        public void close() {
+            longCallbacks.remove(this);
+        }
+
+        void doCall() {
+            callback.accept(new LongMeasurementRecorder(name, instrument));
+        }
+    }
+
+    private class LongMeasurementRecorder extends AbstractInstrument implements ObservableLongMeasurement {
+        LongMeasurementRecorder(String name, MeterRecorder.INSTRUMENT instrument) {
+            super(name, instrument);
+        }
+
+        LongMeasurementRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.GAUGE);
+        }
+
+        @Override
+        public void record(long value) {
+            recorder.call(instrument, name, value, null);
+        }
+
+        @Override
+        public void record(long value, Attributes attributes) {
+            recorder.call(instrument, name, value, toMap(attributes));
+        }
+    }
+
+    // Histograms
+    private class RecordingDoubleHistogramBuilder extends AbstractBuilder implements DoubleHistogramBuilder {
+        RecordingDoubleHistogramBuilder(String name) {
+            super(name);
+        }
+
+        @Override
+        public DoubleHistogramBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public DoubleHistogramBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public LongHistogramBuilder ofLongs() {
+            return new RecordingLongHistogramBuilder(this);
+        }
+
+        @Override
+        public DoubleHistogram build() {
+            return new DoubleHistogramRecorder(name);
+        }
+    }
+
+    private class DoubleHistogramRecorder extends AbstractInstrument implements DoubleHistogram {
+        DoubleHistogramRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.HISTOGRAM);
+        }
+
+        @Override
+        public void record(double value) {
+            recorder.call(getInstrument(), name, value, null);
+        }
+
+        @Override
+        public void record(double value, Attributes attributes) {
+            recorder.call(getInstrument(), name, value, toMap(attributes));
+        }
+
+        @Override
+        public void record(double value, Attributes attributes, Context context) {
+            unimplemented();
+        }
+    }
+
+    private class RecordingLongHistogramBuilder extends AbstractBuilder implements LongHistogramBuilder {
+
+        RecordingLongHistogramBuilder(AbstractBuilder other) {
+            super(other);
+        }
+
+        @Override
+        public LongHistogramBuilder setDescription(String description) {
+            innerSetDescription(description);
+            return this;
+        }
+
+        @Override
+        public LongHistogramBuilder setUnit(String unit) {
+            innerSetUnit(unit);
+            return this;
+        }
+
+        @Override
+        public LongHistogram build() {
+            return new LongHistogramRecorder(name);
+        }
+    }
+
+    private class LongHistogramRecorder extends AbstractInstrument implements LongHistogram {
+        LongHistogramRecorder(String name) {
+            super(name, MeterRecorder.INSTRUMENT.HISTOGRAM);
+        }
+
+        @Override
+        public void record(long value) {
+            recorder.call(getInstrument(), name, value, null);
+        }
+
+        @Override
+        public void record(long value, Attributes attributes) {
+            recorder.call(getInstrument(), name, value, toMap(attributes));
+        }
+
+        @Override
+        public void record(long value, Attributes attributes, Context context) {
+            unimplemented();
+        }
+    }
+
+    abstract static class AbstractBuilder {
+        protected final String name;
+        protected String description;
+        protected String unit;
+
+        AbstractBuilder(String name) {
+            this.name = name;
+        }
+
+        AbstractBuilder(AbstractBuilder other) {
+            this.name = other.name;
+            this.description = other.description;
+            this.unit = other.unit;
+        }
+
+        void innerSetDescription(String description) {
+            this.description = description;
+        }
+
+        void innerSetUnit(String unit) {
+            this.unit = unit;
+        }
+
+        protected void unimplemented() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+    }
+}

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/TestMetric.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/TestMetric.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record TestMetric(Number number, Map<String, Object> attributes) {
+    public TestMetric {
+        Objects.requireNonNull(number);
+    }
+}


### PR DESCRIPTION
Synchronous gauges would only accept the most recent value, regardless of matching attributes.  As attributes should be treated as dimensions, we keep the most recent value with matching attributes.

