### PR TITLE
More robust timeout for repo analysis

### DIFF
--- a/docs/changelog/101184.yaml
+++ b/docs/changelog/101184.yaml
@@ -1,0 +1,6 @@
+pr: 101184
+summary: More robust timeout for repo analysis
+area: Snapshot/Restore
+type: bug
+issues:
+ - 101182

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/10_analyze.yml
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/10_analyze.yml
@@ -176,4 +176,5 @@ setup:
   - match: { status: 500 }
   - match: { error.type: repository_verification_exception }
   - match: { error.reason: "/.*test_repo_slow..analysis.failed.*/" }
-  - match: { error.root_cause.0.type: receive_timeout_transport_exception }
+  - match: { error.root_cause.0.type: repository_verification_exception }
+  - match: { error.root_cause.0.reason: "/.*test_repo_slow..analysis.timed.out.after..1s.*/" }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -355,8 +355,8 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
         blobStore.setDisruption(new Disruption() {
             @Override
-            public boolean compareAndExchangeFails() {
-                return true;
+            public boolean compareAndExchangeReturnsWitness() {
+                return false;
             }
         });
         final var exception = expectThrows(RepositoryVerificationException.class, () -> analyseRepository(request));
@@ -484,8 +484,8 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
             return false;
         }
 
-        default boolean compareAndExchangeFails() {
-            return false;
+        default boolean compareAndExchangeReturnsWitness() {
+            return true;
         }
 
         default BytesReference onCompareAndExchange(BytesRegister register, BytesReference expected, BytesReference updated) {
@@ -661,11 +661,11 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
             ActionListener<OptionalBytesReference> listener
         ) {
             assertPurpose(purpose);
-            if (disruption.compareAndExchangeFails()) {
-                listener.onResponse(OptionalBytesReference.MISSING);
-            } else {
+            if (disruption.compareAndExchangeReturnsWitness()) {
                 final var register = registers.computeIfAbsent(key, ignored -> new BytesRegister());
                 listener.onResponse(OptionalBytesReference.of(disruption.onCompareAndExchange(register, expected, updated)));
+            } else {
+                listener.onResponse(OptionalBytesReference.MISSING);
             }
         }
     }


### PR DESCRIPTION
Replaces the transport-level timeout with an overall timeout on the
whole repository analysis task to ensure that all child tasks terminate
promptly.

Relates #66992
Closes #101182