### PR TITLE
[8.11] ESQL: Support date and time intervals as input params (#101001)

### DIFF
--- a/docs/changelog/101001.yaml
+++ b/docs/changelog/101001.yaml
@@ -1,0 +1,6 @@
+pr: 101001
+summary: "ESQL: Support date and time intervals as input params"
+area: ES|QL
+type: bug
+issues:
+ - 99570

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Alias;
@@ -48,15 +49,14 @@ import org.elasticsearch.xpack.ql.expression.predicate.regex.RegexMatch;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.type.DateUtils;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 
 import java.math.BigInteger;
 import java.time.Duration;
-import java.time.Period;
 import java.time.ZoneId;
+import java.time.temporal.TemporalAmount;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,18 +64,17 @@ import java.util.function.BiFunction;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.parseTemporalAmout;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.DATE_PERIOD;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.TIME_DURATION;
 import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
 import static org.elasticsearch.xpack.ql.parser.ParserUtils.typedParsing;
 import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
-import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToInt;
-import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToLong;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.asLongUnsigned;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAsNumber;
 import static org.elasticsearch.xpack.ql.util.StringUtils.WILDCARD;
 
-abstract class ExpressionBuilder extends IdentifierBuilder {
+public abstract class ExpressionBuilder extends IdentifierBuilder {
 
     private final Map<Token, TypedParamValue> params;
 
@@ -224,19 +223,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         String qualifier = ctx.UNQUOTED_IDENTIFIER().getText().toLowerCase(Locale.ROOT);
 
         try {
-            Object quantity = switch (qualifier) {
-                case "millisecond", "milliseconds" -> Duration.ofMillis(safeToLong(value));
-                case "second", "seconds" -> Duration.ofSeconds(safeToLong(value));
-                case "minute", "minutes" -> Duration.ofMinutes(safeToLong(value));
-                case "hour", "hours" -> Duration.ofHours(safeToLong(value));
-
-                case "day", "days" -> Period.ofDays(safeToInt(safeToLong(value)));
-                case "week", "weeks" -> Period.ofWeeks(safeToInt(safeToLong(value)));
-                case "month", "months" -> Period.ofMonths(safeToInt(safeToLong(value)));
-                case "year", "years" -> Period.ofYears(safeToInt(safeToLong(value)));
-
-                default -> throw new ParsingException(source, "Unexpected time interval qualifier: '{}'", qualifier);
-            };
+            TemporalAmount quantity = parseTemporalAmout(value, qualifier, source);
             return new Literal(source, quantity, quantity instanceof Duration ? TIME_DURATION : DATE_PERIOD);
         } catch (QlIllegalArgumentException | ArithmeticException e) {
             // the range varies by unit: Duration#ofMinutes(), #ofHours() will Math#multiplyExact() to reduce the unit to seconds;
@@ -440,7 +427,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         // otherwise we need to make sure that xcontent-serialized value is converted to the correct type
         try {
 
-            if (DataTypeConverter.canConvert(sourceType, dataType) == false) {
+            if (EsqlDataTypeConverter.canConvert(sourceType, dataType) == false) {
                 throw new ParsingException(
                     source,
                     "Cannot cast value [{}] of type [{}] to parameter type [{}]",
@@ -449,7 +436,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                     dataType
                 );
             }
-            return new Literal(source, DataTypeConverter.converterFor(sourceType, dataType).convert(param.value), dataType);
+            return new Literal(source, EsqlDataTypeConverter.converterFor(sourceType, dataType).convert(param.value), dataType);
         } catch (QlIllegalArgumentException ex) {
             throw new ParsingException(ex, source, "Unexpected actual parameter type [{}] for type [{}]", sourceType, param.type);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.type;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.Converter;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypeConverter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+import java.util.function.Function;
+
+import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToInt;
+import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToLong;
+import static org.elasticsearch.xpack.ql.type.DataTypes.NULL;
+import static org.elasticsearch.xpack.ql.type.DataTypes.isPrimitive;
+import static org.elasticsearch.xpack.ql.type.DataTypes.isString;
+
+public class EsqlDataTypeConverter {
+
+    /**
+     * Returns true if the from type can be converted to the to type, false - otherwise
+     */
+    public static boolean canConvert(DataType from, DataType to) {
+        // Special handling for nulls and if conversion is not requires
+        if (from == to || from == NULL) {
+            return true;
+        }
+        // only primitives are supported so far
+        return isPrimitive(from) && isPrimitive(to) && converterFor(from, to) != null;
+    }
+
+    public static Converter converterFor(DataType from, DataType to) {
+        Converter converter = DataTypeConverter.converterFor(from, to);
+        if (converter != null) {
+            return converter;
+        }
+        if (isString(from) && to == EsqlDataTypes.TIME_DURATION) {
+            return EsqlConverter.STRING_TO_TIME_DURATION;
+        }
+        if (isString(from) && to == EsqlDataTypes.DATE_PERIOD) {
+            return EsqlConverter.STRING_TO_DATE_PERIOD;
+        }
+        return null;
+    }
+
+    public static TemporalAmount parseTemporalAmount(Object val, DataType expectedType) {
+        String errorMessage = "Cannot parse [{}] to {}";
+        String str = String.valueOf(val);
+        if (str == null) {
+            return null;
+        }
+        StringBuilder value = new StringBuilder();
+        StringBuilder qualifier = new StringBuilder();
+        StringBuilder nextBuffer = value;
+        boolean lastWasSpace = false;
+        for (char c : str.trim().toCharArray()) {
+            if (c == ' ') {
+                if (lastWasSpace == false) {
+                    nextBuffer = nextBuffer == value ? qualifier : null;
+                }
+                lastWasSpace = true;
+                continue;
+            }
+            if (nextBuffer == null) {
+                throw new ParsingException(Source.EMPTY, errorMessage, val, expectedType);
+            }
+            nextBuffer.append(c);
+            lastWasSpace = false;
+        }
+
+        if ((value.isEmpty() || qualifier.isEmpty()) == false) {
+            try {
+                TemporalAmount result = parseTemporalAmout(Integer.parseInt(value.toString()), qualifier.toString(), Source.EMPTY);
+                if (EsqlDataTypes.DATE_PERIOD == expectedType && result instanceof Period
+                    || EsqlDataTypes.TIME_DURATION == expectedType && result instanceof Duration) {
+                    return result;
+                }
+                if (result instanceof Period && expectedType == EsqlDataTypes.TIME_DURATION) {
+                    errorMessage += ", did you mean " + EsqlDataTypes.DATE_PERIOD + "?";
+                }
+                if (result instanceof Duration && expectedType == EsqlDataTypes.DATE_PERIOD) {
+                    errorMessage += ", did you mean " + EsqlDataTypes.TIME_DURATION + "?";
+                }
+            } catch (NumberFormatException ex) {
+                // wrong pattern
+            }
+        }
+
+        throw new ParsingException(Source.EMPTY, errorMessage, val, expectedType);
+    }
+
+    /**
+     * Converts arbitrary object to the desired data type.
+     * <p>
+     * Throws QlIllegalArgumentException if such conversion is not possible
+     */
+    public static Object convert(Object value, DataType dataType) {
+        DataType detectedType = EsqlDataTypes.fromJava(value);
+        if (detectedType == dataType || value == null) {
+            return value;
+        }
+        Converter converter = converterFor(detectedType, dataType);
+
+        if (converter == null) {
+            throw new QlIllegalArgumentException(
+                "cannot convert from [{}], type [{}] to [{}]",
+                value,
+                detectedType.typeName(),
+                dataType.typeName()
+            );
+        }
+
+        return converter.convert(value);
+    }
+
+    public static DataType commonType(DataType left, DataType right) {
+        return DataTypeConverter.commonType(left, right);
+    }
+
+    public static TemporalAmount parseTemporalAmout(Number value, String qualifier, Source source) throws QlIllegalArgumentException,
+        ArithmeticException {
+        return switch (qualifier) {
+            case "millisecond", "milliseconds" -> Duration.ofMillis(safeToLong(value));
+            case "second", "seconds" -> Duration.ofSeconds(safeToLong(value));
+            case "minute", "minutes" -> Duration.ofMinutes(safeToLong(value));
+            case "hour", "hours" -> Duration.ofHours(safeToLong(value));
+
+            case "day", "days" -> Period.ofDays(safeToInt(safeToLong(value)));
+            case "week", "weeks" -> Period.ofWeeks(safeToInt(safeToLong(value)));
+            case "month", "months" -> Period.ofMonths(safeToInt(safeToLong(value)));
+            case "year", "years" -> Period.ofYears(safeToInt(safeToLong(value)));
+
+            default -> throw new ParsingException(source, "Unexpected time interval qualifier: '{}'", qualifier);
+        };
+    }
+
+    public enum EsqlConverter implements Converter {
+
+        STRING_TO_DATE_PERIOD(x -> EsqlDataTypeConverter.parseTemporalAmount(x, EsqlDataTypes.DATE_PERIOD)),
+        STRING_TO_TIME_DURATION(x -> EsqlDataTypeConverter.parseTemporalAmount(x, EsqlDataTypes.TIME_DURATION));
+
+        private static final String NAME = "esql-converter";
+        private final Function<Object, Object> converter;
+
+        EsqlConverter(Function<Object, Object> converter) {
+            this.converter = converter;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeEnum(this);
+        }
+
+        public static Converter read(StreamInput in) throws IOException {
+            return in.readEnum(EsqlConverter.class);
+        }
+
+        @Override
+        public Object convert(Object l) {
+            if (l == null) {
+                return null;
+            }
+            return converter.apply(l);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.type;
 
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypeConverter;
 import org.elasticsearch.xpack.ql.type.DataTypeRegistry;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
@@ -52,12 +51,12 @@ public class EsqlDataTypeRegistry implements DataTypeRegistry {
 
     @Override
     public boolean canConvert(DataType from, DataType to) {
-        return DataTypeConverter.canConvert(from, to);
+        return EsqlDataTypeConverter.canConvert(from, to);
     }
 
     @Override
     public Object convert(Object value, DataType type) {
-        return DataTypeConverter.convert(value, type);
+        return EsqlDataTypeConverter.convert(value, type);
     }
 
     @Override
@@ -71,6 +70,6 @@ public class EsqlDataTypeRegistry implements DataTypeRegistry {
         if (left == DATE_PERIOD && right == DATE_PERIOD) {
             return DATE_PERIOD;
         }
-        return DataTypeConverter.commonType(left, right);
+        return EsqlDataTypeConverter.commonType(left, right);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -43,8 +43,11 @@ import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.versionfield.Version;
 
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -709,10 +712,19 @@ public class StatementParserTests extends ESTestCase {
     }
 
     public void testInputParams() {
-        LogicalPlan stm = statement("row x = ?, y = ?", List.of(new TypedParamValue("integer", 1), new TypedParamValue("keyword", "2")));
+        LogicalPlan stm = statement(
+            "row x = ?, y = ?, a = ?, b = ?, c = ?",
+            List.of(
+                new TypedParamValue("integer", 1),
+                new TypedParamValue("keyword", "2"),
+                new TypedParamValue("date_period", "2 days"),
+                new TypedParamValue("time_duration", "4 hours"),
+                new TypedParamValue("version", "1.2.3")
+            )
+        );
         assertThat(stm, instanceOf(Row.class));
         Row row = (Row) stm;
-        assertThat(row.fields().size(), is(2));
+        assertThat(row.fields().size(), is(5));
 
         NamedExpression field = row.fields().get(0);
         assertThat(field.name(), is("x"));
@@ -725,6 +737,59 @@ public class StatementParserTests extends ESTestCase {
         assertThat(field, instanceOf(Alias.class));
         alias = (Alias) field;
         assertThat(alias.child().fold(), is("2"));
+
+        field = row.fields().get(2);
+        assertThat(field.name(), is("a"));
+        assertThat(field, instanceOf(Alias.class));
+        alias = (Alias) field;
+        assertThat(alias.child().fold(), is(Period.ofDays(2)));
+
+        field = row.fields().get(3);
+        assertThat(field.name(), is("b"));
+        assertThat(field, instanceOf(Alias.class));
+        alias = (Alias) field;
+        assertThat(alias.child().fold(), is(Duration.ofHours(4)));
+
+        field = row.fields().get(4);
+        assertThat(field.name(), is("c"));
+        assertThat(field, instanceOf(Alias.class));
+        alias = (Alias) field;
+        assertThat(alias.child().fold().getClass(), is(Version.class));
+        assertThat(alias.child().fold().toString(), is("1.2.3"));
+    }
+
+    public void testWrongIntervalParams() {
+        expectError("row x = ?", List.of(new TypedParamValue("date_period", "12")), "Cannot parse [12] to DATE_PERIOD");
+        expectError("row x = ?", List.of(new TypedParamValue("time_duration", "12")), "Cannot parse [12] to TIME_DURATION");
+        expectError(
+            "row x = ?",
+            List.of(new TypedParamValue("date_period", "12 months foo")),
+            "Cannot parse [12 months foo] to DATE_PERIOD"
+        );
+        expectError(
+            "row x = ?",
+            List.of(new TypedParamValue("time_duration", "12 minutes bar")),
+            "Cannot parse [12 minutes bar] to TIME_DURATION"
+        );
+        expectError("row x = ?", List.of(new TypedParamValue("date_period", "12 foo")), "Unexpected time interval qualifier: 'foo'");
+        expectError("row x = ?", List.of(new TypedParamValue("time_duration", "12 bar")), "Unexpected time interval qualifier: 'bar'");
+        expectError("row x = ?", List.of(new TypedParamValue("date_period", "foo days")), "Cannot parse [foo days] to DATE_PERIOD");
+        expectError(
+            "row x = ?",
+            List.of(new TypedParamValue("time_duration", "bar seconds")),
+            "Cannot parse [bar seconds] to TIME_DURATION"
+        );
+
+        expectError(
+            "row x = ?",
+            List.of(new TypedParamValue("date_period", "2 minutes")),
+            "Cannot parse [2 minutes] to DATE_PERIOD, did you mean TIME_DURATION?"
+        );
+        expectError(
+            "row x = ?",
+            List.of(new TypedParamValue("time_duration", "11 months")),
+            "Cannot parse [11 months] to TIME_DURATION, did you mean DATE_PERIOD?"
+        );
     }
 
     public void testMissingInputParams() {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Support date and time intervals as input params (#101001)