### PR TITLE
Add NotExistAssertion to yml test framework

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -32,7 +32,7 @@ setup:
 "_source: false":
   - do: { search: { body: { _source: false, query: { match_all: {} } } } }
   - length:   { hits.hits: 1  }
-  - not_exist: hits.hits.0._source
+  - not_exists: hits.hits.0._source
 
 ---
 "no filtering":
@@ -44,25 +44,25 @@ setup:
 "_source in body":
   - do: { search: { body: { _source: include.field1, query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exist: hits.hits.0._source.include.field2
+  - not_exists: hits.hits.0._source.include.field2
 
 ---
 "_source_includes and _source in body":
   - do: { search: { _source_includes: include.field1, body: { _source: include.field2, query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exist: hits.hits.0._source.include.field2
+  - not_exists: hits.hits.0._source.include.field2
 
 ---
 "_source_includes":
   - do: { search: { _source_includes: include.field1, body: { query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exist: hits.hits.0._source.include.field2
+  - not_exists: hits.hits.0._source.include.field2
 
 ---
 "_source_excludes":
   - do: { search: { _source_excludes: count, body: { query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include: { field1 : v1 , field2: v2 }}
-  - not_exist: hits.hits.0._source.count
+  - not_exists: hits.hits.0._source.count
 
 ---
 "_source field1 field2":
@@ -73,7 +73,7 @@ setup:
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
   - match:  { hits.hits.0._source.include.field2: v2 }
-  - not_exist: hits.hits.0._source.count
+  - not_exists: hits.hits.0._source.count
 
 ---
 "_source.include field1 field2":
@@ -85,7 +85,7 @@ setup:
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
   - match:  { hits.hits.0._source.include.field2: v2 }
-  - not_exist: hits.hits.0._source.count
+  - not_exists: hits.hits.0._source.count
 
 ---
 "_source includes and excludes":
@@ -97,7 +97,7 @@ setup:
             excludes: "*.field2"
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exist:  hits.hits.0._source.include.field2
+  - not_exists:  hits.hits.0._source.include.field2
 
 ---
 "_source include on bigint":
@@ -108,7 +108,7 @@ setup:
             includes: bigint
           query: { match_all: {} }
   - match:  { hits.hits.0._source.bigint: 72057594037927936 }
-  - not_exist:  hits.hits.0._source.include.field2
+  - not_exists:  hits.hits.0._source.include.field2
 
 
 ---
@@ -127,7 +127,7 @@ setup:
         body:
           stored_fields: [ include.field2 ]
           query: { match_all: {} }
-  - not_exist:  hits.hits.0._source
+  - not_exists:  hits.hits.0._source
 
 ---
 "fields in body with source":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -32,7 +32,7 @@ setup:
 "_source: false":
   - do: { search: { body: { _source: false, query: { match_all: {} } } } }
   - length:   { hits.hits: 1  }
-  - is_false: hits.hits.0._source
+  - not_exist: hits.hits.0._source
 
 ---
 "no filtering":
@@ -44,25 +44,25 @@ setup:
 "_source in body":
   - do: { search: { body: { _source: include.field1, query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - is_false: hits.hits.0._source.include.field2
+  - not_exist: hits.hits.0._source.include.field2
 
 ---
 "_source_includes and _source in body":
   - do: { search: { _source_includes: include.field1, body: { _source: include.field2, query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - is_false: hits.hits.0._source.include.field2
+  - not_exist: hits.hits.0._source.include.field2
 
 ---
 "_source_includes":
   - do: { search: { _source_includes: include.field1, body: { query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - is_false: hits.hits.0._source.include.field2
+  - not_exist: hits.hits.0._source.include.field2
 
 ---
 "_source_excludes":
   - do: { search: { _source_excludes: count, body: { query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include: { field1 : v1 , field2: v2 }}
-  - is_false: hits.hits.0._source.count
+  - not_exist: hits.hits.0._source.count
 
 ---
 "_source field1 field2":
@@ -73,7 +73,7 @@ setup:
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
   - match:  { hits.hits.0._source.include.field2: v2 }
-  - is_false: hits.hits.0._source.count
+  - not_exist: hits.hits.0._source.count
 
 ---
 "_source.include field1 field2":
@@ -85,7 +85,7 @@ setup:
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
   - match:  { hits.hits.0._source.include.field2: v2 }
-  - is_false: hits.hits.0._source.count
+  - not_exist: hits.hits.0._source.count
 
 ---
 "_source includes and excludes":
@@ -97,7 +97,7 @@ setup:
             excludes: "*.field2"
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - is_false:  hits.hits.0._source.include.field2
+  - not_exist:  hits.hits.0._source.include.field2
 
 ---
 "_source include on bigint":
@@ -108,7 +108,7 @@ setup:
             includes: bigint
           query: { match_all: {} }
   - match:  { hits.hits.0._source.bigint: 72057594037927936 }
-  - is_false:  hits.hits.0._source.include.field2
+  - not_exist:  hits.hits.0._source.include.field2
 
 
 ---
@@ -127,7 +127,7 @@ setup:
         body:
           stored_fields: [ include.field2 ]
           query: { match_all: {} }
-  - is_false:  hits.hits.0._source
+  - not_exist:  hits.hits.0._source
 
 ---
 "fields in body with source":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -32,7 +32,7 @@ setup:
 "_source: false":
   - do: { search: { body: { _source: false, query: { match_all: {} } } } }
   - length:   { hits.hits: 1  }
-  - not_exists: hits.hits.0._source
+  - is_false: hits.hits.0._source
 
 ---
 "no filtering":
@@ -44,25 +44,25 @@ setup:
 "_source in body":
   - do: { search: { body: { _source: include.field1, query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exists: hits.hits.0._source.include.field2
+  - is_false: hits.hits.0._source.include.field2
 
 ---
 "_source_includes and _source in body":
   - do: { search: { _source_includes: include.field1, body: { _source: include.field2, query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exists: hits.hits.0._source.include.field2
+  - is_false: hits.hits.0._source.include.field2
 
 ---
 "_source_includes":
   - do: { search: { _source_includes: include.field1, body: { query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exists: hits.hits.0._source.include.field2
+  - is_false: hits.hits.0._source.include.field2
 
 ---
 "_source_excludes":
   - do: { search: { _source_excludes: count, body: { query: { match_all: {} } } } }
   - match:  { hits.hits.0._source.include: { field1 : v1 , field2: v2 }}
-  - not_exists: hits.hits.0._source.count
+  - is_false: hits.hits.0._source.count
 
 ---
 "_source field1 field2":
@@ -73,7 +73,7 @@ setup:
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
   - match:  { hits.hits.0._source.include.field2: v2 }
-  - not_exists: hits.hits.0._source.count
+  - is_false: hits.hits.0._source.count
 
 ---
 "_source.include field1 field2":
@@ -85,7 +85,7 @@ setup:
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
   - match:  { hits.hits.0._source.include.field2: v2 }
-  - not_exists: hits.hits.0._source.count
+  - is_false: hits.hits.0._source.count
 
 ---
 "_source includes and excludes":
@@ -97,7 +97,7 @@ setup:
             excludes: "*.field2"
           query: { match_all: {} }
   - match:  { hits.hits.0._source.include.field1: v1 }
-  - not_exists:  hits.hits.0._source.include.field2
+  - is_false:  hits.hits.0._source.include.field2
 
 ---
 "_source include on bigint":
@@ -108,7 +108,7 @@ setup:
             includes: bigint
           query: { match_all: {} }
   - match:  { hits.hits.0._source.bigint: 72057594037927936 }
-  - not_exists:  hits.hits.0._source.include.field2
+  - is_false:  hits.hits.0._source.include.field2
 
 
 ---
@@ -127,7 +127,7 @@ setup:
         body:
           stored_fields: [ include.field2 ]
           query: { match_all: {} }
-  - not_exists:  hits.hits.0._source
+  - is_false:  hits.hits.0._source
 
 ---
 "fields in body with source":

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ExecutableSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ExecutableSection.java
@@ -37,7 +37,8 @@ public interface ExecutableSection {
         new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("contains"), ContainsAssertion::parse),
         new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("length"), LengthAssertion::parse),
         new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("close_to"), CloseToAssertion::parse),
-        new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("exists"), ExistsAssertion::parse)
+        new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("exists"), ExistsAssertion::parse),
+        new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("not_exists"), NotExistsAssertion::parse)
     );
 
     /**

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/NotExistsAssertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/NotExistsAssertion.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.rest.yaml.section;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.xcontent.XContentLocation;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Represents an exists assert section:
+ * <p>
+ * - not_exists:  get.fields.bar
+ */
+public class NotExistsAssertion extends Assertion {
+
+    private static final Logger logger = LogManager.getLogger(NotExistsAssertion.class);
+
+    public static NotExistsAssertion parse(XContentParser parser) throws IOException {
+        return new NotExistsAssertion(parser.getTokenLocation(), ParserUtils.parseField(parser));
+    }
+
+    public NotExistsAssertion(XContentLocation location, String field) {
+        super(location, field, false /* not used */);
+    }
+
+    @Override
+    protected void doAssert(Object actualValue, Object expectedValue) {
+        logger.trace("assert that field [{}] does not exists with any value", getField());
+        String errorMessage = errorMessage();
+        assertThat(errorMessage, actualValue, nullValue());
+    }
+
+    private String errorMessage() {
+        return "field [" + getField() + "] exists, but should not.";
+    }
+}

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
@@ -185,4 +185,24 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
         AssertionError e = expectThrows(AssertionError.class, () -> existsAssertion.doAssert(null, existsAssertion.getExpectedValue()));
         assertThat(e.getMessage(), containsString("field [get.fields._timestamp] does not exist"));
     }
+
+    public void testDoesNotExist() throws IOException {
+        parser = createParser(YamlXContent.yamlXContent, "get.fields._timestamp");
+
+        NotExistsAssertion existnotExistsAssertion = NotExistsAssertion.parse(parser);
+
+        assertThat(existnotExistsAssertion, notNullValue());
+        assertThat(existnotExistsAssertion.getField(), equalTo("get.fields._timestamp"));
+
+        existnotExistsAssertion.doAssert(null, existnotExistsAssertion.getExpectedValue());
+
+        AssertionError e = expectThrows(
+            AssertionError.class,
+            () -> existnotExistsAssertion.doAssert(
+                randomFrom(1, "", "non-empty", List.of(), Map.of()),
+                existnotExistsAssertion.getExpectedValue()
+            )
+        );
+        assertThat(e.getMessage(), containsString("field [get.fields._timestamp] exists, but should not"));
+    }
 }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
@@ -199,7 +199,7 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
         AssertionError e = expectThrows(
             AssertionError.class,
             () -> existnotExistsAssertion.doAssert(
-                randomFrom(1, "", "non-empty", List.of(), Map.of()),
+                randomFrom(1, "", "non-empty", List.of(), Map.of(), 0, false),
                 existnotExistsAssertion.getExpectedValue()
             )
         );


### PR DESCRIPTION
currently to assert that a field does not exist, tests are using is_false. This has a drawback because is less readable and also would succeed when value is present and has a default value (0, false, etc)

This commit addes a NotExistAssertion to make sure that a field does not exist in a response

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
