### PR TITLE
Mute ProcessWorkerExecutorServiceTests#testAutodetectWorkerExecutorServiceDoesNotSwallowErrors

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
@@ -126,6 +126,7 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101144")
     public void testAutodetectWorkerExecutorServiceDoesNotSwallowErrors() {
         ProcessWorkerExecutorService executor = createExecutorService();
         if (randomBoolean()) {


### PR DESCRIPTION
relates to https://github.com/elastic/elasticsearch/issues/101144