### PR TITLE
Remove more explicit references to SearchResponse in tests

### DIFF
--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/AdjacencyMatrixIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/AdjacencyMatrixIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -35,7 +36,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -102,7 +102,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             .addAggregation(adjacencyMatrix("tags", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2"))))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         AdjacencyMatrix matrix = response.getAggregations().get("tags");
         assertThat(matrix, notNullValue());
@@ -134,7 +134,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             .addAggregation(adjacencyMatrix("tags", "\t", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2"))))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         AdjacencyMatrix matrix = response.getAggregations().get("tags");
         assertThat(matrix, notNullValue());
@@ -157,7 +157,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             .addAggregation(adjacencyMatrix("tags", newMap("all", emptyFilter).add("tag1", termQuery("tag", "tag1"))))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         AdjacencyMatrix filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -180,7 +180,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         AdjacencyMatrix matrix = response.getAggregations().get("tags");
         assertThat(matrix, notNullValue());
@@ -309,7 +309,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/AdjacencyMatrixIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/AdjacencyMatrixIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -36,6 +35,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -102,7 +102,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             .addAggregation(adjacencyMatrix("tags", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2"))))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         AdjacencyMatrix matrix = response.getAggregations().get("tags");
         assertThat(matrix, notNullValue());
@@ -134,7 +134,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             .addAggregation(adjacencyMatrix("tags", "\t", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2"))))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         AdjacencyMatrix matrix = response.getAggregations().get("tags");
         assertThat(matrix, notNullValue());
@@ -157,7 +157,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             .addAggregation(adjacencyMatrix("tags", newMap("all", emptyFilter).add("tag1", termQuery("tag", "tag1"))))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         AdjacencyMatrix filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -180,7 +180,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         AdjacencyMatrix matrix = response.getAggregations().get("tags");
         assertThat(matrix, notNullValue());
@@ -309,7 +309,7 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
@@ -58,7 +58,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -178,7 +177,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
 
     public void testStandAloneTimeSeriesAgg() {
         SearchResponse response = client().prepareSearch("index").setSize(0).addAggregation(timeSeries("by_ts")).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         InternalTimeSeries timeSeries = aggregations.get("by_ts");
@@ -204,7 +203,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
                     .subAggregation(timeSeries("by_ts"))
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         Terms terms = aggregations.get("by_dim");
@@ -232,7 +231,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
                     .subAggregation(timeSeries("by_ts").subAggregation(stats("timestamp").field("@timestamp")))
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         Histogram histogram = aggregations.get("by_time");
@@ -272,7 +271,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
             .setSize(0)
             .addAggregation(timeSeries("by_ts"))
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         InternalTimeSeries timeSeries = aggregations.get("by_ts");
@@ -304,7 +303,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
             .addAggregation(global("everything").subAggregation(sum("all_sum").field("metric_" + metric)))
             .addAggregation(PipelineAggregatorBuilders.sumBucket("total_filter_sum", "by_ts>filter_sum"))
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         InternalTimeSeries timeSeries = aggregations.get("by_ts");
@@ -351,7 +350,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
             .setSize(0)
             .addAggregation(timeSeries("by_ts"))
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         InternalTimeSeries timeSeries = aggregations.get("by_ts");

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.SimpleValue;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matcher;
 import org.junit.After;
 
@@ -40,6 +39,7 @@ import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -125,7 +125,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -170,7 +170,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -235,7 +235,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -293,7 +293,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -353,7 +353,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -421,7 +421,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -504,7 +504,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -562,7 +562,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -580,7 +580,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.SimpleValue;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matcher;
 import org.junit.After;
 
@@ -39,7 +40,6 @@ import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -125,7 +125,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -170,7 +170,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -235,7 +235,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -293,7 +293,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -353,7 +353,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -421,7 +421,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -504,7 +504,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -562,7 +562,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -580,7 +580,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.aggregations.pipeline.BucketHelpers;
 import org.elasticsearch.search.aggregations.pipeline.SimpleValue;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -31,7 +32,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.diff;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -231,7 +231,7 @@ public class SerialDiffIT extends AggregationIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.pipeline.BucketHelpers;
 import org.elasticsearch.search.aggregations.pipeline.SimpleValue;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -32,6 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.diff;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -231,7 +231,7 @@ public class SerialDiffIT extends AggregationIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
@@ -44,7 +44,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketScript;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -88,7 +87,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         ensureGreen("test");
         client().prepareIndex("test").setId("1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
         SearchResponse rsp = buildRequest("doc['foo'] + abs(1)").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(5.0, rsp.getHits().getAt(0).field("foo").getValue(), 0.0D);
     }
@@ -118,7 +117,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         req.setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("text", "hello"), score).boostMode(CombineFunction.REPLACE));
         req.setSearchType(SearchType.DFS_QUERY_THEN_FETCH); // make sure DF is consistent
         SearchResponse rsp = req.get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         SearchHits hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals("1", hits.getAt(0).getId());
@@ -223,7 +222,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         );
 
         SearchResponse rsp = buildRequest("doc['double0'].count() + doc['double1'].count()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         SearchHits hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(5.0, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -231,7 +230,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         assertEquals(5.0, hits.getAt(2).field("foo").getValue(), 0.0D);
 
         rsp = buildRequest("doc['double0'].sum()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(7.5, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -239,7 +238,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         assertEquals(6.0, hits.getAt(2).field("foo").getValue(), 0.0D);
 
         rsp = buildRequest("doc['double0'].avg() + doc['double1'].avg()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(4.3, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -247,7 +246,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         assertEquals(5.5, hits.getAt(2).field("foo").getValue(), 0.0D);
 
         rsp = buildRequest("doc['double0'].median()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(1.5, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -255,7 +254,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         assertEquals(1.25, hits.getAt(2).field("foo").getValue(), 0.0D);
 
         rsp = buildRequest("doc['double0'].min()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(1.0, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -263,7 +262,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         assertEquals(-1.5, hits.getAt(2).field("foo").getValue(), 0.0D);
 
         rsp = buildRequest("doc['double0'].max()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(5.0, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -271,7 +270,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         assertEquals(5.0, hits.getAt(2).field("foo").getValue(), 0.0D);
 
         rsp = buildRequest("doc['double0'].sum()/doc['double0'].count()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(2.5, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -280,7 +279,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
 
         // make sure count() works for missing
         rsp = buildRequest("doc['double2'].count()").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(1.0, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -289,7 +288,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
 
         // make sure .empty works in the same way
         rsp = buildRequest("doc['double2'].empty ? 5.0 : 2.0").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         hits = rsp.getHits();
         assertEquals(3, hits.getTotalHits().value);
         assertEquals(2.0, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -327,7 +326,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("2").setSource("id", 2, "y", 2)
         );
         SearchResponse rsp = buildRequest("doc['x'] + 1").get();
-        ElasticsearchAssertions.assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         SearchHits hits = rsp.getHits();
         assertEquals(2, rsp.getHits().getTotalHits().value);
         assertEquals(5.0, hits.getAt(0).field("foo").getValue(), 0.0D);
@@ -640,22 +639,22 @@ public class MoreExpressionIT extends ESIntegTestCase {
         refresh();
         // access .lat
         SearchResponse rsp = buildRequest("doc['location'].lat").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(61.5240, rsp.getHits().getAt(0).field("foo").getValue(), 1.0D);
         // access .lon
         rsp = buildRequest("doc['location'].lon").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(105.3188, rsp.getHits().getAt(0).field("foo").getValue(), 1.0D);
         // access .empty
         rsp = buildRequest("doc['location'].empty ? 1 : 0").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(0, rsp.getHits().getAt(0).field("foo").getValue(), 1.0D);
         // call haversin
         rsp = buildRequest("haversin(38.9072, 77.0369, doc['location'].lat, doc['location'].lon)").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(3170D, rsp.getHits().getAt(0).field("foo").getValue(), 50D);
     }
@@ -678,14 +677,14 @@ public class MoreExpressionIT extends ESIntegTestCase {
         );
         // access .value
         SearchResponse rsp = buildRequest("doc['vip'].value").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(3, rsp.getHits().getTotalHits().value);
         assertEquals(1.0D, rsp.getHits().getAt(0).field("foo").getValue(), 1.0D);
         assertEquals(0.0D, rsp.getHits().getAt(1).field("foo").getValue(), 1.0D);
         assertEquals(0.0D, rsp.getHits().getAt(2).field("foo").getValue(), 1.0D);
         // access .empty
         rsp = buildRequest("doc['vip'].empty ? 1 : 0").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(3, rsp.getHits().getTotalHits().value);
         assertEquals(0.0D, rsp.getHits().getAt(0).field("foo").getValue(), 1.0D);
         assertEquals(0.0D, rsp.getHits().getAt(1).field("foo").getValue(), 1.0D);
@@ -693,7 +692,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         // ternary operator
         // vip's have a 50% discount
         rsp = buildRequest("doc['vip'] ? doc['price']/2 : doc['price']").get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(3, rsp.getHits().getTotalHits().value);
         assertEquals(0.5D, rsp.getHits().getAt(0).field("foo").getValue(), 1.0D);
         assertEquals(2.0D, rsp.getHits().getAt(1).field("foo").getValue(), 1.0D);
@@ -712,7 +711,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
         Script script = new Script(ScriptType.INLINE, "expression", "doc['foo'].value", Collections.emptyMap());
         builder.setQuery(QueryBuilders.boolQuery().filter(QueryBuilders.scriptQuery(script)));
         SearchResponse rsp = builder.get();
-        assertSearchResponse(rsp);
+        assertNoFailures(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(1.0D, rsp.getHits().getAt(0).field("foo").getValue(), 0.0D);
     }

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ChildrenIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ChildrenIT.java
@@ -36,7 +36,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -50,7 +49,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
             .addAggregation(children("to_comment", "comment"));
         final SearchResponse searchResponse = searchRequest.get();
         long count = categoryToControl.values().stream().mapToLong(control -> control.commentIds.size()).sum();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
         Children childrenAgg = searchResponse.getAggregations().get("to_comment");
         assertThat("Request: " + searchRequest + "\nResponse: " + searchResponse + "\n", childrenAgg.getDocCount(), equalTo(count));
     }
@@ -68,7 +67,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
                     )
             )
             .get();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
 
         Terms categoryTerms = searchResponse.getAggregations().get("category");
         assertThat(categoryTerms.getBuckets().size(), equalTo(categoryToControl.size()));
@@ -107,7 +106,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
                     .subAggregation(children("to_comment", "comment").subAggregation(topHits("top_comments").sort("id", SortOrder.ASC)))
             )
             .get();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
 
         Terms categoryTerms = searchResponse.getAggregations().get("category");
         assertThat(categoryTerms.getBuckets().size(), equalTo(3));
@@ -204,7 +203,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
 
     public void testNonExistingChildType() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("test").addAggregation(children("non-existing", "xyz")).get();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
 
         Children children = searchResponse.getAggregations().get("non-existing");
         assertThat(children.getName(), equalTo("non-existing"));

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,6 +27,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.join.aggregations.JoinAggregationBuilders.parent;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ParentIT extends AbstractParentChildTestCase {
@@ -39,7 +39,7 @@ public class ParentIT extends AbstractParentChildTestCase {
             .addAggregation(parent("to_article", "comment"));
         SearchResponse searchResponse = searchRequest.get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
@@ -58,7 +58,7 @@ public class ParentIT extends AbstractParentChildTestCase {
             .setQuery(matchQuery("randomized", true))
             .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
         SearchResponse searchResponse = searchRequest.get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         long articlesWithComment = articleToControl.values()
             .stream()
@@ -121,7 +121,7 @@ public class ParentIT extends AbstractParentChildTestCase {
                     )
             );
         SearchResponse searchResponse = searchRequest.get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         final Set<String> commenters = getCommenters();
         final Map<String, Set<String>> commenterToComments = getCommenterToComments();
@@ -201,7 +201,7 @@ public class ParentIT extends AbstractParentChildTestCase {
 
     public void testNonExistingParentType() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("test").addAggregation(parent("non-existing", "xyz")).get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         Parent parent = searchResponse.getAggregations().get("non-existing");
         assertThat(parent.getName(), equalTo("non-existing"));
@@ -218,7 +218,7 @@ public class ParentIT extends AbstractParentChildTestCase {
                     .subAggregation(parent("to_article", "comment").subAggregation(terms("to_category").field("category").size(10000)))
             );
         SearchResponse searchResponse = searchRequest.get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         final Set<String> commenters = getCommenters();
         final Map<String, Set<String>> commenterToComments = getCommenterToComments();

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,7 +28,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.join.aggregations.JoinAggregationBuilders.parent;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ParentIT extends AbstractParentChildTestCase {
@@ -39,7 +39,7 @@ public class ParentIT extends AbstractParentChildTestCase {
             .addAggregation(parent("to_article", "comment"));
         SearchResponse searchResponse = searchRequest.get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
@@ -58,7 +58,7 @@ public class ParentIT extends AbstractParentChildTestCase {
             .setQuery(matchQuery("randomized", true))
             .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
         SearchResponse searchResponse = searchRequest.get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         long articlesWithComment = articleToControl.values()
             .stream()
@@ -121,7 +121,7 @@ public class ParentIT extends AbstractParentChildTestCase {
                     )
             );
         SearchResponse searchResponse = searchRequest.get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         final Set<String> commenters = getCommenters();
         final Map<String, Set<String>> commenterToComments = getCommenterToComments();
@@ -201,7 +201,7 @@ public class ParentIT extends AbstractParentChildTestCase {
 
     public void testNonExistingParentType() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("test").addAggregation(parent("non-existing", "xyz")).get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         Parent parent = searchResponse.getAggregations().get("non-existing");
         assertThat(parent.getName(), equalTo("non-existing"));
@@ -218,7 +218,7 @@ public class ParentIT extends AbstractParentChildTestCase {
                     .subAggregation(parent("to_article", "comment").subAggregation(terms("to_category").field("category").size(10000)))
             );
         SearchResponse searchResponse = searchRequest.get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         final Set<String> commenters = getCommenters();
         final Map<String, Set<String>> commenterToComments = getCommenterToComments();

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
@@ -52,6 +52,7 @@ import static org.elasticsearch.join.query.JoinQueryBuilders.hasChildQuery;
 import static org.elasticsearch.join.query.JoinQueryBuilders.hasParentQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
@@ -638,15 +639,14 @@ public class InnerHitsIT extends ParentChildTestCase {
         createIndexRequest("index1", "parent_type", "1", null, "nested_type", Collections.singletonMap("key", "value")).get();
         createIndexRequest("index1", "child_type", "2", "1").get();
         refresh();
-
-        SearchResponse response = client().prepareSearch("index1")
-            .setQuery(
-                hasChildQuery("child_type", matchAllQuery(), ScoreMode.None).ignoreUnmapped(true)
-                    .innerHit(new InnerHitBuilder().setFrom(50).setSize(10).setName("_name"))
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(
+            client().prepareSearch("index1")
+                .setQuery(
+                    hasChildQuery("child_type", matchAllQuery(), ScoreMode.None).ignoreUnmapped(true)
+                        .innerHit(new InnerHitBuilder().setFrom(50).setSize(10).setName("_name"))
+                ),
+            1
+        );
 
         Exception e = expectThrows(
             SearchPhaseExecutionException.class,

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -39,7 +39,6 @@ import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Arrays;
@@ -65,6 +64,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
@@ -288,7 +288,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             .setQuery(QueryBuilders.matchQuery("name", "bar"))
             .addAggregation(AggregationBuilders.global("global").subAggregation(AggregationBuilders.terms("test").field("name")))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         Global global = searchResponse.getAggregations().get("global");
         Terms terms = global.getAggregations().get("test");
         assertThat(terms.getBuckets().size(), equalTo(4));
@@ -299,7 +299,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             .addAggregation(AggregationBuilders.global("global").subAggregation(AggregationBuilders.terms("test").field("name")))
             .addSort("_index", SortOrder.ASC)
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         global = searchResponse.getAggregations().get("global");
         terms = global.getAggregations().get("test");
         assertThat(terms.getBuckets().size(), equalTo(4));
@@ -310,7 +310,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             .addAggregation(AggregationBuilders.terms("test").field("name"))
             .addSort("_index", SortOrder.ASC)
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         terms = searchResponse.getAggregations().get("test");
         assertThat(terms.getBuckets().size(), equalTo(2));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -39,6 +39,7 @@ import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Arrays;
@@ -64,7 +65,6 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
@@ -288,7 +288,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             .setQuery(QueryBuilders.matchQuery("name", "bar"))
             .addAggregation(AggregationBuilders.global("global").subAggregation(AggregationBuilders.terms("test").field("name")))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         Global global = searchResponse.getAggregations().get("global");
         Terms terms = global.getAggregations().get("test");
         assertThat(terms.getBuckets().size(), equalTo(4));
@@ -299,7 +299,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             .addAggregation(AggregationBuilders.global("global").subAggregation(AggregationBuilders.terms("test").field("name")))
             .addSort("_index", SortOrder.ASC)
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         global = searchResponse.getAggregations().get("global");
         terms = global.getAggregations().get("test");
         assertThat(terms.getBuckets().size(), equalTo(4));
@@ -310,7 +310,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             .addAggregation(AggregationBuilders.terms("test").field("name"))
             .addSort("_index", SortOrder.ASC)
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         terms = searchResponse.getAggregations().get("test");
         assertThat(terms.getBuckets().size(), equalTo(2));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/ExceptionRetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/ExceptionRetryIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.TransportService;
@@ -40,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -130,7 +130,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
                 dupCounter++;
             }
         }
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(dupCounter, equalTo(0L));
         assertHitCount(searchResponse, numDocs);
         IndicesStatsResponse index = indicesAdmin().prepareStats("index").clear().setSegments(true).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/ExceptionRetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/ExceptionRetryIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.TransportService;
@@ -39,7 +40,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -130,7 +130,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
                 dupCounter++;
             }
         }
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(dupCounter, equalTo(0L));
         assertHitCount(searchResponse, numDocs);
         IndicesStatsResponse index = indicesAdmin().prepareStats("index").clear().setSegments(true).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -35,6 +35,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHist
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -66,7 +67,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                 dateHistogram("histo").field("f").timeZone(ZoneId.of("+01:00")).minDocCount(0).calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r1);
+        assertNoFailures(r1);
 
         // The cached is actually used
         assertThat(
@@ -85,7 +86,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                         .calendarInterval(DateHistogramInterval.MONTH)
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(r2);
+            assertNoFailures(r2);
             Histogram h1 = r1.getAggregations().get("histo");
             Histogram h2 = r2.getAggregations().get("histo");
             final List<? extends Bucket> buckets1 = h1.getBuckets();
@@ -529,7 +530,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                 .setProfile(profile)
                 .setQuery(QueryBuilders.termQuery("k", "hello"))
                 .get();
-            ElasticsearchAssertions.assertNoFailures(resp);
+            assertNoFailures(resp);
             ElasticsearchAssertions.assertAllSuccessful(resp);
             assertThat(resp.getHits().getTotalHits().value, equalTo(1L));
             if (profile == false) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -35,7 +35,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHist
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -67,7 +66,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                 dateHistogram("histo").field("f").timeZone(ZoneId.of("+01:00")).minDocCount(0).calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        assertSearchResponse(r1);
+        ElasticsearchAssertions.assertNoFailures(r1);
 
         // The cached is actually used
         assertThat(
@@ -86,7 +85,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                         .calendarInterval(DateHistogramInterval.MONTH)
                 )
                 .get();
-            assertSearchResponse(r2);
+            ElasticsearchAssertions.assertNoFailures(r2);
             Histogram h1 = r1.getAggregations().get("histo");
             Histogram h2 = r2.getAggregations().get("histo");
             final List<? extends Bucket> buckets1 = h1.getBuckets();
@@ -530,7 +529,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                 .setProfile(profile)
                 .setQuery(QueryBuilders.termQuery("k", "hello"))
                 .get();
-            assertSearchResponse(resp);
+            ElasticsearchAssertions.assertNoFailures(resp);
             ElasticsearchAssertions.assertAllSuccessful(resp);
             assertThat(resp.getHits().getTotalHits().value, equalTo(1L));
             if (profile == false) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/StressSearchServiceReaperIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/StressSearchServiceReaperIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.tests.util.English;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -19,8 +18,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 
 @ClusterScope(scope = SUITE)
 public class StressSearchServiceReaperIT extends ESIntegTestCase {
@@ -45,9 +43,7 @@ public class StressSearchServiceReaperIT extends ESIntegTestCase {
         indexRandom(true, builders);
         final int iterations = scaledRandomIntBetween(500, 1000);
         for (int i = 0; i < iterations; i++) {
-            SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).setSize(num).get();
-            assertNoFailures(searchResponse);
-            assertHitCount(searchResponse, num);
+            assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(matchAllQuery()).setSize(num), num);
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
@@ -13,13 +13,13 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
 @ESIntegTestCase.SuiteScopeTestCase
 public class AggregationsIntegrationIT extends ESIntegTestCase {
@@ -44,7 +44,7 @@ public class AggregationsIntegrationIT extends ESIntegTestCase {
             .setScroll(TimeValue.timeValueMinutes(1))
             .addAggregation(terms("f").field("f"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         Terms terms = aggregations.get("f");
@@ -53,7 +53,7 @@ public class AggregationsIntegrationIT extends ESIntegTestCase {
         int total = response.getHits().getHits().length;
         while (response.getHits().getHits().length > 0) {
             response = client().prepareSearchScroll(response.getScrollId()).setScroll(TimeValue.timeValueMinutes(1)).get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             assertNull(response.getAggregations());
             total += response.getHits().getHits().length;
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
@@ -13,13 +13,13 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 
 @ESIntegTestCase.SuiteScopeTestCase
 public class AggregationsIntegrationIT extends ESIntegTestCase {
@@ -44,7 +44,7 @@ public class AggregationsIntegrationIT extends ESIntegTestCase {
             .setScroll(TimeValue.timeValueMinutes(1))
             .addAggregation(terms("f").field("f"))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Aggregations aggregations = response.getAggregations();
         assertNotNull(aggregations);
         Terms terms = aggregations.get("f");
@@ -53,7 +53,7 @@ public class AggregationsIntegrationIT extends ESIntegTestCase {
         int total = response.getHits().getHits().length;
         while (response.getHits().getHits().length > 0) {
             response = client().prepareSearchScroll(response.getScrollId()).setScroll(TimeValue.timeValueMinutes(1)).get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             assertNull(response.getAggregations());
             total += response.getHits().getHits().length;
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.util.HashMap;
@@ -25,6 +24,7 @@ import java.util.Map;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -66,7 +66,7 @@ public class CombiIT extends ESIntegTestCase {
             .addAggregation(terms("values").field("value").collectMode(aggCollectionMode))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Aggregations aggs = response.getAggregations();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.util.HashMap;
@@ -24,7 +25,6 @@ import java.util.Map;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -66,7 +66,7 @@ public class CombiIT extends ESIntegTestCase {
             .addAggregation(terms("values").field("value").collectMode(aggCollectionMode))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Aggregations aggs = response.getAggregations();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -57,7 +57,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -367,7 +366,7 @@ public class EquivalenceIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field("values").interval(interval).minDocCount(1))
             .get();
 
-        assertSearchResponse(resp);
+        assertNoFailures(resp);
 
         Terms terms = resp.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -427,7 +426,7 @@ public class EquivalenceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("filter");
         assertNotNull(filter);
@@ -493,7 +492,7 @@ public class EquivalenceIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(r1);
+        assertNoFailures(r1);
         final SearchResponse r2 = client().prepareSearch("idx")
             .addAggregation(
                 terms("f1").field("f1")
@@ -505,7 +504,7 @@ public class EquivalenceIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(r2);
+        assertNoFailures(r2);
 
         final Terms t1 = r1.getAggregations().get("f1");
         final Terms t2 = r2.getAggregations().get("f1");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.InternalBucketMetricValue;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.maxBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
 public class MetadataIT extends ESIntegTestCase {
 
@@ -46,7 +46,7 @@ public class MetadataIT extends ESIntegTestCase {
             .addAggregation(maxBucket("the_max_bucket", "the_terms>the_sum").setMetadata(metadata))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Aggregations aggs = response.getAggregations();
         assertNotNull(aggs);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.InternalBucketMetricValue;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 import java.util.Map;
@@ -22,7 +23,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.maxBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 
 public class MetadataIT extends ESIntegTestCase {
 
@@ -46,7 +46,7 @@ public class MetadataIT extends ESIntegTestCase {
             .addAggregation(maxBucket("the_max_bucket", "the_terms>the_sum").setMetadata(metadata))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Aggregations aggs = response.getAggregations();
         assertNotNull(aggs);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MissingValueIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MissingValueIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.metrics.GeoCentroid;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.cardinality;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
@@ -31,6 +30,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.closeTo;
 
 @ESIntegTestCase.SuiteScopeTestCase
@@ -57,7 +57,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(terms("my_terms").field("non_existing_field").missing("bar"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
         assertEquals(2, terms.getBucketByKey("bar").getDocCount());
@@ -68,14 +68,14 @@ public class MissingValueIT extends ESIntegTestCase {
             SearchResponse response = client().prepareSearch("idx")
                 .addAggregation(terms("my_terms").field("str").executionHint(mode.toString()).missing("bar"))
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Terms terms = response.getAggregations().get("my_terms");
             assertEquals(2, terms.getBuckets().size());
             assertEquals(1, terms.getBucketByKey("foo").getDocCount());
             assertEquals(1, terms.getBucketByKey("bar").getDocCount());
 
             response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("str").missing("foo")).get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             terms = response.getAggregations().get("my_terms");
             assertEquals(1, terms.getBuckets().size());
             assertEquals(2, terms.getBucketByKey("foo").getDocCount());
@@ -84,14 +84,14 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testLongTerms() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("long").missing(4)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
         assertEquals(1, terms.getBucketByKey("3").getDocCount());
         assertEquals(1, terms.getBucketByKey("4").getDocCount());
 
         response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("long").missing(3)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
         assertEquals(2, terms.getBucketByKey("3").getDocCount());
@@ -99,14 +99,14 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testDoubleTerms() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("double").missing(4.5)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
         assertEquals(1, terms.getBucketByKey("4.5").getDocCount());
         assertEquals(1, terms.getBucketByKey("5.5").getDocCount());
 
         response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("double").missing(5.5)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
         assertEquals(2, terms.getBucketByKey("5.5").getDocCount());
@@ -116,7 +116,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(histogram("my_histogram").field("non-existing_field").interval(5).missing(12))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
         assertEquals(10d, histogram.getBuckets().get(0).getKey());
@@ -127,7 +127,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(histogram("my_histogram").field("long").interval(5).missing(7))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(2, histogram.getBuckets().size());
         assertEquals(0d, histogram.getBuckets().get(0).getKey());
@@ -136,7 +136,7 @@ public class MissingValueIT extends ESIntegTestCase {
         assertEquals(1, histogram.getBuckets().get(1).getDocCount());
 
         response = client().prepareSearch("idx").addAggregation(histogram("my_histogram").field("long").interval(5).missing(3)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
         assertEquals(0d, histogram.getBuckets().get(0).getKey());
@@ -147,7 +147,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(dateHistogram("my_histogram").field("date").calendarInterval(DateHistogramInterval.YEAR).missing("2014-05-07"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(2, histogram.getBuckets().size());
         assertEquals("2014-01-01T00:00:00.000Z", histogram.getBuckets().get(0).getKeyAsString());
@@ -158,7 +158,7 @@ public class MissingValueIT extends ESIntegTestCase {
         response = client().prepareSearch("idx")
             .addAggregation(dateHistogram("my_histogram").field("date").calendarInterval(DateHistogramInterval.YEAR).missing("2015-05-07"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
         assertEquals("2015-01-01T00:00:00.000Z", histogram.getBuckets().get(0).getKeyAsString());
@@ -167,7 +167,7 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testCardinality() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(cardinality("card").field("long").missing(2)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Cardinality cardinality = response.getAggregations().get("card");
         assertEquals(2, cardinality.getValue());
     }
@@ -176,14 +176,14 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(percentiles("percentiles").field("long").missing(1000))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Percentiles percentiles = response.getAggregations().get("percentiles");
         assertEquals(1000, percentiles.percentile(100), 0);
     }
 
     public void testStats() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(stats("stats").field("long").missing(5)).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Stats stats = response.getAggregations().get("stats");
         assertEquals(2, stats.getCount());
         assertEquals(4, stats.getAvg(), 0);
@@ -193,7 +193,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(geoBounds("bounds").field("non_existing_field").missing("2,1"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         GeoBounds bounds = response.getAggregations().get("bounds");
         assertThat(bounds.bottomRight().lat(), closeTo(2.0, 1E-5));
         assertThat(bounds.bottomRight().lon(), closeTo(1.0, 1E-5));
@@ -203,7 +203,7 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testGeoBounds() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(geoBounds("bounds").field("location").missing("2,1")).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         GeoBounds bounds = response.getAggregations().get("bounds");
         assertThat(bounds.bottomRight().lat(), closeTo(1.0, 1E-5));
         assertThat(bounds.bottomRight().lon(), closeTo(2.0, 1E-5));
@@ -215,7 +215,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(geoCentroid("centroid").field("location").missing("2,1"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         GeoCentroid centroid = response.getAggregations().get("centroid");
         GeoPoint point = new GeoPoint(1.5, 1.5);
         assertThat(point.getY(), closeTo(centroid.centroid().getY(), 1E-5));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MissingValueIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MissingValueIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.metrics.GeoCentroid;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.cardinality;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
@@ -30,7 +31,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.closeTo;
 
 @ESIntegTestCase.SuiteScopeTestCase
@@ -57,7 +57,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(terms("my_terms").field("non_existing_field").missing("bar"))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
         assertEquals(2, terms.getBucketByKey("bar").getDocCount());
@@ -68,14 +68,14 @@ public class MissingValueIT extends ESIntegTestCase {
             SearchResponse response = client().prepareSearch("idx")
                 .addAggregation(terms("my_terms").field("str").executionHint(mode.toString()).missing("bar"))
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Terms terms = response.getAggregations().get("my_terms");
             assertEquals(2, terms.getBuckets().size());
             assertEquals(1, terms.getBucketByKey("foo").getDocCount());
             assertEquals(1, terms.getBucketByKey("bar").getDocCount());
 
             response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("str").missing("foo")).get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             terms = response.getAggregations().get("my_terms");
             assertEquals(1, terms.getBuckets().size());
             assertEquals(2, terms.getBucketByKey("foo").getDocCount());
@@ -84,14 +84,14 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testLongTerms() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("long").missing(4)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
         assertEquals(1, terms.getBucketByKey("3").getDocCount());
         assertEquals(1, terms.getBucketByKey("4").getDocCount());
 
         response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("long").missing(3)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
         assertEquals(2, terms.getBucketByKey("3").getDocCount());
@@ -99,14 +99,14 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testDoubleTerms() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("double").missing(4.5)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
         assertEquals(1, terms.getBucketByKey("4.5").getDocCount());
         assertEquals(1, terms.getBucketByKey("5.5").getDocCount());
 
         response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("double").missing(5.5)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
         assertEquals(2, terms.getBucketByKey("5.5").getDocCount());
@@ -116,7 +116,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(histogram("my_histogram").field("non-existing_field").interval(5).missing(12))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
         assertEquals(10d, histogram.getBuckets().get(0).getKey());
@@ -127,7 +127,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(histogram("my_histogram").field("long").interval(5).missing(7))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(2, histogram.getBuckets().size());
         assertEquals(0d, histogram.getBuckets().get(0).getKey());
@@ -136,7 +136,7 @@ public class MissingValueIT extends ESIntegTestCase {
         assertEquals(1, histogram.getBuckets().get(1).getDocCount());
 
         response = client().prepareSearch("idx").addAggregation(histogram("my_histogram").field("long").interval(5).missing(3)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
         assertEquals(0d, histogram.getBuckets().get(0).getKey());
@@ -147,7 +147,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(dateHistogram("my_histogram").field("date").calendarInterval(DateHistogramInterval.YEAR).missing("2014-05-07"))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(2, histogram.getBuckets().size());
         assertEquals("2014-01-01T00:00:00.000Z", histogram.getBuckets().get(0).getKeyAsString());
@@ -158,7 +158,7 @@ public class MissingValueIT extends ESIntegTestCase {
         response = client().prepareSearch("idx")
             .addAggregation(dateHistogram("my_histogram").field("date").calendarInterval(DateHistogramInterval.YEAR).missing("2015-05-07"))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
         assertEquals("2015-01-01T00:00:00.000Z", histogram.getBuckets().get(0).getKeyAsString());
@@ -167,7 +167,7 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testCardinality() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(cardinality("card").field("long").missing(2)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Cardinality cardinality = response.getAggregations().get("card");
         assertEquals(2, cardinality.getValue());
     }
@@ -176,14 +176,14 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(percentiles("percentiles").field("long").missing(1000))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Percentiles percentiles = response.getAggregations().get("percentiles");
         assertEquals(1000, percentiles.percentile(100), 0);
     }
 
     public void testStats() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(stats("stats").field("long").missing(5)).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Stats stats = response.getAggregations().get("stats");
         assertEquals(2, stats.getCount());
         assertEquals(4, stats.getAvg(), 0);
@@ -193,7 +193,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(geoBounds("bounds").field("non_existing_field").missing("2,1"))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         GeoBounds bounds = response.getAggregations().get("bounds");
         assertThat(bounds.bottomRight().lat(), closeTo(2.0, 1E-5));
         assertThat(bounds.bottomRight().lon(), closeTo(1.0, 1E-5));
@@ -203,7 +203,7 @@ public class MissingValueIT extends ESIntegTestCase {
 
     public void testGeoBounds() {
         SearchResponse response = client().prepareSearch("idx").addAggregation(geoBounds("bounds").field("location").missing("2,1")).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         GeoBounds bounds = response.getAggregations().get("bounds");
         assertThat(bounds.bottomRight().lat(), closeTo(1.0, 1E-5));
         assertThat(bounds.bottomRight().lon(), closeTo(2.0, 1E-5));
@@ -215,7 +215,7 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(geoCentroid("centroid").field("location").missing("2,1"))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         GeoCentroid centroid = response.getAggregations().get("centroid");
         GeoPoint point = new GeoPoint(1.5, 1.5);
         assertThat(point.getY(), closeTo(centroid.centroid().getY(), 1E-5));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
@@ -14,8 +14,8 @@ import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -79,7 +79,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -113,7 +113,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -149,7 +149,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         UnmappedTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
@@ -14,8 +14,8 @@ import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -79,7 +79,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -113,7 +113,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -149,7 +149,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         UnmappedTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.LongBounds;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 import org.junit.After;
 
@@ -61,6 +60,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -229,7 +229,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -270,7 +270,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .execute()
             .actionGet();
         ZoneId tz = ZoneId.of("+01:00");
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -333,7 +333,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.DAY).minDocCount(1).timeZone(tz).format(format)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -366,7 +366,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.key(true)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -388,7 +388,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -409,7 +409,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -430,7 +430,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -451,7 +451,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -513,7 +513,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -537,7 +537,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -561,7 +561,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -585,7 +585,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -641,7 +641,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -686,7 +686,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("dates").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -730,7 +730,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -781,7 +781,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -836,7 +836,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -876,7 +876,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -927,7 +927,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -940,7 +940,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1130,7 +1130,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 throw e;
             }
         }
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1187,7 +1187,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .extendedBounds(new LongBounds("now/d", "now/d+23h"))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         assertThat(
             "Expected 24 buckets for one day aggregation with hourly interval",
@@ -1245,7 +1245,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .extendedBounds(new LongBounds("2016-01-01T06:00:00Z", "2016-01-08T08:00:00Z"))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1322,7 +1322,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         ZoneId tz = ZoneId.of("+01:00");
 
@@ -1370,7 +1370,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+02:00"));
@@ -1395,7 +1395,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .minDocCount(0)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(4));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+01:00"));
@@ -1432,7 +1432,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .extendedBounds(new LongBounds("2018-01", "2018-01"))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2018-01"));
@@ -1455,7 +1455,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH).timeZone(ZoneId.of("Europe/Berlin"))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("1477954800000"));
@@ -1469,7 +1469,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .format("yyyy-MM-dd")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2016-11-01"));
@@ -1586,7 +1586,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1606,7 +1606,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1622,7 +1622,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1686,7 +1686,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histogram = response.getAggregations().get("histo");
         assertThat(histogram, notNullValue());
@@ -1730,7 +1730,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .addDocValueField("date")
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
@@ -1746,7 +1746,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .addDocValueField("date")
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
@@ -1764,7 +1764,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         InternalDateHistogram histogram = response.getAggregations().get("histo");
         List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
@@ -1782,7 +1782,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         InternalDateHistogram histogram = response.getAggregations().get("histo");
         List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.LongBounds;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 import org.junit.After;
 
@@ -61,7 +62,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -229,7 +229,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -270,7 +270,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .execute()
             .actionGet();
         ZoneId tz = ZoneId.of("+01:00");
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -333,7 +333,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.DAY).minDocCount(1).timeZone(tz).format(format)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -366,7 +366,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.key(true)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -388,7 +388,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -409,7 +409,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -430,7 +430,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -451,7 +451,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -513,7 +513,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -537,7 +537,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -561,7 +561,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -585,7 +585,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -641,7 +641,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -686,7 +686,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("dates").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -730,7 +730,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -781,7 +781,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -836,7 +836,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -876,7 +876,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -927,7 +927,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -940,7 +940,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1130,7 +1130,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 throw e;
             }
         }
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1187,7 +1187,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .extendedBounds(new LongBounds("now/d", "now/d+23h"))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         assertThat(
             "Expected 24 buckets for one day aggregation with hourly interval",
@@ -1245,7 +1245,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .extendedBounds(new LongBounds("2016-01-01T06:00:00Z", "2016-01-08T08:00:00Z"))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1322,7 +1322,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         ZoneId tz = ZoneId.of("+01:00");
 
@@ -1370,7 +1370,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+02:00"));
@@ -1395,7 +1395,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .minDocCount(0)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(4));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+01:00"));
@@ -1432,7 +1432,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .extendedBounds(new LongBounds("2018-01", "2018-01"))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2018-01"));
@@ -1455,7 +1455,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH).timeZone(ZoneId.of("Europe/Berlin"))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("1477954800000"));
@@ -1469,7 +1469,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .format("yyyy-MM-dd")
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         histo = response.getAggregations().get("histo");
         assertThat(histo.getBuckets().size(), equalTo(1));
         assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2016-11-01"));
@@ -1586,7 +1586,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1606,7 +1606,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                     .calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1622,7 +1622,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1686,7 +1686,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histogram = response.getAggregations().get("histo");
         assertThat(histogram, notNullValue());
@@ -1730,7 +1730,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .addDocValueField("date")
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
@@ -1746,7 +1746,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .addDocValueField("date")
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
@@ -1764,7 +1764,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         InternalDateHistogram histogram = response.getAggregations().get("histo");
         List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
@@ -1782,7 +1782,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         InternalDateHistogram histogram = response.getAggregations().get("histo");
         List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.time.ZoneId;
@@ -42,7 +43,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRang
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -136,7 +136,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -171,7 +171,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -217,7 +217,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -264,7 +264,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -318,7 +318,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -364,7 +364,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -420,7 +420,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -495,7 +495,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -541,7 +541,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -661,7 +661,7 @@ public class DateRangeIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -684,7 +684,7 @@ public class DateRangeIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -706,7 +706,7 @@ public class DateRangeIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.time.ZoneId;
@@ -43,6 +42,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRang
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -136,7 +136,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -171,7 +171,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -217,7 +217,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -264,7 +264,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -318,7 +318,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -364,7 +364,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -420,7 +420,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -495,7 +495,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -541,7 +541,7 @@ public class DateRangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -661,7 +661,7 @@ public class DateRangeIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -684,7 +684,7 @@ public class DateRangeIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -706,7 +706,7 @@ public class DateRangeIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.List;
@@ -29,6 +28,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sampler;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -101,7 +101,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
                     .subAggregation(sampler("sample").shardSize(100).subAggregation(max("max_price").field("price")))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms genres = response.getAggregations().get("genres");
         Collection<? extends Bucket> genreBuckets = genres.getBuckets();
         // For this test to be useful we need >1 genre bucket to compare
@@ -133,7 +133,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         Terms authors = sample.getAggregations().get("authors");
         List<? extends Bucket> testBuckets = authors.getBuckets();
@@ -154,7 +154,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
 
         rootTerms.subAggregation(sampleAgg);
         SearchResponse response = client().prepareSearch("test").setSearchType(SearchType.QUERY_THEN_FETCH).addAggregation(rootTerms).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms genres = response.getAggregations().get("genres");
         List<? extends Bucket> genreBuckets = genres.getBuckets();
         for (Terms.Bucket genreBucket : genreBuckets) {
@@ -186,7 +186,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSearchType(SearchType.QUERY_THEN_FETCH)
             .addAggregation(rootSample)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler genreSample = response.getAggregations().get("genreSample");
         Sampler sample = genreSample.getAggregations().get("sample");
 
@@ -217,7 +217,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), greaterThan(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -237,7 +237,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), equalTo(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -256,7 +256,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         sampleAgg = new DiversifiedAggregationBuilder("sample").shardSize(100);
         sampleAgg.field("author").maxDocsPerValue(Integer.MAX_VALUE).executionHint(randomExecutionHint());
@@ -268,7 +268,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.List;
@@ -28,7 +29,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sampler;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -101,7 +101,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
                     .subAggregation(sampler("sample").shardSize(100).subAggregation(max("max_price").field("price")))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms genres = response.getAggregations().get("genres");
         Collection<? extends Bucket> genreBuckets = genres.getBuckets();
         // For this test to be useful we need >1 genre bucket to compare
@@ -133,7 +133,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         Terms authors = sample.getAggregations().get("authors");
         List<? extends Bucket> testBuckets = authors.getBuckets();
@@ -154,7 +154,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
 
         rootTerms.subAggregation(sampleAgg);
         SearchResponse response = client().prepareSearch("test").setSearchType(SearchType.QUERY_THEN_FETCH).addAggregation(rootTerms).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms genres = response.getAggregations().get("genres");
         List<? extends Bucket> genreBuckets = genres.getBuckets();
         for (Terms.Bucket genreBucket : genreBuckets) {
@@ -186,7 +186,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSearchType(SearchType.QUERY_THEN_FETCH)
             .addAggregation(rootSample)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler genreSample = response.getAggregations().get("genreSample");
         Sampler sample = genreSample.getAggregations().get("sample");
 
@@ -217,7 +217,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), greaterThan(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -237,7 +237,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), equalTo(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -256,7 +256,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         sampleAgg = new DiversifiedAggregationBuilder("sample").shardSize(100);
         sampleAgg.field("author").maxDocsPerValue(Integer.MAX_VALUE).executionHint(randomExecutionHint());
@@ -268,7 +268,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,6 +54,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -282,7 +282,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                 new TermsAggregationBuilder("terms").field(field).size(10000).collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(allResponse);
+        assertNoFailures(allResponse);
         DoubleTerms terms = allResponse.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -299,7 +299,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));
@@ -320,7 +320,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -345,7 +345,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -374,7 +374,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -421,7 +421,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -453,7 +453,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -480,7 +480,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -505,7 +505,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -537,7 +537,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -578,7 +578,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms tags = response.getAggregations().get("num_tags");
         assertThat(tags, notNullValue());
@@ -619,7 +619,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -759,7 +759,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -789,7 +789,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -819,7 +819,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -863,7 +863,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -930,7 +930,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -990,7 +990,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1009,7 +1009,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1022,7 +1022,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,7 +55,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -282,7 +282,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                 new TermsAggregationBuilder("terms").field(field).size(10000).collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        assertSearchResponse(allResponse);
+        ElasticsearchAssertions.assertNoFailures(allResponse);
         DoubleTerms terms = allResponse.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -299,7 +299,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));
@@ -320,7 +320,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -345,7 +345,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -374,7 +374,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -421,7 +421,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -453,7 +453,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -480,7 +480,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -505,7 +505,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -537,7 +537,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -578,7 +578,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms tags = response.getAggregations().get("num_tags");
         assertThat(tags, notNullValue());
@@ -619,7 +619,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -759,7 +759,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -789,7 +789,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -819,7 +819,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -863,7 +863,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -930,7 +930,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         DoubleTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -990,7 +990,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1009,7 +1009,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1022,7 +1022,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -29,6 +28,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -81,7 +81,7 @@ public class FilterIT extends ESIntegTestCase {
     public void testSimple() throws Exception {
         SearchResponse response = client().prepareSearch("idx").addAggregation(filter("tag1", termQuery("tag", "tag1"))).get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("tag1");
         assertThat(filter, notNullValue());
@@ -95,7 +95,7 @@ public class FilterIT extends ESIntegTestCase {
         QueryBuilder emptyFilter = new BoolQueryBuilder();
         SearchResponse response = client().prepareSearch("idx").addAggregation(filter("tag1", emptyFilter)).get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("tag1");
         assertThat(filter, notNullValue());
@@ -107,7 +107,7 @@ public class FilterIT extends ESIntegTestCase {
             .addAggregation(filter("tag1", termQuery("tag", "tag1")).subAggregation(avg("avg_value").field("value")))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("tag1");
         assertThat(filter, notNullValue());
@@ -132,7 +132,7 @@ public class FilterIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field("value").interval(2L).subAggregation(filter("filter", matchAllQuery())))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -28,7 +29,6 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -81,7 +81,7 @@ public class FilterIT extends ESIntegTestCase {
     public void testSimple() throws Exception {
         SearchResponse response = client().prepareSearch("idx").addAggregation(filter("tag1", termQuery("tag", "tag1"))).get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("tag1");
         assertThat(filter, notNullValue());
@@ -95,7 +95,7 @@ public class FilterIT extends ESIntegTestCase {
         QueryBuilder emptyFilter = new BoolQueryBuilder();
         SearchResponse response = client().prepareSearch("idx").addAggregation(filter("tag1", emptyFilter)).get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("tag1");
         assertThat(filter, notNullValue());
@@ -107,7 +107,7 @@ public class FilterIT extends ESIntegTestCase {
             .addAggregation(filter("tag1", termQuery("tag", "tag1")).subAggregation(avg("avg_value").field("value")))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("tag1");
         assertThat(filter, notNullValue());
@@ -132,7 +132,7 @@ public class FilterIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field("value").interval(2L).subAggregation(filter("filter", matchAllQuery())))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.Key
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -34,7 +35,6 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filters;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -107,7 +107,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -134,7 +134,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -156,7 +156,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -206,7 +206,7 @@ public class FiltersIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field("value").interval(2L).subAggregation(filters("filters", matchAllQuery())))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -273,7 +273,7 @@ public class FiltersIT extends ESIntegTestCase {
             .addAggregation(filters("tags", termQuery("tag", "tag1"), termQuery("tag", "tag2")))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -303,7 +303,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -334,7 +334,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -360,7 +360,7 @@ public class FiltersIT extends ESIntegTestCase {
             .addAggregation(filters("tags", termQuery("tag", "tag1"), termQuery("tag", "tag2")).otherBucket(true))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -394,7 +394,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.Key
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -35,6 +34,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filters;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -107,7 +107,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -134,7 +134,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -156,7 +156,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -206,7 +206,7 @@ public class FiltersIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field("value").interval(2L).subAggregation(filters("filters", matchAllQuery())))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -273,7 +273,7 @@ public class FiltersIT extends ESIntegTestCase {
             .addAggregation(filters("tags", termQuery("tag", "tag1"), termQuery("tag", "tag2")))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -303,7 +303,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -334,7 +334,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -360,7 +360,7 @@ public class FiltersIT extends ESIntegTestCase {
             .addAggregation(filters("tags", termQuery("tag", "tag1"), termQuery("tag", "tag2")).otherBucket(true))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());
@@ -394,7 +394,7 @@ public class FiltersIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filters filters = response.getAggregations().get("tags");
         assertThat(filters, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
@@ -39,7 +40,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geoDistance;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -144,7 +144,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
         SearchResponse response = client().prepareSearch("idx").addAggregation(builder).get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -191,7 +191,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -240,7 +240,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -287,7 +287,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -335,7 +335,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -462,7 +462,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
@@ -40,6 +39,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geoDistance;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -144,7 +144,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
         SearchResponse response = client().prepareSearch("idx").addAggregation(builder).get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -191,7 +191,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -240,7 +240,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -287,7 +287,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -335,7 +335,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());
@@ -462,7 +462,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range geoDist = response.getAggregations().get("amsterdam_rings");
         assertThat(geoDist, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -37,6 +36,7 @@ import static org.elasticsearch.geometry.utils.Geohash.PRECISION;
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geohashGrid;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -136,7 +136,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             List<? extends Bucket> buckets = geoGrid.getBuckets();
@@ -163,7 +163,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             for (GeoGrid.Bucket cell : geoGrid.getBuckets()) {
@@ -188,7 +188,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 )
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
 
             Filter filter = response.getAggregations().get("filtered");
 
@@ -211,7 +211,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             assertThat(geoGrid.getBuckets().size(), equalTo(0));
@@ -225,7 +225,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             for (GeoGrid.Bucket cell : geoGrid.getBuckets()) {
@@ -245,7 +245,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").size(1).shardSize(100).precision(precision))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             // Check we only have one bucket with the best match for that resolution

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -36,7 +37,6 @@ import static org.elasticsearch.geometry.utils.Geohash.PRECISION;
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geohashGrid;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -136,7 +136,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             List<? extends Bucket> buckets = geoGrid.getBuckets();
@@ -163,7 +163,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             for (GeoGrid.Bucket cell : geoGrid.getBuckets()) {
@@ -188,7 +188,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 )
                 .get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
 
             Filter filter = response.getAggregations().get("filtered");
 
@@ -211,7 +211,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             assertThat(geoGrid.getBuckets().size(), equalTo(0));
@@ -225,7 +225,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").precision(precision))
                 .get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             for (GeoGrid.Bucket cell : geoGrid.getBuckets()) {
@@ -245,7 +245,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 .addAggregation(geohashGrid("geohashgrid").field("location").size(1).shardSize(100).precision(precision))
                 .get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
 
             GeoGrid geoGrid = response.getAggregations().get("geohashgrid");
             // Check we only have one bucket with the best match for that resolution

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GlobalIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GlobalIT.java
@@ -15,13 +15,13 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +65,7 @@ public class GlobalIT extends ESIntegTestCase {
             .addAggregation(global("global").subAggregation(stats("value_stats").field("value")))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         assertThat(global, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GlobalIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GlobalIT.java
@@ -15,13 +15,13 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +65,7 @@ public class GlobalIT extends ESIntegTestCase {
             .addAggregation(global("global").subAggregation(stats("value_stats").field("value")))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         assertThat(global, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -52,6 +51,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -238,7 +238,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -290,7 +290,7 @@ public class HistogramIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).offset(offset))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         // shifting by offset>2 creates new extra bucket [0,offset-1]
         // if offset is >= number of values in original last bucket, that effect is canceled
         int expectedNumberOfBuckets = (offset >= (numDocs % interval + 1)) ? numValueBuckets : numValueBuckets + 1;
@@ -324,7 +324,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.key(true)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -345,7 +345,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.key(false)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -366,7 +366,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.count(true)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -393,7 +393,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.count(false)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -424,7 +424,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -467,7 +467,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -509,7 +509,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -551,7 +551,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -595,7 +595,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -633,7 +633,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -689,7 +689,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         final int numBuckets = (numDocs + 1) / interval - 2 / interval + 1;
         final long[] counts = new long[(numDocs + 1) / interval + 1];
@@ -717,7 +717,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(MULTI_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -738,7 +738,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(MULTI_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.key(false)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -763,7 +763,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         final int numBuckets = (numDocs + 2) / interval - 2 / interval + 1;
         final long[] counts = new long[(numDocs + 2) / interval + 1];
@@ -799,7 +799,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -823,7 +823,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -844,7 +844,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -857,7 +857,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -882,7 +882,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -990,7 +990,7 @@ public class HistogramIT extends ESIntegTestCase {
                 throw e;
             }
         }
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1067,7 +1067,7 @@ public class HistogramIT extends ESIntegTestCase {
                 throw e;
             }
         }
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1110,7 +1110,7 @@ public class HistogramIT extends ESIntegTestCase {
         SearchResponse r = client().prepareSearch("decimal_values")
             .addAggregation(histogram("histo").field("d").interval(0.7).offset(0.05))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
@@ -1157,7 +1157,7 @@ public class HistogramIT extends ESIntegTestCase {
                     .offset(0.05)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1178,7 +1178,7 @@ public class HistogramIT extends ESIntegTestCase {
                     .offset(0.05)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1194,7 +1194,7 @@ public class HistogramIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(histogram("histo").field("d").interval(0.7).offset(0.05))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1280,7 +1280,7 @@ public class HistogramIT extends ESIntegTestCase {
         SearchResponse r = client().prepareSearch("test")
             .addAggregation(histogram("histo").field("d").interval(0.1).hardBounds(new DoubleBounds(0.0, null)))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
@@ -1291,7 +1291,7 @@ public class HistogramIT extends ESIntegTestCase {
         r = client().prepareSearch("test")
             .addAggregation(histogram("histo").field("d").interval(0.1).hardBounds(new DoubleBounds(null, 0.0)))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
@@ -1301,7 +1301,7 @@ public class HistogramIT extends ESIntegTestCase {
         r = client().prepareSearch("test")
             .addAggregation(histogram("histo").field("d").interval(0.1).hardBounds(new DoubleBounds(0.0, 0.3)))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
@@ -1321,7 +1321,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histogram = response.getAggregations().get("histo");
         assertThat(histogram, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -51,7 +52,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -238,7 +238,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -290,7 +290,7 @@ public class HistogramIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx")
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).offset(offset))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         // shifting by offset>2 creates new extra bucket [0,offset-1]
         // if offset is >= number of values in original last bucket, that effect is canceled
         int expectedNumberOfBuckets = (offset >= (numDocs % interval + 1)) ? numValueBuckets : numValueBuckets + 1;
@@ -324,7 +324,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.key(true)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -345,7 +345,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.key(false)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -366,7 +366,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.count(true)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -393,7 +393,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.count(false)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -424,7 +424,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -467,7 +467,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -509,7 +509,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -551,7 +551,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -595,7 +595,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -633,7 +633,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -689,7 +689,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         final int numBuckets = (numDocs + 1) / interval - 2 / interval + 1;
         final long[] counts = new long[(numDocs + 1) / interval + 1];
@@ -717,7 +717,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(MULTI_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -738,7 +738,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(MULTI_VALUED_FIELD_NAME).interval(interval).order(BucketOrder.key(false)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -763,7 +763,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         final int numBuckets = (numDocs + 2) / interval - 2 / interval + 1;
         final long[] counts = new long[(numDocs + 2) / interval + 1];
@@ -799,7 +799,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -823,7 +823,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -844,7 +844,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -857,7 +857,7 @@ public class HistogramIT extends ESIntegTestCase {
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -882,7 +882,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -990,7 +990,7 @@ public class HistogramIT extends ESIntegTestCase {
                 throw e;
             }
         }
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1067,7 +1067,7 @@ public class HistogramIT extends ESIntegTestCase {
                 throw e;
             }
         }
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1110,7 +1110,7 @@ public class HistogramIT extends ESIntegTestCase {
         SearchResponse r = client().prepareSearch("decimal_values")
             .addAggregation(histogram("histo").field("d").interval(0.7).offset(0.05))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
@@ -1157,7 +1157,7 @@ public class HistogramIT extends ESIntegTestCase {
                     .offset(0.05)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1178,7 +1178,7 @@ public class HistogramIT extends ESIntegTestCase {
                     .offset(0.05)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1194,7 +1194,7 @@ public class HistogramIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(histogram("histo").field("d").interval(0.7).offset(0.05))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1280,7 +1280,7 @@ public class HistogramIT extends ESIntegTestCase {
         SearchResponse r = client().prepareSearch("test")
             .addAggregation(histogram("histo").field("d").interval(0.1).hardBounds(new DoubleBounds(0.0, null)))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         Histogram histogram = r.getAggregations().get("histo");
         List<? extends Bucket> buckets = histogram.getBuckets();
@@ -1291,7 +1291,7 @@ public class HistogramIT extends ESIntegTestCase {
         r = client().prepareSearch("test")
             .addAggregation(histogram("histo").field("d").interval(0.1).hardBounds(new DoubleBounds(null, 0.0)))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
@@ -1301,7 +1301,7 @@ public class HistogramIT extends ESIntegTestCase {
         r = client().prepareSearch("test")
             .addAggregation(histogram("histo").field("d").interval(0.1).hardBounds(new DoubleBounds(0.0, 0.3)))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         histogram = r.getAggregations().get("histo");
         buckets = histogram.getBuckets();
@@ -1321,7 +1321,7 @@ public class HistogramIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histogram = response.getAggregations().get("histo");
         assertThat(histogram, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpRangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpRangeIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -25,7 +26,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -73,7 +73,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        assertSearchResponse(rsp);
+        ElasticsearchAssertions.assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -106,7 +106,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        assertSearchResponse(rsp);
+        ElasticsearchAssertions.assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -139,7 +139,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addMaskRange("2001:db8::/64")
             )
             .get();
-        assertSearchResponse(rsp);
+        ElasticsearchAssertions.assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -166,7 +166,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        assertSearchResponse(rsp);
+        ElasticsearchAssertions.assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -199,7 +199,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        assertSearchResponse(rsp);
+        ElasticsearchAssertions.assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpRangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpRangeIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -73,7 +73,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(rsp);
+        assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -106,7 +106,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(rsp);
+        assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -139,7 +139,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addMaskRange("2001:db8::/64")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(rsp);
+        assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -166,7 +166,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(rsp);
+        assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 
@@ -199,7 +199,7 @@ public class IpRangeIT extends ESIntegTestCase {
                     .addUnboundedFrom("192.168.1.10")
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(rsp);
+        assertNoFailures(rsp);
         Range range = rsp.getAggregations().get("my_range");
         assertEquals(3, range.getBuckets().size());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationTestScriptsPlugin;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -23,6 +22,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
 public class IpTermsIT extends AbstractTermsTestCase {
 
@@ -64,7 +64,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
         SearchResponse response = client().prepareSearch("index")
             .addAggregation(new TermsAggregationBuilder("my_terms").script(script).executionHint(randomExecutionHint()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
 
@@ -92,7 +92,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
         SearchResponse response = client().prepareSearch("index")
             .addAggregation(new TermsAggregationBuilder("my_terms").script(script).executionHint(randomExecutionHint()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
 
@@ -120,7 +120,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
             .addAggregation(new TermsAggregationBuilder("my_terms").field("ip").missing("127.0.0.1").executionHint(randomExecutionHint()))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationTestScriptsPlugin;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +23,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 
 public class IpTermsIT extends AbstractTermsTestCase {
 
@@ -64,7 +64,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
         SearchResponse response = client().prepareSearch("index")
             .addAggregation(new TermsAggregationBuilder("my_terms").script(script).executionHint(randomExecutionHint()))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
 
@@ -92,7 +92,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
         SearchResponse response = client().prepareSearch("index")
             .addAggregation(new TermsAggregationBuilder("my_terms").script(script).executionHint(randomExecutionHint()))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
 
@@ -120,7 +120,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
             .addAggregation(new TermsAggregationBuilder("my_terms").field("ip").missing("127.0.0.1").executionHint(randomExecutionHint()))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("my_terms");
         assertEquals(2, terms.getBuckets().size());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/LongTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/LongTermsIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,6 +53,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -268,7 +268,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
         SearchResponse allResponse = client().prepareSearch("idx")
             .addAggregation(new TermsAggregationBuilder("terms").field(field).collectMode(randomFrom(SubAggCollectionMode.values())))
             .get();
-        ElasticsearchAssertions.assertNoFailures(allResponse);
+        assertNoFailures(allResponse);
         LongTerms terms = allResponse.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -285,7 +285,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));
@@ -306,7 +306,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         // Scripts force the results to doubles
         DoubleTerms terms = response.getAggregations().get("terms");
@@ -332,7 +332,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         // Scripts force the results to doubles
         DoubleTerms terms = response.getAggregations().get("terms");
@@ -362,7 +362,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         // The script always converts long to double
         DoubleTerms terms = response.getAggregations().get("terms");
@@ -410,7 +410,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -443,7 +443,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -470,7 +470,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -495,7 +495,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -527,7 +527,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -568,7 +568,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms tags = response.getAggregations().get("num_tags");
         assertThat(tags, notNullValue());
@@ -609,7 +609,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -749,7 +749,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -780,7 +780,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -811,7 +811,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -882,7 +882,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -942,7 +942,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -961,7 +961,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -974,7 +974,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/LongTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/LongTermsIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,7 +54,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -268,7 +268,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
         SearchResponse allResponse = client().prepareSearch("idx")
             .addAggregation(new TermsAggregationBuilder("terms").field(field).collectMode(randomFrom(SubAggCollectionMode.values())))
             .get();
-        assertSearchResponse(allResponse);
+        ElasticsearchAssertions.assertNoFailures(allResponse);
         LongTerms terms = allResponse.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -285,7 +285,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));
@@ -306,7 +306,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         // Scripts force the results to doubles
         DoubleTerms terms = response.getAggregations().get("terms");
@@ -332,7 +332,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         // Scripts force the results to doubles
         DoubleTerms terms = response.getAggregations().get("terms");
@@ -362,7 +362,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         // The script always converts long to double
         DoubleTerms terms = response.getAggregations().get("terms");
@@ -410,7 +410,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -443,7 +443,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -470,7 +470,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -495,7 +495,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -527,7 +527,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -568,7 +568,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms tags = response.getAggregations().get("num_tags");
         assertThat(tags, notNullValue());
@@ -609,7 +609,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -749,7 +749,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -780,7 +780,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -811,7 +811,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -882,7 +882,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         LongTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -942,7 +942,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -961,7 +961,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -974,7 +974,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
@@ -28,7 +29,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.extended
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.core.IsNull.notNullValue;
 
@@ -154,7 +154,7 @@ public class NaNSortingIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         final Terms terms = response.getAggregations().get("terms");
         assertCorrectlySorted(terms, asc, agg);
     }
@@ -183,7 +183,7 @@ public class NaNSortingIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         final Histogram histo = response.getAggregations().get("histo");
         assertCorrectlySorted(histo, asc, agg);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
@@ -29,6 +28,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.extended
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.core.IsNull.notNullValue;
 
@@ -154,7 +154,7 @@ public class NaNSortingIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         final Terms terms = response.getAggregations().get("terms");
         assertCorrectlySorted(terms, asc, agg);
     }
@@ -183,7 +183,7 @@ public class NaNSortingIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         final Histogram histo = response.getAggregations().get("histo");
         assertCorrectlySorted(histo, asc, agg);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
@@ -48,7 +48,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -182,7 +181,7 @@ public class NestedIT extends ESIntegTestCase {
             .addAggregation(nested("nested", "nested").subAggregation(stats("nested_value_stats").field("nested.value")))
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         double min = Double.POSITIVE_INFINITY;
         double max = Double.NEGATIVE_INFINITY;
@@ -231,7 +230,7 @@ public class NestedIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         long docCount = 0;
         long[] counts = new long[numParents + 6];
@@ -284,7 +283,7 @@ public class NestedIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         LongTerms values = response.getAggregations().get("top_values");
         assertThat(values, notNullValue());
@@ -313,7 +312,7 @@ public class NestedIT extends ESIntegTestCase {
                 )
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Nested level1 = response.getAggregations().get("level1");
         assertThat(level1, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -40,7 +41,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -142,7 +142,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getBuckets().size(), equalTo(numDocs + 1));
@@ -200,7 +200,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -241,7 +241,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6).format("#"))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -284,7 +284,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -331,7 +331,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -403,7 +403,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -457,7 +457,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(MULTI_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -517,7 +517,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -581,7 +581,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").script(script).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -622,7 +622,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(MULTI_VALUED_FIELD_NAME).addUnboundedTo(-1).addUnboundedFrom(1000))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -672,7 +672,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").script(script).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -730,7 +730,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -773,7 +773,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -816,7 +816,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -930,7 +930,7 @@ public class RangeIT extends ESIntegTestCase {
                     .addRange(0, 10)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -950,7 +950,7 @@ public class RangeIT extends ESIntegTestCase {
                     .addRange(0, 10)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -963,7 +963,7 @@ public class RangeIT extends ESIntegTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(range("foo").field("i").addRange(0, 10)).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -980,7 +980,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field("route_length_miles").addUnboundedTo(50.0).addRange(50.0, 150.0).addUnboundedFrom(150.0))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -1011,7 +1011,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
@@ -41,6 +40,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -142,7 +142,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getBuckets().size(), equalTo(numDocs + 1));
@@ -200,7 +200,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -241,7 +241,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6).format("#"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -284,7 +284,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -331,7 +331,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -403,7 +403,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -457,7 +457,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(MULTI_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -517,7 +517,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -581,7 +581,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").script(script).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -622,7 +622,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(MULTI_VALUED_FIELD_NAME).addUnboundedTo(-1).addUnboundedFrom(1000))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -672,7 +672,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").script(script).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -730,7 +730,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -773,7 +773,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field(SINGLE_VALUED_FIELD_NAME).addUnboundedTo(3).addRange(3, 6).addUnboundedFrom(6))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -816,7 +816,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -930,7 +930,7 @@ public class RangeIT extends ESIntegTestCase {
                     .addRange(0, 10)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -950,7 +950,7 @@ public class RangeIT extends ESIntegTestCase {
                     .addRange(0, 10)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -963,7 +963,7 @@ public class RangeIT extends ESIntegTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(range("foo").field("i").addRange(0, 10)).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -980,7 +980,7 @@ public class RangeIT extends ESIntegTestCase {
             .addAggregation(range("range").field("route_length_miles").addUnboundedTo(50.0).addRange(50.0, 150.0).addUnboundedFrom(150.0))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -1011,7 +1011,7 @@ public class RangeIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/ReverseNestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/ReverseNestedIT.java
@@ -35,7 +35,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -157,7 +156,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Nested nested = response.getAggregations().get("nested1");
         assertThat(nested, notNullValue());
@@ -339,7 +338,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
         Nested nested = response.getAggregations().get("nested1");
         assertThat(nested.getName(), equalTo("nested1"));
         assertThat(nested.getDocCount(), equalTo(9L));
@@ -371,7 +370,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Nested nested = response.getAggregations().get("nested1");
         assertThat(nested, notNullValue());
@@ -714,7 +713,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Nested nested = response.getAggregations().get("nested1");
         Terms nestedTerms = nested.getAggregations().get("field2");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 
@@ -26,7 +27,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sampler;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -99,7 +99,7 @@ public class SamplerIT extends ESIntegTestCase {
                     .subAggregation(sampler("sample").shardSize(100).subAggregation(max("max_price").field("price")))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms genres = response.getAggregations().get("genres");
         List<? extends Bucket> genreBuckets = genres.getBuckets();
         // For this test to be useful we need >1 genre bucket to compare
@@ -129,7 +129,7 @@ public class SamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         Terms authors = sample.getAggregations().get("authors");
         List<? extends Bucket> testBuckets = authors.getBuckets();
@@ -151,7 +151,7 @@ public class SamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), equalTo(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -169,7 +169,7 @@ public class SamplerIT extends ESIntegTestCase {
             .setExplain(true)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), greaterThan(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -186,6 +186,6 @@ public class SamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 
@@ -27,6 +26,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sampler;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -99,7 +99,7 @@ public class SamplerIT extends ESIntegTestCase {
                     .subAggregation(sampler("sample").shardSize(100).subAggregation(max("max_price").field("price")))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms genres = response.getAggregations().get("genres");
         List<? extends Bucket> genreBuckets = genres.getBuckets();
         // For this test to be useful we need >1 genre bucket to compare
@@ -129,7 +129,7 @@ public class SamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         Terms authors = sample.getAggregations().get("authors");
         List<? extends Bucket> testBuckets = authors.getBuckets();
@@ -151,7 +151,7 @@ public class SamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), equalTo(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -169,7 +169,7 @@ public class SamplerIT extends ESIntegTestCase {
             .setExplain(true)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Sampler sample = response.getAggregations().get("sample");
         assertThat(sample.getDocCount(), greaterThan(0L));
         Terms authors = sample.getAggregations().get("authors");
@@ -186,6 +186,6 @@ public class SamplerIT extends ESIntegTestCase {
             .setSize(60)
             .addAggregation(sampleAgg)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.search.aggregations.bucket.nested.Nested;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
@@ -37,6 +36,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.nested;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -96,7 +96,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         Histogram histo = global.getAggregations().get("histo");
@@ -113,7 +113,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("filter");
         Histogram histo = filter.getAggregations().get("histo");
@@ -129,7 +129,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Missing missing = response.getAggregations().get("missing");
         Histogram histo = missing.getAggregations().get("histo");
@@ -149,7 +149,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         Filter filter = global.getAggregations().get("filter");
@@ -168,7 +168,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Nested nested = response.getAggregations().get("nested");
         Histogram histo = nested.getAggregations().get("histo");
@@ -185,7 +185,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         Histogram histo = terms.getBucketByKey("term").getAggregations().get("histo");
@@ -202,7 +202,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         Histogram histo = terms.getBucketByKey("1").getAggregations().get("histo");
@@ -219,7 +219,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         Histogram histo = terms.getBucketByKey("1.5").getAggregations().get("histo");
@@ -236,7 +236,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         Histogram histo = range.getBuckets().get(0).getAggregations().get("histo");
@@ -253,7 +253,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         Histogram histo = range.getBuckets().get(0).getAggregations().get("histo");
@@ -270,7 +270,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         Histogram histo = range.getBuckets().get(0).getAggregations().get("histo");
@@ -287,7 +287,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram topHisto = response.getAggregations().get("topHisto");
         Histogram histo = topHisto.getBuckets().get(0).getAggregations().get("histo");
@@ -304,7 +304,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram topHisto = response.getAggregations().get("topHisto");
         Histogram histo = topHisto.getBuckets().iterator().next().getAggregations().get("histo");
@@ -321,7 +321,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         GeoGrid grid = response.getAggregations().get("grid");
         Histogram histo = grid.getBuckets().iterator().next().getAggregations().get("histo");
@@ -337,7 +337,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         GeoGrid grid = response.getAggregations().get("grid");
         Histogram histo = grid.getBuckets().iterator().next().getAggregations().get("histo");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.search.aggregations.bucket.nested.Nested;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
@@ -36,7 +37,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.nested;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -96,7 +96,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         Histogram histo = global.getAggregations().get("histo");
@@ -113,7 +113,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Filter filter = response.getAggregations().get("filter");
         Histogram histo = filter.getAggregations().get("histo");
@@ -129,7 +129,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Missing missing = response.getAggregations().get("missing");
         Histogram histo = missing.getAggregations().get("histo");
@@ -149,7 +149,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         Filter filter = global.getAggregations().get("filter");
@@ -168,7 +168,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Nested nested = response.getAggregations().get("nested");
         Histogram histo = nested.getAggregations().get("histo");
@@ -185,7 +185,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         Histogram histo = terms.getBucketByKey("term").getAggregations().get("histo");
@@ -202,7 +202,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         Histogram histo = terms.getBucketByKey("1").getAggregations().get("histo");
@@ -219,7 +219,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         Histogram histo = terms.getBucketByKey("1.5").getAggregations().get("histo");
@@ -236,7 +236,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         Histogram histo = range.getBuckets().get(0).getAggregations().get("histo");
@@ -253,7 +253,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         Histogram histo = range.getBuckets().get(0).getAggregations().get("histo");
@@ -270,7 +270,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         Histogram histo = range.getBuckets().get(0).getAggregations().get("histo");
@@ -287,7 +287,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram topHisto = response.getAggregations().get("topHisto");
         Histogram histo = topHisto.getBuckets().get(0).getAggregations().get("histo");
@@ -304,7 +304,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram topHisto = response.getAggregations().get("topHisto");
         Histogram histo = topHisto.getBuckets().iterator().next().getAggregations().get("histo");
@@ -321,7 +321,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         GeoGrid grid = response.getAggregations().get("grid");
         Histogram histo = grid.getBuckets().iterator().next().getAggregations().get("histo");
@@ -337,7 +337,7 @@ public class ShardReduceIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         GeoGrid grid = response.getAggregations().get("grid");
         Histogram histo = grid.getBuckets().iterator().next().getAggregations().get("histo");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -34,7 +34,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.heuristic.MutualInform
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.ScriptHeuristic;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.search.aggregations.bucket.SharedSignificantTermsTestMethods;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -58,6 +57,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.signific
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantText;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -130,7 +130,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
 
         SearchResponse response = request.get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         assertThat(classes.getBuckets().size(), equalTo(2));
         for (Terms.Bucket classBucket : classes.getBuckets()) {
@@ -287,7 +287,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         }
 
         SearchResponse response1 = request1.get();
-        ElasticsearchAssertions.assertNoFailures(response1);
+        assertNoFailures(response1);
 
         SearchRequestBuilder request2;
         if (useSigText) {
@@ -390,9 +390,9 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 );
         }
         SearchResponse response = request.get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         assertThat(classes.getBuckets().size(), equalTo(2));
         Iterator<? extends Terms.Bucket> classBuckets = classes.getBuckets().iterator();
@@ -428,7 +428,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             .subAggregation(subAgg);
 
         SearchResponse response = client().prepareSearch("test").setQuery(query).addAggregation(agg).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         SignificantTerms sigTerms = response.getAggregations().get("significant_terms");
         assertThat(sigTerms.getBuckets().size(), equalTo(2));
@@ -504,7 +504,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 );
         }
         SearchResponse response = request.get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         for (Terms.Bucket classBucket : ((Terms) response.getAggregations().get("class")).getBuckets()) {
             SignificantTerms sigTerms = classBucket.getAggregations().get("mySignificantTerms");
             for (SignificantTerms.Bucket bucket : sigTerms.getBuckets()) {
@@ -598,7 +598,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic))
                 .get();
         }
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -623,7 +623,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic))
                 .get();
         }
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -640,7 +640,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         } else {
             r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(significantTerms("foo").field("s")).get();
         }
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.heuristic.MutualInform
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.ScriptHeuristic;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.search.aggregations.bucket.SharedSignificantTermsTestMethods;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -57,7 +58,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.signific
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantText;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -130,7 +130,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
 
         SearchResponse response = request.get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         assertThat(classes.getBuckets().size(), equalTo(2));
         for (Terms.Bucket classBucket : classes.getBuckets()) {
@@ -287,7 +287,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         }
 
         SearchResponse response1 = request1.get();
-        assertSearchResponse(response1);
+        ElasticsearchAssertions.assertNoFailures(response1);
 
         SearchRequestBuilder request2;
         if (useSigText) {
@@ -390,9 +390,9 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 );
         }
         SearchResponse response = request.get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         assertThat(classes.getBuckets().size(), equalTo(2));
         Iterator<? extends Terms.Bucket> classBuckets = classes.getBuckets().iterator();
@@ -428,7 +428,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             .subAggregation(subAgg);
 
         SearchResponse response = client().prepareSearch("test").setQuery(query).addAggregation(agg).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         SignificantTerms sigTerms = response.getAggregations().get("significant_terms");
         assertThat(sigTerms.getBuckets().size(), equalTo(2));
@@ -504,7 +504,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 );
         }
         SearchResponse response = request.get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         for (Terms.Bucket classBucket : ((Terms) response.getAggregations().get("class")).getBuckets()) {
             SignificantTerms sigTerms = classBucket.getAggregations().get("mySignificantTerms");
             for (SignificantTerms.Bucket bucket : sigTerms.getBuckets()) {
@@ -598,7 +598,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic))
                 .get();
         }
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -623,7 +623,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic))
                 .get();
         }
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -640,7 +640,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         } else {
             r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(significantTerms("foo").field("s")).get();
         }
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,7 +29,6 @@ import java.util.Map;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -278,7 +278,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx")
             .addAggregation(
@@ -291,7 +291,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
     }
@@ -310,7 +310,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -323,7 +323,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -344,7 +344,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountErrorSingleResponse(size, testResponse);
     }
@@ -364,7 +364,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -378,7 +378,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -398,7 +398,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -412,7 +412,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -432,7 +432,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -446,7 +446,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -467,7 +467,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -482,7 +482,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -503,7 +503,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -518,7 +518,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -537,7 +537,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx")
             .addAggregation(
@@ -550,7 +550,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
     }
@@ -569,7 +569,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -582,7 +582,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -603,7 +603,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountErrorSingleResponse(size, testResponse);
     }
@@ -623,7 +623,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -637,7 +637,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -657,7 +657,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -671,7 +671,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -691,7 +691,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -705,7 +705,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -726,7 +726,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -741,7 +741,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -762,7 +762,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -777,7 +777,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -796,7 +796,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx")
             .addAggregation(
@@ -809,7 +809,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
     }
@@ -828,7 +828,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -841,7 +841,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -862,7 +862,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountErrorSingleResponse(size, testResponse);
     }
@@ -882,7 +882,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -896,7 +896,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -916,7 +916,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -930,7 +930,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -950,7 +950,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -964,7 +964,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -985,7 +985,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -1000,7 +1000,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -1021,7 +1021,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(accurateResponse);
+        ElasticsearchAssertions.assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -1036,7 +1036,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(testResponse);
+        ElasticsearchAssertions.assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -1057,7 +1057,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
                     .collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1112,7 +1112,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
                     .collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms.getDocCountError(), equalTo(0L));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,6 +28,7 @@ import java.util.Map;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -278,7 +278,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx")
             .addAggregation(
@@ -291,7 +291,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
     }
@@ -310,7 +310,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -323,7 +323,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -344,7 +344,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountErrorSingleResponse(size, testResponse);
     }
@@ -364,7 +364,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -378,7 +378,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -398,7 +398,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -412,7 +412,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -432,7 +432,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -446,7 +446,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -467,7 +467,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -482,7 +482,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -503,7 +503,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -518,7 +518,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -537,7 +537,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx")
             .addAggregation(
@@ -550,7 +550,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
     }
@@ -569,7 +569,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -582,7 +582,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -603,7 +603,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountErrorSingleResponse(size, testResponse);
     }
@@ -623,7 +623,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -637,7 +637,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -657,7 +657,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -671,7 +671,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -691,7 +691,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -705,7 +705,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -726,7 +726,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -741,7 +741,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -762,7 +762,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -777,7 +777,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -796,7 +796,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx")
             .addAggregation(
@@ -809,7 +809,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
     }
@@ -828,7 +828,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -841,7 +841,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -862,7 +862,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountErrorSingleResponse(size, testResponse);
     }
@@ -882,7 +882,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -896,7 +896,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -916,7 +916,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -930,7 +930,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -950,7 +950,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -964,7 +964,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertNoDocCountError(size, accurateResponse, testResponse);
     }
@@ -985,7 +985,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -1000,7 +1000,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -1021,7 +1021,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(accurateResponse);
+        assertNoFailures(accurateResponse);
 
         SearchResponse testResponse = client().prepareSearch("idx_single_shard")
             .addAggregation(
@@ -1036,7 +1036,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(testResponse);
+        assertNoFailures(testResponse);
 
         assertUnboundedDocCountError(size, accurateResponse, testResponse);
     }
@@ -1057,7 +1057,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
                     .collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1112,7 +1112,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
                     .collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms.getDocCountError(), equalTo(0L));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.ArrayList;
@@ -25,7 +26,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TermsShardMinDocCountIT extends ESIntegTestCase {
@@ -72,7 +72,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                 )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         InternalFilter filteredBucket = response.getAggregations().get("inclass");
         SignificantTerms sigterms = filteredBucket.getAggregations().get("mySignificantTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(0));
@@ -89,7 +89,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                 )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         filteredBucket = response.getAggregations().get("inclass");
         sigterms = filteredBucket.getAggregations().get("mySignificantTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(2));
@@ -136,7 +136,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                     .order(BucketOrder.key(true))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Terms sigterms = response.getAggregations().get("myTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(0));
 
@@ -151,7 +151,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                     .order(BucketOrder.key(true))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         sigterms = response.getAggregations().get("myTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(2));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.ArrayList;
@@ -26,6 +25,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TermsShardMinDocCountIT extends ESIntegTestCase {
@@ -72,7 +72,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                 )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         InternalFilter filteredBucket = response.getAggregations().get("inclass");
         SignificantTerms sigterms = filteredBucket.getAggregations().get("mySignificantTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(0));
@@ -89,7 +89,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                 )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         filteredBucket = response.getAggregations().get("inclass");
         sigterms = filteredBucket.getAggregations().get("mySignificantTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(2));
@@ -136,7 +136,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                     .order(BucketOrder.key(true))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Terms sigterms = response.getAggregations().get("myTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(0));
 
@@ -151,7 +151,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
                     .order(BucketOrder.key(true))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         sigterms = response.getAggregations().get("myTerms");
         assertThat(sigterms.getBuckets().size(), equalTo(2));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -58,7 +59,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -305,7 +305,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                 new TermsAggregationBuilder("terms").field(field).size(10000).collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        assertSearchResponse(allResponse);
+        ElasticsearchAssertions.assertNoFailures(allResponse);
         StringTerms terms = allResponse.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -322,7 +322,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));
@@ -343,7 +343,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -368,7 +368,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -397,7 +397,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -426,7 +426,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -473,7 +473,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -504,7 +504,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -536,7 +536,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -564,7 +564,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -655,7 +655,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -697,7 +697,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -760,7 +760,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -823,7 +823,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -972,7 +972,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1004,7 +1004,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1037,7 +1037,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1073,7 +1073,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1157,7 +1157,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1188,7 +1188,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -1241,7 +1241,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1260,7 +1260,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1273,7 +1273,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1297,7 +1297,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
             SearchResponse response = client().prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true)).get();
 
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             LongTerms terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -59,6 +58,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -305,7 +305,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                 new TermsAggregationBuilder("terms").field(field).size(10000).collectMode(randomFrom(SubAggCollectionMode.values()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(allResponse);
+        assertNoFailures(allResponse);
         StringTerms terms = allResponse.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -322,7 +322,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));
@@ -343,7 +343,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -368,7 +368,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -397,7 +397,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -426,7 +426,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -473,7 +473,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -504,7 +504,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -536,7 +536,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -564,7 +564,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -655,7 +655,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -697,7 +697,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -760,7 +760,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -823,7 +823,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms tags = response.getAggregations().get("tags");
         assertThat(tags, notNullValue());
@@ -972,7 +972,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1004,7 +1004,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1037,7 +1037,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1073,7 +1073,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1157,7 +1157,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1188,7 +1188,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
         assertThat(terms.getName(), equalTo("terms"));
@@ -1241,7 +1241,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1260,7 +1260,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                     .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1273,7 +1273,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1297,7 +1297,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
             SearchResponse response = client().prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true)).get();
 
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             LongTerms terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
             assertThat(terms.getName(), equalTo("terms"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats.Bounds;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -38,7 +39,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -873,7 +873,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -892,7 +892,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -905,7 +905,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(extendedStats("foo").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats.Bounds;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +38,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -873,7 +873,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -892,7 +892,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -905,7 +905,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(extendedStats("foo").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
@@ -13,8 +13,8 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -30,7 +30,7 @@ public class GeoBoundsIT extends SpatialBoundsAggregationTestBase<GeoPoint> {
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(false))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         GeoPoint geoValuesTopLeft = new GeoPoint(38, -179);
         GeoPoint geoValuesBottomRight = new GeoPoint(-24, 178);
@@ -54,7 +54,7 @@ public class GeoBoundsIT extends SpatialBoundsAggregationTestBase<GeoPoint> {
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(true))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         GeoBounds geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
@@ -13,8 +13,8 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -30,7 +30,7 @@ public class GeoBoundsIT extends SpatialBoundsAggregationTestBase<GeoPoint> {
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(false))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         GeoPoint geoValuesTopLeft = new GeoPoint(38, -179);
         GeoPoint geoValuesBottomRight = new GeoPoint(-24, 178);
@@ -54,7 +54,7 @@ public class GeoBoundsIT extends SpatialBoundsAggregationTestBase<GeoPoint> {
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(true))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         GeoBounds geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -14,11 +14,11 @@ import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geohashGrid;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -35,7 +35,7 @@ public class GeoCentroidIT extends CentroidAggregationTestBase {
                     .subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         GeoGrid grid = response.getAggregations().get("geoGrid");
         assertThat(grid, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -14,11 +14,11 @@ import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geohashGrid;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -35,7 +35,7 @@ public class GeoCentroidIT extends CentroidAggregationTestBase {
                     .subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         GeoGrid grid = response.getAggregations().get("geoGrid");
         assertThat(grid, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -39,7 +40,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -584,7 +584,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -604,7 +604,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -620,7 +620,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
             .setSize(0)
             .addAggregation(percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR).field("d"))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +39,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -584,7 +584,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -604,7 +604,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -620,7 +620,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
             .setSize(0)
             .addAggregation(percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR).field("d"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,7 +42,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -554,7 +554,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -575,7 +575,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -591,7 +591,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
             .setSize(0)
             .addAggregation(percentiles("foo").method(PercentilesMethod.HDR).field("d").percentiles(50.0))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +41,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -554,7 +554,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -575,7 +575,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -591,7 +591,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
             .setSize(0)
             .addAggregation(percentiles("foo").method(PercentilesMethod.HDR).field("d").percentiles(50.0))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +45,7 @@ import static org.elasticsearch.search.aggregations.metrics.MedianAbsoluteDeviat
 import static org.elasticsearch.search.aggregations.metrics.MedianAbsoluteDeviationAggregatorTests.IsCloseToRelative.closeToRelative;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -517,7 +517,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -536,7 +536,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -549,7 +549,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(randomBuilder().field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +46,6 @@ import static org.elasticsearch.search.aggregations.metrics.MedianAbsoluteDeviat
 import static org.elasticsearch.search.aggregations.metrics.MedianAbsoluteDeviationAggregatorTests.IsCloseToRelative.closeToRelative;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -517,7 +517,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -536,7 +536,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -549,7 +549,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(randomBuilder().field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.Before;
 
@@ -50,6 +49,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.scriptedMetric;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -363,7 +363,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(scriptedMetric("scripted").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -411,7 +411,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -463,7 +463,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -517,7 +517,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -580,7 +580,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -648,7 +648,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -707,7 +707,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(numDocs));
 
         Global global = searchResponse.getAggregations().get("global");
@@ -765,7 +765,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -815,7 +815,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -859,7 +859,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -917,7 +917,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -952,7 +952,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(new Script(ScriptType.STORED, null, "reduceScript_stored", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -1012,7 +1012,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
         Aggregation aggregation = response.getAggregations().get("histo");
         assertThat(aggregation, notNullValue());
@@ -1150,7 +1150,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("foo").initScript(ndInitScript).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1166,7 +1166,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(ndMapScript).combineScript(combineScript).reduceScript(reduceScript))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1182,7 +1182,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(ndRandom).reduceScript(reduceScript))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1198,7 +1198,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(ndRandom))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1214,7 +1214,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.Before;
 
@@ -49,7 +50,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.scriptedMetric;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -363,7 +363,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(scriptedMetric("scripted").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -411,7 +411,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -463,7 +463,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -517,7 +517,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -580,7 +580,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -648,7 +648,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -707,7 +707,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(numDocs));
 
         Global global = searchResponse.getAggregations().get("global");
@@ -765,7 +765,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -815,7 +815,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -859,7 +859,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -917,7 +917,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -952,7 +952,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     .reduceScript(new Script(ScriptType.STORED, null, "reduceScript_stored", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
         Aggregation aggregation = response.getAggregations().get("scripted");
@@ -1012,7 +1012,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
         Aggregation aggregation = response.getAggregations().get("histo");
         assertThat(aggregation, notNullValue());
@@ -1150,7 +1150,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 scriptedMetric("foo").initScript(ndInitScript).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1166,7 +1166,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(ndMapScript).combineScript(combineScript).reduceScript(reduceScript))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1182,7 +1182,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(ndRandom).reduceScript(reduceScript))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1198,7 +1198,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(ndRandom))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1214,7 +1214,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             .setSize(0)
             .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +35,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -261,7 +261,7 @@ public class StatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -280,7 +280,7 @@ public class StatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -293,7 +293,7 @@ public class StatsIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(stats("foo").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +34,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -261,7 +261,7 @@ public class StatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -280,7 +280,7 @@ public class StatsIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -293,7 +293,7 @@ public class StatsIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(stats("foo").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.core.IsNull;
 
 import java.util.ArrayList;
@@ -39,6 +38,7 @@ import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugi
 import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugin.VALUE_SCRIPT;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -238,7 +238,7 @@ public class SumIT extends AbstractNumericTestCase {
                 sum("foo").field("d").script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, RANDOM_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -256,7 +256,7 @@ public class SumIT extends AbstractNumericTestCase {
                 sum("foo").field("d").script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, VALUE_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -269,7 +269,7 @@ public class SumIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(sum("foo").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -286,7 +286,7 @@ public class SumIT extends AbstractNumericTestCase {
             .addAggregation(sum("sum").field("route_length_miles"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Sum sum = response.getAggregations().get("sum");
         assertThat(sum, IsNull.notNullValue());
@@ -299,7 +299,7 @@ public class SumIT extends AbstractNumericTestCase {
             .addAggregation(terms("terms").field("transit_mode").subAggregation(sum("sum").field("route_length_miles")))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.core.IsNull;
 
 import java.util.ArrayList;
@@ -38,7 +39,6 @@ import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugi
 import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugin.VALUE_SCRIPT;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -238,7 +238,7 @@ public class SumIT extends AbstractNumericTestCase {
                 sum("foo").field("d").script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, RANDOM_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -256,7 +256,7 @@ public class SumIT extends AbstractNumericTestCase {
                 sum("foo").field("d").script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, VALUE_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -269,7 +269,7 @@ public class SumIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(sum("foo").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -286,7 +286,7 @@ public class SumIT extends AbstractNumericTestCase {
             .addAggregation(sum("sum").field("route_length_miles"))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Sum sum = response.getAggregations().get("sum");
         assertThat(sum, IsNull.notNullValue());
@@ -299,7 +299,7 @@ public class SumIT extends AbstractNumericTestCase {
             .addAggregation(terms("terms").field("transit_mode").subAggregation(sum("sum").field("route_length_miles")))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -39,7 +40,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -495,7 +495,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -514,7 +514,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -530,7 +530,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
             .setSize(0)
             .addAggregation(percentileRanks("foo", new double[] { 50.0 }).field("d"))
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +39,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -495,7 +495,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -514,7 +514,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -530,7 +530,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
             .setSize(0)
             .addAggregation(percentileRanks("foo", new double[] { 50.0 }).field("d"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,7 +42,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -468,7 +468,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -488,7 +488,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -501,7 +501,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(percentiles("foo").field("d").percentiles(50.0)).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +41,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -468,7 +468,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -488,7 +488,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
                     .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -501,7 +501,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(percentiles("foo").field("d").percentiles(50.0)).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -65,7 +65,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xcontent.XContentFactory.smileBuilder;
 import static org.elasticsearch.xcontent.XContentFactory.yamlBuilder;
@@ -320,7 +319,7 @@ public class TopHitsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -354,7 +353,7 @@ public class TopHitsIT extends ESIntegTestCase {
             .addAggregation(terms("terms").executionHint(randomExecutionHint()).field("group").subAggregation(topHits("hits")))
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         assertThat(response.getHits().getTotalHits().value, equalTo(8L));
         assertThat(response.getHits().getHits().length, equalTo(0));
@@ -388,7 +387,7 @@ public class TopHitsIT extends ESIntegTestCase {
             .addAggregation(terms("terms").executionHint(randomExecutionHint()).field("group"))
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         assertThat(response.getHits().getTotalHits().value, equalTo(8L));
         assertThat(response.getHits().getHits().length, equalTo(0));
@@ -409,7 +408,7 @@ public class TopHitsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -442,7 +441,7 @@ public class TopHitsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -469,7 +468,7 @@ public class TopHitsIT extends ESIntegTestCase {
             .addAggregation(global("global").subAggregation(topHits("hits")))
             .get();
 
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
 
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
@@ -494,7 +493,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     .subAggregation(topHits("hits").sort(SortBuilders.fieldSort(SORT_FIELD).order(SortOrder.DESC)).from(from).size(size))
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         SearchResponse control = client().prepareSearch("idx")
             .setFrom(from)
@@ -502,7 +501,7 @@ public class TopHitsIT extends ESIntegTestCase {
             .setPostFilter(QueryBuilders.termQuery(TERMS_AGGS_FIELD, "val0"))
             .addSort(SORT_FIELD, SortOrder.DESC)
             .get();
-        assertSearchResponse(control);
+        assertNoFailures(control);
         SearchHits controlHits = control.getHits();
 
         Terms terms = response.getAggregations().get("terms");
@@ -541,7 +540,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     .subAggregation(max("max_sort").field(SORT_FIELD))
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -578,7 +577,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     .subAggregation(max("max_score").field("value"))
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -632,7 +631,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -699,7 +698,7 @@ public class TopHitsIT extends ESIntegTestCase {
 
     public void testEmptyIndex() throws Exception {
         SearchResponse response = client().prepareSearch("empty").addAggregation(topHits("hits")).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         TopHits hits = response.getAggregations().get("hits");
         assertThat(hits, notNullValue());
@@ -718,7 +717,7 @@ public class TopHitsIT extends ESIntegTestCase {
                         .subAggregation(topHits("hits").trackScores(trackScore).size(1).sort("_index", SortOrder.DESC))
                 )
                 .get();
-            assertSearchResponse(response);
+            assertNoFailures(response);
 
             Terms terms = response.getAggregations().get("terms");
             assertThat(terms, notNullValue());
@@ -1077,7 +1076,7 @@ public class TopHitsIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -1139,7 +1138,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     )
                 )
                 .get();
-            assertSearchResponse(r);
+            assertNoFailures(r);
 
             assertThat(
                 indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1162,7 +1161,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     )
                 )
                 .get();
-            assertSearchResponse(r);
+            assertNoFailures(r);
 
             assertThat(
                 indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1180,7 +1179,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     topHits("foo").scriptField("bar", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "5", Collections.emptyMap()))
                 )
                 .get();
-            assertSearchResponse(r);
+            assertNoFailures(r);
 
             assertThat(
                 indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1203,7 +1202,7 @@ public class TopHitsIT extends ESIntegTestCase {
                     )
                 )
                 .get();
-            assertSearchResponse(r);
+            assertNoFailures(r);
 
             assertThat(
                 indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1216,7 +1215,7 @@ public class TopHitsIT extends ESIntegTestCase {
 
             // Ensure that non-scripted requests are cached as normal
             r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(topHits("foo")).get();
-            assertSearchResponse(r);
+            assertNoFailures(r);
 
             assertThat(
                 indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -38,6 +37,7 @@ import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugi
 import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugin.VALUE_FIELD_SCRIPT;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -241,7 +241,7 @@ public class ValueCountIT extends ESIntegTestCase {
                 count("foo").field("d").script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, RANDOM_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -260,7 +260,7 @@ public class ValueCountIT extends ESIntegTestCase {
                     .script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, VALUE_FIELD_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -273,7 +273,7 @@ public class ValueCountIT extends ESIntegTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(count("foo").field("d")).get();
-        ElasticsearchAssertions.assertNoFailures(r);
+        assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -37,7 +38,6 @@ import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugi
 import static org.elasticsearch.search.aggregations.metrics.MetricAggScriptPlugin.VALUE_FIELD_SCRIPT;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -241,7 +241,7 @@ public class ValueCountIT extends ESIntegTestCase {
                 count("foo").field("d").script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, RANDOM_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -260,7 +260,7 @@ public class ValueCountIT extends ESIntegTestCase {
                     .script(new Script(ScriptType.INLINE, METRIC_SCRIPT_ENGINE, VALUE_FIELD_SCRIPT, Collections.emptyMap()))
             )
             .get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -273,7 +273,7 @@ public class ValueCountIT extends ESIntegTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         r = client().prepareSearch("cache_test_idx").setSize(0).addAggregation(count("foo").field("d")).get();
-        assertSearchResponse(r);
+        ElasticsearchAssertions.assertNoFailures(r);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -38,6 +37,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -134,7 +134,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">_count"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get(histoName);
         assertThat(histo, notNullValue());
@@ -170,7 +170,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -208,7 +208,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -250,7 +250,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -308,7 +308,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -355,7 +355,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -385,7 +385,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("nested_terms_bucket", termsName + ">nested_histo_bucket." + nestedMetric()))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -37,7 +38,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -134,7 +134,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">_count"))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get(histoName);
         assertThat(histo, notNullValue());
@@ -170,7 +170,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -208,7 +208,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum"))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -250,7 +250,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -308,7 +308,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -355,7 +355,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum"))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -385,7 +385,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .addAggregation(BucketMetricsPipelineAgg("nested_terms_bucket", termsName + ">nested_histo_bucket." + nestedMetric()))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -43,6 +42,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketScript;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -174,7 +174,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -224,7 +224,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -274,7 +274,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -320,7 +320,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -366,7 +366,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -413,7 +413,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -463,7 +463,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -509,7 +509,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -552,7 +552,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -602,7 +602,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -630,7 +630,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -683,7 +683,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -732,7 +732,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -791,7 +791,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -885,7 +885,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -940,7 +940,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -42,7 +43,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketScript;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -174,7 +174,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -224,7 +224,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -274,7 +274,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Range range = response.getAggregations().get("range");
         assertThat(range, notNullValue());
@@ -320,7 +320,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -366,7 +366,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -413,7 +413,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -463,7 +463,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -509,7 +509,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -552,7 +552,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -602,7 +602,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram deriv = response.getAggregations().get("histo");
         assertThat(deriv, notNullValue());
@@ -630,7 +630,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -683,7 +683,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -732,7 +732,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -791,7 +791,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -885,7 +885,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -940,7 +940,7 @@ public class BucketScriptIT extends ESIntegTestCase {
             )
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats.Bounds;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +27,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.extendedStatsBucket;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -104,7 +104,7 @@ public class ExtendedStatsBucketIT extends BucketMetricsPipeLineAggregationTestC
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L))
             .addAggregation(extendedStatsBucket("extended_stats_bucket", "histo>_count").sigma(sigma))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         assertThat(histo.getName(), equalTo("histo"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats.Bounds;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +26,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.extendedStatsBucket;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -104,7 +104,7 @@ public class ExtendedStatsBucketIT extends BucketMetricsPipeLineAggregationTestC
             .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L))
             .addAggregation(extendedStatsBucket("extended_stats_bucket", "histo>_count").sigma(sigma))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         assertThat(histo.getName(), equalTo("histo"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.Sum;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -29,6 +28,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.percentilesBucket;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -73,7 +73,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
             .addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -110,7 +110,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
             .addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum").setPercents(PERCENTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -208,7 +208,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
             .addAggregation(percentilesBucket("percentile_terms_bucket", termsName + ">percentile_histo_bucket[99.9]").setPercents(percent))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.Sum;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -28,7 +29,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.percentilesBucket;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -73,7 +73,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
             .addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum"))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -110,7 +110,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
             .addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum").setPercents(PERCENTS))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());
@@ -208,7 +208,7 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
             .addAggregation(percentilesBucket("percentile_terms_bucket", termsName + ">percentile_histo_bucket[99.9]").setPercents(percent))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get(termsName);
         assertThat(terms, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -32,8 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 
 public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
 
@@ -193,9 +192,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
             indicesAdmin().prepareClose("test").execute().get();
             indicesAdmin().prepareOpen("test").execute().get();
             ensureGreen();
-            SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.matchQuery("test", "init")).get();
-            assertNoFailures(searchResponse);
-            assertHitCount(searchResponse, numInitialDocs);
+            assertHitCountAndNoFailures(client().prepareSearch().setQuery(QueryBuilders.matchQuery("test", "init")), numInitialDocs);
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
@@ -39,7 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -75,7 +75,7 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch()
             .setSource(new SearchSourceBuilder().ext(Collections.singletonList(new TermVectorsFetchBuilder("test"))))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(
             ((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("i"),
             equalTo(2)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
@@ -40,6 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -75,7 +75,7 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch()
             .setSource(new SearchSourceBuilder().ext(Collections.singletonList(new TermVectorsFetchBuilder("test"))))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(
             ((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("i"),
             equalTo(2)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -50,6 +50,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
@@ -952,9 +953,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         QueryBuilder query = nestedQuery("nested", matchQuery("nested.field", "value1"), ScoreMode.Avg).innerHit(
             new InnerHitBuilder().setSize(ArrayUtil.MAX_ARRAY_LENGTH - 1)
         );
-        SearchResponse response = client().prepareSearch("index2").setQuery(query).get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(client().prepareSearch("index2").setQuery(query), 1);
     }
 
     public void testTooHighResultWindow() throws Exception {
@@ -966,15 +965,15 @@ public class InnerHitsIT extends ESIntegTestCase {
             )
             .setRefreshPolicy(IMMEDIATE)
             .get();
-        SearchResponse response = client().prepareSearch("index2")
-            .setQuery(
-                nestedQuery("nested", matchQuery("nested.field", "value1"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFrom(50).setSize(10).setName("_name")
-                )
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(
+            client().prepareSearch("index2")
+                .setQuery(
+                    nestedQuery("nested", matchQuery("nested.field", "value1"), ScoreMode.Avg).innerHit(
+                        new InnerHitBuilder().setFrom(50).setSize(10).setName("_name")
+                    )
+                ),
+            1
+        );
 
         Exception e = expectThrows(
             SearchPhaseExecutionException.class,

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -93,7 +93,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHigh
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNotHighlighted;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -3349,7 +3348,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 )
                 .get();
 
-            assertSearchResponse(r1);
+            assertNoFailures(r1);
             assertThat(r1.getHits().getTotalHits().value, equalTo(1L));
             assertHighlight(r1, 0, "field", 0, 1, equalTo("<x>hello</x> world"));
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -63,7 +63,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -1033,7 +1032,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
             );
         }
         SearchResponse resp = req.get();
-        assertSearchResponse(resp);
+        assertNoFailures(resp);
         for (SearchHit hit : resp.getHits().getHits()) {
             final int id = Integer.parseInt(hit.getId());
             Map<String, DocumentField> fields = hit.getFields();
@@ -1271,7 +1270,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         );
 
         SearchResponse response = client().prepareSearch("test").addStoredField("field1").get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 1);
 
         Map<String, DocumentField> fields = response.getHits().getAt(0).getMetadataFields();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,6 +46,7 @@ import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.scriptFunction;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -137,7 +137,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
                 )
         ).actionGet();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         SearchHits hits = response.getHits();
         assertThat(hits.getTotalHits().value, equalTo(20L));
         int idCounter = 19;

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +41,6 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -94,7 +94,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 )
             )
         ).actionGet();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
     }
 
@@ -110,7 +110,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 searchSource().query(functionScoreQuery(scriptFunction(script))).aggregation(terms("score_agg").script(script))
             )
         ).actionGet();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsString(), equalTo("1.0"));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
@@ -201,7 +201,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
     }
 
     protected void assertMinScoreSearchResponses(int numDocs, SearchResponse searchResponse, int numMatchingDocs) {
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat((int) searchResponse.getHits().getTotalHits().value, is(numMatchingDocs));
         int pos = 0;
         for (int hitId = numDocs - 1; (numDocs - hitId) < searchResponse.getHits().getTotalHits().value; hitId--) {
@@ -219,7 +219,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
         SearchResponse termQuery = client().search(
             new SearchRequest(new String[] {}).source(searchSource().explain(true).query(termQuery("text", "text")))
         ).get();
-        assertSearchResponse(termQuery);
+        ElasticsearchAssertions.assertNoFailures(termQuery);
         assertThat(termQuery.getHits().getTotalHits().value, equalTo(1L));
         float termQueryScore = termQuery.getHits().getAt(0).getScore();
 
@@ -234,7 +234,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 searchSource().explain(true).query(functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(0.1f))
             )
         ).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
         assertThat(response.getHits().getAt(0).getScore(), equalTo(expectedScore));
 
@@ -244,7 +244,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
             )
         ).get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(0L));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,6 +40,7 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -94,7 +94,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 )
             )
         ).actionGet();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
     }
 
@@ -110,7 +110,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 searchSource().query(functionScoreQuery(scriptFunction(script))).aggregation(terms("score_agg").script(script))
             )
         ).actionGet();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsString(), equalTo("1.0"));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
@@ -201,7 +201,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
     }
 
     protected void assertMinScoreSearchResponses(int numDocs, SearchResponse searchResponse, int numMatchingDocs) {
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat((int) searchResponse.getHits().getTotalHits().value, is(numMatchingDocs));
         int pos = 0;
         for (int hitId = numDocs - 1; (numDocs - hitId) < searchResponse.getHits().getTotalHits().value; hitId--) {
@@ -219,7 +219,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
         SearchResponse termQuery = client().search(
             new SearchRequest(new String[] {}).source(searchSource().explain(true).query(termQuery("text", "text")))
         ).get();
-        ElasticsearchAssertions.assertNoFailures(termQuery);
+        assertNoFailures(termQuery);
         assertThat(termQuery.getHits().getTotalHits().value, equalTo(1L));
         float termQueryScore = termQuery.getHits().getAt(0).getScore();
 
@@ -234,7 +234,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 searchSource().explain(true).query(functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(0.1f))
             )
         ).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
         assertThat(response.getHits().getAt(0).getScore(), equalTo(expectedScore));
 
@@ -244,7 +244,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
             )
         ).get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(0L));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -49,7 +49,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirs
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFourthHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThirdHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
@@ -85,7 +84,7 @@ public class QueryRescorerIT extends ESIntegTestCase {
                 )
                 .setSize(randomIntBetween(2, 10))
                 .get();
-            assertSearchResponse(searchResponse);
+            assertNoFailures(searchResponse);
             assertFirstHit(searchResponse, hasScore(100.f));
             int numDocsWith100AsAScore = 0;
             for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoPointScriptDocValuesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoPointScriptDocValuesIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.hamcrest.BaseMatcher;
@@ -36,7 +37,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -164,7 +164,7 @@ public class GeoPointScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
             .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         final double qLat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat));
         final double qLon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lon));
@@ -208,7 +208,7 @@ public class GeoPointScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
             .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         for (int i = 0; i < size; i++) {
             lats[i] = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lats[i]));
@@ -247,7 +247,7 @@ public class GeoPointScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("height", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "height", Collections.emptyMap()))
             .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("lat").getValue(), equalTo(Double.NaN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoPointScriptDocValuesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoPointScriptDocValuesIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.hamcrest.BaseMatcher;
@@ -37,6 +36,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -164,7 +164,7 @@ public class GeoPointScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
             .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         final double qLat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat));
         final double qLon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lon));
@@ -208,7 +208,7 @@ public class GeoPointScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
             .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         for (int i = 0; i < size; i++) {
             lats[i] = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lats[i]));
@@ -247,7 +247,7 @@ public class GeoPointScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("height", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "height", Collections.emptyMap()))
             .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("lat").getValue(), equalTo(Double.NaN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
@@ -43,7 +43,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertOrderedSearchHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertRequestBuilderThrows;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -609,7 +608,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
                 .maxQueryTerms(max_query_terms)
                 .minimumShouldMatch("0%");
             SearchResponse response = client().prepareSearch("test").setQuery(mltQuery).get();
-            assertSearchResponse(response);
+            assertNoFailures(response);
             assertHitCount(response, max_query_terms);
         }
     }
@@ -642,7 +641,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
                 .minimumShouldMatch(minimumShouldMatch);
             logger.info("Testing with minimum_should_match = {}", minimumShouldMatch);
             SearchResponse response = client().prepareSearch("test").setQuery(mltQuery).get();
-            assertSearchResponse(response);
+            assertNoFailures(response);
             if (minimumShouldMatch.equals("0%")) {
                 assertHitCount(response, 10);
             } else {
@@ -672,7 +671,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .maxQueryTerms(100)
             .minimumShouldMatch("100%"); // strict all terms must match!
         SearchResponse response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 1);
     }
 
@@ -698,14 +697,14 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .minDocFreq(0)
             .minimumShouldMatch("0%");
         SearchResponse response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 0);
 
         logger.info("Checking with an empty document ...");
         XContentBuilder emptyDoc = jsonBuilder().startObject().endObject();
         mltQuery = moreLikeThisQuery(null, new Item[] { new Item("test", emptyDoc) }).minTermFreq(0).minDocFreq(0).minimumShouldMatch("0%");
         response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 0);
 
         logger.info("Checking the document matches otherwise ...");
@@ -717,7 +716,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .minDocFreq(0)
             .minimumShouldMatch("100%");  // strict all terms must match but date is ignored
         response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 1);
     }
 
@@ -746,7 +745,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .maxQueryTerms(100)
             .minimumShouldMatch("0%");
         SearchResponse response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, numFields);
 
         logger.info("Now check like this doc, but ignore one doc in the index, then two and so on...");
@@ -761,7 +760,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
                 .minimumShouldMatch("0%");
 
             response = client().prepareSearch("test").setQuery(mltQuery).get();
-            assertSearchResponse(response);
+            assertNoFailures(response);
             assertHitCount(response, numFields - (i + 1));
         }
     }
@@ -785,7 +784,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .include(true)
             .minimumShouldMatch("1%");
         SearchResponse response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 2);
 
         mltQuery = moreLikeThisQuery(new String[] { "text" }, null, new Item[] { new Item("test", "1") }).minTermFreq(0)
@@ -793,7 +792,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .include(true)
             .minimumShouldMatch("1%");
         response = client().prepareSearch("test").setQuery(mltQuery).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 1);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.SearchProfileShardResult;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MapMatcher;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -42,7 +43,6 @@ import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -127,7 +127,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             .setProfile(true)
             .addAggregation(histogram("histo").field(NUMBER_FIELD).interval(1L))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -171,7 +171,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -258,7 +258,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -329,7 +329,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     .subAggregation(max("max").field(NUMBER_FIELD))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -398,7 +398,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -615,7 +615,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(0));
@@ -652,7 +652,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     .subAggregation(new MaxAggregationBuilder("m").field("date"))
             )
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("dateidx").numPrimaries));
@@ -724,7 +724,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                 .setProfile(true)
                 .addAggregation(new DateHistogramAggregationBuilder("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
             assertThat(profileResults, notNullValue());
             assertThat(profileResults.size(), equalTo(getNumShards("date_filter_by_filter_disabled").numPrimaries));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.SearchProfileShardResult;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MapMatcher;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -43,6 +42,7 @@ import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -127,7 +127,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             .setProfile(true)
             .addAggregation(histogram("histo").field(NUMBER_FIELD).interval(1L))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -171,7 +171,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -258,7 +258,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -329,7 +329,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     .subAggregation(max("max").field(NUMBER_FIELD))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -398,7 +398,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
@@ -615,7 +615,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     )
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(0));
@@ -652,7 +652,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                     .subAggregation(new MaxAggregationBuilder("m").field("date"))
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
         assertThat(profileResults, notNullValue());
         assertThat(profileResults.size(), equalTo(getNumShards("dateidx").numPrimaries));
@@ -724,7 +724,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                 .setProfile(true)
                 .addAggregation(new DateHistogramAggregationBuilder("histo").field("date").calendarInterval(DateHistogramInterval.MONTH))
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
             assertThat(profileResults, notNullValue());
             assertThat(profileResults.size(), equalTo(getNumShards("date_filter_by_filter_disabled").numPrimaries));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/ExistsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/ExistsIT.java
@@ -31,7 +31,6 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 
 public class ExistsIT extends ESIntegTestCase {
 
@@ -115,14 +114,14 @@ public class ExistsIT extends ESIntegTestCase {
 
         final long numDocs = sources.length;
         SearchResponse allDocs = client().prepareSearch("idx").setSize(sources.length).get();
-        assertSearchResponse(allDocs);
+        assertNoFailures(allDocs);
         assertHitCount(allDocs, numDocs);
         for (Map.Entry<String, Integer> entry : expected.entrySet()) {
             final String fieldName = entry.getKey();
             final int count = entry.getValue();
             // exists
             SearchResponse resp = client().prepareSearch("idx").setQuery(QueryBuilders.existsQuery(fieldName)).get();
-            assertSearchResponse(resp);
+            assertNoFailures(resp);
             try {
                 assertEquals(
                     String.format(
@@ -201,7 +200,7 @@ public class ExistsIT extends ESIntegTestCase {
             int expectedCount = entry.getValue();
 
             SearchResponse response = client().prepareSearch("idx").setQuery(QueryBuilders.existsQuery(fieldName)).get();
-            assertSearchResponse(response);
+            assertNoFailures(response);
             assertHitCount(response, expectedCount);
         }
     }
@@ -233,7 +232,7 @@ public class ExistsIT extends ESIntegTestCase {
         indexRandom(true, false, indexRequests);
 
         SearchResponse response = client().prepareSearch("idx").setQuery(QueryBuilders.existsQuery("foo-alias")).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 2);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -104,10 +104,10 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasScore;
@@ -452,9 +452,10 @@ public class SearchQueryIT extends ESIntegTestCase {
             );
         }
         {
-            SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_index", indexNames))).get();
-            SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, indexNames.length);
+            assertHitCountAndNoFailures(
+                client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_index", indexNames))),
+                indexNames.length
+            );
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -50,7 +50,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoSearchHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertRequestBuilderThrows;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -517,7 +516,7 @@ public class SearchScrollIT extends ESIntegTestCase {
         assertSearchHits(response, "1");
 
         response = client().prepareSearchScroll(response.getScrollId()).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertHitCount(response, 1);
         assertNoSearchHits(response);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -46,6 +46,7 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -190,29 +191,25 @@ public class SimpleSearchIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("3").setSource("field", "1967-01-01T00:00").get();
         ensureGreen();
         refresh();
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d/d"))
-            .get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d/d")),
+            2L
+        );
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05T02:00").lte("2010-01-06T02:00"))
-            .get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05T02:00").lte("2010-01-06T02:00")),
+            2L
+        );
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05T02:00").lt("2010-01-06T02:00"))
-            .get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05T02:00").lt("2010-01-06T02:00")),
+            1L
+        );
 
-        searchResponse = client().prepareSearch("test")
-            .setQuery(QueryBuilders.rangeQuery("field").gt("2010-01-05T02:00").lt("2010-01-06T02:00"))
-            .get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 0L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("2010-01-05T02:00").lt("2010-01-06T02:00")),
+            0L
+        );
 
         assertHitCount(
             client().prepareSearch("test").setQuery(QueryBuilders.queryStringQuery("field:[2010-01-03||+2d TO 2010-01-04||+2d/d]")),
@@ -220,12 +217,10 @@ public class SimpleSearchIT extends ESIntegTestCase {
         );
 
         // a string value of "1000" should be parsed as the year 1000 and return all three docs
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("1000")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 3L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("1000")), 3L);
 
         // a numeric value of 1000 should be parsed as 1000 millis since epoch and return only docs after 1970
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt(1000)).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt(1000)).get();
         assertNoFailures(searchResponse);
         assertHitCount(searchResponse, 2L);
         String[] expectedIds = new String[] { "1", "2" };
@@ -245,37 +240,14 @@ public class SimpleSearchIT extends ESIntegTestCase {
         ensureGreen();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("A").lte("B")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("A").lte("B")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("A").lt("B")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte(null).lt("C")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 3L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("B").lt(null)).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt(null).lt(null)).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 4L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("").lt(null)).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 4L);
-
-        searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("").lt(null)).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 3L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("A").lte("B")), 2L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("A").lte("B")), 1L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("A").lt("B")), 1L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte(null).lt("C")), 3L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("B").lt(null)), 2L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt(null).lt(null)), 4L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("").lt(null)), 4L);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("").lt(null)), 3L);
     }
 
     public void testSimpleTerminateAfterCount() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -63,7 +63,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
@@ -126,7 +125,7 @@ public class FieldSortIT extends ESIntegTestCase {
             .setSize(10)
             .get();
         logClusterState();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
 
         for (int j = 1; j < searchResponse.getHits().getHits().length; j++) {
             Number current = (Number) searchResponse.getHits().getHits()[j].getSourceAsMap().get("entry");
@@ -140,7 +139,7 @@ public class FieldSortIT extends ESIntegTestCase {
             .setSize(10)
             .get();
         logClusterState();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
 
         for (int j = 1; j < searchResponse.getHits().getHits().length; j++) {
             Number current = (Number) searchResponse.getHits().getHits()[j].getSourceAsMap().get("entry");
@@ -184,7 +183,7 @@ public class FieldSortIT extends ESIntegTestCase {
             .addSort(new FieldSortBuilder("timeUpdated").order(SortOrder.ASC).unmappedType("date"))
             .setSize(docs)
             .get();
-        assertSearchResponse(allDocsResponse);
+        assertNoFailures(allDocsResponse);
 
         final int numiters = randomIntBetween(1, 20);
         for (int i = 0; i < numiters; i++) {
@@ -197,7 +196,7 @@ public class FieldSortIT extends ESIntegTestCase {
                 .addSort(new FieldSortBuilder("timeUpdated").order(SortOrder.ASC).unmappedType("date"))
                 .setSize(scaledRandomIntBetween(1, docs))
                 .get();
-            assertSearchResponse(searchResponse);
+            assertNoFailures(searchResponse);
             for (int j = 0; j < searchResponse.getHits().getHits().length; j++) {
                 assertThat(
                     searchResponse.toString() + "\n vs. \n" + allDocsResponse.toString(),
@@ -1765,13 +1764,13 @@ public class FieldSortIT extends ESIntegTestCase {
         );
 
         SearchResponse response = client().prepareSearch("test").addSort(SortBuilders.fieldSort("ip")).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertEquals(2, response.getHits().getTotalHits().value);
         assertArrayEquals(new String[] { "192.168.1.7" }, response.getHits().getAt(0).getSortValues());
         assertArrayEquals(new String[] { "2001:db8::ff00:42:8329" }, response.getHits().getAt(1).getSortValues());
 
         response = client().prepareSearch("test").addSort(SortBuilders.fieldSort("ip")).searchAfter(new Object[] { "192.168.1.7" }).get();
-        assertSearchResponse(response);
+        assertNoFailures(response);
         assertEquals(2, response.getHits().getTotalHits().value);
         assertEquals(1, response.getHits().getHits().length);
         assertArrayEquals(new String[] { "2001:db8::ff00:42:8329" }, response.getHits().getAt(0).getSortValues());
@@ -2080,7 +2079,7 @@ public class FieldSortIT extends ESIntegTestCase {
             .addSort(new FieldSortBuilder("long_field").order(SortOrder.DESC))
             .setSize(10)
             .get();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
         long previousLong = Long.MAX_VALUE;
         for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
             // check the correct sort order
@@ -2092,7 +2091,7 @@ public class FieldSortIT extends ESIntegTestCase {
 
         // *** 2. sort ASC on long_field
         searchResponse = client().prepareSearch().addSort(new FieldSortBuilder("long_field").order(SortOrder.ASC)).setSize(10).get();
-        assertSearchResponse(searchResponse);
+        assertNoFailures(searchResponse);
         previousLong = Long.MIN_VALUE;
         for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
             // check the correct sort order
@@ -2120,7 +2119,7 @@ public class FieldSortIT extends ESIntegTestCase {
                 .addSort(new FieldSortBuilder("foo"))
                 .setSize(10)
                 .get();
-            assertSearchResponse(searchResponse);
+            assertNoFailures(searchResponse);
         }
 
         String errMsg = "Can't sort on field [foo]; the field has incompatible sort types";

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +40,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -193,7 +193,7 @@ public class SearchStatsIT extends ESIntegTestCase {
             .setSize(size)
             .setScroll(TimeValue.timeValueMinutes(2))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         // refresh the stats now that scroll contexts are opened
         indicesStats = indicesAdmin().prepareStats(index).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -40,6 +39,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -193,7 +193,7 @@ public class SearchStatsIT extends ESIntegTestCase {
             .setSize(size)
             .setScroll(TimeValue.timeValueMinutes(2))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         // refresh the stats now that scroll contexts are opened
         indicesStats = indicesAdmin().prepareStats(index).get();

--- a/server/src/test/java/org/elasticsearch/index/fieldstats/FieldStatsProviderRefreshTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fieldstats/FieldStatsProviderRefreshTests.java
@@ -16,9 +16,9 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -48,7 +48,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
             .setSize(0)
             .setQuery(QueryBuilders.rangeQuery("s").gte("a").lte("g"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r1);
+        assertNoFailures(r1);
         assertThat(r1.getHits().getTotalHits().value, equalTo(3L));
         assertRequestCacheStats(0, 1);
 
@@ -58,7 +58,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
             .setSize(0)
             .setQuery(QueryBuilders.rangeQuery("s").gte("a").lte("g"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r2);
+        assertNoFailures(r2);
         assertThat(r2.getHits().getTotalHits().value, equalTo(3L));
         assertRequestCacheStats(1, 1);
 
@@ -73,7 +73,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
             .setSize(0)
             .setQuery(QueryBuilders.rangeQuery("s").gte("a").lte("g"))
             .get();
-        ElasticsearchAssertions.assertNoFailures(r3);
+        assertNoFailures(r3);
         assertThat(r3.getHits().getTotalHits().value, equalTo(5L));
         assertRequestCacheStats(1, 2);
     }

--- a/server/src/test/java/org/elasticsearch/index/fieldstats/FieldStatsProviderRefreshTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fieldstats/FieldStatsProviderRefreshTests.java
@@ -16,9 +16,9 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -48,7 +48,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
             .setSize(0)
             .setQuery(QueryBuilders.rangeQuery("s").gte("a").lte("g"))
             .get();
-        assertSearchResponse(r1);
+        ElasticsearchAssertions.assertNoFailures(r1);
         assertThat(r1.getHits().getTotalHits().value, equalTo(3L));
         assertRequestCacheStats(0, 1);
 
@@ -58,7 +58,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
             .setSize(0)
             .setQuery(QueryBuilders.rangeQuery("s").gte("a").lte("g"))
             .get();
-        assertSearchResponse(r2);
+        ElasticsearchAssertions.assertNoFailures(r2);
         assertThat(r2.getHits().getTotalHits().value, equalTo(3L));
         assertRequestCacheStats(1, 1);
 
@@ -73,7 +73,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
             .setSize(0)
             .setQuery(QueryBuilders.rangeQuery("s").gte("a").lte("g"))
             .get();
-        assertSearchResponse(r3);
+        ElasticsearchAssertions.assertNoFailures(r3);
         assertThat(r3.getHits().getTotalHits().value, equalTo(5L));
         assertRequestCacheStats(1, 2);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +18,7 @@ import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.is;
 
@@ -79,11 +79,11 @@ public abstract class ShardSizeTestCase extends ESIntegTestCase {
         indexRandom(true, docs);
 
         SearchResponse resp = client().prepareSearch("idx").setRouting(routing1).setQuery(matchAllQuery()).get();
-        ElasticsearchAssertions.assertNoFailures(resp);
+        assertNoFailures(resp);
         long totalOnOne = resp.getHits().getTotalHits().value;
         assertThat(totalOnOne, is(15L));
         resp = client().prepareSearch("idx").setRouting(routing2).setQuery(matchAllQuery()).get();
-        ElasticsearchAssertions.assertNoFailures(resp);
+        assertNoFailures(resp);
         long totalOnTwo = resp.getHits().getTotalHits().value;
         assertThat(totalOnTwo, is(12L));
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,7 +19,6 @@ import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.is;
 
@@ -79,11 +79,11 @@ public abstract class ShardSizeTestCase extends ESIntegTestCase {
         indexRandom(true, docs);
 
         SearchResponse resp = client().prepareSearch("idx").setRouting(routing1).setQuery(matchAllQuery()).get();
-        assertSearchResponse(resp);
+        ElasticsearchAssertions.assertNoFailures(resp);
         long totalOnOne = resp.getHits().getTotalHits().value;
         assertThat(totalOnOne, is(15L));
         resp = client().prepareSearch("idx").setRouting(routing2).setQuery(matchAllQuery()).get();
-        assertSearchResponse(resp);
+        ElasticsearchAssertions.assertNoFailures(resp);
         long totalOnTwo = resp.getHits().getTotalHits().value;
         assertThat(totalOnTwo, is(12L));
     }

--- a/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -16,6 +16,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.Assert;
 
@@ -28,7 +29,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.signific
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.ESIntegTestCase.client;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SharedSignificantTermsTestMethods {
@@ -51,7 +51,7 @@ public class SharedSignificantTermsTestMethods {
             .addAggregation(terms("class").field(CLASS_FIELD).subAggregation(significantTerms("sig_terms").field(TEXT_FIELD)))
             .execute()
             .actionGet();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         Assert.assertThat(classes.getBuckets().size(), equalTo(2));
         for (Terms.Bucket classBucket : classes.getBuckets()) {

--- a/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -16,7 +16,6 @@ import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.Assert;
 
@@ -29,6 +28,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.signific
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.ESIntegTestCase.client;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SharedSignificantTermsTestMethods {
@@ -51,7 +51,7 @@ public class SharedSignificantTermsTestMethods {
             .addAggregation(terms("class").field(CLASS_FIELD).subAggregation(significantTerms("sig_terms").field(TEXT_FIELD)))
             .execute()
             .actionGet();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         Assert.assertThat(classes.getBuckets().size(), equalTo(2));
         for (Terms.Bucket classBucket : classes.getBuckets()) {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
@@ -14,8 +14,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import org.elasticsearch.test.ESIntegTestCase;
-
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 public abstract class AbstractTermsTestCase extends ESIntegTestCase {
 
@@ -41,7 +40,7 @@ public abstract class AbstractTermsTestCase extends ESIntegTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            assertSearchResponse(allTerms);
+            ElasticsearchAssertions.assertNoFailures(allTerms);
 
             Terms terms = allTerms.getAggregations().get("terms");
             assertEquals(0, terms.getSumOfOtherDocCounts()); // size is 0
@@ -59,7 +58,7 @@ public abstract class AbstractTermsTestCase extends ESIntegTestCase {
                                 .collectMode(randomFrom(SubAggCollectionMode.values()))
                         )
                         .get();
-                    assertSearchResponse(resp);
+                    ElasticsearchAssertions.assertNoFailures(resp);
                     terms = resp.getAggregations().get("terms");
                     assertEquals(Math.min(size, totalNumTerms), terms.getBuckets().size());
                     assertEquals(sumOfDocCounts, sumOfDocCounts(terms));

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
@@ -14,7 +14,8 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.ExecutionMode;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 
 public abstract class AbstractTermsTestCase extends ESIntegTestCase {
 
@@ -40,7 +41,7 @@ public abstract class AbstractTermsTestCase extends ESIntegTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(allTerms);
+            assertNoFailures(allTerms);
 
             Terms terms = allTerms.getAggregations().get("terms");
             assertEquals(0, terms.getSumOfOtherDocCounts()); // size is 0
@@ -58,7 +59,7 @@ public abstract class AbstractTermsTestCase extends ESIntegTestCase {
                                 .collectMode(randomFrom(SubAggCollectionMode.values()))
                         )
                         .get();
-                    ElasticsearchAssertions.assertNoFailures(resp);
+                    assertNoFailures(resp);
                     terms = resp.getAggregations().get("terms");
                     assertEquals(Math.min(size, totalNumTerms), terms.getBuckets().size());
                     assertEquals(sumOfDocCounts, sumOfDocCounts(terms));

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -234,7 +234,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
             .addSort(SortBuilders.fieldSort(NUMBER_FIELD_NAME).order(SortOrder.ASC))
             .setSize(5000)
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         long totalHits = response.getHits().getTotalHits().value;
         XContentBuilder builder = XContentFactory.jsonBuilder();
         ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -31,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -234,7 +234,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
             .addSort(SortBuilders.fieldSort(NUMBER_FIELD_NAME).order(SortOrder.ASC))
             .setSize(5000)
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         long totalHits = response.getHits().getTotalHits().value;
         XContentBuilder builder = XContentFactory.jsonBuilder();
         ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
@@ -15,10 +15,10 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -38,7 +38,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(response.getHits().getTotalHits().value, equalTo(0L));
@@ -52,7 +52,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
         SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());
@@ -65,7 +65,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
         SearchResponse response = client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME)
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());
@@ -79,7 +79,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());
@@ -93,7 +93,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(global("global").subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)))
             .get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         assertThat(global, notNullValue());
@@ -120,7 +120,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(centroidAgg(aggName()).field(MULTI_VALUED_FIELD_NAME))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         CentroidAggregation geoCentroid = searchResponse.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
@@ -15,10 +15,10 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -38,7 +38,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(response.getHits().getTotalHits().value, equalTo(0L));
@@ -52,7 +52,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
         SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());
@@ -65,7 +65,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
         SearchResponse response = client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME)
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());
@@ -79,7 +79,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());
@@ -93,7 +93,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(global("global").subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)))
             .get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Global global = response.getAggregations().get("global");
         assertThat(global, notNullValue());
@@ -120,7 +120,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
             .setQuery(matchAllQuery())
             .addAggregation(centroidAgg(aggName()).field(MULTI_VALUED_FIELD_NAME))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         CentroidAggregation geoCentroid = searchResponse.getAggregations().get(aggName());
         assertThat(geoCentroid, notNullValue());

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
@@ -17,13 +17,13 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -41,7 +41,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
     public void testSingleValuedField() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)).get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -60,7 +60,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(global("global").subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
 
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
@@ -100,7 +100,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
     public void testMultiValuedField() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), MULTI_VALUED_FIELD_NAME)).get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -118,7 +118,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -134,7 +134,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -171,7 +171,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(terms("terms").field(NUMBER_FIELD_NAME).subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -194,7 +194,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
@@ -17,13 +17,13 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -41,7 +41,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
     public void testSingleValuedField() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)).get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -60,7 +60,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(global("global").subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
 
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
@@ -100,7 +100,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
     public void testMultiValuedField() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), MULTI_VALUED_FIELD_NAME)).get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -118,7 +118,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -134,7 +134,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());
@@ -171,7 +171,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(terms("terms").field(NUMBER_FIELD_NAME).subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         Terms terms = response.getAggregations().get("terms");
         assertThat(terms, notNullValue());
@@ -194,7 +194,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
             .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
             .get();
 
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
         assertThat(geoBounds, notNullValue());

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
@@ -37,7 +37,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.CoreMatchers;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -115,7 +115,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -123,7 +123,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         // default query, without specifying relation (expect intersects)
         searchResponse = client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry)).get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -181,7 +181,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo(1L));
         assertThat(searchHits.getAt(0).getId(), equalTo("1"));
@@ -223,7 +223,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.INTERSECTS))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(searchResponse);
+            assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(2));
             assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
@@ -234,7 +234,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.WITHIN))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(searchResponse);
+            assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(2));
             assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
@@ -245,7 +245,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.DISJOINT))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(searchResponse);
+            assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(1));
             assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
@@ -255,7 +255,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.CONTAINS))
                 .get();
 
-            ElasticsearchAssertions.assertNoFailures(searchResponse);
+            assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(0));
         }
@@ -283,7 +283,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
@@ -341,7 +341,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("point2"));
@@ -354,7 +354,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                     .indexedShapePath(indexedShapePath)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
     }
 
@@ -621,7 +621,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setTrackTotalHits(true)
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.INTERSECTS))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) line.length()));
     }
@@ -647,7 +647,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setTrackTotalHits(true)
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) linearRing.length()));
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
@@ -37,6 +37,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.CoreMatchers;
@@ -47,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -115,7 +115,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -123,7 +123,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         // default query, without specifying relation (expect intersects)
         searchResponse = client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry)).get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -181,7 +181,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo(1L));
         assertThat(searchHits.getAt(0).getId(), equalTo("1"));
@@ -223,7 +223,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.INTERSECTS))
                 .get();
 
-            assertSearchResponse(searchResponse);
+            ElasticsearchAssertions.assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(2));
             assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
@@ -234,7 +234,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.WITHIN))
                 .get();
 
-            assertSearchResponse(searchResponse);
+            ElasticsearchAssertions.assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(2));
             assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
@@ -245,7 +245,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.DISJOINT))
                 .get();
 
-            assertSearchResponse(searchResponse);
+            ElasticsearchAssertions.assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(1));
             assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
@@ -255,7 +255,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.CONTAINS))
                 .get();
 
-            assertSearchResponse(searchResponse);
+            ElasticsearchAssertions.assertNoFailures(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
             assertThat(searchResponse.getHits().getHits().length, equalTo(0));
         }
@@ -283,7 +283,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
@@ -341,7 +341,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             )
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("point2"));
@@ -354,7 +354,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
                     .indexedShapePath(indexedShapePath)
             )
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
     }
 
@@ -621,7 +621,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setTrackTotalHits(true)
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.INTERSECTS))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) line.length()));
     }
@@ -647,7 +647,7 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setTrackTotalHits(true)
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) linearRing.length()));
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.query.AbstractGeometryQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -43,7 +44,6 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -150,28 +150,28 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .indexedShapeIndex("shapes")
             .indexedShapePath(defaultFieldName);
         SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.2.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.2.3.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
 
         // now test the query variant
@@ -179,19 +179,19 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .indexedShapeIndex("shapes")
             .indexedShapePath(defaultFieldName);
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.2.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.2.3.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -220,7 +220,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
 
         QueryBuilder intersects = queryBuilder().intersectionQuery(defaultFieldName, queryCollection);
         SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(intersects).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertTrue("query: " + intersects + " doc: " + Strings.toString(docSource), result.getHits().getTotalHits().value > 0);
     }
 
@@ -350,7 +350,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, query))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("blakely"));
@@ -395,7 +395,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         SearchResponse result = client().prepareSearch(defaultIndexName)
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, point))
             .get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -408,7 +408,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         client().prepareIndex(defaultIndexName).setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
         QueryBuilder filter = queryBuilder().shapeQuery(defaultFieldName, innerPolygon).relation(ShapeRelation.CONTAINS);
         SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(filter).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
     }
 
@@ -424,7 +424,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
 
         ExistsQueryBuilder eqb = existsQuery(defaultFieldName);
         SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(eqb).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -461,7 +461,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, "Big_Rectangle"))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -470,7 +470,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, "Big_Rectangle"))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -492,7 +492,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         SearchResponse result = client().prepareSearch(defaultIndexName)
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, polygon))
             .get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -539,26 +539,26 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon1)));
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertSearchResponse(result);
+            ElasticsearchAssertions.assertNoFailures(result);
             assertHitCount(result, 1);
         }
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon2)));
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertSearchResponse(result);
+            ElasticsearchAssertions.assertNoFailures(result);
             assertHitCount(result, 0);
         }
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon1, polygon2)));
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertSearchResponse(result);
+            ElasticsearchAssertions.assertNoFailures(result);
             assertHitCount(result, 1);
         }
         {
             // no shape
             QueryBuilder filter = queryBuilder().shapeQuery(defaultFieldName, GeometryCollection.EMPTY);
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertSearchResponse(result);
+            ElasticsearchAssertions.assertNoFailures(result);
             assertHitCount(result, 0);
         }
     }
@@ -627,7 +627,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
                 .setTrackTotalHits(true)
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS))
                 .get();
-            assertSearchResponse(searchResponse);
+            ElasticsearchAssertions.assertNoFailures(searchResponse);
             SearchHits searchHits = searchResponse.getHits();
             assertThat(searchHits.getTotalHits().value, equalTo(1L));
         }
@@ -652,7 +652,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
                 .setTrackTotalHits(true)
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS))
                 .get();
-            assertSearchResponse(searchResponse);
+            ElasticsearchAssertions.assertNoFailures(searchResponse);
             SearchHits searchHits = searchResponse.getHits();
             assertThat(searchHits.getTotalHits().value, equalTo(1L));
         }
@@ -685,7 +685,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setTrackTotalHits(true)
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, center).relation(ShapeRelation.INTERSECTS))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) polygons.length));
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.query.AbstractGeometryQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -44,6 +43,7 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -150,28 +150,28 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .indexedShapeIndex("shapes")
             .indexedShapePath(defaultFieldName);
         SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.2.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.2.3.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
 
         // now test the query variant
@@ -179,19 +179,19 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .indexedShapeIndex("shapes")
             .indexedShapePath(defaultFieldName);
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.2.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.2.3.geo");
         result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -220,7 +220,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
 
         QueryBuilder intersects = queryBuilder().intersectionQuery(defaultFieldName, queryCollection);
         SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(intersects).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertTrue("query: " + intersects + " doc: " + Strings.toString(docSource), result.getHits().getTotalHits().value > 0);
     }
 
@@ -350,7 +350,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, query))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("blakely"));
@@ -395,7 +395,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         SearchResponse result = client().prepareSearch(defaultIndexName)
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, point))
             .get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -408,7 +408,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         client().prepareIndex(defaultIndexName).setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
         QueryBuilder filter = queryBuilder().shapeQuery(defaultFieldName, innerPolygon).relation(ShapeRelation.CONTAINS);
         SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(filter).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
     }
 
@@ -424,7 +424,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
 
         ExistsQueryBuilder eqb = existsQuery(defaultFieldName);
         SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(eqb).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -461,7 +461,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, "Big_Rectangle"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -470,7 +470,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, "Big_Rectangle"))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -492,7 +492,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         SearchResponse result = client().prepareSearch(defaultIndexName)
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, polygon))
             .get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -539,26 +539,26 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon1)));
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            ElasticsearchAssertions.assertNoFailures(result);
+            assertNoFailures(result);
             assertHitCount(result, 1);
         }
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon2)));
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            ElasticsearchAssertions.assertNoFailures(result);
+            assertNoFailures(result);
             assertHitCount(result, 0);
         }
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon1, polygon2)));
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            ElasticsearchAssertions.assertNoFailures(result);
+            assertNoFailures(result);
             assertHitCount(result, 1);
         }
         {
             // no shape
             QueryBuilder filter = queryBuilder().shapeQuery(defaultFieldName, GeometryCollection.EMPTY);
             SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            ElasticsearchAssertions.assertNoFailures(result);
+            assertNoFailures(result);
             assertHitCount(result, 0);
         }
     }
@@ -627,7 +627,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
                 .setTrackTotalHits(true)
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS))
                 .get();
-            ElasticsearchAssertions.assertNoFailures(searchResponse);
+            assertNoFailures(searchResponse);
             SearchHits searchHits = searchResponse.getHits();
             assertThat(searchHits.getTotalHits().value, equalTo(1L));
         }
@@ -652,7 +652,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
                 .setTrackTotalHits(true)
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS))
                 .get();
-            ElasticsearchAssertions.assertNoFailures(searchResponse);
+            assertNoFailures(searchResponse);
             SearchHits searchHits = searchResponse.getHits();
             assertThat(searchHits.getTotalHits().value, equalTo(1L));
         }
@@ -685,7 +685,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setTrackTotalHits(true)
             .setQuery(queryBuilder().shapeQuery(defaultFieldName, center).relation(ShapeRelation.INTERSECTS))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) polygons.length));
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
@@ -25,7 +25,6 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
@@ -37,7 +36,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoShapeQueryBuilder> {
@@ -160,11 +159,10 @@ public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoSh
 
         Point filterShape = new Point(179, 0);
 
-        SearchResponse result = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().intersectionQuery(defaultFieldName, filterShape))
-            .get();
-        ElasticsearchAssertions.assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().intersectionQuery(defaultFieldName, filterShape)),
+            1
+        );
     }
 
     protected Line makeRandomLine() {

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
@@ -25,6 +25,7 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
@@ -37,7 +38,6 @@ import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoShapeQueryBuilder> {
@@ -163,7 +163,7 @@ public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoSh
         SearchResponse result = client().prepareSearch(defaultIndexName)
             .setQuery(queryBuilder().intersectionQuery(defaultFieldName, filterShape))
             .get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -267,7 +267,7 @@ public class ElasticsearchAssertions {
     public static void assertSortValues(SearchRequestBuilder searchRequestBuilder, Object[]... sortValues) {
         var searchResponse = searchRequestBuilder.get();
         try {
-            assertSearchResponse(searchResponse);
+            assertNoFailures(searchResponse);
             SearchHit[] hits = searchResponse.getHits().getHits();
             assertEquals(sortValues.length, hits.length);
             for (int i = 0; i < sortValues.length; ++i) {
@@ -309,6 +309,16 @@ public class ElasticsearchAssertions {
         final TotalHits totalHits = countResponse.getHits().getTotalHits();
         if (totalHits.relation != TotalHits.Relation.EQUAL_TO || totalHits.value != expectedHitCount) {
             fail("Count is " + totalHits + " but " + expectedHitCount + " was expected. " + formatShardStatus(countResponse));
+        }
+    }
+
+    public static void assertHitCountAndNoFailures(SearchRequestBuilder searchRequestBuilder, long expectedHitCount) {
+        var res = searchRequestBuilder.get();
+        try {
+            assertHitCount(res, expectedHitCount);
+            assertNoFailures(res);
+        } finally {
+            res.decRef();
         }
     }
 
@@ -657,23 +667,6 @@ public class ElasticsearchAssertions {
 
         Exception e = expectThrows(Exception.class, future::actionGet);
         assertThat(extraInfo, ExceptionsHelper.status(e), equalTo(status));
-    }
-
-    /**
-     * Applies basic assertions on the SearchResponse. This method checks if all shards were successful, if
-     * any of the shards threw an exception and if the response is serializable.
-     */
-    public static SearchResponse assertSearchResponse(SearchRequestBuilder request) {
-        return assertSearchResponse(request.get());
-    }
-
-    /**
-     * Applies basic assertions on the SearchResponse. This method checks if all shards were successful, if
-     * any of the shards threw an exception and if the response is serializable.
-     */
-    public static SearchResponse assertSearchResponse(SearchResponse response) {
-        assertNoFailures(response);
-        return response;
     }
 
     /**

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.metrics.Min;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -42,6 +41,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -104,7 +104,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .setSize(numDocs)
                     .addSort("ul_field", SortOrder.ASC)
                     .get();
-                ElasticsearchAssertions.assertNoFailures(response);
+                assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, numDocs);
                 int i = 0;
@@ -119,7 +119,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .setSize(numDocs)
                     .addSort("ul_field", SortOrder.DESC)
                     .get();
-                ElasticsearchAssertions.assertNoFailures(response);
+                assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, numDocs);
                 int i = numDocs - 1;
@@ -135,7 +135,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.ASC)
                     .searchAfter(new Long[] { 100L })
                     .get();
-                ElasticsearchAssertions.assertNoFailures(response);
+                assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 7);
                 int i = 3;
@@ -151,7 +151,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.ASC)
                     .searchAfter(new BigInteger[] { new BigInteger("18446744073709551614") })
                     .get();
-                ElasticsearchAssertions.assertNoFailures(response);
+                assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 2);
                 int i = 8;
@@ -167,7 +167,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.ASC)
                     .searchAfter(new String[] { "18446744073709551614" })
                     .get();
-                ElasticsearchAssertions.assertNoFailures(response);
+                assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 2);
                 int i = 8;
@@ -203,7 +203,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.DESC)
                     .searchAfter(new BigInteger[] { new BigInteger("18446744073709551615") })
                     .get();
-                ElasticsearchAssertions.assertNoFailures(response);
+                assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 8);
                 int i = 7;
@@ -218,7 +218,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
         // terms agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(terms("ul_terms").field("ul_field")).get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Terms terms = response.getAggregations().get("ul_terms");
 
             long[] expectedBucketDocCounts = { 2, 2, 2, 1, 1, 1, 1 };
@@ -244,7 +244,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                 .setSize(0)
                 .addAggregation(histogram("ul_histo").field("ul_field").interval(9E18).minDocCount(0))
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Histogram histo = response.getAggregations().get("ul_histo");
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
@@ -265,7 +265,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     range("ul_range").field("ul_field").addUnboundedTo(9.0E18).addRange(9.0E18, 1.8E19).addUnboundedFrom(1.8E19)
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Range range = response.getAggregations().get("ul_range");
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
@@ -281,7 +281,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
         // sum agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(sum("ul_sum").field("ul_field")).get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Sum sum = response.getAggregations().get("ul_sum");
             double expectedSum = Arrays.stream(values).mapToDouble(Number::doubleValue).sum();
             assertEquals(expectedSum, sum.value(), 0.001);
@@ -289,14 +289,14 @@ public class UnsignedLongTests extends ESIntegTestCase {
         // max agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(max("ul_max").field("ul_field")).get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Max max = response.getAggregations().get("ul_max");
             assertEquals(1.8446744073709551615E19, max.value(), 0.001);
         }
         // min agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(min("ul_min").field("ul_field")).get();
-            ElasticsearchAssertions.assertNoFailures(response);
+            assertNoFailures(response);
             Min min = response.getAggregations().get("ul_min");
             assertEquals(0, min.value(), 0.001);
         }

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.search.aggregations.metrics.Min;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -41,7 +42,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -104,7 +104,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .setSize(numDocs)
                     .addSort("ul_field", SortOrder.ASC)
                     .get();
-                assertSearchResponse(response);
+                ElasticsearchAssertions.assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, numDocs);
                 int i = 0;
@@ -119,7 +119,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .setSize(numDocs)
                     .addSort("ul_field", SortOrder.DESC)
                     .get();
-                assertSearchResponse(response);
+                ElasticsearchAssertions.assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, numDocs);
                 int i = numDocs - 1;
@@ -135,7 +135,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.ASC)
                     .searchAfter(new Long[] { 100L })
                     .get();
-                assertSearchResponse(response);
+                ElasticsearchAssertions.assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 7);
                 int i = 3;
@@ -151,7 +151,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.ASC)
                     .searchAfter(new BigInteger[] { new BigInteger("18446744073709551614") })
                     .get();
-                assertSearchResponse(response);
+                ElasticsearchAssertions.assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 2);
                 int i = 8;
@@ -167,7 +167,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.ASC)
                     .searchAfter(new String[] { "18446744073709551614" })
                     .get();
-                assertSearchResponse(response);
+                ElasticsearchAssertions.assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 2);
                 int i = 8;
@@ -203,7 +203,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     .addSort("ul_field", SortOrder.DESC)
                     .searchAfter(new BigInteger[] { new BigInteger("18446744073709551615") })
                     .get();
-                assertSearchResponse(response);
+                ElasticsearchAssertions.assertNoFailures(response);
                 SearchHit[] hits = response.getHits().getHits();
                 assertEquals(hits.length, 8);
                 int i = 7;
@@ -218,7 +218,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
         // terms agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(terms("ul_terms").field("ul_field")).get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Terms terms = response.getAggregations().get("ul_terms");
 
             long[] expectedBucketDocCounts = { 2, 2, 2, 1, 1, 1, 1 };
@@ -244,7 +244,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                 .setSize(0)
                 .addAggregation(histogram("ul_histo").field("ul_field").interval(9E18).minDocCount(0))
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Histogram histo = response.getAggregations().get("ul_histo");
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
@@ -265,7 +265,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
                     range("ul_range").field("ul_field").addUnboundedTo(9.0E18).addRange(9.0E18, 1.8E19).addUnboundedFrom(1.8E19)
                 )
                 .get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Range range = response.getAggregations().get("ul_range");
 
             long[] expectedBucketDocCounts = { 3, 3, 4 };
@@ -281,7 +281,7 @@ public class UnsignedLongTests extends ESIntegTestCase {
         // sum agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(sum("ul_sum").field("ul_field")).get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Sum sum = response.getAggregations().get("ul_sum");
             double expectedSum = Arrays.stream(values).mapToDouble(Number::doubleValue).sum();
             assertEquals(expectedSum, sum.value(), 0.001);
@@ -289,14 +289,14 @@ public class UnsignedLongTests extends ESIntegTestCase {
         // max agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(max("ul_max").field("ul_field")).get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Max max = response.getAggregations().get("ul_max");
             assertEquals(1.8446744073709551615E19, max.value(), 0.001);
         }
         // min agg
         {
             SearchResponse response = client().prepareSearch("idx").setSize(0).addAggregation(min("ul_min").field("ul_field")).get();
-            assertSearchResponse(response);
+            ElasticsearchAssertions.assertNoFailures(response);
             Min min = response.getAggregations().get("ul_min");
             assertEquals(0, min.value(), 0.001);
         }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -51,6 +51,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsAction;
@@ -70,7 +71,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
@@ -470,7 +470,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
                 dateHistogram("histo").field("f").timeZone(ZoneId.of("+01:00")).minDocCount(0).calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        assertSearchResponse(r1);
+        ElasticsearchAssertions.assertNoFailures(r1);
 
         assertRequestCacheState(client(), "test-index", 0, 1);
 
@@ -491,7 +491,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
                         .calendarInterval(DateHistogramInterval.MONTH)
                 )
                 .get();
-            assertSearchResponse(r2);
+            ElasticsearchAssertions.assertNoFailures(r2);
             assertRequestCacheState(client(), "test-index", i + 1, 1);
             Histogram h1 = r1.getAggregations().get("histo");
             Histogram h2 = r2.getAggregations().get("histo");

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -51,7 +51,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.snapshots.SnapshotInfo;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsAction;
@@ -71,6 +70,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
@@ -470,7 +470,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
                 dateHistogram("histo").field("f").timeZone(ZoneId.of("+01:00")).minDocCount(0).calendarInterval(DateHistogramInterval.MONTH)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(r1);
+        assertNoFailures(r1);
 
         assertRequestCacheState(client(), "test-index", 0, 1);
 
@@ -491,7 +491,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
                         .calendarInterval(DateHistogramInterval.MONTH)
                 )
                 .get();
-            ElasticsearchAssertions.assertNoFailures(r2);
+            assertNoFailures(r2);
             assertRequestCacheState(client(), "test-index", i + 1, 1);
             Histogram h1 = r1.getAggregations().get("histo");
             Histogram h2 = r2.getAggregations().get("histo");

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -96,7 +96,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
@@ -541,14 +540,14 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         SearchResponse result = client().filterWithHeader(
             Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
         ).prepareSearch("query_index").setQuery(new PercolateQueryBuilder("query", "doc_index", "1", null, null, null)).get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         // user2 can access the query_index itself (without performing percolate search)
         result = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
             .prepareSearch("query_index")
             .setQuery(QueryBuilders.matchAllQuery())
             .get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         // user2 cannot access doc#1 of the doc_index so the percolate search fails because doc#1 cannot be found
         ResourceNotFoundException e = expectThrows(
@@ -596,14 +595,14 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
             requestBuilder.setQuery(shapeQuery);
         }
         result = requestBuilder.get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         // user2 does not have access to doc#1 of the shape_index
         result = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
             .prepareSearch("search_index")
             .setQuery(QueryBuilders.matchAllQuery())
             .get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         IllegalArgumentException e;
         if (randomBoolean()) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -82,7 +82,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
@@ -485,33 +484,33 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         SearchResponse result = client().filterWithHeader(
             Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user7", USERS_PASSWD))
         ).prepareSearch("query_index").setQuery(percolateQuery).get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         result = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
             .prepareSearch("query_index")
             .setQuery(QueryBuilders.matchAllQuery())
             .get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         // user 3 can see the fields of the percolated document, but not the "query" field of the indexed query
         result = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
             .prepareSearch("query_index")
             .setQuery(percolateQuery)
             .get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 0);
         result = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user9", USERS_PASSWD)))
             .prepareSearch("query_index")
             .setQuery(QueryBuilders.matchAllQuery())
             .get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         // user 9 can see the fields of the index query, but not the field of the indexed document to be percolated
         result = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user9", USERS_PASSWD)))
             .prepareSearch("query_index")
             .setQuery(percolateQuery)
             .get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 0);
     }
 
@@ -573,7 +572,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             requestBuilder.setQuery(shapeQuery1);
         }
         result = requestBuilder.get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         // user sees the queried point but not the querying shape
         final ShapeQueryBuilder shapeQuery2 = new ShapeQueryBuilder("field", "2").relation(ShapeRelation.WITHIN)
@@ -611,7 +610,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             requestBuilder.setQuery(shapeQuery3);
         }
         result = requestBuilder.get();
-        assertSearchResponse(result);
+        assertNoFailures(result);
         assertHitCount(result, 0);
     }
 

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -27,7 +27,6 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
@@ -52,6 +51,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -268,7 +268,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
             .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("lat").getValue(), equalTo(value.getY()));
         assertThat(fields.get("lon").getValue(), equalTo(value.getX()));
@@ -323,7 +323,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("height", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "height", Collections.emptyMap()))
             .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()))
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("lat").getValue(), equalTo(Double.NaN));
         assertThat(fields.get("lon").getValue(), equalTo(Double.NaN));

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
@@ -51,7 +52,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -268,7 +268,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
             .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("lat").getValue(), equalTo(value.getY()));
         assertThat(fields.get("lon").getValue(), equalTo(value.getX()));
@@ -323,7 +323,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             .addScriptField("height", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "height", Collections.emptyMap()))
             .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()))
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("lat").getValue(), equalTo(Double.NaN));
         assertThat(fields.get("lon").getValue(), equalTo(Double.NaN));

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -35,7 +36,6 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -176,43 +176,43 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
             .indexedShapeIndex(indexName)
             .indexedShapePath("location");
         SearchResponse result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.location");
         result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.2.location");
         result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.2.3.location");
         result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
 
         // now test the query variant
         ShapeQueryBuilder query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.2.location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.2.3.location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -265,7 +265,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
     public void testExistsQuery() {
         ExistsQueryBuilder eqb = QueryBuilders.existsQuery(FIELD);
         SearchResponse result = client().prepareSearch(INDEX).setQuery(eqb).get();
-        assertSearchResponse(result);
+        ElasticsearchAssertions.assertNoFailures(result);
         assertHitCount(result, numDocs);
     }
 
@@ -288,7 +288,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         Rectangle rectangle = new Rectangle(-50, 50, 50, -50);
         ShapeQueryBuilder queryBuilder = new ShapeQueryBuilder("location", rectangle).relation(ShapeRelation.CONTAINS);
         SearchResponse response = client().prepareSearch("test_contains").setQuery(queryBuilder).get();
-        assertSearchResponse(response);
+        ElasticsearchAssertions.assertNoFailures(response);
 
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
     }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -36,6 +35,7 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -176,43 +176,43 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
             .indexedShapeIndex(indexName)
             .indexedShapePath("location");
         SearchResponse result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.location");
         result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.2.location");
         result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.2.3.location");
         result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
 
         // now test the query variant
         ShapeQueryBuilder query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.2.location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.2.3.location");
         result = client().prepareSearch(searchIndex).setQuery(query).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, 1);
     }
 
@@ -265,7 +265,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
     public void testExistsQuery() {
         ExistsQueryBuilder eqb = QueryBuilders.existsQuery(FIELD);
         SearchResponse result = client().prepareSearch(INDEX).setQuery(eqb).get();
-        ElasticsearchAssertions.assertNoFailures(result);
+        assertNoFailures(result);
         assertHitCount(result, numDocs);
     }
 
@@ -288,7 +288,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         Rectangle rectangle = new Rectangle(-50, 50, 50, -50);
         ShapeQueryBuilder queryBuilder = new ShapeQueryBuilder("location", rectangle).relation(ShapeRelation.CONTAINS);
         SearchResponse response = client().prepareSearch("test_contains").setQuery(queryBuilder).get();
-        ElasticsearchAssertions.assertNoFailures(response);
+        assertNoFailures(response);
 
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
     }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
@@ -21,6 +21,7 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -32,7 +33,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -87,7 +87,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -95,7 +95,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
         // default query, without specifying relation (expect intersects)
         searchResponse = client().prepareSearch(defaultIndexName).setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle)).get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -124,7 +124,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -153,7 +153,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo(1L));
         assertThat(searchHits.getAt(0).getId(), equalTo("1"));
@@ -195,7 +195,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, mp).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(2));
         assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
@@ -225,7 +225,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
@@ -283,7 +283,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             )
             .get();
 
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("point2"));
@@ -295,7 +295,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
                     .indexedShapePath(indexedShapePath)
             )
             .get();
-        assertSearchResponse(searchResponse);
+        ElasticsearchAssertions.assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
     }
 

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
@@ -21,7 +21,6 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESSingleNodeTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -33,6 +32,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -87,7 +87,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -95,7 +95,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
         // default query, without specifying relation (expect intersects)
         searchResponse = client().prepareSearch(defaultIndexName).setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle)).get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -124,7 +124,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
@@ -153,7 +153,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo(1L));
         assertThat(searchHits.getAt(0).getId(), equalTo("1"));
@@ -195,7 +195,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, mp).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(2));
         assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
@@ -225,7 +225,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             .setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
@@ -283,7 +283,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             )
             .get();
 
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getHits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("point2"));
@@ -295,7 +295,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
                     .indexedShapePath(indexedShapePath)
             )
             .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
+        assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
     }
 


### PR DESCRIPTION
Remove `assertSearchResponse` which was just an alias for `assertNoFailures` and then cleanup many spots in the result by combining the hit count and no failure assertion into a single method.

follow-up to #100966 