### PR TITLE
More consistent logging messages for snapshot deletion

### DIFF
--- a/docs/changelog/101024.yaml
+++ b/docs/changelog/101024.yaml
@@ -1,0 +1,5 @@
+pr: 101024
+summary: More consistent logging messages for snapshot deletion
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 
 public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
 
-    public void testDeletingSnapshotsIsLoggedAfterClusterStateIsProcessed() throws InterruptedException {
+    public void testDeletingSnapshotsIsLoggedAfterClusterStateIsProcessed() throws Exception {
         createRepository("test-repo", "fs");
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
@@ -68,6 +68,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             assertThat(e.getMessage(), containsString("[test-repo:does-not-exist] is missing"));
             assertThat(startDeleteSnapshot("test-repo", "test-snapshot").actionGet().isAcknowledged(), is(true));
 
+            awaitNoMoreRunningOperations(); // ensure background file deletion is completed
             mockLogAppender.assertAllExpectationsMatched();
         } finally {
             Loggers.removeAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.snapshots.mockstore.MockRepository;
+import org.elasticsearch.test.MockLogAppender;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
+
+    public void testDeletingSnapshotsIsLoggedAfterClusterStateIsProcessed() throws InterruptedException {
+        createRepository("test-repo", "fs");
+        createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
+        createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
+
+        final MockLogAppender mockLogAppender = new MockLogAppender();
+
+        try {
+            mockLogAppender.start();
+            Loggers.addAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
+
+            mockLogAppender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "[does-not-exist]",
+                    SnapshotsService.class.getName(),
+                    Level.INFO,
+                    "deleting snapshots [does-not-exist] from repository [test-repo]"
+                )
+            );
+
+            mockLogAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "[test-snapshot]",
+                    SnapshotsService.class.getName(),
+                    Level.INFO,
+                    "deleting snapshots [test-snapshot] from repository [test-repo]"
+                )
+            );
+
+            final SnapshotMissingException e = expectThrows(
+                SnapshotMissingException.class,
+                () -> startDeleteSnapshot("test-repo", "does-not-exist").actionGet()
+            );
+            assertThat(e.getMessage(), containsString("[test-repo:does-not-exist] is missing"));
+            assertThat(startDeleteSnapshot("test-repo", "test-snapshot").actionGet().isAcknowledged(), is(true));
+
+            mockLogAppender.assertAllExpectationsMatched();
+        } finally {
+            Loggers.removeAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
+            mockLogAppender.stop();
+            deleteRepository("test-repo");
+        }
+    }
+
+    public void testSnapshotDeletionFailureShouldBeLogged() throws InterruptedException {
+        createRepository("test-repo", "mock");
+        createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
+        createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
+
+        final MockLogAppender mockLogAppender = new MockLogAppender();
+
+        try {
+            mockLogAppender.start();
+            Loggers.addAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
+
+            mockLogAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "[test-snapshot]",
+                    SnapshotsService.class.getName(),
+                    Level.WARN,
+                    "failed to complete snapshot deletion for [test-snapshot] from repository [test-repo]"
+                )
+            );
+
+            final MockRepository mockRepository = getRepositoryOnMaster("test-repo");
+            mockRepository.setRandomControlIOExceptionRate(1.0);
+            final Exception e = expectThrows(Exception.class, () -> startDeleteSnapshot("test-repo", "test-snapshot").actionGet());
+            assertThat(e.getCause().getMessage(), containsString("Random IOException"));
+
+            mockLogAppender.assertAllExpectationsMatched();
+        } finally {
+            Loggers.removeAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
+            mockLogAppender.stop();
+            deleteRepository("test-repo");
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -206,33 +206,6 @@ public class GatewayServiceTests extends ESTestCase {
         assertThat(clusterService.state().nodes().getDataNodes().size(), equalTo(newDataNodeCount));
     }
 
-    public void test() {
-        final Settings.Builder settingsBuilder = Settings.builder();
-        final ClusterState initialState = buildClusterState(1, 0);
-        final ClusterService clusterService = createClusterService(settingsBuilder, initialState);
-        assertClusterStateBlocks(clusterService, true);
-
-        clusterService.submitUnbatchedStateUpdateTask("set", new ClusterStateUpdateTask() {
-
-            @Override
-            public ClusterState execute(ClusterState currentState) throws Exception {
-                logger.info("execute");
-                return currentState;
-            }
-
-            @Override
-            public void clusterStateProcessed(ClusterState initialState, ClusterState newState) {
-                logger.info("clusterStateProcessed");
-            }
-
-            @Override
-            public void onFailure(Exception e) {}
-        });
-
-        deterministicTaskQueue.runAllTasksInTimeOrder();
-
-    }
-
     public void testImmediateRecovery() {
         final Settings.Builder settingsBuilder = Settings.builder();
         final int expectedNumberOfDataNodes = randomIntBetween(1, 3);

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -206,6 +206,33 @@ public class GatewayServiceTests extends ESTestCase {
         assertThat(clusterService.state().nodes().getDataNodes().size(), equalTo(newDataNodeCount));
     }
 
+    public void test() {
+        final Settings.Builder settingsBuilder = Settings.builder();
+        final ClusterState initialState = buildClusterState(1, 0);
+        final ClusterService clusterService = createClusterService(settingsBuilder, initialState);
+        assertClusterStateBlocks(clusterService, true);
+
+        clusterService.submitUnbatchedStateUpdateTask("set", new ClusterStateUpdateTask() {
+
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                logger.info("execute");
+                return currentState;
+            }
+
+            @Override
+            public void clusterStateProcessed(ClusterState initialState, ClusterState newState) {
+                logger.info("clusterStateProcessed");
+            }
+
+            @Override
+            public void onFailure(Exception e) {}
+        });
+
+        deterministicTaskQueue.runAllTasksInTimeOrder();
+
+    }
+
     public void testImmediateRecovery() {
         final Settings.Builder settingsBuilder = Settings.builder();
         final int expectedNumberOfDataNodes = randomIntBetween(1, 3);


### PR DESCRIPTION
This PR makes sure that the start message ("deleting snapshots ...") is logged after the cluster state is processed and any failures before finishing updating the new repositoryData are always logged at warning level.

Resolves: #99057
Resolves: #100481
