### PR TITLE
[8.10] Migrate painless and runtime fields common tests to new test clusters (#101021)

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -9,8 +9,8 @@
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask;
 
 apply plugin: 'elasticsearch.validate-rest-spec'
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
 esplugin {
@@ -42,6 +42,7 @@ dependencies {
     api 'org.ow2.asm:asm-analysis:7.2'
     api 'org.ow2.asm:asm:7.2'
     spi project('spi')
+    clusterModules project(':modules:mapper-extras')
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/modules/lang-painless/src/yamlRestTest/java/org/elasticsearch/painless/LangPainlessClientYamlTestSuiteIT.java
+++ b/modules/lang-painless/src/yamlRestTest/java/org/elasticsearch/painless/LangPainlessClientYamlTestSuiteIT.java
@@ -11,11 +11,21 @@ package org.elasticsearch.painless;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 /** Runs yaml rest tests */
 public class LangPainlessClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("lang-painless")
+        .module("mapper-extras")
+        .systemProperty("es.scripting.update.ctx_in_params", "false")
+        .systemProperty("es.transport.cname_in_publish_address", "true")
+        .build();
 
     public LangPainlessClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -24,5 +34,10 @@ public class LangPainlessClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }

--- a/modules/runtime-fields-common/build.gradle
+++ b/modules/runtime-fields-common/build.gradle
@@ -7,8 +7,8 @@
  */
 
 apply plugin: 'elasticsearch.validate-rest-spec'
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
 esplugin {
   description 'Module for runtime fields features and extensions that have large dependencies'

--- a/modules/runtime-fields-common/src/yamlRestTest/java/org/elasticsearch/painless/RuntimeFieldsClientYamlTestSuiteIT.java
+++ b/modules/runtime-fields-common/src/yamlRestTest/java/org/elasticsearch/painless/RuntimeFieldsClientYamlTestSuiteIT.java
@@ -11,11 +11,16 @@ package org.elasticsearch.painless;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 /** Runs yaml rest tests */
 public class RuntimeFieldsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("runtime-fields-common").build();
 
     public RuntimeFieldsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -24,5 +29,10 @@ public class RuntimeFieldsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCas
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Migrate painless and runtime fields common tests to new test clusters (#101021)