### PR TITLE
Add ParentTaskAssigningClient.getParentTask accessor method

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/ParentTaskAssigningClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ParentTaskAssigningClient.java
@@ -38,6 +38,10 @@ public class ParentTaskAssigningClient extends FilterClient {
         this(in, new TaskId(localNode.getId(), parentTask.getId()));
     }
 
+    public TaskId getParentTask() {
+        return parentTask;
+    }
+
     /**
      * Fetch the wrapped client. Use this to make calls that don't set {@link ActionRequest#setParentTask(TaskId)}.
      */

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -36,6 +36,8 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
             }
         };
         try (ParentTaskAssigningClient client = new ParentTaskAssigningClient(mock, parentTaskId[0])) {
+            assertEquals(parentTaskId[0], client.getParentTask());
+
             // All of these should have the parentTaskId set
             client.bulk(new BulkRequest());
             client.search(new SearchRequest());


### PR DESCRIPTION
This PR exposes parent task id used by the `ParentTaskAssigningClient` class.

Marking `>non-issue` as this new accessor method is not used anywhere.