### PR TITLE
[8.10] [DOCS] Inconsistent ulimit (#100948)

### DIFF
--- a/docs/reference/setup/sysconfig/configuring.asciidoc
+++ b/docs/reference/setup/sysconfig/configuring.asciidoc
@@ -20,7 +20,7 @@ require that system limits are specified in a
 On Linux systems, `ulimit` can be used to change resource limits on a
 temporary basis. Limits usually need to be set as `root` before switching to
 the user that will run Elasticsearch. For example, to set the number of
-open file handles (`ulimit -n`) to 65,536, you can do the following:
+open file handles (`ulimit -n`) to 65,535, you can do the following:
 
 [source,sh]
 --------------------------------

--- a/docs/reference/setup/sysconfig/file-descriptors.asciidoc
+++ b/docs/reference/setup/sysconfig/file-descriptors.asciidoc
@@ -10,7 +10,7 @@ limited only by available resources.
 Elasticsearch uses a lot of file descriptors or file handles. Running out of
 file descriptors can be disastrous and will most probably lead to data loss.
 Make sure to increase the limit on the number of open files descriptors for
-the user running Elasticsearch to 65,536 or higher.
+the user running Elasticsearch to 65,535 or higher.
 
 For the `.zip` and `.tar.gz` packages, set <<ulimit,`ulimit -n 65535`>> as
 root before starting Elasticsearch,   or set `nofile` to `65535` in


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOCS] Inconsistent ulimit (#100948)