### PR TITLE
[8.11] Increase K/V look-back time interval (#101205)

### DIFF
--- a/docs/changelog/101205.yaml
+++ b/docs/changelog/101205.yaml
@@ -1,0 +1,5 @@
+pr: 101205
+summary: Increase K/V look-back time interval
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -79,11 +79,12 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
      * K/V indices (such as profiling-stacktraces) are assumed to contain data from their creation date until the creation date
      * of the next index that is created by rollover. Due to client-side caching of K/V data we need to extend the validity period
      * of the prior index by this time. This means that for queries that cover a time period around the time when a new index has
-     * been created we will query not only the new index but also the prior one (for up to three hours by default).
+     * been created we will query not only the new index but also the prior one (for up to four hours by default). The default value
+     * on the client is three hours but to ensure we won't miss anything due to unlucky timing, we add a bit more slack (1 hour).
      */
     public static final Setting<TimeValue> PROFILING_KV_INDEX_OVERLAP = Setting.positiveTimeSetting(
         "xpack.profiling.kv_index.overlap",
-        TimeValue.timeValueHours(3),
+        TimeValue.timeValueHours(4),
         Setting.Property.NodeScope
     );
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Increase K/V look-back time interval (#101205)