### PR TITLE
[8.11] ESQL: Fix intermittently failing PowTest.testEvaluate {TestCase=pow(integer, double)} (#100970)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -220,7 +220,9 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
             }
         }
         assertThat(result, not(equalTo(Double.NaN)));
+        assert testCase.getMatcher().matches(Double.POSITIVE_INFINITY) == false;
         assertThat(result, not(equalTo(Double.POSITIVE_INFINITY)));
+        assert testCase.getMatcher().matches(Double.NEGATIVE_INFINITY) == false;
         assertThat(result, not(equalTo(Double.NEGATIVE_INFINITY)));
         assertThat(result, testCase.getMatcher());
         if (testCase.getExpectedWarnings() != null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/PowTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/PowTests.java
@@ -185,8 +185,8 @@ public class PowTests extends AbstractScalarFunctionTestCase {
                 )
             ),
             new TestCaseSupplier("pow(integer, double)", () -> {
-                // Negative numbers to a non-integer power are NaN
-                int base = randomIntBetween(0, 1000);
+                // Positive numbers to a non-integer power
+                int base = randomIntBetween(1, 1000);
                 double exp = randomDoubleBetween(-10.0, 10.0, true);
                 double expected = Math.pow(base, exp);
                 TestCaseSupplier.TestCase testCase = new TestCaseSupplier.TestCase(
@@ -336,7 +336,7 @@ public class PowTests extends AbstractScalarFunctionTestCase {
             }),
             new TestCaseSupplier("pow(long, double)", () -> {
                 // Negative numbers to non-integer power are NaN
-                long base = randomLongBetween(0, 1000);
+                long base = randomLongBetween(1, 1000);
                 double exp = randomDoubleBetween(-10.0, 10.0, true);
                 double expected = Math.pow(base, exp);
                 TestCaseSupplier.TestCase testCase = new TestCaseSupplier.TestCase(


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Fix intermittently failing PowTest.testEvaluate {TestCase=pow(integer, double)} (#100970)