### PR TITLE
[8.11] ESQL: add serialization support for MvExpand and EsqlProject logical plan nodes (#101071)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -112,7 +112,9 @@ import org.elasticsearch.xpack.esql.plan.logical.Dissect.Parser;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -255,9 +257,11 @@ public final class PlanNamedTypes {
             of(LogicalPlan.class, EsRelation.class, PlanNamedTypes::writeEsRelation, PlanNamedTypes::readEsRelation),
             of(LogicalPlan.class, Eval.class, PlanNamedTypes::writeEval, PlanNamedTypes::readEval),
             of(LogicalPlan.class, Enrich.class, PlanNamedTypes::writeEnrich, PlanNamedTypes::readEnrich),
+            of(LogicalPlan.class, EsqlProject.class, PlanNamedTypes::writeEsqlProject, PlanNamedTypes::readEsqlProject),
             of(LogicalPlan.class, Filter.class, PlanNamedTypes::writeFilter, PlanNamedTypes::readFilter),
             of(LogicalPlan.class, Grok.class, PlanNamedTypes::writeGrok, PlanNamedTypes::readGrok),
             of(LogicalPlan.class, Limit.class, PlanNamedTypes::writeLimit, PlanNamedTypes::readLimit),
+            of(LogicalPlan.class, MvExpand.class, PlanNamedTypes::writeMvExpand, PlanNamedTypes::readMvExpand),
             of(LogicalPlan.class, OrderBy.class, PlanNamedTypes::writeOrderBy, PlanNamedTypes::readOrderBy),
             of(LogicalPlan.class, Project.class, PlanNamedTypes::writeProject, PlanNamedTypes::readProject),
             of(LogicalPlan.class, TopN.class, PlanNamedTypes::writeTopN, PlanNamedTypes::readTopN),
@@ -683,7 +687,7 @@ public final class PlanNamedTypes {
     }
 
     static EsRelation readEsRelation(PlanStreamInput in) throws IOException {
-        return new EsRelation(in.readSource(), readEsIndex(in), readAttributes(in));
+        return new EsRelation(in.readSource(), readEsIndex(in), readAttributes(in), in.readBoolean());
     }
 
     static void writeEsRelation(PlanStreamOutput out, EsRelation relation) throws IOException {
@@ -691,6 +695,7 @@ public final class PlanNamedTypes {
         out.writeNoSource();
         writeEsIndex(out, relation.index());
         writeAttributes(out, relation.output());
+        out.writeBoolean(relation.frozen());
     }
 
     static Eval readEval(PlanStreamInput in) throws IOException {
@@ -723,6 +728,16 @@ public final class PlanNamedTypes {
         enrich.policy().policy().writeTo(out);
         writeEsIndex(out, enrich.policy().index().get());
         writeNamedExpressions(out, enrich.enrichFields());
+    }
+
+    static EsqlProject readEsqlProject(PlanStreamInput in) throws IOException {
+        return new EsqlProject(in.readSource(), in.readLogicalPlanNode(), readNamedExpressions(in));
+    }
+
+    static void writeEsqlProject(PlanStreamOutput out, EsqlProject project) throws IOException {
+        out.writeNoSource();
+        out.writeLogicalPlanNode(project.child());
+        writeNamedExpressions(out, project.projections());
     }
 
     static Filter readFilter(PlanStreamInput in) throws IOException {
@@ -762,6 +777,16 @@ public final class PlanNamedTypes {
         out.writeNoSource();
         out.writeExpression(limit.limit());
         out.writeLogicalPlanNode(limit.child());
+    }
+
+    static MvExpand readMvExpand(PlanStreamInput in) throws IOException {
+        return new MvExpand(in.readSource(), in.readLogicalPlanNode(), in.readNamedExpression());
+    }
+
+    static void writeMvExpand(PlanStreamOutput out, MvExpand mvExpand) throws IOException {
+        out.writeNoSource();
+        out.writeLogicalPlanNode(mvExpand.child());
+        out.writeNamedExpression(mvExpand.target());
     }
 
     static OrderBy readOrderBy(PlanStreamInput in) throws IOException {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/plan/logical/EsRelation.java
@@ -34,7 +34,7 @@ public class EsRelation extends LeafPlan {
         this(source, index, attributes, false);
     }
 
-    private EsRelation(Source source, EsIndex index, List<Attribute> attributes, boolean frozen) {
+    public EsRelation(Source source, EsIndex index, List<Attribute> attributes, boolean frozen) {
         super(source);
         this.index = index;
         this.attrs = attributes;
@@ -43,7 +43,7 @@ public class EsRelation extends LeafPlan {
 
     @Override
     protected NodeInfo<EsRelation> info() {
-        return NodeInfo.create(this, EsRelation::new, index, frozen);
+        return NodeInfo.create(this, EsRelation::new, index, attrs, frozen);
     }
 
     private static List<Attribute> flatten(Source source, Map<String, EsField> mapping) {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: add serialization support for MvExpand and EsqlProject logical plan nodes (#101071)