### PR TITLE
Remove more explicit references to SearchResponse in tests

### DIFF
--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
@@ -612,18 +612,17 @@ public class InnerHitsIT extends ParentChildTestCase {
         createIndexRequest("index1", "child_type", "2", "1").get();
         client().prepareIndex("index2").setId("3").setSource("key", "value").get();
         refresh();
-
-        SearchResponse response = client().prepareSearch("index1", "index2")
-            .setQuery(
-                boolQuery().should(
-                    hasChildQuery("child_type", matchAllQuery(), ScoreMode.None).ignoreUnmapped(true)
-                        .innerHit(new InnerHitBuilder().setIgnoreUnmapped(true))
-                ).should(termQuery("key", "value"))
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 2);
-        assertSearchHits(response, "1", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("index1", "index2")
+                .setQuery(
+                    boolQuery().should(
+                        hasChildQuery("child_type", matchAllQuery(), ScoreMode.None).ignoreUnmapped(true)
+                            .innerHit(new InnerHitBuilder().setIgnoreUnmapped(true))
+                    ).should(termQuery("key", "value"))
+                ),
+            "1",
+            "3"
+        );
     }
 
     public void testTooHighResultWindow() {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.percolator;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -47,7 +46,7 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.scriptQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -87,17 +86,17 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .execute()
             .actionGet();
-        SearchResponse response = client().prepareSearch("index")
-            .setQuery(
-                new PercolateQueryBuilder(
-                    "query",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field1", "b").endObject()),
-                    XContentType.JSON
-                )
-            )
-            .get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "1");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("index")
+                .setQuery(
+                    new PercolateQueryBuilder(
+                        "query",
+                        BytesReference.bytes(jsonBuilder().startObject().field("field1", "b").endObject()),
+                        XContentType.JSON
+                    )
+                ),
+            "1"
+        );
     }
 
     public void testPercolateQueryWithNestedDocuments_doNotLeakBitsetCacheEntries() throws Exception {
@@ -265,17 +264,17 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
             .get();
         indicesAdmin().prepareRefresh().get();
 
-        SearchResponse response = client().prepareSearch("test")
-            .setQuery(
-                new PercolateQueryBuilder(
-                    "query",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field1", "value").endObject()),
-                    XContentType.JSON
-                )
-            )
-            .get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "1");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test")
+                .setQuery(
+                    new PercolateQueryBuilder(
+                        "query",
+                        BytesReference.bytes(jsonBuilder().startObject().field("field1", "value").endObject()),
+                        XContentType.JSON
+                    )
+                ),
+            "1"
+        );
     }
 
     public void testRangeQueriesWithNow() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
@@ -75,7 +75,7 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
         DeleteResponse delete = client().prepareDelete("test", "1").setRefreshPolicy(RefreshPolicy.WAIT_UNTIL).get();
         assertEquals(DocWriteResponse.Result.DELETED, delete.getResult());
         assertFalse("request shouldn't have forced a refresh", delete.forcedRefresh());
-        assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get());
+        assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")));
     }
 
     public void testUpdate() throws InterruptedException, ExecutionException {
@@ -109,7 +109,7 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
             .get();
         assertEquals(2, update.getVersion());
         assertFalse("request shouldn't have forced a refresh", update.forcedRefresh());
-        assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "cat")).get());
+        assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "cat")));
     }
 
     public void testBulk() {
@@ -129,7 +129,7 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
         bulk = client().prepareBulk().setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
         bulk.add(client().prepareDelete("test", "1"));
         assertBulkSuccess(bulk.get());
-        assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get());
+        assertNoSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")));
 
         // Update makes a noop
         bulk = client().prepareBulk().setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -88,7 +88,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         assertFalse(indexService.getIndexSettings().isExplicitRefresh());
         ensureGreen();
         AtomicInteger totalNumDocs = new AtomicInteger(Integer.MAX_VALUE);
-        assertNoSearchHits(client().prepareSearch().get());
+        assertNoSearchHits(client().prepareSearch());
         int numDocs = scaledRandomIntBetween(25, 100);
         totalNumDocs.set(numDocs);
         CountDownLatch indexingDone = new CountDownLatch(numDocs);

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -79,7 +80,7 @@ import static org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase.forEachF
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
@@ -522,9 +523,7 @@ public class RelocationIT extends ESIntegTestCase {
         final int numIters = randomIntBetween(10, 20);
         for (int i = 0; i < numIters; i++) {
             logger.info(" --> checking iteration {}", i);
-            SearchResponse afterRelocation = client().prepareSearch().setSize(ids.size()).get();
-            assertNoFailures(afterRelocation);
-            assertSearchHits(afterRelocation, ids.toArray(new String[ids.size()]));
+            assertSearchHitsWithoutFailures(client().prepareSearch().setSize(ids.size()), ids.toArray(Strings.EMPTY_ARRAY));
         }
         stopped.set(true);
         for (Thread searchThread : searchThreads) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -52,7 +52,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllS
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
@@ -922,17 +922,17 @@ public class InnerHitsIT extends ESIntegTestCase {
         client().prepareIndex("index2").setId("3").setSource("key", "value").get();
         refresh();
 
-        SearchResponse response = client().prepareSearch("index1", "index2")
-            .setQuery(
-                boolQuery().should(
-                    nestedQuery("nested_type", matchAllQuery(), ScoreMode.None).ignoreUnmapped(true)
-                        .innerHit(new InnerHitBuilder().setIgnoreUnmapped(true))
-                ).should(termQuery("key", "value"))
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 2);
-        assertSearchHits(response, "1", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("index1", "index2")
+                .setQuery(
+                    boolQuery().should(
+                        nestedQuery("nested_type", matchAllQuery(), ScoreMode.None).ignoreUnmapped(true)
+                            .innerHit(new InnerHitBuilder().setIgnoreUnmapped(true))
+                    ).should(termQuery("key", "value"))
+                ),
+            "1",
+            "3"
+        );
     }
 
     public void testUseMaxDocInsteadOfSize() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.hamcrest.Matchers.anyOf;
@@ -348,17 +348,18 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(1L));
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(
-                randomizeType(
-                    multiMatchQuery("the Ul", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase").operator(
-                        Operator.OR
-                    ).type(MatchQueryParser.Type.PHRASE_PREFIX)
-                )
-            )
-            .get();
-        assertSearchHits(searchResponse, "ultimate2", "ultimate1");
-        assertHitCount(searchResponse, 2L);
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test")
+                .setQuery(
+                    randomizeType(
+                        multiMatchQuery("the Ul", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase").operator(
+                            Operator.OR
+                        ).type(MatchQueryParser.Type.PHRASE_PREFIX)
+                    )
+                ),
+            "ultimate2",
+            "ultimate1"
+        );
     }
 
     public void testSingleField() throws NoSuchFieldException, IllegalAccessException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -106,6 +106,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirs
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
@@ -414,20 +415,13 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("3").setSource("field1", "value3")
         );
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(constantScoreQuery(idsQuery().addIds("1", "3"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
-
-        searchResponse = client().prepareSearch().setQuery(idsQuery().addIds("1", "3")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(constantScoreQuery(idsQuery().addIds("1", "3"))), "1", "3");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(idsQuery().addIds("1", "3")), "1", "3");
 
         assertHitCount(client().prepareSearch().setQuery(idsQuery().addIds("7", "10")), 0L);
 
         // repeat..., with terms
-        searchResponse = client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_id", "1", "3"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_id", "1", "3"))), "1", "3");
     }
 
     public void testTermIndexQuery() throws Exception {
@@ -440,22 +434,22 @@ public class SearchQueryIT extends ESIntegTestCase {
         }
 
         for (String indexName : indexNames) {
-            SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(termQuery("_index", indexName))).get();
-            SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, 1L);
-            assertSearchHits(searchResponse, indexName + "1");
+            assertSearchHitsWithoutFailures(
+                client().prepareSearch().setQuery(constantScoreQuery(termQuery("_index", indexName))),
+                indexName + "1"
+            );
         }
         for (String indexName : indexNames) {
-            SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_index", indexName))).get();
-            SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, 1L);
-            assertSearchHits(searchResponse, indexName + "1");
+            assertSearchHitsWithoutFailures(
+                client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_index", indexName))),
+                indexName + "1"
+            );
         }
         for (String indexName : indexNames) {
-            SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("_index", indexName))).get();
-            SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, 1L);
-            assertSearchHits(searchResponse, indexName + "1");
+            assertSearchHitsWithoutFailures(
+                client().prepareSearch().setQuery(constantScoreQuery(matchQuery("_index", indexName))),
+                indexName + "1"
+            );
         }
         {
             SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_index", indexNames))).get();
@@ -516,35 +510,15 @@ public class SearchQueryIT extends ESIntegTestCase {
                 )
         );
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(existsQuery("field1")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
-
-        searchResponse = client().prepareSearch().setQuery(constantScoreQuery(existsQuery("field1"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
-
-        searchResponse = client().prepareSearch().setQuery(queryStringQuery("_exists_:field1")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
-
-        searchResponse = client().prepareSearch().setQuery(existsQuery("field2")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
-
-        searchResponse = client().prepareSearch().setQuery(existsQuery("field3")).get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("4"));
-
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(existsQuery("field1")), "1", "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(constantScoreQuery(existsQuery("field1"))), "1", "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(queryStringQuery("_exists_:field1")), "1", "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(existsQuery("field2")), "1", "3");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(existsQuery("field3")), "4");
         // wildcard check
-        searchResponse = client().prepareSearch().setQuery(existsQuery("x*")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
-
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(existsQuery("x*")), "1", "2");
         // object check
-        searchResponse = client().prepareSearch().setQuery(existsQuery("obj1")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(existsQuery("obj1")), "1", "2");
     }
 
     public void testPassQueryOrFilterAsJSONString() throws Exception {
@@ -603,21 +577,22 @@ public class SearchQueryIT extends ESIntegTestCase {
         );
         assertHitCount(client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(0))), 0L);
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(1)))
-            .get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
-
-        searchResponse = client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromString("AUTO"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromEdits(1))),
+            "1",
+            "2"
+        );
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromString("AUTO"))),
+            "1",
+            "2"
+        );
 
         assertHitCount(client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness(Fuzziness.fromString("AUTO:5,7"))), 0L);
-
-        searchResponse = client().prepareSearch().setQuery(matchQuery("text", "unify").fuzziness(Fuzziness.fromString("AUTO:5,7"))).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "2");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(matchQuery("text", "unify").fuzziness(Fuzziness.fromString("AUTO:5,7"))),
+            "2"
+        );
     }
 
     public void testMultiMatchQuery() throws Exception {
@@ -631,40 +606,31 @@ public class SearchQueryIT extends ESIntegTestCase {
         );
 
         MultiMatchQueryBuilder builder = multiMatchQuery("value1 value2 value4", "field1", "field2");
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(builder)
-            .addAggregation(AggregationBuilders.terms("field1").field("field1.keyword"))
-            .get();
-
-        assertHitCount(searchResponse, 2L);
         // this uses dismax so scores are equal and the order can be arbitrary
-        assertSearchHits(searchResponse, "1", "2");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(builder).addAggregation(AggregationBuilders.terms("field1").field("field1.keyword")),
+            "1",
+            "2"
+        );
 
-        searchResponse = client().prepareSearch().setQuery(builder).get();
-
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(builder), "1", "2");
 
         indicesAdmin().prepareRefresh("test").get();
         builder = multiMatchQuery("value1", "field1", "field2").operator(Operator.AND); // Operator only applies on terms inside a field!
                                                                                         // Fields are always OR-ed together.
-        searchResponse = client().prepareSearch().setQuery(builder).get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("1"));
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(builder), "1");
 
         refresh();
         builder = multiMatchQuery("value1", "field1").field("field3", 1.5f).operator(Operator.AND); // Operator only applies on terms inside
                                                                                                     // a field! Fields are always OR-ed
                                                                                                     // together.
-        searchResponse = client().prepareSearch().setQuery(builder).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "3", "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(builder), "3", "1");
 
         indicesAdmin().prepareRefresh("test").get();
         builder = multiMatchQuery("value1").field("field1").field("field3", 1.5f).operator(Operator.AND); // Operator only applies on terms
                                                                                                           // inside a field! Fields are
                                                                                                           // always OR-ed together.
-        searchResponse = client().prepareSearch().setQuery(builder).get();
+        SearchResponse searchResponse = client().prepareSearch().setQuery(builder).get();
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "1");
 
@@ -693,9 +659,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         }
 
         builder.lenient(true);
-        searchResponse = client().prepareSearch().setQuery(builder).get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("1"));
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(builder), "1");
     }
 
     public void testMatchQueryZeroTermsQuery() {
@@ -894,46 +858,39 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("3").setSource("str", "3", "lng", 3L, "dbl", 3.0d),
             client().prepareIndex("test").setId("4").setSource("str", "4", "lng", 4L, "dbl", 4.0d)
         );
-
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "1", "4"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "4");
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 2, 3 }))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "2", "3");
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 2, 3 }))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "2", "3");
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new int[] { 1, 3 }))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new float[] { 2, 4 }))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "2", "4");
-
+        assertSearchHitsWithoutFailures(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "1", "4"))), "1", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 2, 3 }))),
+            "2",
+            "3"
+        );
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 2, 3 }))),
+            "2",
+            "3"
+        );
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new int[] { 1, 3 }))),
+            "1",
+            "3"
+        );
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new float[] { 2, 4 }))),
+            "2",
+            "4"
+        );
         // test partial matching
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "2", "5"))).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("2"));
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 2, 5 }))).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("2"));
-
-        searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 2, 5 }))).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("2"));
-
+        assertSearchHitsWithoutFailures(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "2", "5"))), "2");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 2, 5 }))),
+            "2"
+        );
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 2, 5 }))),
+            "2"
+        );
         // test valid type, but no matching terms
         assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "5", "6"))), 0L);
-
         assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("dbl", new double[] { 5, 6 }))), 0L);
         assertHitCount(client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("lng", new long[] { 5, 6 }))), 0L);
     }
@@ -1014,50 +971,55 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("3").setSource("term", "3"),
             client().prepareIndex("test").setId("4").setSource("term", "4")
         );
-
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "1", "terms")))
-            .get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "1", "terms"))),
+            "1",
+            "3"
+        );
 
         // same as above, just on the _id...
-        searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("_id", new TermsLookup("lookup", "1", "terms"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("_id", new TermsLookup("lookup", "1", "terms"))),
+            "1",
+            "3"
+        );
 
         // another search with same parameters...
-        searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "1", "terms"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "1", "terms"))),
+            "1",
+            "3"
+        );
 
-        searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "2", "terms"))).get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("2"));
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "2", "terms"))),
+            "2"
+        );
 
-        searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "3", "terms"))).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "2", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "3", "terms"))),
+            "2",
+            "4"
+        );
 
         assertHitCount(client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup", "4", "terms"))), 0L);
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "1", "arr.term")))
-            .get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "1", "arr.term"))),
+            "1",
+            "3"
+        );
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "2", "arr.term")))
-            .get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("2"));
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "2", "arr.term"))),
+            "2"
+        );
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "3", "arr.term")))
-            .get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "2", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "3", "arr.term"))),
+            "2",
+            "4"
+        );
 
         assertHitCount(
             client().prepareSearch("test").setQuery(termsLookupQuery("not_exists", new TermsLookup("lookup2", "3", "arr.term"))),
@@ -1737,17 +1699,12 @@ public class SearchQueryIT extends ESIntegTestCase {
             client().prepareIndex("test1").setId("2").setSource("field", "trying out Elasticsearch")
         );
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(matchPhrasePrefixQuery("field", "Johnnie la").slop(between(2, 5)))
-            .get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
-        searchResponse = client().prepareSearch().setQuery(matchPhrasePrefixQuery("field", "trying")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "2");
-        searchResponse = client().prepareSearch().setQuery(matchPhrasePrefixQuery("field", "try")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "2");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(matchPhrasePrefixQuery("field", "Johnnie la").slop(between(2, 5))),
+            "1"
+        );
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(matchPhrasePrefixQuery("field", "trying")), "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(matchPhrasePrefixQuery("field", "try")), "2");
     }
 
     public void testQueryStringParserCache() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -51,6 +51,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirs
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -84,29 +85,30 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("6").setSource("otherbody", "spaghetti")
         );
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar")).get();
-        assertHitCount(searchResponse, 3L);
-        assertSearchHits(searchResponse, "1", "2", "3");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar")), "1", "2", "3");
 
         // Tests boost value setting. In this case doc 1 should always be ranked above the other
         // two matches.
-        searchResponse = client().prepareSearch()
+        SearchResponse searchResponse = client().prepareSearch()
             .setQuery(boolQuery().should(simpleQueryStringQuery("\"foo bar\"").boost(10.0f)).should(termQuery("body", "eggplant")))
             .get();
         assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("3"));
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").defaultOperator(Operator.AND)).get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("3"));
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").defaultOperator(Operator.AND)),
+            "3"
+        );
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("\"quux baz\" +(eggplant | spaghetti)")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "4", "5");
-
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("eggplants").analyzer("mock_snowball")).get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("4"));
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("\"quux baz\" +(eggplant | spaghetti)")),
+            "4",
+            "5"
+        );
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("eggplants").analyzer("mock_snowball")),
+            "4"
+        );
 
         searchResponse = client().prepareSearch()
             .setQuery(simpleQueryStringQuery("spaghetti").field("body", 1000.0f).field("otherbody", 2.0f).queryName("myquery"))
@@ -116,9 +118,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertSearchHits(searchResponse, "5", "6");
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("myquery"));
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("spaghetti").field("*body")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "5", "6");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("spaghetti").field("*body")), "5", "6");
     }
 
     public void testSimpleQueryStringMinimumShouldMatch() throws Exception {
@@ -134,31 +134,35 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         );
 
         logger.info("--> query 1");
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").minimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "3", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").minimumShouldMatch("2")),
+            "3",
+            "4"
+        );
 
         logger.info("--> query 2");
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2"))
-            .get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "3", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2")),
+            "3",
+            "4"
+        );
 
         // test case from #13884
         logger.info("--> query 3");
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo").field("body").field("body2").field("body3").minimumShouldMatch("-50%"))
-            .get();
-        assertHitCount(searchResponse, 3L);
-        assertSearchHits(searchResponse, "1", "3", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch()
+                .setQuery(simpleQueryStringQuery("foo").field("body").field("body2").field("body3").minimumShouldMatch("-50%")),
+            "1",
+            "3",
+            "4"
+        );
 
         logger.info("--> query 4");
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo bar baz").field("body").field("body2").minimumShouldMatch("70%"))
-            .get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "3", "4");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body").field("body2").minimumShouldMatch("70%")),
+            "3",
+            "4"
+        );
 
         indexRandom(
             true,
@@ -170,23 +174,32 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         );
 
         logger.info("--> query 5");
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2"))
-            .get();
-        assertHitCount(searchResponse, 4L);
-        assertSearchHits(searchResponse, "3", "4", "7", "8");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2")),
+            "3",
+            "4",
+            "7",
+            "8"
+        );
 
         logger.info("--> query 6");
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").minimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 5L);
-        assertSearchHits(searchResponse, "3", "4", "6", "7", "8");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").minimumShouldMatch("2")),
+            "3",
+            "4",
+            "6",
+            "7",
+            "8"
+        );
 
         logger.info("--> query 7");
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo bar baz").field("body2").field("other").minimumShouldMatch("70%"))
-            .get();
-        assertHitCount(searchResponse, 3L);
-        assertSearchHits(searchResponse, "6", "7", "8");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch()
+                .setQuery(simpleQueryStringQuery("foo bar baz").field("body2").field("other").minimumShouldMatch("70%")),
+            "6",
+            "7",
+            "8"
+        );
     }
 
     public void testNestedFieldSimpleQueryString() throws IOException {
@@ -211,21 +224,10 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("body", "foo bar baz").get();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
-
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
-
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body.sub")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
-
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body.sub")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body")), "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body")), "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body.sub")), "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body.sub")), "1");
     }
 
     public void testSimpleQueryStringFlags() throws ExecutionException, InterruptedException {
@@ -240,23 +242,26 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("6").setSource("otherbody", "spaghetti")
         );
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo bar").flags(SimpleQueryStringFlag.ALL))
-            .get();
-        assertHitCount(searchResponse, 3L);
-        assertSearchHits(searchResponse, "1", "2", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").flags(SimpleQueryStringFlag.ALL)),
+            "1",
+            "2",
+            "3"
+        );
 
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo | bar").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.OR))
-            .get();
-        assertHitCount(searchResponse, 3L);
-        assertSearchHits(searchResponse, "1", "2", "3");
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch()
+                .setQuery(simpleQueryStringQuery("foo | bar").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.OR)),
+            "1",
+            "2",
+            "3"
+        );
 
-        searchResponse = client().prepareSearch()
-            .setQuery(simpleQueryStringQuery("foo | bar").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.NONE))
-            .get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("3"));
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch()
+                .setQuery(simpleQueryStringQuery("foo | bar").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.NONE)),
+            "3"
+        );
 
         assertHitCount(
             client().prepareSearch()
@@ -274,18 +279,18 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
             1L
         );
 
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                simpleQueryStringQuery("quuz~1 + egg*").flags(
-                    SimpleQueryStringFlag.WHITESPACE,
-                    SimpleQueryStringFlag.AND,
-                    SimpleQueryStringFlag.FUZZY,
-                    SimpleQueryStringFlag.PREFIX
-                )
-            )
-            .get();
-        assertHitCount(searchResponse, 1L);
-        assertFirstHit(searchResponse, hasId("4"));
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch()
+                .setQuery(
+                    simpleQueryStringQuery("quuz~1 + egg*").flags(
+                        SimpleQueryStringFlag.WHITESPACE,
+                        SimpleQueryStringFlag.AND,
+                        SimpleQueryStringFlag.FUZZY,
+                        SimpleQueryStringFlag.PREFIX
+                    )
+                ),
+            "4"
+        );
     }
 
     public void testSimpleQueryStringLenient() throws ExecutionException, InterruptedException {
@@ -305,10 +310,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
-        searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field").lenient(true)).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field").lenient(true)), "1");
     }
 
     // Issue #7967
@@ -320,12 +322,9 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         );
 
         BoolQueryBuilder q = boolQuery().should(simpleQueryStringQuery("bar").field("num").field("body").lenient(true));
-        SearchResponse resp = client().prepareSearch("test").setQuery(q).get();
-        assertNoFailures(resp);
         // the bug is that this would be parsed into basically a match_all
         // query and this would match both documents
-        assertHitCount(resp, 1);
-        assertSearchHits(resp, "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch("test").setQuery(q), "1");
     }
 
     public void testSimpleQueryStringAnalyzeWildcard() throws ExecutionException, InterruptedException, IOException {
@@ -346,32 +345,21 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex("test1").setId("1").setSource("location", "Köln"));
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("Köln*").field("location")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("Köln*").field("location")), "1");
     }
 
     public void testSimpleQueryStringUsesFieldAnalyzer() throws Exception {
         client().prepareIndex("test").setId("1").setSource("foo", 123, "bar", "abc").get();
         client().prepareIndex("test").setId("2").setSource("foo", 234, "bar", "bcd").get();
-
         refresh();
-
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("123").field("foo").field("bar")).get();
-        assertHitCount(searchResponse, 1L);
-        assertSearchHits(searchResponse, "1");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("123").field("foo").field("bar")), "1");
     }
 
     public void testSimpleQueryStringOnIndexMetaField() throws Exception {
         client().prepareIndex("test").setId("1").setSource("foo", 123, "bar", "abc").get();
         client().prepareIndex("test").setId("2").setSource("foo", 234, "bar", "bcd").get();
-
         refresh();
-
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("test").field("_index")).get();
-        assertHitCount(searchResponse, 2L);
-        assertSearchHits(searchResponse, "1", "2");
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("test").field("_index")), "1", "2");
     }
 
     public void testEmptySimpleQueryStringWithAnalysis() throws Exception {
@@ -393,9 +381,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex("test1").setId("1").setSource("body", "Some Text"));
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("the*").field("body")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 0L);
+        assertSearchHitsWithoutFailures(client().prepareSearch().setQuery(simpleQueryStringQuery("the*").field("body")));
     }
 
     public void testBasicAllQuery() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -223,6 +223,15 @@ public class ElasticsearchAssertions {
         return msg.toString();
     }
 
+    public static void assertNoSearchHits(SearchRequestBuilder searchRequestBuilder) {
+        var searchResponse = searchRequestBuilder.get();
+        try {
+            assertNoSearchHits(searchResponse);
+        } finally {
+            searchResponse.decRef();
+        }
+    }
+
     public static void assertNoSearchHits(SearchResponse searchResponse) {
         assertThat(searchResponse.getHits().getHits(), emptyArray());
     }
@@ -242,6 +251,17 @@ public class ElasticsearchAssertions {
             searchResponse.getHits(),
             transformedItemsMatch(SearchHit::getId, containsInAnyOrder(ids))
         );
+    }
+
+    public static void assertSearchHitsWithoutFailures(SearchRequestBuilder requestBuilder, String... ids) {
+        var res = requestBuilder.get();
+        try {
+            assertNoFailures(res);
+            assertHitCount(res, ids.length);
+            assertSearchHits(res, ids);
+        } finally {
+            res.decRef();
+        }
     }
 
     public static void assertSortValues(SearchRequestBuilder searchRequestBuilder, Object[]... sortValues) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -95,6 +95,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
@@ -208,32 +209,29 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("3").setSource("field3", "value3").setRefreshPolicy(IMMEDIATE).get();
 
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        )
-            .prepareSearch("test")
-            .setQuery(randomBoolean() ? QueryBuilders.termQuery("field1", "value1") : QueryBuilders.matchAllQuery())
-            .get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "1");
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(randomBoolean() ? QueryBuilders.termQuery("field2", "value2") : QueryBuilders.matchAllQuery())
-            .get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "2");
-
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(randomBoolean() ? QueryBuilders.termQuery("field1", "value1") : QueryBuilders.matchAllQuery()),
+            "1"
+        );
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(randomBoolean() ? QueryBuilders.termQuery("field2", "value2") : QueryBuilders.matchAllQuery()),
+            "2"
+        );
         QueryBuilder combined = QueryBuilders.boolQuery()
             .should(QueryBuilders.termQuery("field2", "value2"))
             .should(QueryBuilders.termQuery("field1", "value1"))
             .minimumShouldMatch(1);
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .setQuery(randomBoolean() ? combined : QueryBuilders.matchAllQuery())
-            .get();
-        assertHitCount(response, 2);
-        assertSearchHits(response, "1", "2");
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(randomBoolean() ? combined : QueryBuilders.matchAllQuery()),
+            "1",
+            "2"
+        );
     }
 
     public void testGetApi() throws Exception {
@@ -676,11 +674,14 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
         // Lookup doc#1 is: visible to user1 and user3, but hidden from user2
         TermsQueryBuilder lookup = QueryBuilders.termsLookupQuery("search_field", new TermsLookup("lookup_index", "1", "lookup_field"));
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        ).prepareSearch("search_index").setQuery(lookup).get();
-        assertHitCount(response, 3);
-        assertSearchHits(response, "1", "2", "3");
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(lookup),
+            "1",
+            "2",
+            "3"
+        );
 
         assertHitCount(
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
@@ -688,13 +689,16 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
                 .setQuery(lookup),
             0
         );
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(lookup)
-            .get();
-        assertHitCount(response, 5);
-        assertSearchHits(response, "1", "2", "3", "4", "5");
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(lookup),
+            "1",
+            "2",
+            "3",
+            "4",
+            "5"
+        );
         // Lookup doc#2 is: hidden from user1, visible to user2 and user3
         lookup = QueryBuilders.termsLookupQuery("search_field", new TermsLookup("lookup_index", "2", "lookup_field"));
         assertHitCount(
@@ -704,20 +708,21 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
                 .get(),
             0
         );
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(lookup)
-            .get();
-        assertHitCount(response, 2);
-        assertSearchHits(response, "2", "5");
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(lookup)
-            .get();
-        assertHitCount(response, 3);
-        assertSearchHits(response, "1", "2", "5");
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(lookup),
+            "2",
+            "5"
+        );
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(lookup),
+            "1",
+            "2",
+            "5"
+        );
     }
 
     public void testTVApi() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -81,7 +81,7 @@ import static org.elasticsearch.join.query.JoinQueryBuilders.hasChildQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
@@ -633,20 +633,19 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         client().prepareIndex("lookup_index").setId("2").setSource("other", "value2", "field", "value2").setRefreshPolicy(IMMEDIATE).get();
 
         // user sees the terms doc field
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD))
-        )
-            .prepareSearch("search_index")
-            .setQuery(QueryBuilders.termsLookupQuery("field", new TermsLookup("lookup_index", "1", "field")))
-            .get();
-        assertHitCount(response, 2);
-        assertSearchHits(response, "1", "2");
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
-            .prepareSearch("search_index")
-            .setQuery(QueryBuilders.termsLookupQuery("field", new TermsLookup("lookup_index", "2", "field")))
-            .get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "1");
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(QueryBuilders.termsLookupQuery("field", new TermsLookup("lookup_index", "1", "field"))),
+            "1",
+            "2"
+        );
+        assertSearchHitsWithoutFailures(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
+                .prepareSearch("search_index")
+                .setQuery(QueryBuilders.termsLookupQuery("field", new TermsLookup("lookup_index", "2", "field"))),
+            "1"
+        );
         // user does not see the terms doc field
         assertHitCount(
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
@@ -74,7 +74,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         createIndicesWithRandomAliases("test1", "test2", "index1", "index2");
         IndexNotFoundException e = expectThrows(
             IndexNotFoundException.class,
-            () -> trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()), "index*")
+            trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()), "index*")
         );
         assertEquals("no such index [index*]", e.getMessage());
     }
@@ -86,7 +86,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     public void testEmptyClusterSearchForAllDisallowNoIndices() {
         IndexNotFoundException e = expectThrows(
             IndexNotFoundException.class,
-            () -> trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()))
+            trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()))
         );
         assertEquals("no such index [[]]", e.getMessage());
     }
@@ -98,7 +98,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     public void testEmptyClusterSearchForWildcardDisallowNoIndices() {
         IndexNotFoundException e = expectThrows(
             IndexNotFoundException.class,
-            () -> trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()), "*")
+            trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()), "*")
         );
         assertEquals("no such index [*]", e.getMessage());
     }
@@ -112,7 +112,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         createIndicesWithRandomAliases("index1", "index2");
         IndexNotFoundException e = expectThrows(
             IndexNotFoundException.class,
-            () -> trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()))
+            trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()))
         );
         assertEquals("no such index [[]]", e.getMessage());
     }
@@ -126,19 +126,19 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         createIndicesWithRandomAliases("index1", "index2");
         IndexNotFoundException e = expectThrows(
             IndexNotFoundException.class,
-            () -> trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()), "*")
+            trySearch(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()), "*")
         );
         assertEquals("no such index [*]", e.getMessage());
     }
 
     public void testExplicitNonAuthorizedIndex() {
         createIndicesWithRandomAliases("test1", "test2", "index1");
-        assertThrowsAuthorizationExceptionDefaultUsers(() -> trySearch("test*", "index1"), SearchAction.NAME);
+        assertThrowsAuthorizationExceptionDefaultUsers(() -> trySearch("test*", "index1").get(), SearchAction.NAME);
     }
 
     public void testIndexNotFound() {
         createIndicesWithRandomAliases("test1", "test2", "index1");
-        assertThrowsAuthorizationExceptionDefaultUsers(() -> trySearch("missing"), SearchAction.NAME);
+        assertThrowsAuthorizationExceptionDefaultUsers(() -> trySearch("missing").get(), SearchAction.NAME);
     }
 
     public void testIndexNotFoundIgnoreUnavailable() {
@@ -199,8 +199,8 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     }
 
     public void testMissingDateMath() {
-        expectThrows(ElasticsearchSecurityException.class, () -> trySearch("<unauthorized-datemath-{now/M}>"));
-        expectThrows(IndexNotFoundException.class, () -> trySearch("<test-datemath-{now/M}>"));
+        expectThrows(ElasticsearchSecurityException.class, trySearch("<unauthorized-datemath-{now/M}>"));
+        expectThrows(IndexNotFoundException.class, trySearch("<test-datemath-{now/M}>"));
     }
 
     public void testMultiSearchUnauthorizedIndex() {
@@ -415,6 +415,10 @@ public class ReadActionsTests extends SecurityIntegTestCase {
 
     private SearchRequestBuilder trySearch(IndicesOptions options, String... indices) {
         return client().prepareSearch(indices).setIndicesOptions(options);
+    }
+
+    private static <T extends Throwable> T expectThrows(Class<T> expectedType, SearchRequestBuilder searchRequestBuilder) {
+        return expectThrows(expectedType, searchRequestBuilder::get);
     }
 
     private static void assertReturnedIndices(SearchRequestBuilder searchRequestBuilder, String... indices) {


### PR DESCRIPTION
Follow up to #100966 introducing new combined assertion `assertSearchHitsWithoutFailures` to combine no-failure, count, and id assertions into one block.
