### PR TITLE
Fix build randomization to account for null strings

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/BuildUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BuildUtils.java
@@ -100,6 +100,7 @@ public class BuildUtils {
     }
 
     private static String randomStringExcept(final String s) {
-        return randomAlphaOfLength(13 - s.length());
+        int len = s == null ? 0 : s.length();
+        return randomAlphaOfLength(13 - len);
     }
 }


### PR DESCRIPTION
Since adding qualifier as a nullable string, the build utils which mutates Build objects for tests may experience an NPE. This commit handles null for string values.

closes #100994