### PR TITLE
[8.11] Fix painless execute api and tsdb issue. (#101212)

### DIFF
--- a/docs/changelog/101212.yaml
+++ b/docs/changelog/101212.yaml
@@ -1,0 +1,6 @@
+pr: 101212
+summary: Fix painless execute api and tsdb issue
+area: TSDB
+type: bug
+issues:
+ - 101072

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -52,6 +52,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -758,7 +759,13 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
                 try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig(defaultAnalyzer))) {
                     BytesReference document = request.contextSetup.document;
                     XContentType xContentType = request.contextSetup.xContentType;
-                    SourceToParse sourceToParse = new SourceToParse("_id", document, xContentType);
+                    String id;
+                    if (indexService.getIndexSettings().getMode() == IndexMode.TIME_SERIES) {
+                        id = null; // The id gets auto generated for time series indices.
+                    } else {
+                        id = "_id";
+                    }
+                    SourceToParse sourceToParse = new SourceToParse(id, document, xContentType);
                     DocumentMapper documentMapper = indexService.mapperService().documentMapper();
                     if (documentMapper == null) {
                         documentMapper = DocumentMapper.createEmpty(indexService.mapperService());

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
@@ -1,0 +1,60 @@
+---
+tsdb_execute_painless_api:
+  - skip:
+      version: " - 8.11.99"
+      reason: fixed in 8.12.0 and later
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [metricset, k8s.pod.uid]
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      ip:
+                        type: ip
+                      network:
+                        properties:
+                          tx:
+                            type: long
+                          rx:
+                            type: long
+
+  - do:
+      scripts_painless_execute:
+        body:
+          script:
+            source: "emit(doc['k8s.pod.network.tx'].value < 1000);"
+          context: "boolean_field"
+          context_setup:
+            index: test_index
+            document:
+              "@timestamp": "2021-04-28T18:51:03.142Z"
+              metricset: pod
+              k8s:
+                pod:
+                  name: dog
+                  uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9
+                  ip: 10.10.55.3
+                  network:
+                    tx: 111434595272
+                    rx: 430605511
+
+  - match: { result: [false] }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/150_runtime_fields.yml
@@ -1,8 +1,8 @@
 ---
 tsdb_execute_painless_api:
   - skip:
-      version: " - 8.11.99"
-      reason: fixed in 8.12.0 and later
+      version: " - 8.11.00"
+      reason: fixed in 8.11.1 and later
 
   - do:
       indices.create:


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix painless execute api and tsdb issue. (#101212)