### PR TITLE
Don't downsample in flamegraph test

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -8,6 +8,11 @@
 package org.elasticsearch.xpack.profiling;
 
 public class GetFlameGraphActionIT extends ProfilingTestCase {
+    @Override
+    protected boolean useOnlyAllEvents() {
+        return true;
+    }
+
     public void testGetStackTracesUnfiltered() throws Exception {
         GetStackTracesRequest request = new GetStackTracesRequest(1, null);
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();


### PR DESCRIPTION
With this commit we avoid downsampling in the flamegraph API test as this is a rather basic test that checks whether the API works in general. Tests for downsampling are done in other places already.