### PR TITLE
Update docker.asciidoc

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -116,7 +116,7 @@ curl --cacert http_ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200
 
 ===== Add more nodes
 
-. Use an existing node to generate a enrollment token for the new node.
+. Use an existing node to generate an enrollment token for the new node.
 +
 [source,sh]
 ----


### PR DESCRIPTION
In the modified text an 'a' was changed to an 'an' in the phrasing: '...generate a enrollment token...'

It is now '...generate an enrollment token...'