### PR TITLE
[8.11] Clarify search application search API documentation (#100930)

### DIFF
--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -59,6 +59,7 @@ The <<search-template,search template>> associated with this search application.
 (Required, object)
 The associated mustache template.
 
+[[put-search-application-dictionary-param]]
 `dictionary`::
 (Optional, object)
 The dictionary used to validate the parameters used with the <<search-application-search, search application search>> API. The dictionary must be a valid JSON schema.

--- a/docs/reference/search-application/apis/search-application-render-query.asciidoc
+++ b/docs/reference/search-application/apis/search-application-render-query.asciidoc
@@ -8,9 +8,11 @@ preview::[]
 <titleabbrev>Render Search Application Query</titleabbrev>
 ++++
 
-Given specified query parameters, creates an Elasticsearch query to run. Any unspecified template parameters will be
-assigned their default values if applicable. Returns the specific Elasticsearch query that would be generated and
-run by calling <<search-application-search,search application search>>.
+Given specified query parameters, generates an {es} query using the search template associated with the search
+application or a default template if none is specified.
+Unspecified template parameters will be assigned their default values (if applicable).
+Returns the specific {es} query that would be generated and executed by calling
+<<search-application-search,search application search>>.
 
 [[search-application-render-query-request]]
 ==== {api-request-title}
@@ -27,10 +29,26 @@ Requires read privileges on the backing alias of the search application.
 
 `params`::
 (Optional, map of strings to objects)
-Query parameters specific to this request, which will override any defaults specified in the template.
+Query parameters used to generate the {es} query from the search template associated with the search application.
+If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
+
+[NOTE]
+====
+The search application can be configured to validate search template parameters.
+See the `dictionary` parameter in the <<put-search-application-dictionary-param, put search application>> API for more
+information.
+====
 
 [[search-application-render-query-response-codes]]
 ==== {api-response-codes-title}
+
+`400`::
+Invalid parameter passed to search template.
+Examples include:
+
+- Missing required parameter
+- Invalid parameter data type
+- Invalid parameter value
 
 `404`::
 Search Application `<name>` does not exist.
@@ -38,8 +56,8 @@ Search Application `<name>` does not exist.
 [[search-application-render-query-example]]
 ==== {api-examples-title}
 
-The following example renders a query for a search application called `my-app`. In this case, the `from` and `size`
-parameters are not specified, so default values are pulled from the search application template.
+The following example generates a query for a search application called `my-app` that uses the search template from
+the <<search-application-api-bm25-template, text search example>>:
 
 ////
 [source,console]
@@ -99,14 +117,8 @@ POST _application/search_application/my-app/_render_query
   "params": {
     "query_string": "my first query",
     "text_fields": [
-        {
-            "name": "title",
-            "boost": 10
-        },
-        {
-            "name": "text",
-            "boost": 1
-        }
+      {"name": "title", "boost": 5},
+      {"name": "description", "boost": 1}
     ]
   }
 }
@@ -117,19 +129,21 @@ A sample response:
 [source,console-result]
 ----
 {
-    "from": 0,
-    "size": 10,
-    "query": {
-        "multi_match": {
-            "query": "my first query",
-            "fields": [
-                "text^1.0",
-                "title^10.0"
-            ]
-        }
-    },
-    "explain": false
+  "from": 0,
+  "size": 10,
+  "query": {
+    "multi_match": {
+      "query": "my first query",
+      "fields": [
+        "description^1.0",
+        "title^5.0"
+      ]
+    }
+  },
+  "explain": false
 }
 ----
 // TEST[continued]
 
+In this case, the `from`, `size`, and `explain` parameters are not specified in the request, so the default values
+specified in the search template are used.

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -8,8 +8,9 @@ beta::[]
 <titleabbrev>Search Application Search</titleabbrev>
 ++++
 
-Given specified query parameters, creates an Elasticsearch query to run. Any unspecified template parameters will be
-assigned their default values if applicable.
+Given specified query parameters, generates and executes an {es} query using the search template associated
+with the search application or a default template if none is specified.
+Unspecified template parameters will be assigned their default values (if applicable).
 
 [[search-application-search-request]]
 ==== {api-request-title}
@@ -28,10 +29,26 @@ Requires read privileges on the backing alias of the search application.
 
 `params`::
 (Optional, map of strings to objects)
-Query parameters specific to this request, which will override any defaults specified in the template.
+Query parameters used to generate the {es} query from the search template associated with the search application.
+If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
+
+[NOTE]
+====
+The search application can be configured to validate search template parameters.
+See the `dictionary` parameter in the <<put-search-application-dictionary-param, put search application>> API for more
+information.
+====
 
 [[search-application-search-response-codes]]
 ==== {api-response-codes-title}
+
+`400`::
+Invalid parameter passed to search template.
+Examples include:
+
+- Missing required parameter
+- Invalid parameter data type
+- Invalid parameter value
 
 `404`::
 Search Application `<name>` does not exist.
@@ -39,12 +56,19 @@ Search Application `<name>` does not exist.
 [[search-application-search-example]]
 ==== {api-examples-title}
 
-The following example performs a search against a search application called `my-app`:
+The following example executes a search against a search application called `my-app` that uses the search template from
+the <<search-application-api-bm25-template, text search example>>:
 
 ////
 [source,console]
 ----
 PUT /index1
+
+PUT /index1/_doc/1?refresh=true
+{
+  "title": "Sample document",
+  "description": "A sample document that matches my first query"
+}
 
 PUT _application/search_application/my-app
 {
@@ -57,7 +81,7 @@ PUT _application/search_application/my-app
         "query": {
           "multi_match": {
             "query": "{{query_string}}",
-            "fields": [{{#text_fields}}"{{name}}^{{boost}}"{{^last}},{{/last}}{{/text_fields}}]
+            "fields": [{{#text_fields}}"{{name}}^{{boost}}",{{/text_fields}}]
           }
         },
         "explain": "{{explain}}",
@@ -68,8 +92,8 @@ PUT _application/search_application/my-app
       "params": {
         "query_string": "*",
         "text_fields": [
-          {"name": "title", "boost": 10, "last": false},
-          {"name": "description", "boost": 5, "last": true}
+          {"name": "title", "boost": 10},
+          {"name": "description", "boost": 5}
         ],
         "explain": false,
         "from": 0,
@@ -97,23 +121,62 @@ DELETE /index1
 POST _application/search_application/my-app/_search
 {
   "params": {
-    "value": "my first query",
-    "size": 10,
-    "from": 0,
+    "query_string": "my first query",
     "text_fields": [
-        {
-            "name": "title",
-            "boost": 10
-        },
-        {
-            "name": "text",
-            "boost": 1
-        }
+      {"name": "title", "boost": 5},
+      {"name": "description", "boost": 1}
     ]
   }
 }
 ----
 
-The expected results are search results from the query that was run.
+The generated {es} query would look like:
 
+[source,console-result]
+----
+{
+  "from": 0,
+  "size": 10,
+  "query": {
+    "multi_match": {
+      "query": "my first query",
+      "fields": [
+        "description^1.0",
+        "title^5.0"
+      ]
+    }
+  },
+  "explain": false
+}
+----
+// TESTRESPONSE[skip:result of request not run in this document]
 
+In this case, the `from`, `size`, and `explain` parameters are not specified in the request, so the default values
+specified in the search template are used.
+
+The expected response is the search results from the {es} query that was generated & executed.
+The response format is the same as that used by the <<search-api-response-body,{es} Search API>>:
+
+[source,console-result]
+----
+{
+  "took": 5,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 0.8630463,
+    "hits": ...
+  }
+}
+----
+// TESTRESPONSE[s/"took": 5/"took": $body.$_path/]
+// TESTRESPONSE[s/"hits": \.\.\./"hits": $body.$_path/]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Clarify search application search API documentation (#100930)](https://github.com/elastic/elasticsearch/pull/100930)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)