### PR TITLE
[7.17] [ci] Disable periodic java-matrix, java-fips-matrix, and bwc jobs in Jenkins (#101234)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+bwc-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+bwc-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+bwc
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/8 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+bwc.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+bwc.yml
@@ -1,5 +1,5 @@
 ---
-jjbb-template: matrix-gradle-unix.yml
+jjbb-template: matrix-gradle-unix-disabled.yml
 vars:
   - job-name: elastic+elasticsearch+%BRANCH%+periodic+bwc
   - job-display-name: "elastic / elasticsearch # %BRANCH% - backwards compatibility matrix"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+java-fips-matrix
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/12 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix.yml
@@ -2,7 +2,8 @@
 - job:
     name: "elastic+elasticsearch+%BRANCH%+periodic+java-fips-matrix"
     display-name: "elastic / elasticsearch # %BRANCH% - java fips compatibility matrix"
-    description: "Testing of the Elasticsearch %BRANCH% branch java FIPS compatibility matrix.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     project-type: matrix
     child-workspace: /dev/shm/elastic+elasticsearch+%BRANCH%+periodic+java-fips-matrix
     node: master

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+java-matrix-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+java-matrix-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+java-matrix
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/12 * * *"

--- a/.ci/templates.t/matrix-gradle-unix-disabled.yml
+++ b/.ci/templates.t/matrix-gradle-unix-disabled.yml
@@ -1,11 +1,11 @@
 ---
 - job:
-    name: "elastic+elasticsearch+%BRANCH%+periodic+java-matrix"
-    display-name: "elastic / elasticsearch # %BRANCH% - java compatibility matrix"
+    name: "{job-name}"
+    display-name: "{job-display-name}"
     description: "This job has been migrated to Buildkite.\n"
     disabled: true
     project-type: matrix
-    child-workspace: /dev/shm/elastic+elasticsearch+%BRANCH%+periodic+java-matrix
+    child-workspace: /dev/shm/{job-name}
     node: master
     scm:
       - git:
@@ -18,16 +18,15 @@
             - "general-purpose"
       - axis:
           type: yaml
-          filename: ".ci/matrix-runtime-javas.yml"
-          name: "ES_RUNTIME_JAVA"
+          filename: "{matrix-yaml-file}"
+          name: "{matrix-variable}"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
-          $WORKSPACE/.ci/scripts/run-gradle.sh -Dbwc.checkout.align=true check
+          $WORKSPACE/.ci/scripts/run-gradle.sh {gradle-args}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Disable periodic java-matrix, java-fips-matrix, and bwc jobs in Jenkins (#101234)](https://github.com/elastic/elasticsearch/pull/101234)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)