### PR TITLE
[8.11] Skip tsdb delete test for unsupported versions (#101124)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
@@ -1,4 +1,10 @@
 ---
+setup:
+  - skip:
+      version: "8.7.00 - 8.9.99"
+      reason: "Synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests"
+
+---
 "basic tsdb delete":
   - skip:
       version: " - 8.8.0"


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Skip tsdb delete test for unsupported versions (#101124)