### PR TITLE
[8.10] Disable packaging tests in Jenkins (#101088)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+packaging-tests-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+packaging-tests-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+packaging-tests
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/8 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+packaging-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+packaging-tests.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+periodic+packaging-tests
     display-name: "elastic / elasticsearch # %BRANCH% - packaging tests"
-    description: "Testing of the Elasticsearch %BRANCH% branch packaging tests.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     project-type: multijob
     node: master
     vault: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Disable packaging tests in Jenkins (#101088)](https://github.com/elastic/elasticsearch/pull/101088)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)