### PR TITLE
ESQL: Fix escaping of backslash in LIKE operator

### DIFF
--- a/docs/changelog/101120.yaml
+++ b/docs/changelog/101120.yaml
@@ -1,0 +1,6 @@
+pr: 101120
+summary: "ESQL: Fix escaping of backslash in LIKE operator"
+area: ES|QL
+type: bug
+issues:
+ - 101106

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -276,10 +276,10 @@ emp_no:integer | first_name:keyword | last_name:keyword
 
 
 likeWithPath
-row x = "C:\\\\foo\\bar.exe" | mv_expand x | where x LIKE "C:\\\\\\\\*";
+row x = "C:\\foo\\bar.exe" | mv_expand x | where x LIKE "C:\\\\*";
 
 x:keyword
-C:\\foo\bar.exe
+C:\foo\bar.exe
 ;
 
 likeWithPathNoMatch

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -273,3 +273,17 @@ emp_no:integer | first_name:keyword | last_name:keyword
 10086          | Somnath            | Foote
 10088          | Jungsoon           | Syrzycki
 ;
+
+
+likeWithPath
+row x = "C:\\\\foo\\bar.exe" | mv_expand x | where x LIKE "C:\\\\\\\\*";
+
+x:keyword
+C:\\foo\bar.exe
+;
+
+likeWithPathNoMatch
+row x = "C:\\foo\\bar.exe" | mv_expand x | where x LIKE "C:\\\\\\\\*";
+
+x:keyword
+;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/RegexMatch.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/RegexMatch.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ql.expression.predicate.regex;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Nullability;
 import org.elasticsearch.xpack.ql.expression.function.scalar.UnaryScalarFunction;
@@ -69,6 +70,9 @@ public abstract class RegexMatch<T extends StringPattern> extends UnaryScalarFun
     @Override
     public Boolean fold() {
         Object val = field().fold();
+        if (val instanceof BytesRef br) {
+            val = br.utf8ToString();
+        }
         return RegexProcessor.RegexOperation.match(val, pattern().asJavaRegex());
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -157,7 +157,7 @@ public final class StringUtils {
                     case '*' -> regex.append(escaped ? "\\*" : ".*");
                     case '?' -> regex.append(escaped ? "\\?" : ".");
                     default -> {
-                        if (escaped) {
+                        if (escaped && escape != curr) {
                             throw new QlIllegalArgumentException(
                                 "Invalid sequence - escape character is not followed by special wildcard char"
                             );

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -139,7 +139,8 @@ public final class StringUtils {
     // * -> .*
     // ? -> .
     // escape character - can be 0 (in which case no regex gets escaped) or
-    // should be followed by % or _ (otherwise an exception is thrown)
+    // should be followed by * or ? or the escape character itself (otherwise an exception is thrown).
+    // Using * or ? as escape characters should be avoided because it will make it impossible to enter them as literals
     public static String wildcardToJavaPattern(String pattern, char escape) {
         StringBuilder regex = new StringBuilder(pattern.length() + 4);
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
@@ -52,4 +52,7 @@ public class StringUtilsTests extends ESTestCase {
         assertEquals("^foo\\*$", wildcardToJavaPattern("foox*", 'x'));
     }
 
+    public void testEscapedEscape() {
+        assertEquals("^\\\\\\\\$", wildcardToJavaPattern("\\\\\\\\", '\\'));
+    }
 }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
@@ -53,8 +53,6 @@ public class StringUtilsTests extends ESTestCase {
     }
 
     public void testEscapedEscape() {
-        assertEquals("""
-            ^\\\\$""", wildcardToJavaPattern("""
-            \\\\""", '\\'));
+        assertEquals("^\\\\\\\\$", wildcardToJavaPattern("\\\\\\\\", '\\'));
     }
 }

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
@@ -53,6 +53,8 @@ public class StringUtilsTests extends ESTestCase {
     }
 
     public void testEscapedEscape() {
-        assertEquals("^\\\\\\\\$", wildcardToJavaPattern("\\\\\\\\", '\\'));
+        assertEquals("""
+            ^\\\\$""", wildcardToJavaPattern("""
+            \\\\""", '\\'));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/101106

Fixing a bug in escaping backslash character in LIKE operator, eg. the typical query that tries to match a file path 
``` ... | where path LIKE "C:\\\\*"```

Also including here a little fix to correctly fold RegexMatch expressions (LIKE/RLIKE) when the input is a BytesRef.