### PR TITLE
Update painless and runtime field tests to use a replica

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/100_terms_agg.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/100_terms_agg.yml
@@ -4,7 +4,7 @@ setup:
           index: test_1
           body:
             settings:
-              number_of_replicas: 0
+              number_of_replicas: 1
             mappings:
               properties:
                 str:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/110_script_score_boost.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/110_script_score_boost.yml
@@ -10,7 +10,7 @@ setup:
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
+              number_of_replicas: 1
           mappings:
             properties:
               k:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/130_metric_agg.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/130_metric_agg.yml
@@ -4,7 +4,7 @@ setup:
         index: test
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               double:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/140_dense_vector_basic.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/140_dense_vector_basic.yml
@@ -7,7 +7,7 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               vector:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/145_dense_vector_byte_basic.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/145_dense_vector_byte_basic.yml
@@ -9,7 +9,7 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               vector:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/150_dense_vector_l1l2.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/150_dense_vector_l1l2.yml
@@ -7,7 +7,7 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               my_dense_vector:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/155_dense_vector_byte_l1l2.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/155_dense_vector_byte_l1l2.yml
@@ -9,7 +9,7 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               my_dense_vector:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/160_dense_vector_special_cases.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/160_dense_vector_special_cases.yml
@@ -7,7 +7,7 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
             number_of_shards: 1
           mappings:
             properties:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/165_dense_vector_byte_special_cases.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/165_dense_vector_byte_special_cases.yml
@@ -9,7 +9,7 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
+            number_of_replicas: 1
             number_of_shards: 1
           mappings:
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/100_geo_point.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/100_geo_point.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               location_from_doc_value:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/101_geo_point_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/102_geo_point_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/103_geo_point_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/103_geo_point_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               location_from_doc_value:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/10_keyword.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               day_of_week:
@@ -311,7 +311,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               users.first_script:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/110_composite.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/110_composite.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               http:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/111_search_time_composite.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/111_search_time_composite.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 2
-            number_of_replicas: 0
+            number_of_replicas: 1
   - do:
       bulk:
         index: test

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/114_composite_errors.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/114_composite_errors.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               rtf:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/11_keyword_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/11_keyword_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/12_keyword_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/12_keyword_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/13_keyword_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/13_keyword_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               timestamp:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/150_nested_runtime_fields.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/150_nested_runtime_fields.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               name:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/20_long.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/20_long.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               voltage_times_ten:
@@ -195,7 +195,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               users.first_script:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/21_long_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/21_long_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/22_long_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/22_long_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/23_long_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               timestamp:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/24_long_errors.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/24_long_errors.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               rtf:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/250_grok.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/250_grok.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               http.clientip:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/260_dissect.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/260_dissect.yml
@@ -5,7 +5,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               http.clientip:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/30_double.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/30_double.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               voltage_percent:
@@ -151,7 +151,7 @@ setup:
   - match: {hits.total.value: 2}
   - match: {hits.hits.0._source.voltage: 0.0}
   - match: {hits.hits.1._source.voltage: 4.0}
-  
+
   - do:
       search:
         index: sensor

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/31_double_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/31_double_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/32_double_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/32_double_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/33_double_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               timestamp:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/34_double_errors.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/34_double_errors.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               rtf:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/40_date.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/40_date.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               tomorrow:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/41_date_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/41_date_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/42_date_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/42_date_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/43_date_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/43_date_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               tomorrow:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/44_date_errors.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/44_date_errors.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               rtf:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/50_ip.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/50_ip.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               ip:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/51_ip_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/51_ip_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/52_ip_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/52_ip_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/53_ip_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/53_ip_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               ip:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/54_ip_errors.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/54_ip_errors.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               rtf:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/60_boolean.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               over_v:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/61_boolean_from_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/61_boolean_from_source.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             runtime:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/62_boolean_source_in_query.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/62_boolean_source_in_query.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             dynamic: false
             properties:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/63_boolean_calculated_at_index.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/63_boolean_calculated_at_index.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               timestamp:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/64_boolean_errors.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/64_boolean_errors.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               rtf:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/80_multiple_indices.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/80_multiple_indices.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               day_of_week:
@@ -94,7 +94,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             properties:
               message:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/90_loops.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/90_loops.yml
@@ -6,7 +6,7 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            number_of_replicas: 1
           mappings:
             runtime:
               tight_loop:


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/99835 we want to run these test in environments where 0 replicas is unsupported.