### PR TITLE
Log field-caps Exceptions at WARN level even when partial results are returned

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -278,6 +278,20 @@ public final class ExceptionsHelper {
         return uniqueFailures.toArray(new ShardOperationFailedException[0]);
     }
 
+    /**
+     * @param t Throwable to inspect
+     * @return true if the Throwable is an instance of an Exception that indicates
+     *         that either a Node or shard is unavailable/disconnected.
+     */
+    public static boolean isNodeOrShardUnavailableTypeException(Throwable t) {
+        return (t instanceof org.elasticsearch.action.NoShardAvailableActionException
+            || t instanceof org.elasticsearch.action.UnavailableShardsException
+            || t instanceof org.elasticsearch.node.NodeClosedException
+            || t instanceof org.elasticsearch.transport.NodeDisconnectedException
+            || t instanceof org.elasticsearch.discovery.MasterNotDiscoveredException
+            || t instanceof org.elasticsearch.transport.NodeNotConnectedException);
+    }
+
     private static class GroupBy {
         final String reason;
         final String index;

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -279,6 +279,10 @@ public final class ExceptionsHelper {
     }
 
     /**
+     * Utility method useful for determine whether to log an Exception or perhaps
+     * avoid logging a stacktrace if the caller/logger is not interested in these
+     * types of node/shard issues.
+     *
      * @param t Throwable to inspect
      * @return true if the Throwable is an instance of an Exception that indicates
      *         that either a Node or shard is unavailable/disconnected.
@@ -289,7 +293,8 @@ public final class ExceptionsHelper {
             || t instanceof org.elasticsearch.node.NodeClosedException
             || t instanceof org.elasticsearch.transport.NodeDisconnectedException
             || t instanceof org.elasticsearch.discovery.MasterNotDiscoveredException
-            || t instanceof org.elasticsearch.transport.NodeNotConnectedException);
+            || t instanceof org.elasticsearch.transport.NodeNotConnectedException
+            || t instanceof org.elasticsearch.cluster.block.ClusterBlockException);
     }
 
     private static class GroupBy {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -470,7 +470,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         }
 
         void collect(String index, Exception e) {
-            Exception prev = failuresByIndex.putIfAbsent(index, e);
+            failuresByIndex.putIfAbsent(index, e);
         }
 
         void clear() {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -325,7 +325,27 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         } else {
             collectResponseMap(responseMapBuilder, responseMap);
         }
+
+        // The merge method is only called on the primary coordinator for cross-cluster field caps, so we
+        // log relevant "5xx" errors that occurred in this 2xx response to ensure they are only logged once.
+        // These failures have already been deduplicated, before this method was called.
+        for (FieldCapabilitiesFailure failure : failures) {
+            LOGGER.warn(
+                "Field caps partial-results Exception for indices " + Arrays.toString(failure.getIndices()),
+                failure.getException()
+            );
+        }
         return new FieldCapabilitiesResponse(indices, Collections.unmodifiableMap(responseMap), failures);
+    }
+
+    private static boolean shouldLogException(Exception e) {
+        // ConnectTransportExceptions are thrown when a cluster marked with skip_unavailable=false are not available for searching
+        // (Clusters marked with skip_unavailable=false return a different error that is considered a 4xx error.)
+        // In such a case, the field-caps endpoint returns a 200 (unless all clusters failed).
+        // To keep the logs from being too noisy, we choose not to log the ConnectTransportException here.
+        return e instanceof org.elasticsearch.transport.ConnectTransportException == false
+            && ExceptionsHelper.status(e).getStatus() >= 500
+            && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false;
     }
 
     private static void collectResponseMapIncludingUnmapped(
@@ -441,7 +461,6 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
 
         List<FieldCapabilitiesFailure> build(Set<String> successfulIndices) {
             Map<Tuple<String, String>, FieldCapabilitiesFailure> indexFailures = new HashMap<>();
-            Set<String> exceptionsLogged = new HashSet<>();
             for (Map.Entry<String, Exception> failure : failuresByIndex.entrySet()) {
                 String index = failure.getKey();
                 Exception e = failure.getValue();
@@ -457,16 +476,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                     );
                 }
             }
-            ArrayList<FieldCapabilitiesFailure> failures = new ArrayList<>(indexFailures.size());
-            for (FieldCapabilitiesFailure value : indexFailures.values()) {
-                Exception e = value.getException();
-                // log 500 errors that are not Node/Shard unavailable type errors (and only once per Exception type)
-                if (ExceptionsHelper.status(e).getStatus() >= 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
-                    LOGGER.warn("Field caps Exception for indices: {}", value.getIndices(), e);
-                }
-                failures.add(value);
-            }
-            return failures;
+            return new ArrayList<>(indexFailures.values());
         }
 
         void collect(String index, Exception e) {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -330,10 +330,12 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         // log relevant "5xx" errors that occurred in this 2xx response to ensure they are only logged once.
         // These failures have already been deduplicated, before this method was called.
         for (FieldCapabilitiesFailure failure : failures) {
-            LOGGER.warn(
-                "Field caps partial-results Exception for indices " + Arrays.toString(failure.getIndices()),
-                failure.getException()
-            );
+            if (shouldLogException(failure.getException())) {
+                LOGGER.warn(
+                    "Field caps partial-results Exception for indices " + Arrays.toString(failure.getIndices()),
+                    failure.getException()
+                );
+            }
         }
         return new FieldCapabilitiesResponse(indices, Collections.unmodifiableMap(responseMap), failures);
     }


### PR DESCRIPTION
Field-caps requests that result in an error to the user (4xx and 5xx HTTP status), are already
logged by the RestResponse "rest.suppressed" logger.

This PR addresses 5xx-type errors that occur in the field-caps endpoint when partial results
(a 2xx successful search response) is returned to the user. The errors that occurred are
enumerated to the end user in the field-caps response, but not logged.

The logging is done in the TransportFieldCapabilities.merge method since that method is
only called on the primary coordinator during a cross-cluster field-caps search. This ensures
that there is not double logging of exceptions across nodes of the cluster.

This PR also creates a method for a set of Exceptions that we generally do not want to
log in the search or aggs codebase. I added it to the top level ExceptionsHelper class
rather than a search-specific one so it can be easily accessible for other packages.