### PR TITLE
Log tripping circuit breaker as warning.

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -412,7 +412,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             CircuitBreaker.Durability durability = memoryUsed.transientChildUsage >= memoryUsed.permanentChildUsage
                 ? CircuitBreaker.Durability.TRANSIENT
                 : CircuitBreaker.Durability.PERMANENT;
-            logger.debug(() -> format("%s", messageString));
+            logger.warn(() -> format("%s", messageString));
             throw new CircuitBreakingException(messageString, memoryUsed.totalUsage, parentLimit, durability);
         }
     }


### PR DESCRIPTION
Adjust log level of the message that gets logged when throwing `CircuitBreakingException` in `HierarchyCircuitBreakerService` from debug to warning.

A similar log log in `ChildMemoryCircuitBreaker` is logged as warning. I think it makes sense to the same here?