### PR TITLE
Throw when wrapping rate agg in DeferableBucketAggregator

### DIFF
--- a/docs/changelog/101032.yaml
+++ b/docs/changelog/101032.yaml
@@ -1,0 +1,5 @@
+pr: 101032
+summary: Throw when wrapping rate agg in `DeferableBucketAggregator`
+area: TSDB
+type: bug
+issues: []

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/100_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/100_tsdb.yml
@@ -84,3 +84,60 @@ aggretate multi_terms:
   - match: { aggregations.m_terms.buckets.1.doc_count: 3 }
   - match: { aggregations.m_terms.buckets.2.key_as_string: "{k8s.pod.uid=947e4ced-1786-4e53-9e0c-5c447e959507, metricset=pod}|10.10.55.2" }
   - match: { aggregations.m_terms.buckets.2.doc_count: 1 }
+
+---
+"Auto date histogram on counter":
+  - do:
+      indices.create:
+        index: test2
+        body:
+          settings:
+            mode: time_series
+            routing_path: [dim]
+            time_series:
+              start_time: "2023-01-01T00:00:00.000Z"
+          mappings:
+            properties:
+              dim:
+                type: keyword
+                time_series_dimension: true
+              data:
+                type: integer
+                time_series_metric: counter
+              "@timestamp":
+                type: date
+
+  - do:
+      bulk:
+        index: test2
+        refresh: true
+        body:
+          - '{ "index": {} }'
+          - '{ "@timestamp":"2023-01-01T13:03:08.138Z","data":"10", "dim": "A"}'
+          - '{ "index": {}}'
+          - '{ "@timestamp":"2023-01-02T13:03:09.138Z","data":"20", "dim": "A"}'
+          - '{ "index": {}}'
+          - '{ "@timestamp":"2023-02-01T13:03:10.138Z","data":"30", "dim": "B"}'
+
+  - do:
+      catch: /Wrapping a time-series rate aggregation within a DeferableBucketAggregator is not supported/
+      search:
+        size: 0
+        index: test2
+        body:
+          aggs:
+            histo:
+              auto_date_histogram:
+                field: "@timestamp"
+                "buckets": 4
+              aggs:
+                ts_data_rate:
+                  time_series:
+                    keyed: false
+                  aggs:
+                    data_rate:
+                      rate:
+                        field: data
+                        unit: day
+
+


### PR DESCRIPTION
`TimeSeriesRateAggregator` requires processing docs in sorted order by `[_tsid, @timestamp]`. This is usually enforced when wrapping it with `TimeSeriesAggregator` that collects docs in this order. However, if  `TimeSeriesAggregator` is in turn wrapped with a subclass of `DeferableBucketAggregator`, the latter provides the doc ids to collect so in-order doc collection is bypassed. In this case, `TimeSeriesRateAggregator` can't process the docs properly and returns wrong results, e.g. "Infinity" or "NaN".

Until this case is properly supported, throw an exception to notify the user that this type of aggregation is not supported.

Related to #100945