### PR TITLE
[TEST] Skip tsdb delete test for versions 8.7-8-10

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
@@ -1,4 +1,10 @@
 ---
+setup:
+  - skip:
+      version: "8.7.00 - 8.9.99"
+      reason: "Synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests"
+
+---
 "basic tsdb delete":
   - skip:
       version: " - 8.8.0"


### PR DESCRIPTION
Yet another test affected by the fix for showing the synthetic source, #98808. This can trigger an assert in older versions as the mapping they produce (without synthetic source) doesn't match the one they may get from the master, if the latter is in version 8.10+.

Fixes #101121