### PR TITLE
Increase K/V look-back time interval

### DIFF
--- a/docs/changelog/101205.yaml
+++ b/docs/changelog/101205.yaml
@@ -1,0 +1,5 @@
+pr: 101205
+summary: Increase K/V look-back time interval
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -79,11 +79,12 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
      * K/V indices (such as profiling-stacktraces) are assumed to contain data from their creation date until the creation date
      * of the next index that is created by rollover. Due to client-side caching of K/V data we need to extend the validity period
      * of the prior index by this time. This means that for queries that cover a time period around the time when a new index has
-     * been created we will query not only the new index but also the prior one (for up to three hours by default).
+     * been created we will query not only the new index but also the prior one (for up to four hours by default). The default value
+     * on the client is three hours but to ensure we won't miss anything due to unlucky timing, we add a bit more slack (1 hour).
      */
     public static final Setting<TimeValue> PROFILING_KV_INDEX_OVERLAP = Setting.positiveTimeSetting(
         "xpack.profiling.kv_index.overlap",
-        TimeValue.timeValueHours(3),
+        TimeValue.timeValueHours(4),
         Setting.Property.NodeScope
     );
 


### PR DESCRIPTION
With this commit we increase the look-back time interval from 3 hours to 4 hours by default. This look-back time interval is applied to determine the correct K/V indices to query around a rollover. As the new index may not have all data immediately after a rollover, we also need to query the old index. Clients may cache data for up to 3 hours but to avoid unlucky timing we add a bit of slack and increase the time interval to 4 hours.