### PR TITLE
Fix VectorTileRestIT#testCentroidGridTypeOnPolygon

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -581,5 +581,19 @@ public class GeoUtils {
         return GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat));
     }
 
+    /**
+     * Transforms the provided longitude to the previous longitude in lucene quantize space.
+     */
+    public static double quantizeLonDown(double lon) {
+        return GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lon) - 1);
+    }
+
+    /**
+     * Transforms the provided latitude to the next latitude in lucene quantize space.
+     */
+    public static double quantizeLatUp(double lat) {
+        return GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat) + 1);
+    }
+
     private GeoUtils() {}
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileUtilsTests.java
@@ -256,12 +256,12 @@ public class GeoTileUtilsTests extends ESTestCase {
                 Matchers.anyOf(equalTo(x + 1), equalTo(tiles - 1))
             );
             // next encoded value down belongs to the tile
-            assertThat(GeoTileUtils.getXTile(quantizeLonDown(rectangle.getMaxX()), tiles), equalTo(x));
+            assertThat(GeoTileUtils.getXTile(GeoUtils.quantizeLonDown(rectangle.getMaxX()), tiles), equalTo(x));
             // min longitude belongs to the tile
             assertThat(GeoTileUtils.getXTile(GeoUtils.quantizeLon(rectangle.getMinX()), tiles), equalTo(x));
             if (x != 0) {
                 // next encoded value down belongs to the previous tile
-                assertThat(GeoTileUtils.getXTile(quantizeLonDown(rectangle.getMinX()), tiles), equalTo(x - 1));
+                assertThat(GeoTileUtils.getXTile(GeoUtils.quantizeLonDown(rectangle.getMinX()), tiles), equalTo(x - 1));
             }
         }
     }
@@ -276,7 +276,7 @@ public class GeoTileUtilsTests extends ESTestCase {
             assertThat(GeoTileUtils.getYTile(GeoUtils.quantizeLat(rectangle.getMaxLat()), tiles), equalTo(y));
             if (y != 0) {
                 // next encoded value up belongs to the previous tile
-                assertThat(GeoTileUtils.getYTile(quantizeLatUp(rectangle.getMaxLat()), tiles), equalTo(y - 1));
+                assertThat(GeoTileUtils.getYTile(GeoUtils.quantizeLatUp(rectangle.getMaxLat()), tiles), equalTo(y - 1));
             }
             // min latitude belongs to the next tile except the last one
             assertThat(
@@ -284,15 +284,8 @@ public class GeoTileUtilsTests extends ESTestCase {
                 Matchers.anyOf(equalTo(y + 1), equalTo(tiles - 1))
             );
             // next encoded value up belongs to the tile
-            assertThat(GeoTileUtils.getYTile(quantizeLatUp(rectangle.getMinLat()), tiles), equalTo(y));
+            assertThat(GeoTileUtils.getYTile(GeoUtils.quantizeLatUp(rectangle.getMinLat()), tiles), equalTo(y));
         }
     }
 
-    private static double quantizeLonDown(double lon) {
-        return GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lon) - 1);
-    }
-
-    private static double quantizeLatUp(double lat) {
-        return GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat) + 1);
-    }
 }

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -579,7 +579,6 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(ex.getMessage(), Matchers.containsString("Invalid aggregation name [_mvt_name]"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101038")
     public void testCentroidGridTypeOnPolygon() throws Exception {
         final Request mvtRequest = new Request(getHttpMethod(), INDEX_POLYGON + "/_mvt/location/" + (z + 2) + "/" + 4 * x + "/" + 4 * y);
         mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_type\": \"centroid\",  \"grid_precision\": 2}");

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/GridType.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/GridType.java
@@ -16,6 +16,9 @@ import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
 import java.io.IOException;
 import java.util.Locale;
 
+import static org.elasticsearch.common.geo.GeoUtils.quantizeLatUp;
+import static org.elasticsearch.common.geo.GeoUtils.quantizeLonDown;
+
 /**
  * Enum containing the basic geometry types for serializing {@link InternalGeoGridBucket}
  */
@@ -42,8 +45,8 @@ enum GridType {
             throws IOException {
             final Rectangle r = gridAggregation.toRectangle(key);
             final InternalGeoCentroid centroid = bucket.getAggregations().get(RestVectorTileAction.CENTROID_AGG_NAME);
-            final double featureLon = Math.min(Math.max(centroid.centroid().getX(), r.getMinLon()), r.getMaxLon());
-            final double featureLat = Math.min(Math.max(centroid.centroid().getY(), r.getMinLat()), r.getMaxLat());
+            final double featureLon = Math.min(Math.max(centroid.centroid().getX(), r.getMinLon()), quantizeLonDown(r.getMaxLon()));
+            final double featureLat = Math.min(Math.max(centroid.centroid().getY(), quantizeLatUp(r.getMinLat())), r.getMaxLat());
             return featureFactory.point(featureLon, featureLat);
         }
     };


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/100826 we made the boundaries for geotiles always behave properly in the lucene encoding space. This seems to upset how we adjust centroids when they are out of bounds on the vector tiles API. Let's adjust the boundaries here so the adjusted centroid is always in bounds.

fixes https://github.com/elastic/elasticsearch/issues/101038