### PR TITLE
Add an RRF Retriever

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/retriever/ClassicRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/ClassicRetrieverBuilder.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.builder.SubSearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rescore.RescorerBuilder;
@@ -363,12 +364,8 @@ public final class ClassicRetrieverBuilder extends RetrieverBuilder<ClassicRetri
     }
 
     public void doExtractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
-        if (searchSourceBuilder.query() == null) {
-            if (queryBuilder != null) {
-                searchSourceBuilder.query(queryBuilder);
-            }
-        } else {
-            throw new IllegalStateException("[query] cannot be declared as a retriever value and as a global value");
+        if (queryBuilder != null) {
+            searchSourceBuilder.subSearches().add(new SubSearchSourceBuilder(queryBuilder));
         }
 
         if (searchSourceBuilder.searchAfter() == null) {

--- a/server/src/main/java/org/elasticsearch/search/retriever/ClassicRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/ClassicRetrieverBuilder.java
@@ -114,7 +114,7 @@ public final class ClassicRetrieverBuilder extends RetrieverBuilder<ClassicRetri
     private CollapseBuilder collapseBuilder;
 
     public ClassicRetrieverBuilder() {
-        super();
+
     }
 
     public ClassicRetrieverBuilder(ClassicRetrieverBuilder original) {

--- a/server/src/main/java/org/elasticsearch/search/retriever/ClassicRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/ClassicRetrieverBuilder.java
@@ -113,7 +113,7 @@ public final class ClassicRetrieverBuilder extends RetrieverBuilder<ClassicRetri
     private CollapseBuilder collapseBuilder;
 
     public ClassicRetrieverBuilder() {
-
+        super();
     }
 
     public ClassicRetrieverBuilder(ClassicRetrieverBuilder original) {

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankPlugin.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankPlugin.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.rank.RankBuilder;
 import org.elasticsearch.search.rank.RankShardResult;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -18,7 +19,7 @@ import org.elasticsearch.xcontent.ParseField;
 
 import java.util.List;
 
-public class RRFRankPlugin extends Plugin {
+public class RRFRankPlugin extends Plugin implements SearchPlugin {
 
     public static final LicensedFeature.Momentary RANK_RRF_FEATURE = LicensedFeature.momentary(
         null,
@@ -39,5 +40,10 @@ public class RRFRankPlugin extends Plugin {
     @Override
     public List<NamedXContentRegistry.Entry> getNamedXContent() {
         return List.of(new NamedXContentRegistry.Entry(RankBuilder.class, new ParseField(NAME), RRFRankBuilder::fromXContent));
+    }
+
+    @Override
+    public List<RetrieverSpec<?>> getRetrievers() {
+        return List.of(new RetrieverSpec<>(new ParseField(NAME), RRFRetrieverBuilder::new, RRFRetrieverBuilder::fromXContent));
     }
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -24,16 +24,18 @@ import java.util.Collections;
 import java.util.List;
 
 /*
-curl -X GET -u elastic:password "localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'                                            [15:24:27]─┘
+curl -X GET -u elastic:password "localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
 {
     "retriever": {
         "rrf": {
             "retrievers": [
-                "classic": {
-                    "query": {
-                        "match_all": {}
-                    },
-                    "sort": {"user.id.keyword": "desc"}
+                {
+                    "classic": {
+                        "query": {
+                            "match_all": {}
+                        },
+                        "sort": {"user.id.keyword": "desc"}
+                    }
                 }
             ]
         }
@@ -57,6 +59,7 @@ public final class RRFRetrieverBuilder extends RetrieverBuilder<RRFRetrieverBuil
         PARSER.declareObjectArray((v, l) -> v.retrieverBuilders = l, (p, c) -> {
             String name = p.currentName();
             p.nextToken();
+            if (true) throw new IllegalStateException(name);
             return (RetrieverBuilder<?>)p.namedObject(RetrieverBuilder.class, name, c);
         }, RETRIEVERS_FIELD);
         PARSER.declareInt((b, v) -> b.windowSize = v, WINDOW_SIZE_FIELD);

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.rank.rrf;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.retriever.RetrieverBuilder;
+import org.elasticsearch.search.retriever.RetrieverParserContext;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/*
+curl -X GET -u elastic:password "localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'                                            [15:24:27]─┘
+{
+    "retriever": {
+        "rrf": {
+            "retrievers": [
+                "classic": {
+                    "query": {
+                        "match_all": {}
+                    },
+                    "sort": {"user.id.keyword": "desc"}
+                }
+            ]
+        }
+    }
+}
+'
+ */
+
+public final class RRFRetrieverBuilder extends RetrieverBuilder<RRFRetrieverBuilder> {
+
+    public static final ParseField RETRIEVERS_FIELD = new ParseField("retrievers");
+    public static final ParseField WINDOW_SIZE_FIELD = new ParseField("window_size");
+    public static final ParseField RANK_CONSTANT_FIELD = new ParseField("rank_constant");
+
+    public static final ObjectParser<RRFRetrieverBuilder, RetrieverParserContext> PARSER = new ObjectParser<>(
+        RRFRankPlugin.NAME,
+        RRFRetrieverBuilder::new
+    );
+
+    static {
+        PARSER.declareObjectArray((v, l) -> v.retrieverBuilders = l, (p, c) -> {
+            String name = p.currentName();
+            p.nextToken();
+            return (RetrieverBuilder<?>)p.namedObject(RetrieverBuilder.class, name, c);
+        }, RETRIEVERS_FIELD);
+        PARSER.declareInt((b, v) -> b.windowSize = v, WINDOW_SIZE_FIELD);
+        PARSER.declareInt((b, v) -> b.rankConstant = v, RANK_CONSTANT_FIELD);
+
+        RetrieverBuilder.declareBaseParserFields(RRFRankPlugin.NAME, PARSER);
+    }
+
+    public static RRFRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
+        return PARSER.apply(parser, context);
+    }
+
+    private List<? extends RetrieverBuilder<?>> retrieverBuilders = Collections.emptyList();
+    private int windowSize;
+    private int rankConstant;
+
+    public RRFRetrieverBuilder() {
+
+    }
+
+    public RRFRetrieverBuilder(RRFRetrieverBuilder original) {
+        super(original);
+        retrieverBuilders = original.retrieverBuilders;
+        windowSize = original.windowSize;
+        rankConstant = original.rankConstant;
+    }
+
+    @SuppressWarnings("unchecked")
+    public RRFRetrieverBuilder(StreamInput in) throws IOException {
+        super(in);
+        retrieverBuilders = (List<RetrieverBuilder<?>>)(Object)in.readNamedWriteableCollectionAsList(RetrieverBuilder.class);
+        windowSize = in.readVInt();
+        rankConstant = in.readVInt();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return RRFRankPlugin.NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersions.RETRIEVERS_ADDED;
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteableCollection(retrieverBuilders);
+        out.writeVInt(windowSize);
+        out.writeVInt(rankConstant);
+    }
+
+    @Override
+    protected void doToXContent(XContentBuilder builder, Params params) throws IOException {
+        for (RetrieverBuilder<?> retrieverBuilder : retrieverBuilders) {
+            builder.startArray(RETRIEVERS_FIELD.getPreferredName());
+            retrieverBuilder.toXContent(builder, params);
+            builder.endArray();
+        }
+
+        builder.field(WINDOW_SIZE_FIELD.getPreferredName(), windowSize);
+        builder.field(RANK_CONSTANT_FIELD.getPreferredName(), rankConstant);
+    }
+
+    @Override
+    protected RRFRetrieverBuilder shallowCopyInstance() {
+        return new RRFRetrieverBuilder(this);
+    }
+
+    @Override
+    public void doExtractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
+
+    }
+}


### PR DESCRIPTION
This change adds an `RRFRetrieverBuilder` using the same strategy as `ClassicRetrieverBuilder` where we extract the parsed request body into a `SearchSourceBuilder`.