### PR TITLE
Set longer settings update task timeout

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
@@ -62,7 +62,7 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
             .cluster()
             .prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().put(BlockingClusterSettingTestPlugin.TEST_BLOCKING_SETTING.getKey(), true).build())
-            .setMasterNodeTimeout(TimeValue.timeValueMillis(10L))
+            .setMasterNodeTimeout(TimeValue.timeValueMillis(100L))
             .execute();
 
         logger.info("--> waiting for cluster state update to be blocked");


### PR DESCRIPTION
It appears that task cancelation is executed before the settings update is event starting in testClusterSettingsUpdateNotAcknowledged. This change uses longer timeout to improve the probability of blocking.

Related to: #98918
