### PR TITLE
Log errors in RestResponse regardless of error_trace parameter

### DIFF
--- a/docs/changelog/101066.yaml
+++ b/docs/changelog/101066.yaml
@@ -1,6 +1,6 @@
 pr: 101066
 summary: Log errors in `RestResponse` regardless of `error_trace` parameter
-area: "Infra/Core, Search"
+area: "Infra/Core"
 type: enhancement
 issues:
  - 100884

--- a/docs/changelog/101066.yaml
+++ b/docs/changelog/101066.yaml
@@ -1,0 +1,6 @@
+pr: 101066
+summary: Log errors in `RestResponse` regardless of `error_trace` parameter
+area: "Infra/Core, Search"
+type: enhancement
+issues:
+ - 100884

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -115,7 +115,7 @@ public class RestResponse {
     @SuppressWarnings("this-escape")
     public RestResponse(RestChannel channel, RestStatus status, Exception e) throws IOException {
         this.status = status;
-        ToXContent.Params params = paramsFromRequest(channel.request());
+        ToXContent.Params params = channel.request();
         if (params.paramAsBoolean(REST_EXCEPTION_SKIP_STACK_TRACE, REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT) && e != null) {
             // log exception only if it is not returned in the response
             Supplier<?> messageSupplier = () -> String.format(
@@ -130,6 +130,9 @@ public class RestResponse {
             } else {
                 SUPPRESSED_ERROR_LOGGER.warn(messageSupplier, e);
             }
+        }
+        if (params.paramAsBoolean("error_trace", false) && status != RestStatus.UNAUTHORIZED) {
+            params = new ToXContent.DelegatingMapParams(singletonMap(REST_EXCEPTION_SKIP_STACK_TRACE, "false"), params);
         }
         try (XContentBuilder builder = channel.newErrorBuilder()) {
             build(builder, params, status, channel.detailedErrorsEnabled(), e);
@@ -162,18 +165,6 @@ public class RestResponse {
 
     public RestStatus status() {
         return this.status;
-    }
-
-    private ToXContent.Params paramsFromRequest(RestRequest restRequest) {
-        ToXContent.Params params = restRequest;
-        if (restRequest.paramAsBoolean("error_trace", REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT == false) && skipStackTrace() == false) {
-            params = new ToXContent.DelegatingMapParams(singletonMap(REST_EXCEPTION_SKIP_STACK_TRACE, "false"), params);
-        }
-        return params;
-    }
-
-    protected boolean skipStackTrace() {
-        return status() == RestStatus.UNAUTHORIZED;
     }
 
     private static void build(

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -479,11 +479,10 @@ public class RestResponseTests extends ESTestCase {
         // setting "rest.exception.stacktrace.skip" to false should prevent logging to happen
         request.params().put(REST_EXCEPTION_SKIP_STACK_TRACE, "false");
         assertLogging(channel, new ElasticsearchException("simulated"), null, null, null);
-        // setting "error_trace" to true currently also prevents logging
+        // setting "error_trace" to true should not affect logging
         request.params().clear();
         request.params().put("error_trace", "true");
-        assertLogging(channel, new ElasticsearchException("simulated"), null, null, null);
-        // we still seem to log 401s though, regardless of "error_trace" setting
+        assertLogging(channel, new ElasticsearchException("simulated"), Level.WARN, "500", "simulated");
         assertLogging(
             channel,
             new ElasticsearchSecurityException("unauthorized", RestStatus.UNAUTHORIZED),

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -476,9 +476,6 @@ public class RestResponseTests extends ESTestCase {
             "unauthorized"
         );
 
-        // setting "rest.exception.stacktrace.skip" to false should prevent logging to happen
-        request.params().put(REST_EXCEPTION_SKIP_STACK_TRACE, "false");
-        assertLogging(channel, new ElasticsearchException("simulated"), null, null, null);
         // setting "error_trace" to true should not affect logging
         request.params().clear();
         request.params().put("error_trace", "true");


### PR DESCRIPTION
Currently, setting the "error_trace" request parameter to "true" leads to error stack traces being
included in the rest response, but will prevent logging them in the "rest.suppressed" logger in the
`RestResponse` class. 
In order to improve visibility of those errors in our logs, this PR changes the logging behavior be 
independent of the "error_trace" request parameter and only take the "rest.exception.stacktrace.skip"
parameter into account, which is only used internally.

Closes #100884