### PR TITLE
ESQL: improve recursion in PlanNamedTypesTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -671,12 +671,13 @@ public class PlanNamedTypesTests extends ESTestCase {
         if (depth > 2) {
             return Map.of(); // prevent infinite recursion (between EsField and properties)
         }
+        depth += 1;
         int size = randomIntBetween(0, 5);
         Map<String, EsField> map = new HashMap<>();
         for (int i = 0; i < size; i++) {
             map.put(
                 randomAlphaOfLength(randomIntBetween(1, 10)), // name
-                randomEsField(depth++)
+                randomEsField(depth)
             );
         }
         return Map.copyOf(map);


### PR DESCRIPTION
Minor test fix to improve the robustness of recursion when creating properties. The incremented depth should be passed when creating the EsField, rather than post-incremented. 