### PR TITLE
[7.17] [buildkite] Increase release-tests timeout

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -76,7 +76,7 @@ steps:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
   - label: release-tests
     command: .buildkite/scripts/release-tests.sh
-    timeout_in_minutes: 300
+    timeout_in_minutes: 360
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -1267,7 +1267,7 @@ steps:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
   - label: release-tests
     command: .buildkite/scripts/release-tests.sh
-    timeout_in_minutes: 300
+    timeout_in_minutes: 360
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [buildkite] Increase release-tests timeout (4d10ea18)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)