### PR TITLE
Increase GeoHexGridTiler#FACTOR after #100826

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTiler.java
@@ -240,7 +240,7 @@ public abstract class GeoHexGridTiler extends GeoGridTiler {
         private final GeoBoundingBox bbox;
         private final GeoHexVisitor visitor;
         private final int resolution;
-        private static final double FACTOR = 0.36;
+        private static final double FACTOR = 0.37;
 
         BoundedGeoHexGridTiler(int resolution, GeoBoundingBox bbox) {
             super(resolution);


### PR DESCRIPTION
in https://github.com/elastic/elasticsearch/pull/100826 we added a more aggressive way to handle geotile boundaries which it seems to affect our correction factor for  GeoHexGridTiler. Just increasing it a bit makes the failing test happy.

fixes https://github.com/elastic/elasticsearch/issues/101139