### PR TITLE
Remove explicit SearchResponse references from spatial module test code

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -18,7 +17,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -34,99 +33,105 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
     protected abstract ValuesSourceAggregationBuilder<?> centroidAgg(String name);
 
     public void testEmptyAggregation() {
-        SearchResponse response = client().prepareSearch(EMPTY_IDX_NAME)
-            .setQuery(matchAllQuery())
-            .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
-            .get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            client().prepareSearch(EMPTY_IDX_NAME)
+                .setQuery(matchAllQuery())
+                .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
+                assertThat(response.getHits().getTotalHits().value, equalTo(0L));
+                assertThat(geoCentroid, notNullValue());
+                assertThat(geoCentroid.getName(), equalTo(aggName()));
+                assertThat(geoCentroid.centroid(), equalTo(null));
+                assertEquals(0, geoCentroid.count());
+            }
+        );
 
-        CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
-        assertThat(response.getHits().getTotalHits().value, equalTo(0L));
-        assertThat(geoCentroid, notNullValue());
-        assertThat(geoCentroid.getName(), equalTo(aggName()));
-        assertThat(geoCentroid.centroid(), equalTo(null));
-        assertEquals(0, geoCentroid.count());
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
-            .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
-            .get();
-        assertNoFailures(response);
-
-        CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
-        assertThat(geoCentroid, notNullValue());
-        assertThat(geoCentroid.getName(), equalTo(aggName()));
-        assertThat(geoCentroid.centroid(), equalTo(null));
-        assertEquals(0, geoCentroid.count());
+        assertNoFailuresAndResponse(
+            client().prepareSearch(UNMAPPED_IDX_NAME).addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
+                assertThat(geoCentroid, notNullValue());
+                assertThat(geoCentroid.getName(), equalTo(aggName()));
+                assertThat(geoCentroid.centroid(), equalTo(null));
+                assertEquals(0, geoCentroid.count());
+            }
+        );
     }
 
     public void testPartiallyUnmapped() {
-        SearchResponse response = client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME)
-            .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
-            .get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME).addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
+                assertThat(geoCentroid, notNullValue());
+                assertThat(geoCentroid.getName(), equalTo(aggName()));
+                assertSameCentroid(geoCentroid.centroid(), singleCentroid);
+                assertEquals(numDocs, geoCentroid.count());
+            }
+        );
 
-        CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
-        assertThat(geoCentroid, notNullValue());
-        assertThat(geoCentroid.getName(), equalTo(aggName()));
-        assertSameCentroid(geoCentroid.centroid(), singleCentroid);
-        assertEquals(numDocs, geoCentroid.count());
     }
 
     public void testSingleValuedField() {
-        SearchResponse response = client().prepareSearch(IDX_NAME)
-            .setQuery(matchAllQuery())
-            .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
-            .get();
-        assertNoFailures(response);
-
-        CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
-        assertThat(geoCentroid, notNullValue());
-        assertThat(geoCentroid.getName(), equalTo(aggName()));
-        assertSameCentroid(geoCentroid.centroid(), singleCentroid);
-        assertEquals(numDocs, geoCentroid.count());
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME)
+                .setQuery(matchAllQuery())
+                .addAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
+                assertThat(geoCentroid, notNullValue());
+                assertThat(geoCentroid.getName(), equalTo(aggName()));
+                assertSameCentroid(geoCentroid.centroid(), singleCentroid);
+                assertEquals(numDocs, geoCentroid.count());
+            }
+        );
     }
 
     public void testSingleValueFieldGetProperty() {
-        SearchResponse response = client().prepareSearch(IDX_NAME)
-            .setQuery(matchAllQuery())
-            .addAggregation(global("global").subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME)))
-            .get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME)
+                .setQuery(matchAllQuery())
+                .addAggregation(global("global").subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))),
+            response -> {
+                Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), equalTo("global"));
+                assertThat(global.getDocCount(), equalTo((long) numDocs));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
-        Global global = response.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo((long) numDocs));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().size(), equalTo(1));
-
-        CentroidAggregation geoCentroid = global.getAggregations().get(aggName());
-        InternalAggregation agg = (InternalAggregation) global;
-        assertThat(geoCentroid, notNullValue());
-        assertThat(geoCentroid.getName(), equalTo(aggName()));
-        assertThat((CentroidAggregation) agg.getProperty(aggName()), sameInstance(geoCentroid));
-        assertSameCentroid(geoCentroid.centroid(), singleCentroid);
-        assertSimilarValue(((SpatialPoint) agg.getProperty(aggName() + ".value")).getY(), singleCentroid.getY());
-        assertSimilarValue(((SpatialPoint) agg.getProperty(aggName() + ".value")).getX(), singleCentroid.getX());
-        assertSimilarValue((double) agg.getProperty(aggName() + "." + coordinateName("y")), singleCentroid.getY());
-        assertSimilarValue((double) agg.getProperty(aggName() + "." + coordinateName("x")), singleCentroid.getX());
-        assertEquals(numDocs, (long) ((InternalAggregation) global).getProperty(aggName() + ".count"));
+                CentroidAggregation geoCentroid = global.getAggregations().get(aggName());
+                InternalAggregation agg = (InternalAggregation) global;
+                assertThat(geoCentroid, notNullValue());
+                assertThat(geoCentroid.getName(), equalTo(aggName()));
+                assertThat((CentroidAggregation) agg.getProperty(aggName()), sameInstance(geoCentroid));
+                assertSameCentroid(geoCentroid.centroid(), singleCentroid);
+                assertSimilarValue(((SpatialPoint) agg.getProperty(aggName() + ".value")).getY(), singleCentroid.getY());
+                assertSimilarValue(((SpatialPoint) agg.getProperty(aggName() + ".value")).getX(), singleCentroid.getX());
+                assertSimilarValue((double) agg.getProperty(aggName() + "." + coordinateName("y")), singleCentroid.getY());
+                assertSimilarValue((double) agg.getProperty(aggName() + "." + coordinateName("x")), singleCentroid.getX());
+                assertEquals(numDocs, (long) ((InternalAggregation) global).getProperty(aggName() + ".count"));
+            }
+        );
     }
 
     public void testMultiValuedField() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch(IDX_NAME)
-            .setQuery(matchAllQuery())
-            .addAggregation(centroidAgg(aggName()).field(MULTI_VALUED_FIELD_NAME))
-            .get();
-        assertNoFailures(searchResponse);
-
-        CentroidAggregation geoCentroid = searchResponse.getAggregations().get(aggName());
-        assertThat(geoCentroid, notNullValue());
-        assertThat(geoCentroid.getName(), equalTo(aggName()));
-        assertSameCentroid(geoCentroid.centroid(), multiCentroid);
-        assertEquals(2 * numDocs, geoCentroid.count());
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME)
+                .setQuery(matchAllQuery())
+                .addAggregation(centroidAgg(aggName()).field(MULTI_VALUED_FIELD_NAME)),
+            response -> {
+                CentroidAggregation geoCentroid = response.getAggregations().get(aggName());
+                assertThat(geoCentroid, notNullValue());
+                assertThat(geoCentroid.getName(), equalTo(aggName()));
+                assertSameCentroid(geoCentroid.centroid(), multiCentroid);
+                assertEquals(2 * numDocs, geoCentroid.count());
+            }
+        );
     }
 
     /** Override this if the spatial data uses different coordinate names (eg. Geo uses lon/at instead of x/y */

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.util.BigArray;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -23,7 +22,7 @@ import java.util.List;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -39,171 +38,176 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
     protected abstract void assertBoundsLimits(SpatialBounds<T> spatialBounds);
 
     public void testSingleValuedField() throws Exception {
-        SearchResponse response = client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)).get();
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                T topLeft = geoBounds.topLeft();
+                T bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE));
+            }
+        );
 
-        assertNoFailures(response);
-
-        SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        T topLeft = geoBounds.topLeft();
-        T bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE));
     }
 
     public void testSingleValuedField_getProperty() {
-        SearchResponse searchResponse = client().prepareSearch(IDX_NAME)
-            .setQuery(matchAllQuery())
-            .addAggregation(global("global").subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)))
-            .get();
 
-        assertNoFailures(searchResponse);
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME)
+                .setQuery(matchAllQuery())
+                .addAggregation(global("global").subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))),
+            response -> {
+                Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), equalTo("global"));
+                assertThat(global.getDocCount(), equalTo((long) numDocs));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
-        Global global = searchResponse.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo((long) numDocs));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                SpatialBounds<T> geobounds = global.getAggregations().get(aggName());
+                assertThat(geobounds, notNullValue());
+                assertThat(geobounds.getName(), equalTo(aggName()));
+                assertThat((SpatialBounds<?>) ((InternalAggregation) global).getProperty(aggName()), sameInstance(geobounds));
+                T topLeft = geobounds.topLeft();
+                T bottomRight = geobounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE));
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty(aggName() + ".top"),
+                    closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE)
+                );
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty(aggName() + ".left"),
+                    closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE)
+                );
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty(aggName() + ".bottom"),
+                    closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE)
+                );
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty(aggName() + ".right"),
+                    closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE)
+                );
+            }
+        );
 
-        SpatialBounds<T> geobounds = global.getAggregations().get(aggName());
-        assertThat(geobounds, notNullValue());
-        assertThat(geobounds.getName(), equalTo(aggName()));
-        assertThat((SpatialBounds<?>) ((InternalAggregation) global).getProperty(aggName()), sameInstance(geobounds));
-        T topLeft = geobounds.topLeft();
-        T bottomRight = geobounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE));
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty(aggName() + ".top"),
-            closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE)
-        );
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty(aggName() + ".left"),
-            closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE)
-        );
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty(aggName() + ".bottom"),
-            closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE)
-        );
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty(aggName() + ".right"),
-            closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE)
-        );
     }
 
     public void testMultiValuedField() throws Exception {
-        SearchResponse response = client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), MULTI_VALUED_FIELD_NAME)).get();
-
-        assertNoFailures(response);
-
-        SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        T topLeft = geoBounds.topLeft();
-        T bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(multiTopLeft.getY(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(multiTopLeft.getX(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(multiBottomRight.getY(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(multiBottomRight.getX(), GEOHASH_TOLERANCE));
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME).addAggregation(boundsAgg(aggName(), MULTI_VALUED_FIELD_NAME)),
+            response -> {
+                SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                T topLeft = geoBounds.topLeft();
+                T bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(multiTopLeft.getY(), GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(multiTopLeft.getX(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(multiBottomRight.getY(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(multiBottomRight.getX(), GEOHASH_TOLERANCE));
+            }
+        );
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
-            .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
-            .get();
-
-        assertNoFailures(response);
-
-        SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        T topLeft = geoBounds.topLeft();
-        T bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft, equalTo(null));
-        assertThat(bottomRight, equalTo(null));
+        assertNoFailuresAndResponse(
+            client().prepareSearch(UNMAPPED_IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                T topLeft = geoBounds.topLeft();
+                T bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft, equalTo(null));
+                assertThat(bottomRight, equalTo(null));
+            }
+        );
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME)
-            .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
-            .get();
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                T topLeft = geoBounds.topLeft();
+                T bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE));
+            }
+        );
 
-        assertNoFailures(response);
-
-        SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        T topLeft = geoBounds.topLeft();
-        T bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(singleTopLeft.getY(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(singleTopLeft.getX(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(singleBottomRight.getY(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(singleBottomRight.getX(), GEOHASH_TOLERANCE));
     }
 
     public void testEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch(EMPTY_IDX_NAME)
-            .setQuery(matchAllQuery())
-            .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
-            .get();
+        assertNoFailuresAndResponse(
+            client().prepareSearch(EMPTY_IDX_NAME).setQuery(matchAllQuery()).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(0L));
+                SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                T topLeft = geoBounds.topLeft();
+                T bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft, equalTo(null));
+                assertThat(bottomRight, equalTo(null));
+            }
+        );
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
-        SpatialBounds<T> geoBounds = searchResponse.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        T topLeft = geoBounds.topLeft();
-        T bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft, equalTo(null));
-        assertThat(bottomRight, equalTo(null));
     }
 
     /**
      * This test forces the bounds {@link MetricsAggregator} to resize the {@link BigArray}s it uses to ensure they are resized correctly
      */
     public void testSingleValuedFieldAsSubAggToHighCardTermsAgg() {
-        SearchResponse response = client().prepareSearch(HIGH_CARD_IDX_NAME)
-            .addAggregation(terms("terms").field(NUMBER_FIELD_NAME).subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)))
-            .get();
 
-        assertNoFailures(response);
-
-        Terms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        List<? extends Bucket> buckets = terms.getBuckets();
-        assertThat(buckets.size(), equalTo(10));
-        for (int i = 0; i < 10; i++) {
-            Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat("InternalBucket " + bucket.getKey() + " has wrong number of documents", bucket.getDocCount(), equalTo(1L));
-            SpatialBounds<T> geoBounds = bucket.getAggregations().get(aggName());
-            assertThat(geoBounds, notNullValue());
-            assertThat(geoBounds.getName(), equalTo(aggName()));
-            assertBoundsLimits(geoBounds);
-        }
+        assertNoFailuresAndResponse(
+            client().prepareSearch(HIGH_CARD_IDX_NAME)
+                .addAggregation(terms("terms").field(NUMBER_FIELD_NAME).subAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))),
+            response -> {
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                List<? extends Bucket> buckets = terms.getBuckets();
+                assertThat(buckets.size(), equalTo(10));
+                for (int i = 0; i < 10; i++) {
+                    Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat("InternalBucket " + bucket.getKey() + " has wrong number of documents", bucket.getDocCount(), equalTo(1L));
+                    SpatialBounds<T> geoBounds = bucket.getAggregations().get(aggName());
+                    assertThat(geoBounds, notNullValue());
+                    assertThat(geoBounds.getName(), equalTo(aggName()));
+                    assertBoundsLimits(geoBounds);
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldWithZeroLon() {
-        SearchResponse response = client().prepareSearch(IDX_ZERO_NAME)
-            .addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME))
-            .get();
-
-        assertNoFailures(response);
-
-        SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        T topLeft = geoBounds.topLeft();
-        T bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(1.0, GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(0.0, GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(1.0, GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(0.0, GEOHASH_TOLERANCE));
+        assertNoFailuresAndResponse(
+            client().prepareSearch(IDX_ZERO_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME)),
+            response -> {
+                SpatialBounds<T> geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                T topLeft = geoBounds.topLeft();
+                T bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(1.0, GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(0.0, GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(1.0, GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(0.0, GEOHASH_TOLERANCE));
+            }
+        );
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -52,6 +51,8 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -184,8 +185,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         );
 
         indexRandom(true, client().prepareIndex("test").setId("0").setSource("shape", polygonGeoJson));
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(client().prepareSearch("test").setQuery(matchAllQuery()), 1L);
     }
 
     /**
@@ -216,12 +216,11 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
             }""";
 
         indexRandom(true, client().prepareIndex("test").setId("0").setSource(source, XContentType.JSON).setRouting("ABC"));
-
-        SearchResponse searchResponse = client().prepareSearch("test")
-            .setQuery(queryBuilder().shapeQuery("shape", "0").indexedShapeIndex("test").indexedShapeRouting("ABC"))
-            .get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch("test")
+                .setQuery(queryBuilder().shapeQuery("shape", "0").indexedShapeIndex("test").indexedShapeRouting("ABC")),
+            1L
+        );
     }
 
     public void testDisallowExpensiveQueries() throws InterruptedException, IOException {
@@ -251,7 +250,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
             SearchRequestBuilder builder = client().prepareSearch("test")
                 .setQuery(queryBuilder().shapeQuery("shape", new Circle(0, 0, 77000)));
             if (allowExpensiveQueries()) {
-                assertThat(builder.get().getHits().getTotalHits().value, equalTo(1L));
+                assertHitCount(builder, 1L);
             } else {
                 ElasticsearchException e = expectThrows(ElasticsearchException.class, builder::get);
                 assertEquals(
@@ -267,7 +266,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
 
             // Set search.allow_expensive_queries to "true"
             updateClusterSettings(Settings.builder().put("search.allow_expensive_queries", true));
-            assertThat(builder.get().getHits().getTotalHits().value, equalTo(1L));
+            assertHitCount(builder, 1L);
         } finally {
             updateClusterSettings(Settings.builder().put("search.allow_expensive_queries", (String) null));
         }
@@ -304,12 +303,13 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         client().admin().indices().prepareRefresh().get();
 
         // Point in polygon
-        SearchResponse result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(3, 3)))
-            .get();
-        assertHitCount(result, 1);
-        assertFirstHit(result, hasId("1"));
+        assertResponse(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(3, 3))),
+            response -> {
+                assertHitCount(response, 1L);
+                assertFirstHit(response, hasId("1"));
+            }
+        );
 
         // Point in polygon hole
         assertHitCount(
@@ -322,20 +322,24 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         // of the polygon NOT the hole
 
         // Point on polygon border
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(10.0, 5.0)))
-            .get();
-        assertHitCount(result, 1);
-        assertFirstHit(result, hasId("1"));
+        assertResponse(
+            client().prepareSearch()
+                .setQuery(matchAllQuery())
+                .setPostFilter(queryBuilder().intersectionQuery("area", new Point(10.0, 5.0))),
+            response -> {
+                assertHitCount(response, 1L);
+                assertFirstHit(response, hasId("1"));
+            }
+        );
 
         // Point on hole border
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(5.0, 2.0)))
-            .get();
-        assertHitCount(result, 1);
-        assertFirstHit(result, hasId("1"));
+        assertResponse(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(5.0, 2.0))),
+            response -> {
+                assertHitCount(response, 1L);
+                assertFirstHit(response, hasId("1"));
+            }
+        );
 
         // Point not in polygon
         assertHitCount(
@@ -344,12 +348,13 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         );
 
         // Point in polygon hole
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().disjointQuery("area", new Point(4.5, 4.5)))
-            .get();
-        assertHitCount(result, 1);
-        assertFirstHit(result, hasId("1"));
+        assertResponse(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().disjointQuery("area", new Point(4.5, 4.5))),
+            response -> {
+                assertHitCount(response, 1L);
+                assertFirstHit(response, hasId("1"));
+            }
+        );
 
         // Create a polygon that fills the empty area of the polygon defined above
         Polygon inverse = new Polygon(
@@ -362,12 +367,13 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         client().admin().indices().prepareRefresh().get();
 
         // re-check point on polygon hole
-        result = client().prepareSearch()
-            .setQuery(matchAllQuery())
-            .setPostFilter(queryBuilder().intersectionQuery("area", new Point(4.5, 4.5)))
-            .get();
-        assertHitCount(result, 1);
-        assertFirstHit(result, hasId("2"));
+        assertResponse(
+            client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(4.5, 4.5))),
+            response -> {
+                assertHitCount(response, 1L);
+                assertFirstHit(response, hasId("2"));
+            }
+        );
 
         // Polygon WithIn Polygon
         Polygon WithIn = new Polygon(new LinearRing(new double[] { -30, -30, 30, 30, -30 }, new double[] { -30, 30, 30, -30, -30 }));
@@ -393,7 +399,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
 
         assertHitCount(
             client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(174, -4))),
-            1
+            1L
         );
 
         // In geo coordinates the polygon wraps the dateline, so we need to search within valid longitude ranges
@@ -402,15 +408,15 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
             client().prepareSearch()
                 .setQuery(matchAllQuery())
                 .setPostFilter(queryBuilder().intersectionQuery("area", new Point(xWrapped, -4))),
-            1
+            1L
         );
         assertHitCount(
             client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(180, -4))),
-            0
+            0L
         );
         assertHitCount(
             client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(queryBuilder().intersectionQuery("area", new Point(180, -6))),
-            1
+            1L
         );
     }
 
@@ -435,16 +441,15 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
             assertFalse("unable to index data: " + item.getFailureMessage(), item.isFailed());
         }
 
-        client().admin().indices().prepareRefresh().get();
+        assertNoFailures(client().admin().indices().prepareRefresh().get());
         String key = "DE";
 
-        SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("_id", key)).get();
-
-        assertHitCount(searchResponse, 1);
-
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), equalTo(key));
-        }
+        assertResponse(client().prepareSearch().setQuery(matchQuery("_id", key)), response -> {
+            assertHitCount(response, 1);
+            for (SearchHit hit : response.getHits()) {
+                assertThat(hit.getId(), equalTo(key));
+            }
+        });
 
         // We extract this to another method to allow some tests to ignore this part
         doDistanceAndBoundingBoxTest(key);

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.geo;
 
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -29,7 +28,6 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.query.AbstractGeometryQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -43,7 +41,8 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -93,9 +92,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setSource(GeoJson.toXContent(multiPoint, jsonBuilder().startObject().field(defaultFieldName), null).endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
-
-        SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery("alias", multiPoint)).get();
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery("alias", multiPoint)), 1L);
     }
 
     public void testShapeFetchingPath() throws Exception {
@@ -149,50 +146,40 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath(defaultFieldName);
-        SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 1L);
+
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.geo");
-        result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 1L);
+
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.2.geo");
-        result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 1L);
+
         filter = queryBuilder().shapeQuery(defaultFieldName, "1")
             .relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex("shapes")
             .indexedShapePath("1.2.3.geo");
-        result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 1L);
 
         // now test the query variant
         QueryBuilder query = queryBuilder().shapeQuery(defaultFieldName, "1")
             .indexedShapeIndex("shapes")
             .indexedShapePath(defaultFieldName);
-        result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(query), 1L);
+
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.geo");
-        result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(query), 1L);
+
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.2.geo");
-        result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(query), 1L);
+
         query = queryBuilder().shapeQuery(defaultFieldName, "1").indexedShapeIndex("shapes").indexedShapePath("1.2.3.geo");
-        result = client().prepareSearch(defaultIndexName).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(query), 1L);
     }
 
     public void testRandomGeoCollectionQuery() throws Exception {
@@ -219,9 +206,9 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         GeometryCollection<Geometry> queryCollection = new GeometryCollection<>(queryGeometries);
 
         QueryBuilder intersects = queryBuilder().intersectionQuery(defaultFieldName, queryCollection);
-        SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(intersects).get();
-        assertNoFailures(result);
-        assertTrue("query: " + intersects + " doc: " + Strings.toString(docSource), result.getHits().getTotalHits().value > 0);
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName).setQuery(intersects), response -> {
+            assertTrue("query: " + intersects + " doc: " + Strings.toString(docSource), response.getHits().getTotalHits().value > 0);
+        });
     }
 
     public void testGeometryCollectionRelations() throws Exception {
@@ -243,18 +230,24 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             geometries.add(new Point(1, 2));
             geometries.add(new Point(-2, -1));
             GeometryCollection<Geometry> collection = new GeometryCollection<>(geometries);
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.CONTAINS))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
-            response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
-            response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.DISJOINT))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.CONTAINS)),
+                1L
+            );
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.INTERSECTS)),
+                1L
+            );
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.DISJOINT)),
+                0L
+            );
         }
         {
             // A geometry collection that is partially within the indexed shape
@@ -262,18 +255,24 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             geometries.add(new Point(1, 2));
             geometries.add(new Point(20, 30));
             GeometryCollection<Geometry> collection = new GeometryCollection<>(geometries);
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.CONTAINS))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
-            response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
-            response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.DISJOINT))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.CONTAINS)),
+                0L
+            );
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.INTERSECTS)),
+                1L
+            );
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.DISJOINT)),
+                0L
+            );
         }
         {
             // A geometry collection that is disjoint with the indexed shape
@@ -281,18 +280,24 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             geometries.add(new Point(-20, -30));
             geometries.add(new Point(20, 30));
             GeometryCollection<Geometry> collection = new GeometryCollection<>(geometries);
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.CONTAINS))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
-            response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
-            response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.DISJOINT))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.CONTAINS)),
+                0L
+            );
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.INTERSECTS)),
+                0L
+            );
+
+            assertHitCount(
+                client().prepareSearch(defaultIndexName)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, collection).relation(ShapeRelation.DISJOINT)),
+                1L
+            );
         }
     }
 
@@ -346,14 +351,15 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
 
         // This search would fail if both geoshape indexing and geoshape filtering
         // used the bottom-level optimization in SpatialPrefixTree#recursiveGetNodes.
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().intersectionQuery(defaultFieldName, query))
-            .get();
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().intersectionQuery(defaultFieldName, query)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("blakely"));
+            }
+        );
 
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("blakely"));
     }
 
     public void testIndexedShapeReferenceSourceDisabled() throws Exception {
@@ -392,11 +398,10 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .endObject();
         client().prepareIndex(defaultIndexName).setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
-        SearchResponse result = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().intersectionQuery(defaultFieldName, point))
-            .get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().intersectionQuery(defaultFieldName, point)),
+            1L
+        );
     }
 
     public void testContainsShapeQuery() throws Exception {
@@ -407,9 +412,8 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         XContentBuilder docSource = GeoJson.toXContent(polygon, jsonBuilder().startObject().field(defaultFieldName), null).endObject();
         client().prepareIndex(defaultIndexName).setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
         QueryBuilder filter = queryBuilder().shapeQuery(defaultFieldName, innerPolygon).relation(ShapeRelation.CONTAINS);
-        SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(filter).get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(filter), 1L);
     }
 
     public void testExistsQuery() throws Exception {
@@ -423,9 +427,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         client().prepareIndex(defaultIndexName).setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         ExistsQueryBuilder eqb = existsQuery(defaultFieldName);
-        SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(eqb).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(eqb), 1L);
     }
 
     public void testIndexedShapeReference() throws Exception {
@@ -457,23 +459,23 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().intersectionQuery(defaultFieldName, "Big_Rectangle"))
-            .get();
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().intersectionQuery(defaultFieldName, "Big_Rectangle")),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+            }
+        );
 
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
-
-        searchResponse = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, "Big_Rectangle"))
-            .get();
-
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, "Big_Rectangle")),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+            }
+        );
     }
 
     public void testQueryRandomGeoCollection() throws Exception {
@@ -489,11 +491,10 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         XContentBuilder docSource = GeoJson.toXContent(gcb, jsonBuilder().startObject().field(defaultFieldName), null).endObject();
         client().prepareIndex(defaultIndexName).setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
-        SearchResponse result = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().intersectionQuery(defaultFieldName, polygon))
-            .get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().intersectionQuery(defaultFieldName, polygon)),
+            1L
+        );
     }
 
     public void testShapeFilterWithDefinedGeoCollection() throws Exception {
@@ -538,28 +539,20 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
 
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon1)));
-            SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertNoFailures(result);
-            assertHitCount(result, 1);
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 1L);
         }
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon2)));
-            SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertNoFailures(result);
-            assertHitCount(result, 0);
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 0L);
         }
         {
             QueryBuilder filter = queryBuilder().intersectionQuery(defaultFieldName, new GeometryCollection<>(List.of(polygon1, polygon2)));
-            SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertNoFailures(result);
-            assertHitCount(result, 1);
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 1L);
         }
         {
             // no shape
             QueryBuilder filter = queryBuilder().shapeQuery(defaultFieldName, GeometryCollection.EMPTY);
-            SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter).get();
-            assertNoFailures(result);
-            assertHitCount(result, 0);
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName).setQuery(matchAllQuery()).setPostFilter(filter), 0L);
         }
     }
 
@@ -592,22 +585,29 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
             ).setRefreshPolicy(IMMEDIATE)
         ).actionGet();
 
-        SearchResponse response = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.WITHIN))
-            .get();
-        assertEquals(2, response.getHits().getTotalHits().value);
-        response = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.INTERSECTS))
-            .get();
-        assertEquals(2, response.getHits().getTotalHits().value);
-        response = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.DISJOINT))
-            .get();
-        assertEquals(2, response.getHits().getTotalHits().value);
-        response = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.CONTAINS))
-            .get();
-        assertEquals(0, response.getHits().getTotalHits().value);
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.WITHIN)),
+            2L
+        );
+
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.INTERSECTS)),
+            2L
+        );
+
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.DISJOINT)),
+            2L
+        );
+
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, circle).relation(ShapeRelation.CONTAINS)),
+            0L
+        );
     }
 
     public void testIndexLineQueryPoints() throws Exception {
@@ -623,13 +623,12 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         // all points from a line intersect with the line
         for (int i = 0; i < line.length(); i++) {
             Point point = new Point(line.getLon(i), line.getLat(i));
-            SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-                .setTrackTotalHits(true)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertNoFailures(searchResponse);
-            SearchHits searchHits = searchResponse.getHits();
-            assertThat(searchHits.getTotalHits().value, equalTo(1L));
+            assertHitCountAndNoFailures(
+                client().prepareSearch(defaultIndexName)
+                    .setTrackTotalHits(true)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS)),
+                1L
+            );
         }
     }
 
@@ -648,13 +647,12 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         LinearRing linearRing = polygon.getPolygon();
         for (int i = 0; i < linearRing.length(); i++) {
             Point point = new Point(linearRing.getLon(i), linearRing.getLat(i));
-            SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-                .setTrackTotalHits(true)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertNoFailures(searchResponse);
-            SearchHits searchHits = searchResponse.getHits();
-            assertThat(searchHits.getTotalHits().value, equalTo(1L));
+            assertHitCountAndNoFailures(
+                client().prepareSearch(defaultIndexName)
+                    .setTrackTotalHits(true)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.INTERSECTS)),
+                1L
+            );
         }
     }
 
@@ -681,13 +679,12 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
                 .get();
         }
         Geometry center = WellKnownText.fromWKT(StandardValidator.instance(false), false, polygons[0]);
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-            .setTrackTotalHits(true)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, center).relation(ShapeRelation.INTERSECTS))
-            .get();
-        assertNoFailures(searchResponse);
-        SearchHits searchHits = searchResponse.getHits();
-        assertThat(searchHits.getTotalHits().value, equalTo((long) polygons.length));
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, center).relation(ShapeRelation.INTERSECTS)),
+            polygons.length
+        );
     }
 
     protected abstract Line makeRandomLine();

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.geo;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -26,6 +25,8 @@ import static org.elasticsearch.index.query.QueryBuilders.geoBoundingBoxQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoDistanceQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -103,60 +104,79 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
 
         client().admin().indices().prepareRefresh().get();
 
-        SearchResponse searchResponse = client().prepareSearch() // from NY
-            .setQuery(geoBoundingBoxQuery("location").setCorners(40.73, -74.1, 40.717, -73.99))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(2));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
-        }
+        assertResponse(
+            client().prepareSearch() // from NY
+                .setQuery(geoBoundingBoxQuery("location").setCorners(40.73, -74.1, 40.717, -73.99)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                for (SearchHit hit : response.getHits()) {
+                    assertThat(hit.getId(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
+                }
+            }
+        );
 
-        searchResponse = client().prepareSearch() // from NY
-            .setQuery(geoBoundingBoxQuery("location").setCorners(40.73, -74.1, 40.717, -73.99))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(2));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
-        }
+        assertResponse(
+            client().prepareSearch() // from NY
+                .setQuery(geoBoundingBoxQuery("location").setCorners(40.73, -74.1, 40.717, -73.99)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                for (SearchHit hit : response.getHits()) {
+                    assertThat(hit.getId(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
+                }
+            }
+        );
 
-        searchResponse = client().prepareSearch() // top == bottom && left == right
-            .setQuery(geoBoundingBoxQuery("location").setCorners(40.7143528, -74.0059731, 40.7143528, -74.0059731))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), equalTo("1"));
-        }
+        assertResponse(
+            client().prepareSearch() // top == bottom && left == right
+                .setQuery(geoBoundingBoxQuery("location").setCorners(40.7143528, -74.0059731, 40.7143528, -74.0059731)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                for (SearchHit hit : response.getHits()) {
+                    assertThat(hit.getId(), equalTo("1"));
+                }
+            }
+        );
 
-        searchResponse = client().prepareSearch() // top == bottom
-            .setQuery(geoBoundingBoxQuery("location").setCorners(40.759011, -74.00009, 40.759011, -73.0059731))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), equalTo("2"));
-        }
+        assertResponse(
+            client().prepareSearch() // top == bottom
+                .setQuery(geoBoundingBoxQuery("location").setCorners(40.759011, -74.00009, 40.759011, -73.0059731)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                for (SearchHit hit : response.getHits()) {
+                    assertThat(hit.getId(), equalTo("2"));
+                }
+            }
+        );
 
-        searchResponse = client().prepareSearch() // left == right
-            .setQuery(geoBoundingBoxQuery("location").setCorners(41.8, -73.9844722, 40.7, -73.9844722))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), equalTo("2"));
-        }
+        assertResponse(
+            client().prepareSearch() // left == right
+                .setQuery(geoBoundingBoxQuery("location").setCorners(41.8, -73.9844722, 40.7, -73.9844722)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                for (SearchHit hit : response.getHits()) {
+                    assertThat(hit.getId(), equalTo("2"));
+                }
+            }
+        );
 
         // Distance query
-        searchResponse = client().prepareSearch() // from NY
-            .setQuery(geoDistanceQuery("location").point(40.5, -73.9).distance(25, DistanceUnit.KILOMETERS))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(2));
-        for (SearchHit hit : searchResponse.getHits()) {
-            assertThat(hit.getId(), anyOf(equalTo("7"), equalTo("4")));
-        }
+        assertResponse(
+            client().prepareSearch() // from NY
+                .setQuery(geoDistanceQuery("location").point(40.5, -73.9).distance(25, DistanceUnit.KILOMETERS)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                for (SearchHit hit : response.getHits()) {
+                    assertThat(hit.getId(), anyOf(equalTo("7"), equalTo("4")));
+                }
+            }
+        );
+
     }
 
     public void testLimit2BoundingBox() throws Exception {
@@ -189,121 +209,128 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 880))
-                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 880))
-                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 880))
+                        .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
+                ),
+            1L
+        );
 
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 534))
-                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 534))
-                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 534))
+                        .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
+                ),
+            1L
+        );
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 534))
+                        .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
+                ),
+            1L
+        );
 
         // top == bottom && left == right
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 880))
-                    .filter(geoBoundingBoxQuery("location").setCorners(18.036842, 59.328355000000002, 18.036842, 59.328355000000002))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 534))
-                    .filter(
-                        geoBoundingBoxQuery("location").setCorners(
-                            45.509526999999999,
-                            -73.570986000000005,
-                            45.509526999999999,
-                            -73.570986000000005
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 880))
+                        .filter(geoBoundingBoxQuery("location").setCorners(18.036842, 59.328355000000002, 18.036842, 59.328355000000002))
+                ),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 534))
+                        .filter(
+                            geoBoundingBoxQuery("location").setCorners(
+                                45.509526999999999,
+                                -73.570986000000005,
+                                45.509526999999999,
+                                -73.570986000000005
+                            )
                         )
-                    )
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+                ),
+            1L
+        );
 
         // top == bottom
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 880))
-                    .filter(geoBoundingBoxQuery("location").setCorners(18.036842, 143.5, 18.036842, 113.96875))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 534))
-                    .filter(geoBoundingBoxQuery("location").setCorners(45.509526999999999, 143.5, 45.509526999999999, 113.96875))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 880))
+                        .filter(geoBoundingBoxQuery("location").setCorners(18.036842, 143.5, 18.036842, 113.96875))
+                ),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 534))
+                        .filter(geoBoundingBoxQuery("location").setCorners(45.509526999999999, 143.5, 45.509526999999999, 113.96875))
+                ),
+            1L
+        );
 
         // left == right
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 880))
-                    .filter(
-                        geoBoundingBoxQuery("location").setCorners(
-                            74.579421999999994,
-                            59.328355000000002,
-                            -66.668903999999998,
-                            59.328355000000002
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 880))
+                        .filter(
+                            geoBoundingBoxQuery("location").setCorners(
+                                74.579421999999994,
+                                59.328355000000002,
+                                -66.668903999999998,
+                                59.328355000000002
+                            )
                         )
-                    )
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 534))
-                    .filter(
-                        geoBoundingBoxQuery("location").setCorners(
-                            74.579421999999994,
-                            -73.570986000000005,
-                            -66.668903999999998,
-                            -73.570986000000005
+                ),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 534))
+                        .filter(
+                            geoBoundingBoxQuery("location").setCorners(
+                                74.579421999999994,
+                                -73.570986000000005,
+                                -66.668903999999998,
+                                -73.570986000000005
+                            )
                         )
-                    )
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+                ),
+            1L
+        );
 
         // Distance query
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 880))
-                    .filter(geoDistanceQuery("location").point(20, 60.0).distance(500, DistanceUnit.MILES))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 880))
+                        .filter(geoDistanceQuery("location").point(20, 60.0).distance(500, DistanceUnit.MILES))
+                ),
+            1L
+        );
 
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                boolQuery().must(termQuery("userid", 534))
-                    .filter(geoDistanceQuery("location").point(45.0, -73.0).distance(500, DistanceUnit.MILES))
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    boolQuery().must(termQuery("userid", 534))
+                        .filter(geoDistanceQuery("location").point(45.0, -73.0).distance(500, DistanceUnit.MILES))
+                ),
+            1L
+        );
     }
 
     public void testCompleteLonRange() throws Exception {
@@ -336,60 +363,77 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180)),
+            1L
+        );
 
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180)),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180)),
+            2L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180)),
+            2L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360)),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360)),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360)),
+            2L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360)),
+            2L
+        );
 
         // top == bottom
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE)
-                    .setCorners(59.328355000000002, 0, 59.328355000000002, 360)
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        searchResponse = client().prepareSearch()
-            .setQuery(
-                geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE)
-                    .setCorners(59.328355000000002, -180, 59.328355000000002, 180)
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE)
+                        .setCorners(59.328355000000002, 0, 59.328355000000002, 360)
+                ),
+            1L
+        );
+
+        assertHitCount(
+            client().prepareSearch()
+                .setQuery(
+                    geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE)
+                        .setCorners(59.328355000000002, -180, 59.328355000000002, 180)
+                ),
+            1L
+        );
 
         // Distance query
-        searchResponse = client().prepareSearch()
-            .setQuery(geoDistanceQuery("location").point(60.0, -20.0).distance(1800, DistanceUnit.MILES))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(
+            client().prepareSearch().setQuery(geoDistanceQuery("location").point(60.0, -20.0).distance(1800, DistanceUnit.MILES)),
+            1L
+        );
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -389,24 +389,24 @@ public class ElasticsearchAssertions {
     public static void assertFailures(SearchRequestBuilder searchRequestBuilder, RestStatus restStatus, Matcher<String> reasonMatcher) {
         // when the number for shards is randomized and we expect failures
         // we can either run into partial or total failures depending on the current number of shards
-        assertResponse(searchRequestBuilder, response -> {
-            try {
+        try {
+            assertResponse(searchRequestBuilder, response -> {
                 assertThat("Expected shard failures, got none", response.getShardFailures(), not(emptyArray()));
                 for (ShardSearchFailure shardSearchFailure : response.getShardFailures()) {
                     assertThat(shardSearchFailure.status(), equalTo(restStatus));
                     assertThat(shardSearchFailure.reason(), reasonMatcher);
                 }
-            } catch (SearchPhaseExecutionException e) {
-                assertThat(e.status(), equalTo(restStatus));
-                assertThat(e.toString(), reasonMatcher);
-                for (ShardSearchFailure shardSearchFailure : e.shardFailures()) {
-                    assertThat(shardSearchFailure.status(), equalTo(restStatus));
-                    assertThat(shardSearchFailure.reason(), reasonMatcher);
-                }
-            } catch (Exception e) {
-                fail("SearchPhaseExecutionException expected but got " + e.getClass());
+            });
+        } catch (SearchPhaseExecutionException e) {
+            assertThat(e.status(), equalTo(restStatus));
+            assertThat(e.toString(), reasonMatcher);
+            for (ShardSearchFailure shardSearchFailure : e.shardFailures()) {
+                assertThat(shardSearchFailure.status(), equalTo(restStatus));
+                assertThat(shardSearchFailure.reason(), reasonMatcher);
             }
-        });
+        } catch (Exception e) {
+            fail("SearchPhaseExecutionException expected but got " + e.getClass());
+        }
     }
 
     public static void assertNoFailures(BaseBroadcastResponse response) {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -255,8 +255,7 @@ public class ElasticsearchAssertions {
     }
 
     public static void assertSortValues(SearchRequestBuilder searchRequestBuilder, Object[]... sortValues) {
-        assertResponse(searchRequestBuilder, res -> {
-            assertNoFailures(res);
+        assertNoFailuresAndResponse(searchRequestBuilder, res -> {
             SearchHit[] hits = res.getHits().getHits();
             assertEquals(sortValues.length, hits.length);
             for (int i = 0; i < sortValues.length; ++i) {

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -290,7 +290,6 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
                 doTestLabelPosition(fields, GeoTestUtils.geoShapeValue(new Point(value.getX(), value.getY())));
             }
         });
-
     }
 
     private void doTestLabelPosition(Map<String, DocumentField> fields, GeoShapeValues.GeoShapeValue expectedLabelPosition)

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -7,7 +7,7 @@
 package org.elasticsearch.xpack.spatial.search;
 
 import org.apache.lucene.geo.Circle;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.geo.BoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -51,7 +51,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -259,37 +260,37 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
 
         GeoShapeValues.GeoShapeValue value = GeoTestUtils.geoShapeValue(geometry);
 
-        SearchResponse searchResponse = client().prepareSearch()
+        SearchRequestBuilder searchRequest = client().prepareSearch()
             .addStoredField("_source")
             .addScriptField("lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "lat", Collections.emptyMap()))
             .addScriptField("lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "lon", Collections.emptyMap()))
             .addScriptField("height", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "height", Collections.emptyMap()))
             .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()))
             .addScriptField("label_lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lat", Collections.emptyMap()))
-            .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()))
-            .get();
-        assertNoFailures(searchResponse);
-        Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
-        assertThat(fields.get("lat").getValue(), equalTo(value.getY()));
-        assertThat(fields.get("lon").getValue(), equalTo(value.getX()));
-        assertThat(fields.get("height").getValue(), equalTo(value.boundingBox().maxY() - value.boundingBox().minY()));
-        assertThat(fields.get("width").getValue(), equalTo(value.boundingBox().maxX() - value.boundingBox().minX()));
+            .addScriptField("label_lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "label_lon", Collections.emptyMap()));
 
-        // Check label position is in the geometry, but with a tolerance constructed as a circle of 1m radius to handle quantization
-        Point labelPosition = new Point(fields.get("label_lon").getValue(), fields.get("label_lat").getValue());
-        Circle tolerance = new Circle(labelPosition.getY(), labelPosition.getX(), 1);
-        assertTrue(
-            "Expect label position " + labelPosition + " to intersect geometry " + geometry,
-            value.relate(tolerance) != GeoRelation.QUERY_DISJOINT
-        );
+        assertCheckedResponse(searchRequest, response -> {
+            Map<String, DocumentField> fields = response.getHits().getHits()[0].getFields();
+            assertThat(fields.get("lat").getValue(), equalTo(value.getY()));
+            assertThat(fields.get("lon").getValue(), equalTo(value.getX()));
+            assertThat(fields.get("height").getValue(), equalTo(value.boundingBox().maxY() - value.boundingBox().minY()));
+            assertThat(fields.get("width").getValue(), equalTo(value.boundingBox().maxX() - value.boundingBox().minX()));
+            // Check label position is in the geometry, but with a tolerance constructed as a circle of 1m radius to handle quantization
+            Point labelPosition = new Point(fields.get("label_lon").getValue(), fields.get("label_lat").getValue());
+            Circle tolerance = new Circle(labelPosition.getY(), labelPosition.getX(), 1);
+            assertTrue(
+                "Expect label position " + labelPosition + " to intersect geometry " + geometry,
+                value.relate(tolerance) != GeoRelation.QUERY_DISJOINT
+            );
+            // Check that the label position is the expected one, or the centroid in certain polygon cases
+            if (expectedLabelPosition != null) {
+                doTestLabelPosition(fields, expectedLabelPosition);
+            } else if (fallbackToCentroid && value.dimensionalShapeType() == DimensionalShapeType.POLYGON) {
+                // Use the centroid for all polygons, unless overwritten for specific cases
+                doTestLabelPosition(fields, GeoTestUtils.geoShapeValue(new Point(value.getX(), value.getY())));
+            }
+        });
 
-        // Check that the label position is the expected one, or the centroid in certain polygon cases
-        if (expectedLabelPosition != null) {
-            doTestLabelPosition(fields, expectedLabelPosition);
-        } else if (fallbackToCentroid && value.dimensionalShapeType() == DimensionalShapeType.POLYGON) {
-            // Use the centroid for all polygons, unless overwritten for specific cases
-            doTestLabelPosition(fields, GeoTestUtils.geoShapeValue(new Point(value.getX(), value.getY())));
-        }
     }
 
     private void doTestLabelPosition(Map<String, DocumentField> fields, GeoShapeValues.GeoShapeValue expectedLabelPosition)
@@ -316,18 +317,18 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
 
         indicesAdmin().prepareRefresh("test").get();
 
-        SearchResponse searchResponse = client().prepareSearch()
+        SearchRequestBuilder searchRequestBuilder = client().prepareSearch()
             .addStoredField("_source")
             .addScriptField("lat", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "lat", Collections.emptyMap()))
             .addScriptField("lon", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "lon", Collections.emptyMap()))
             .addScriptField("height", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "height", Collections.emptyMap()))
-            .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()))
-            .get();
-        assertNoFailures(searchResponse);
-        Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
-        assertThat(fields.get("lat").getValue(), equalTo(Double.NaN));
-        assertThat(fields.get("lon").getValue(), equalTo(Double.NaN));
-        assertThat(fields.get("height").getValue(), equalTo(Double.NaN));
-        assertThat(fields.get("width").getValue(), equalTo(Double.NaN));
+            .addScriptField("width", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "width", Collections.emptyMap()));
+        assertNoFailuresAndResponse(searchRequestBuilder, response -> {
+            Map<String, DocumentField> fields = response.getHits().getHits()[0].getFields();
+            assertThat(fields.get("lat").getValue(), equalTo(Double.NaN));
+            assertThat(fields.get("lon").getValue(), equalTo(Double.NaN));
+            assertThat(fields.get("height").getValue(), equalTo(Double.NaN));
+            assertThat(fields.get("width").getValue(), equalTo(Double.NaN));
+        });
     }
 }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeWithDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeWithDocValuesIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.spatial.search;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.geometry.Geometry;
@@ -41,6 +40,7 @@ import static org.elasticsearch.index.query.QueryBuilders.geoDistanceQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -150,14 +150,15 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
         refresh();
 
         BytesReference source = BytesReference.bytes(jsonBuilder().startObject().field("field1", "POINT(4.51 52.20)").endObject());
-        SearchResponse response = client().prepareSearch()
-            .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
-            .addSort("id", SortOrder.ASC)
-            .get();
-        assertHitCount(response, 3);
-        assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-        assertThat(response.getHits().getAt(2).getId(), equalTo("3"));
+        assertNoFailuresAndResponse(
+            client().prepareSearch().setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON)).addSort("id", SortOrder.ASC),
+            response -> {
+                assertHitCount(response, 3);
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+                assertThat(response.getHits().getAt(2).getId(), equalTo("3"));
+            }
+        );
     }
 
     // make sure we store the normalised geometry
@@ -178,18 +179,19 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
 
         indexRandom(true, client().prepareIndex("test").setId("0").setSource(source, XContentType.JSON));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setFetchSource(false).addStoredField("shape").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        SearchHit searchHit = searchResponse.getHits().getAt(0);
-        assertThat(searchHit.field("shape").getValue(), instanceOf(BytesRef.class));
-        BytesRef bytesRef = searchHit.field("shape").getValue();
-        Geometry geometry = WellKnownBinary.fromWKB(
-            StandardValidator.instance(true),
-            false,
-            bytesRef.bytes,
-            bytesRef.offset,
-            bytesRef.length
-        );
-        assertThat(geometry.type(), equalTo(ShapeType.MULTIPOLYGON));
+        assertNoFailuresAndResponse(client().prepareSearch("test").setFetchSource(false).addStoredField("shape"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            SearchHit searchHit = response.getHits().getAt(0);
+            assertThat(searchHit.field("shape").getValue(), instanceOf(BytesRef.class));
+            BytesRef bytesRef = searchHit.field("shape").getValue();
+            Geometry geometry = WellKnownBinary.fromWKB(
+                StandardValidator.instance(true),
+                false,
+                bytesRef.bytes,
+                bytesRef.offset,
+                bytesRef.length
+            );
+            assertThat(geometry.type(), equalTo(ShapeType.MULTIPOLYGON));
+        });
     }
 }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/LegacyGeoShapeWithDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/LegacyGeoShapeWithDocValuesIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.spatial.search;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -25,8 +24,8 @@ import java.util.Collections;
 
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 
 public class LegacyGeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
 
@@ -103,7 +102,6 @@ public class LegacyGeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
         }));
 
         // test self crossing of circles
-        SearchResponse searchResponse = client().prepareSearch("test").setQuery(geoShapeQuery("shape", new Circle(30, 50, 77000))).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(client().prepareSearch("test").setQuery(geoShapeQuery("shape", new Circle(30, 50, 77000))), 1L);
     }
 }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.spatial.search;
 
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.settings.Settings;
@@ -35,10 +34,10 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
@@ -175,45 +174,29 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         ShapeQueryBuilder filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("location");
-        SearchResponse result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter), 1L);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.location");
-        result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter), 1L);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.2.location");
-        result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter), 1L);
         filter = new ShapeQueryBuilder("location", "1").relation(ShapeRelation.INTERSECTS)
             .indexedShapeIndex(indexName)
             .indexedShapePath("1.2.3.location");
-        result = client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(QueryBuilders.matchAllQuery()).setPostFilter(filter), 1L);
 
         // now test the query variant
         ShapeQueryBuilder query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("location");
-        result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(query), 1L);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.location");
-        result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(query), 1L);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.2.location");
-        result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(query), 1L);
         query = new ShapeQueryBuilder("location", "1").indexedShapeIndex(indexName).indexedShapePath("1.2.3.location");
-        result = client().prepareSearch(searchIndex).setQuery(query).get();
-        assertNoFailures(result);
-        assertHitCount(result, 1);
+        assertHitCountAndNoFailures(client().prepareSearch(searchIndex).setQuery(query), 1L);
     }
 
     /**
@@ -239,11 +222,10 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         client().prepareIndex(INDEX).setId("0").setSource(source, XContentType.JSON).setRouting("ABC").get();
         indicesAdmin().prepareRefresh(INDEX).get();
 
-        SearchResponse searchResponse = client().prepareSearch(INDEX)
-            .setQuery(new ShapeQueryBuilder(FIELD, "0").indexedShapeIndex(INDEX).indexedShapeRouting("ABC"))
-            .get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) numDocs + 1));
+        assertHitCount(
+            client().prepareSearch(INDEX).setQuery(new ShapeQueryBuilder(FIELD, "0").indexedShapeIndex(INDEX).indexedShapeRouting("ABC")),
+            (long) numDocs + 1
+        );
     }
 
     public void testNullShape() {
@@ -264,16 +246,16 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
 
     public void testExistsQuery() {
         ExistsQueryBuilder eqb = QueryBuilders.existsQuery(FIELD);
-        SearchResponse result = client().prepareSearch(INDEX).setQuery(eqb).get();
-        assertNoFailures(result);
-        assertHitCount(result, numDocs);
+        assertHitCountAndNoFailures(client().prepareSearch(INDEX).setQuery(eqb), numDocs);
     }
 
     public void testFieldAlias() {
-        SearchResponse response = client().prepareSearch(INDEX)
-            .setQuery(new ShapeQueryBuilder("alias", queryGeometry).relation(ShapeRelation.INTERSECTS))
-            .get();
-        assertTrue(response.getHits().getTotalHits().value > 0);
+        assertResponse(
+            client().prepareSearch(INDEX).setQuery(new ShapeQueryBuilder("alias", queryGeometry).relation(ShapeRelation.INTERSECTS)),
+            response -> {
+                assertTrue(response.getHits().getTotalHits().value > 0);
+            }
+        );
     }
 
     public void testContainsShapeQuery() {
@@ -287,10 +269,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         // index the mbr of the collection
         Rectangle rectangle = new Rectangle(-50, 50, 50, -50);
         ShapeQueryBuilder queryBuilder = new ShapeQueryBuilder("location", rectangle).relation(ShapeRelation.CONTAINS);
-        SearchResponse response = client().prepareSearch("test_contains").setQuery(queryBuilder).get();
-        assertNoFailures(response);
-
-        assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCountAndNoFailures(client().prepareSearch("test_contains").setQuery(queryBuilder), 1L);
     }
 
     public void testGeometryCollectionRelations() throws IOException {
@@ -318,51 +297,60 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         {
             // A geometry collection that is fully within the indexed shape
             GeometryCollection<Geometry> collection = new GeometryCollection<>(List.of(new Point(1, 2), new Point(-2, -1)));
-            SearchResponse response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.CONTAINS))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
-            response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
-            response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.DISJOINT))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.CONTAINS)),
+                1L
+            );
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.INTERSECTS)),
+                1L
+            );
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.DISJOINT)),
+                0L
+            );
         }
         {
             // A geometry collection (as multi point) that is partially within the indexed shape
             MultiPoint multiPoint = new MultiPoint(List.of(new Point(1, 2), new Point(20, 30)));
-            SearchResponse response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", multiPoint).relation(ShapeRelation.CONTAINS))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
-            response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", multiPoint).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
-            response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", multiPoint).relation(ShapeRelation.DISJOINT))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", multiPoint).relation(ShapeRelation.CONTAINS)),
+                0L
+            );
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", multiPoint).relation(ShapeRelation.INTERSECTS)),
+                1L
+            );
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", multiPoint).relation(ShapeRelation.DISJOINT)),
+                0L
+            );
         }
         {
             // A geometry collection that is disjoint with the indexed shape
             MultiPoint multiPoint = new MultiPoint(List.of(new Point(-20, -30), new Point(20, 30)));
             GeometryCollection<Geometry> collection = new GeometryCollection<>(List.of(multiPoint));
-            SearchResponse response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.CONTAINS))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
-            response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.INTERSECTS))
-                .get();
-            assertEquals(0, response.getHits().getTotalHits().value);
-            response = client().prepareSearch("test_collections")
-                .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.DISJOINT))
-                .get();
-            assertEquals(1, response.getHits().getTotalHits().value);
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.CONTAINS)),
+                0L
+            );
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.INTERSECTS)),
+                0L
+            );
+            assertHitCount(
+                client().prepareSearch("test_collections")
+                    .setQuery(new ShapeQueryBuilder("geometry", collection).relation(ShapeRelation.DISJOINT)),
+                1L
+            );
         }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.spatial.index.query;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.settings.Settings;
@@ -35,6 +34,7 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.geoIntersectionQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 
@@ -131,9 +131,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
             .get();
 
         // test that point was inserted
-        SearchResponse response = client().prepareSearch("geo_points_only").setQuery(matchAllQuery()).get();
-
-        assertEquals(2, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch("geo_points_only").setQuery(matchAllQuery()), 2L);
     }
 
     public void testPointsOnly() throws Exception {
@@ -183,10 +181,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
         }
 
         // test that point was inserted
-        SearchResponse response = client().prepareSearch("geo_points_only")
-            .setQuery(geoIntersectionQuery(defaultFieldName, geometry))
-            .get();
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch("geo_points_only").setQuery(geoIntersectionQuery(defaultFieldName, geometry)), 1L);
     }
 
     public void testFieldAlias() throws IOException {
@@ -227,8 +222,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)).get();
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)), 1L);
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")


### PR DESCRIPTION
This PR adds new ElasticsearchAssertions#assertRespose methods that take a consumer for further inspection of the response. I refactor the ElasticsearchAssertions so all methods are calling this new method so there is only a few places where we call #decRef().