### PR TITLE
Include totals in flamegraph response

### DIFF
--- a/docs/changelog/101126.yaml
+++ b/docs/changelog/101126.yaml
@@ -1,0 +1,5 @@
+pr: 101126
+summary: Include totals in flamegraph response
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+public class GetFlameGraphActionIT extends ProfilingTestCase {
+    public void testGetStackTracesUnfiltered() throws Exception {
+        GetStackTracesRequest request = new GetStackTracesRequest(1, null);
+        GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();
+        // only spot-check top level properties - detailed tests are done in unit tests
+        assertEquals(4, response.getSize());
+        assertEquals(1.0d, response.getSamplingRate(), 0.001d);
+        assertEquals(3, response.getSelfCPU());
+        assertEquals(4, response.getTotalCPU());
+        assertEquals(1, response.getTotalSamples());
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
@@ -23,6 +23,9 @@ import java.util.Map;
 public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXContentObject {
     private final int size;
     private final double samplingRate;
+    private final int selfCPU;
+    private final int totalCPU;
+    private final long totalSamples;
     private final List<Map<String, Integer>> edges;
     private final List<String> fileIds;
     private final List<Integer> frameTypes;
@@ -51,6 +54,9 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         this.sourceLines = in.readCollectionAsList(StreamInput::readInt);
         this.countInclusive = in.readCollectionAsList(StreamInput::readInt);
         this.countExclusive = in.readCollectionAsList(StreamInput::readInt);
+        this.selfCPU = in.readInt();
+        this.totalCPU = in.readInt();
+        this.totalSamples = in.readLong();
     }
 
     public GetFlamegraphResponse(
@@ -67,7 +73,10 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         List<String> sourceFileNames,
         List<Integer> sourceLines,
         List<Integer> countInclusive,
-        List<Integer> countExclusive
+        List<Integer> countExclusive,
+        int selfCPU,
+        int totalCPU,
+        long totalSamples
     ) {
         this.size = size;
         this.samplingRate = samplingRate;
@@ -83,6 +92,9 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         this.sourceLines = sourceLines;
         this.countInclusive = countInclusive;
         this.countExclusive = countExclusive;
+        this.selfCPU = selfCPU;
+        this.totalCPU = totalCPU;
+        this.totalSamples = totalSamples;
     }
 
     @Override
@@ -101,6 +113,9 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         out.writeCollection(this.sourceLines, StreamOutput::writeInt);
         out.writeCollection(this.countInclusive, StreamOutput::writeInt);
         out.writeCollection(this.countExclusive, StreamOutput::writeInt);
+        out.writeInt(this.selfCPU);
+        out.writeInt(this.totalCPU);
+        out.writeLong(this.totalSamples);
     }
 
     public int getSize() {
@@ -159,6 +174,18 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return sourceLines;
     }
 
+    public int getSelfCPU() {
+        return selfCPU;
+    }
+
+    public int getTotalCPU() {
+        return totalCPU;
+    }
+
+    public long getTotalSamples() {
+        return totalSamples;
+    }
+
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(
@@ -187,6 +214,9 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
             ChunkedToXContentHelper.array("CountExclusive", Iterators.map(countExclusive.iterator(), e -> (b, p) -> b.value(e))),
             Iterators.single((b, p) -> b.field("Size", size)),
             Iterators.single((b, p) -> b.field("SamplingRate", samplingRate)),
+            Iterators.single((b, p) -> b.field("SelfCPU", selfCPU)),
+            Iterators.single((b, p) -> b.field("TotalCPU", totalCPU)),
+            Iterators.single((b, p) -> b.field("TotalSamples", totalSamples)),
             ChunkedToXContentHelper.endObject()
         );
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -206,6 +206,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                         stackTraceEvents.put(bucket.getKeyAsString(), finalCount);
                     }
                 }
+                responseBuilder.setTotalSamples(totalFinalCount);
                 log.debug(
                     "Found [{}] stacktrace events, resampled with sample rate [{}] to [{}] events ([{}] unique stack traces).",
                     totalCount,
@@ -500,6 +501,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         private Map<String, String> executables;
         private Map<String, Integer> stackTraceEvents;
         private double samplingRate;
+        private long totalSamples;
 
         public void setStackTraces(Map<String, StackTrace> stackTraces) {
             this.stackTraces = stackTraces;
@@ -545,8 +547,20 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             this.samplingRate = rate;
         }
 
+        public void setTotalSamples(long totalSamples) {
+            this.totalSamples = totalSamples;
+        }
+
         public GetStackTracesResponse build() {
-            return new GetStackTracesResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, samplingRate);
+            return new GetStackTracesResponse(
+                stackTraces,
+                stackFrames,
+                executables,
+                stackTraceEvents,
+                totalFrames,
+                samplingRate,
+                totalSamples
+            );
         }
     }
 }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesResponseTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesResponseTests.java
@@ -42,9 +42,10 @@ public class GetStackTracesResponseTests extends AbstractWireSerializingTestCase
             )
         );
         Map<String, String> executables = randomNullable(Map.of("QCCDqjSg3bMK1C4YRK6Tiw", "libc.so.6"));
-        Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), randomIntBetween(1, 200)));
+        int totalSamples = randomIntBetween(1, 200);
+        Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), totalSamples));
 
-        return new GetStackTracesResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, 1.0);
+        return new GetStackTracesResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, 1.0, totalSamples);
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
@@ -48,7 +48,8 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 0,
-                1.0
+                1.0,
+                0
             );
         });
         RestRequest profilingRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
@@ -73,7 +74,8 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 0,
-                0.0
+                0.0,
+                0
             );
         });
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
@@ -48,7 +48,8 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
             Map.of("fr28zxcZ2UDasxYuu6dV-w", "containerd"),
             Map.of("2buqP1GpF-TXYmL4USW8gA", 1),
             9,
-            1.0d
+            1.0d,
+            1
         );
         GetFlamegraphResponse response = TransportGetFlamegraphAction.buildFlamegraph(stacktraces);
         assertNotNull(response);
@@ -111,10 +112,14 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), response.getFunctionOffsets());
         assertEquals(List.of("", "", "", "", "", "", "", "", "", ""), response.getSourceFileNames());
         assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), response.getSourceLines());
+        assertEquals(1, response.getSelfCPU());
+        assertEquals(10, response.getTotalCPU());
+        assertEquals(1L, response.getTotalSamples());
+
     }
 
     public void testCreateEmptyFlamegraphWithRootNode() {
-        GetStackTracesResponse stacktraces = new GetStackTracesResponse(Map.of(), Map.of(), Map.of(), Map.of(), 0, 1.0d);
+        GetStackTracesResponse stacktraces = new GetStackTracesResponse(Map.of(), Map.of(), Map.of(), Map.of(), 0, 1.0d, 0);
         GetFlamegraphResponse response = TransportGetFlamegraphAction.buildFlamegraph(stacktraces);
         assertNotNull(response);
         assertEquals(1, response.getSize());
@@ -131,5 +136,8 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(List.of(0), response.getFunctionOffsets());
         assertEquals(List.of(""), response.getSourceFileNames());
         assertEquals(List.of(0), response.getSourceLines());
+        assertEquals(0, response.getSelfCPU());
+        assertEquals(0, response.getTotalCPU());
+        assertEquals(0L, response.getTotalSamples());
     }
 }


### PR DESCRIPTION
With this commit we include a few summary metrics in the flamegraph response:

* total number of samples
* total self CPU
* total CPU

These properties simplify rendering differential flamegraphs.