### PR TITLE
Introduce OperationPurpose#REPOSITORY_ANALYSIS

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/OperationPurpose.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/OperationPurpose.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.Strings;
  */
 public enum OperationPurpose {
     SNAPSHOT("Snapshot"),
+    REPOSITORY_ANALYSIS("RepositoryAnalysis"),
     CLUSTER_STATE("ClusterState"),
     INDICES("Indices"),
     TRANSLOG("Translog");

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -348,18 +348,23 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
                     };
                     if (atomic) {
                         try {
-                            blobContainer.writeBlobAtomic(OperationPurpose.SNAPSHOT, request.blobName, bytesReference, failIfExists);
+                            blobContainer.writeBlobAtomic(
+                                OperationPurpose.REPOSITORY_ANALYSIS,
+                                request.blobName,
+                                bytesReference,
+                                failIfExists
+                            );
                         } catch (BlobWriteAbortedException e) {
                             assert request.getAbortWrite() : "write unexpectedly aborted";
                         }
                     } else {
-                        blobContainer.writeBlob(OperationPurpose.SNAPSHOT, request.blobName, bytesReference, failIfExists);
+                        blobContainer.writeBlob(OperationPurpose.REPOSITORY_ANALYSIS, request.blobName, bytesReference, failIfExists);
                     }
                 } else {
                     cancellableThreads.execute(() -> {
                         try {
                             blobContainer.writeBlob(
-                                OperationPurpose.SNAPSHOT,
+                                OperationPurpose.REPOSITORY_ANALYSIS,
                                 request.blobName,
                                 repository.maybeRateLimitSnapshots(
                                     new RandomBlobContentStream(content, request.getTargetLength()),
@@ -478,7 +483,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
                 logger.trace(() -> "analysis failed [" + request.getDescription() + "] cleaning up", exception);
             }
             try {
-                blobContainer.deleteBlobsIgnoringIfNotExists(OperationPurpose.SNAPSHOT, Iterators.single(request.blobName));
+                blobContainer.deleteBlobsIgnoringIfNotExists(OperationPurpose.REPOSITORY_ANALYSIS, Iterators.single(request.blobName));
             } catch (IOException ioException) {
                 exception.addSuppressed(ioException);
                 logger.warn(

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/GetBlobChecksumAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/GetBlobChecksumAction.java
@@ -98,10 +98,10 @@ public class GetBlobChecksumAction extends ActionType<GetBlobChecksumAction.Resp
             final InputStream rawInputStream;
             try {
                 if (request.isWholeBlob()) {
-                    rawInputStream = blobContainer.readBlob(OperationPurpose.SNAPSHOT, request.getBlobName());
+                    rawInputStream = blobContainer.readBlob(OperationPurpose.REPOSITORY_ANALYSIS, request.getBlobName());
                 } else {
                     rawInputStream = blobContainer.readBlob(
-                        OperationPurpose.SNAPSHOT,
+                        OperationPurpose.REPOSITORY_ANALYSIS,
                         request.getBlobName(),
                         request.getRangeStart(),
                         request.getRangeLength()

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RegisterAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RegisterAnalyzeAction.java
@@ -121,7 +121,7 @@ public class RegisterAnalyzeAction extends ActionType<ActionResponse.Empty> {
                             protected void doRun() {
                                 if (((CancellableTask) task).notifyIfCancelled(listener) == false) {
                                     blobContainer.compareAndExchangeRegister(
-                                        OperationPurpose.SNAPSHOT,
+                                        OperationPurpose.REPOSITORY_ANALYSIS,
                                         registerName,
                                         bytesFromLong(currentValue),
                                         bytesFromLong(currentValue + 1L),
@@ -169,10 +169,10 @@ public class RegisterAnalyzeAction extends ActionType<ActionResponse.Empty> {
             };
 
             if (request.getInitialRead() > request.getRequestCount()) {
-                blobContainer.getRegister(OperationPurpose.SNAPSHOT, registerName, initialValueListener);
+                blobContainer.getRegister(OperationPurpose.REPOSITORY_ANALYSIS, registerName, initialValueListener);
             } else {
                 blobContainer.compareAndExchangeRegister(
-                    OperationPurpose.SNAPSHOT,
+                    OperationPurpose.REPOSITORY_ANALYSIS,
                     registerName,
                     bytesFromLong(request.getInitialRead()),
                     bytesFromLong(

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -630,16 +630,16 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
                             }
                         }, ref), listener -> {
                             switch (random.nextInt(3)) {
-                                case 0 -> getBlobContainer().getRegister(OperationPurpose.SNAPSHOT, registerName, listener);
+                                case 0 -> getBlobContainer().getRegister(OperationPurpose.REPOSITORY_ANALYSIS, registerName, listener);
                                 case 1 -> getBlobContainer().compareAndExchangeRegister(
-                                    OperationPurpose.SNAPSHOT,
+                                    OperationPurpose.REPOSITORY_ANALYSIS,
                                     registerName,
                                     RegisterAnalyzeAction.bytesFromLong(expectedFinalRegisterValue),
                                     new BytesArray(new byte[] { (byte) 0xff }),
                                     listener
                                 );
                                 case 2 -> getBlobContainer().compareAndSetRegister(
-                                    OperationPurpose.SNAPSHOT,
+                                    OperationPurpose.REPOSITORY_ANALYSIS,
                                     registerName,
                                     RegisterAnalyzeAction.bytesFromLong(expectedFinalRegisterValue),
                                     new BytesArray(new byte[] { (byte) 0xff }),
@@ -689,7 +689,7 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
                 try {
                     final BlobContainer blobContainer = getBlobContainer();
                     final Set<String> missingBlobs = new HashSet<>(expectedBlobs);
-                    final Map<String, BlobMetadata> blobsMap = blobContainer.listBlobs(OperationPurpose.SNAPSHOT);
+                    final Map<String, BlobMetadata> blobsMap = blobContainer.listBlobs(OperationPurpose.REPOSITORY_ANALYSIS);
                     missingBlobs.removeAll(blobsMap.keySet());
 
                     if (missingBlobs.isEmpty()) {
@@ -712,11 +712,11 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
         private void deleteContainer() {
             try {
                 final BlobContainer blobContainer = getBlobContainer();
-                blobContainer.delete(OperationPurpose.SNAPSHOT);
+                blobContainer.delete(OperationPurpose.REPOSITORY_ANALYSIS);
                 if (failure.get() != null) {
                     return;
                 }
-                final Map<String, BlobMetadata> blobsMap = blobContainer.listBlobs(OperationPurpose.SNAPSHOT);
+                final Map<String, BlobMetadata> blobsMap = blobContainer.listBlobs(OperationPurpose.REPOSITORY_ANALYSIS);
                 if (blobsMap.isEmpty() == false) {
                     final RepositoryVerificationException repositoryVerificationException = new RepositoryVerificationException(
                         request.repositoryName,


### PR DESCRIPTION
Allows to distinguish blob store access for repo analysis from other
snapshot activities.