### PR TITLE
[ML] Revert remove rethrow change for AbstractProcessWorkerExecutorService

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ml.job.process;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.SuppressForbidden;
@@ -20,7 +21,6 @@ import java.util.Objects;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -50,7 +50,7 @@ public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> e
      *                  for execution when the queue is full a 429 error is thrown.
      * @param queueSupplier BlockingQueue constructor
      */
-    @SuppressForbidden(reason = "wraps a queue and handles errors appropriately")
+    @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
     public AbstractProcessWorkerExecutorService(
         ThreadContext contextHolder,
         String processName,
@@ -107,14 +107,12 @@ public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> e
             while (running.get()) {
                 Runnable runnable = queue.poll(500, TimeUnit.MILLISECONDS);
                 if (runnable != null) {
-                    assert runnable instanceof RunnableFuture<?> == false
-                        : "Rethrowing errors for RunnableFuture instances is not supported";
-
                     try {
                         runnable.run();
                     } catch (Exception e) {
                         logger.error(() -> "error handling process [" + processName + "] operation", e);
                     }
+                    EsExecutors.rethrowErrors(ThreadContext.unwrap(runnable));
                 } else if (shouldShutdownAfterCompletingWork.get()) {
                     running.set(false);
                 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
@@ -126,7 +126,6 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101144")
     public void testAutodetectWorkerExecutorServiceDoesNotSwallowErrors() {
         ProcessWorkerExecutorService executor = createExecutorService();
         if (randomBoolean()) {


### PR DESCRIPTION
This PR reverts the change here: https://github.com/elastic/elasticsearch/pull/100925 because it is possible to get `RunnableFuture` when `submit` is called.

That is specifically used here: https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java#L163

Fixes https://github.com/elastic/elasticsearch/issues/101144