### PR TITLE
[8.11] `WaitForSnapshotStep` verifies if the index belongs to the latest snapshot of that SLM policy (#100911)

### DIFF
--- a/docs/changelog/100911.yaml
+++ b/docs/changelog/100911.yaml
@@ -1,0 +1,6 @@
+pr: 100911
+summary: '`WaitForSnapshotStep` verifies if the index belongs to the latest snapshot
+  of that SLM policy'
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotAction.java
@@ -62,7 +62,7 @@ public class WaitForSnapshotAction implements LifecycleAction {
     @Override
     public List<Step> toSteps(Client client, String phase, StepKey nextStepKey) {
         StepKey waitForSnapshotKey = new StepKey(phase, NAME, WaitForSnapshotStep.NAME);
-        return Collections.singletonList(new WaitForSnapshotStep(waitForSnapshotKey, nextStepKey, policy));
+        return Collections.singletonList(new WaitForSnapshotStep(waitForSnapshotKey, nextStepKey, client, policy));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStep.java
@@ -8,10 +8,15 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicyMetadata;
 
@@ -20,11 +25,12 @@ import java.util.Locale;
 import java.util.Objects;
 
 /***
- * A step that waits for snapshot to be taken by SLM to ensure we have backup before we delete the index.
- * It will signal error if it can't get data needed to do the check (action time from ILM and SLM metadata)
- * and will only return success if execution of SLM policy took place after index entered the wait for snapshot action.
+ * A step that waits for snapshot to be taken by SLM that includes the index in question to ensure we have backup
+ * before we delete the index. It will signal error if it can't get data needed to do the check (action time from ILM
+ * and SLM metadata) and will only return success if execution of SLM policy took place after index entered the wait
+ * for snapshot action and the latest successful snapshot includes the index.
  */
-public class WaitForSnapshotStep extends ClusterStateWaitStep {
+public class WaitForSnapshotStep extends AsyncWaitStep {
 
     static final String NAME = "wait-for-snapshot";
     private static final Logger logger = LogManager.getLogger(WaitForSnapshotStep.class);
@@ -32,32 +38,40 @@ public class WaitForSnapshotStep extends ClusterStateWaitStep {
     private static final String MESSAGE_FIELD = "message";
     private static final String POLICY_NOT_EXECUTED_MESSAGE = "waiting for policy '%s' to be executed since %s";
     private static final String POLICY_NOT_FOUND_MESSAGE = "configured policy '%s' not found";
+    private static final String INDEX_NOT_INCLUDED_IN_SNAPSHOT_MESSAGE =
+        "the last successful snapshot of policy '%s' does not include index '%s'";
+
+    private static final String UNEXPECTED_SNAPSHOT_STATE_MESSAGE =
+        "unexpected number of snapshots retrieved for repository '%s' and snapshot '%s' (expected 1, found %d)";
     private static final String NO_INDEX_METADATA_MESSAGE = "no index metadata found for index '%s'";
     private static final String NO_ACTION_TIME_MESSAGE = "no information about ILM action start in index metadata for index '%s'";
 
     private final String policy;
 
-    WaitForSnapshotStep(StepKey key, StepKey nextStepKey, String policy) {
-        super(key, nextStepKey);
+    WaitForSnapshotStep(StepKey key, StepKey nextStepKey, Client client, String policy) {
+        super(key, nextStepKey, client);
         this.policy = policy;
     }
 
     @Override
-    public Result isConditionMet(Index index, ClusterState clusterState) {
-        IndexMetadata indexMetadata = clusterState.metadata().index(index);
+    public void evaluateCondition(Metadata metadata, Index index, Listener listener, TimeValue masterTimeout) {
+        IndexMetadata indexMetadata = metadata.index(index);
         if (indexMetadata == null) {
-            throw error(NO_INDEX_METADATA_MESSAGE, index.getName());
+            listener.onFailure(error(NO_INDEX_METADATA_MESSAGE, index.getName()));
+            return;
         }
 
         Long actionTime = indexMetadata.getLifecycleExecutionState().actionTime();
 
         if (actionTime == null) {
-            throw error(NO_ACTION_TIME_MESSAGE, index.getName());
+            listener.onFailure(error(NO_ACTION_TIME_MESSAGE, index.getName()));
+            return;
         }
 
-        SnapshotLifecycleMetadata snapMeta = clusterState.metadata().custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleMetadata snapMeta = metadata.custom(SnapshotLifecycleMetadata.TYPE);
         if (snapMeta == null || snapMeta.getSnapshotConfigurations().containsKey(policy) == false) {
-            throw error(POLICY_NOT_FOUND_MESSAGE, policy);
+            listener.onFailure(error(POLICY_NOT_FOUND_MESSAGE, policy));
+            return;
         }
         SnapshotLifecyclePolicyMetadata snapPolicyMeta = snapMeta.getSnapshotConfigurations().get(policy);
         if (snapPolicyMeta.getLastSuccess() == null
@@ -79,7 +93,8 @@ public class WaitForSnapshotStep extends ClusterStateWaitStep {
                     snapPolicyMeta.getLastSuccess().getSnapshotFinishTimestamp()
                 );
             }
-            return new Result(false, notExecutedMessage(actionTime));
+            listener.onResponse(false, notExecutedMessage(actionTime));
+            return;
         }
         logger.debug(
             "executing policy because snapshot start time {} is after action time {}, snapshot timestamp is {}",
@@ -87,7 +102,24 @@ public class WaitForSnapshotStep extends ClusterStateWaitStep {
             actionTime,
             snapPolicyMeta.getLastSuccess().getSnapshotFinishTimestamp()
         );
-        return new Result(true, null);
+        String snapshotName = snapPolicyMeta.getLastSuccess().getSnapshotName();
+        String repositoryName = snapPolicyMeta.getPolicy().getRepository();
+        GetSnapshotsRequest request = new GetSnapshotsRequest().repositories(repositoryName)
+            .snapshots(new String[] { snapshotName })
+            .includeIndexNames(true)
+            .verbose(false);
+        getClient().admin().cluster().getSnapshots(request, ActionListener.wrap(response -> {
+            if (response.getSnapshots().size() != 1) {
+                listener.onFailure(error(UNEXPECTED_SNAPSHOT_STATE_MESSAGE, repositoryName, snapshotName, response.getSnapshots().size()));
+            } else {
+                if (response.getSnapshots().get(0).indices().contains(index.getName())) {
+                    listener.onResponse(true, EmptyInfo.INSTANCE);
+                } else {
+                    listener.onFailure(error(INDEX_NOT_INCLUDED_IN_SNAPSHOT_MESSAGE, policy, index.getName()));
+                }
+            }
+        }, listener::onFailure));
+
     }
 
     public String getPolicy() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -6,6 +6,11 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.client.internal.ClusterAdminClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -13,19 +18,41 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
 import org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicyMetadata;
+import org.junit.Before;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 
 public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapshotStep> {
 
+    private final ClusterAdminClient clusterAdminClient = mock(ClusterAdminClient.class);
+
+    @Before
+    public void setupClusterClient() {
+        Mockito.when(adminClient.cluster()).thenReturn(clusterAdminClient);
+    }
+
     @Override
     protected WaitForSnapshotStep createRandomInstance() {
-        return new WaitForSnapshotStep(randomStepKey(), randomStepKey(), randomAlphaOfLengthBetween(1, 10));
+        return new WaitForSnapshotStep(randomStepKey(), randomStepKey(), client, randomAlphaOfLengthBetween(1, 10));
     }
 
     @Override
@@ -41,12 +68,12 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 
-        return new WaitForSnapshotStep(key, nextKey, policy);
+        return new WaitForSnapshotStep(key, nextKey, client, policy);
     }
 
     @Override
     protected WaitForSnapshotStep copyInstance(WaitForSnapshotStep instance) {
-        return new WaitForSnapshotStep(instance.getKey(), instance.getNextStepKey(), instance.getPolicy());
+        return new WaitForSnapshotStep(instance.getKey(), instance.getNextStepKey(), client, instance.getPolicy());
     }
 
     public void testNoSlmPolicies() {
@@ -60,14 +87,24 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         Metadata.Builder meta = Metadata.builder().indices(indices);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
         WaitForSnapshotStep instance = createRandomInstance();
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> instance.isConditionMet(indexMetadata.getIndex(), clusterState)
-        );
-        assertTrue(e.getMessage().contains(instance.getPolicy()));
+        SetOnce<Exception> error = new SetOnce<>();
+        instance.evaluateCondition(clusterState.metadata(), indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
+                logger.warn("expected an error got unexpected response {}", conditionMet);
+                throw new AssertionError("unexpected method call");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(error.get().getMessage(), containsString("'" + instance.getPolicy() + "' not found"));
     }
 
-    public void testSlmPolicyNotExecuted() throws IOException {
+    public void testSlmPolicyNotExecuted() {
         WaitForSnapshotStep instance = createRandomInstance();
         SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
             .setModifiedDate(randomLong())
@@ -88,9 +125,23 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
         Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
-        ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
-        assertFalse(result.isComplete());
-        assertTrue(getMessage(result).contains("to be executed"));
+        SetOnce<Boolean> isConditionMet = new SetOnce<>();
+        SetOnce<ToXContentObject> informationContext = new SetOnce<>();
+        instance.evaluateCondition(clusterState.metadata(), indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
+                isConditionMet.set(conditionMet);
+                informationContext.set(info);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.warn("unexpected onFailure call", e);
+                throw new AssertionError("unexpected method call");
+            }
+        }, MASTER_TIMEOUT);
+        assertThat(isConditionMet.get(), is(false));
+        assertTrue(toString(informationContext.get()).contains("to be executed"));
     }
 
     public void testSlmPolicyExecutedBeforeStep() throws IOException {
@@ -98,9 +149,36 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         assertSlmPolicyExecuted(false, false);
     }
 
-    public void testSlmPolicyExecutedAfterStep() throws IOException {
+    public void testSlmPolicyExecutedAfterStep() {
+        String repoName = randomAlphaOfLength(10);
+        String snapshotName = randomAlphaOfLength(10);
+        String indexName = randomAlphaOfLength(10);
         // The snapshot was started and finished after the phase time, so we do expect the step to finish:
-        assertSlmPolicyExecuted(true, true);
+        GetSnapshotsResponse response = new GetSnapshotsResponse(
+            List.of(
+                new SnapshotInfo(
+                    new Snapshot(randomAlphaOfLength(10), new SnapshotId(snapshotName, randomAlphaOfLength(10))),
+                    List.of(indexName),
+                    List.of(),
+                    List.of(),
+                    SnapshotState.SUCCESS
+                )
+            ),
+            Map.of(),
+            null,
+            0,
+            0
+        );
+        Mockito.doAnswer(invocationOnMock -> {
+            GetSnapshotsRequest request = (GetSnapshotsRequest) invocationOnMock.getArguments()[0];
+            assertGetSnapshotRequest(repoName, snapshotName, request);
+            @SuppressWarnings("unchecked")
+            ActionListener<GetSnapshotsResponse> listener = (ActionListener<GetSnapshotsResponse>) invocationOnMock.getArguments()[1];
+            listener.onResponse(response);
+            return null;
+        }).when(clusterAdminClient).getSnapshots(any(), any());
+
+        assertSlmPolicyExecuted(repoName, snapshotName, indexName, true, true);
     }
 
     public void testSlmPolicyNotExecutedWhenStartIsBeforePhaseTime() throws IOException {
@@ -108,16 +186,102 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         assertSlmPolicyExecuted(false, true);
     }
 
-    private void assertSlmPolicyExecuted(boolean startTimeAfterPhaseTime, boolean finishTimeAfterPhaseTime) throws IOException {
+    public void testIndexNotBackedUpYet() {
+        String repoName = randomAlphaOfLength(10);
+        String snapshotName = randomAlphaOfLength(10);
+        String indexName = randomAlphaOfLength(10);
+
+        // The latest snapshot does not contain the index we are interested in
+        GetSnapshotsResponse response = new GetSnapshotsResponse(
+            List.of(
+                new SnapshotInfo(
+                    new Snapshot(randomAlphaOfLength(10), new SnapshotId(snapshotName, randomAlphaOfLength(10))),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    SnapshotState.SUCCESS
+                )
+            ),
+            Map.of(),
+            null,
+            0,
+            0
+        );
+        Mockito.doAnswer(invocationOnMock -> {
+            GetSnapshotsRequest request = (GetSnapshotsRequest) invocationOnMock.getArguments()[0];
+            assertGetSnapshotRequest(repoName, snapshotName, request);
+            @SuppressWarnings("unchecked")
+            ActionListener<GetSnapshotsResponse> listener = (ActionListener<GetSnapshotsResponse>) invocationOnMock.getArguments()[1];
+            listener.onResponse(response);
+            return null;
+        }).when(clusterAdminClient).getSnapshots(any(), any());
+
+        long phaseTime = randomLongBetween(100, 100000);
+        long actionTime = phaseTime + randomLongBetween(100, 100000);
+        WaitForSnapshotStep instance = createRandomInstance();
+        SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
+            .setModifiedDate(randomLong())
+            .setPolicy(new SnapshotLifecyclePolicy("", "", "", repoName, null, null))
+            .setLastSuccess(new SnapshotInvocationRecord(snapshotName, actionTime + 10, actionTime + 100, ""))
+            .build();
+        SnapshotLifecycleMetadata smlMetadata = new SnapshotLifecycleMetadata(
+            Map.of(instance.getPolicy(), slmPolicy),
+            OperationMode.RUNNING,
+            null
+        );
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Map.of("action_time", Long.toString(actionTime)))
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5))
+            .build();
+        Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
+        SetOnce<Exception> error = new SetOnce<>();
+        instance.evaluateCondition(clusterState.metadata(), indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
+                logger.warn("expected an error got unexpected response {}", conditionMet);
+                throw new AssertionError("unexpected method call");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(error.get().getMessage(), containsString("does not include index '" + indexName + "'"));
+    }
+
+    private void assertSlmPolicyExecuted(boolean startTimeAfterPhaseTime, boolean finishTimeAfterPhaseTime) {
+        assertSlmPolicyExecuted(
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            startTimeAfterPhaseTime,
+            finishTimeAfterPhaseTime
+        );
+    }
+
+    private void assertSlmPolicyExecuted(
+        String repoName,
+        String snapshotName,
+        String indexName,
+        boolean startTimeAfterPhaseTime,
+        boolean finishTimeAfterPhaseTime
+    ) {
         long phaseTime = randomLong();
 
         WaitForSnapshotStep instance = createRandomInstance();
         SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
             .setModifiedDate(randomLong())
-            .setPolicy(new SnapshotLifecyclePolicy("", "", "", "", null, null))
+            .setPolicy(new SnapshotLifecyclePolicy("", "", "", repoName, null, null))
             .setLastSuccess(
                 new SnapshotInvocationRecord(
-                    "",
+                    snapshotName,
                     phaseTime + (startTimeAfterPhaseTime ? 10 : -100),
                     phaseTime + (finishTimeAfterPhaseTime ? 100 : -10),
                     ""
@@ -130,7 +294,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             null
         );
 
-        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
             .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Map.of("action_time", Long.toString(phaseTime)))
             .settings(settings(IndexVersion.current()))
             .numberOfShards(randomIntBetween(1, 5))
@@ -139,17 +303,40 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
         Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
-        ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
+        SetOnce<Boolean> isConditionMet = new SetOnce<>();
+        SetOnce<ToXContentObject> informationContext = new SetOnce<>();
+        instance.evaluateCondition(clusterState.metadata(), indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
+                isConditionMet.set(conditionMet);
+                informationContext.set(info);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.warn("unexpected onFailure call", e);
+                throw new AssertionError("unexpected method call");
+            }
+        }, MASTER_TIMEOUT);
         if (startTimeAfterPhaseTime) {
-            assertTrue(result.isComplete());
-            assertNull(result.getInfomationContext());
+            assertThat(isConditionMet.get(), is(true));
+            assertThat(informationContext.get(), is(EmptyInfo.INSTANCE));
         } else {
-            assertFalse(result.isComplete());
-            assertTrue(getMessage(result).contains("to be executed"));
+            assertThat(isConditionMet.get(), is(false));
+            assertThat(toString(informationContext.get()), containsString("to be executed"));
         }
     }
 
-    public void testNullStartTime() throws IOException {
+    private void assertGetSnapshotRequest(String repoName, String snapshotName, GetSnapshotsRequest request) {
+        assertThat(request.repositories().length, is(1));
+        assertThat(request.repositories()[0], equalTo(repoName));
+        assertThat(request.snapshots().length, is(1));
+        assertThat(request.snapshots()[0], equalTo(snapshotName));
+        assertThat(request.includeIndexNames(), is(true));
+        assertThat(request.verbose(), is(false));
+    }
+
+    public void testNullStartTime() {
         long phaseTime = randomLong();
 
         WaitForSnapshotStep instance = createRandomInstance();
@@ -173,14 +360,24 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
         Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> instance.isConditionMet(indexMetadata.getIndex(), clusterState)
-        );
-        assertTrue(e.getMessage().contains("no information about ILM action start"));
+        SetOnce<Exception> error = new SetOnce<>();
+        instance.evaluateCondition(clusterState.metadata(), indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+            @Override
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
+                logger.warn("expected an error got unexpected response {}", conditionMet);
+                throw new AssertionError("unexpected method call");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+            }
+        }, MASTER_TIMEOUT);
+
+        assertThat(error.get().getMessage(), containsString("no information about ILM action start"));
     }
 
-    private String getMessage(ClusterStateWaitStep.Result result) throws IOException {
-        return Strings.toString(result.getInfomationContext());
+    private String toString(ToXContentObject info) {
+        return Strings.toString(info);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - `WaitForSnapshotStep` verifies if the index belongs to the latest snapshot of that SLM policy (#100911)